### PR TITLE
feat: add access context scaffolding

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+/**
+ * Middleware placeholder (resolução de tenant entrará aqui depois).
+ * Mantém pass-through para não quebrar o build.
+ */
+export function middleware(_req: NextRequest) {
+  return NextResponse.next();
+}
+
+// Se quiser restringir rotas no futuro, adicione "matcher" aqui.
+// export const config = { matcher: ['/dashboard/:path*'] };

--- a/src/lib/access/audit.ts
+++ b/src/lib/access/audit.ts
@@ -1,0 +1,19 @@
+import type { AccessContext } from './types';
+
+/**
+ * Auditoria de eventos de contexto (MVP obrigatório).
+ * Implementação real usará RPC/queue -> triggers -> audit_logs.
+ * Aqui mantemos só as assinaturas.
+ */
+
+export async function auditAccountSwitch(_ctx: AccessContext): Promise<void> {
+  // TODO: chamar RPC audit_context_event('account_switch', ...)
+}
+
+export async function auditActingAsEnter(_ctx: AccessContext): Promise<void> {
+  // TODO: RPC audit_context_event('acting_as_enter', ...)
+}
+
+export async function auditActingAsExit(_ctx: AccessContext): Promise<void> {
+  // TODO: RPC audit_context_event('acting_as_exit', ...)
+}

--- a/src/lib/access/getAccessContext.ts
+++ b/src/lib/access/getAccessContext.ts
@@ -1,0 +1,19 @@
+import type { AccessContext, AccessInput } from './types';
+import { AccessError } from './types';
+
+/**
+ * Resolve o tenant (account_slug), valida vínculo ativo e monta o AccessContext.
+ * Depende de Supabase (RLS ON) e de fetchPlanAndLimits(). Apenas assinatura aqui.
+ */
+export async function getAccessContext(
+  _input: AccessInput,
+): Promise<AccessContext> {
+  // TODO:
+  // 1) Resolver account_slug por host/subdomínio (preferência) ou rota
+  // 2) Obter account_id por slug (RLS)
+  // 3) Ler vínculo (account_users) -> status e role (RLS)
+  // 4) Ler super_admin e definir acting_as quando representar uma account
+  // 5) Carregar plan/limits via view/RPC
+  // 6) Retornar AccessContext completo
+  throw new AccessError('UNRESOLVED_TENANT', 'Tenant não resolvido.');
+}

--- a/src/lib/access/guards.ts
+++ b/src/lib/access/guards.ts
@@ -1,0 +1,50 @@
+import { AccessError } from './types';
+import type { AccessContext, Role } from './types';
+
+/** Compara hierarquia de papéis */
+const roleWeight: Record<Role, number> = {
+  viewer: 1,
+  editor: 2,
+  admin: 3,
+  owner: 4,
+};
+
+export function requireActive(ctx: AccessContext): void {
+  if (ctx.status !== 'active') {
+    throw new AccessError('INACTIVE_MEMBER', 'Vínculo não está ativo.');
+  }
+}
+
+export function requireRole(ctx: AccessContext, atLeast: Role): void {
+  if (roleWeight[ctx.role] < roleWeight[atLeast]) {
+    throw new AccessError('FORBIDDEN_ACCOUNT', 'Permissão insuficiente.');
+  }
+}
+
+/** Ex.: domínios só admin/owner */
+export function canManageDomains(ctx: AccessContext): boolean {
+  return roleWeight[ctx.role] >= roleWeight['admin'];
+}
+
+/** Ex.: integrações só admin/owner */
+export function canManageIntegrations(ctx: AccessContext): boolean {
+  return roleWeight[ctx.role] >= roleWeight['admin'];
+}
+
+/**
+ * Protege o último owner: o chamador deve verificar
+ * se a operação deixaria a conta sem owner e, se sim, bloquear.
+ * A implementação real recebe um provider que retorna a contagem de owners.
+ */
+export type OwnerCountProvider = (account_id: string) => Promise<number>;
+
+export async function protectLastOwner(
+  ctx: AccessContext,
+  ownerCountProvider: OwnerCountProvider,
+): Promise<void> {
+  if (ctx.role !== 'owner') return; // operação pode ser gerencial; validação ainda é necessária
+  const owners = await ownerCountProvider(ctx.account_id);
+  if (owners <= 1) {
+    throw new AccessError('NO_OWNER_GUARD', 'Ação proibida: último owner.');
+  }
+}

--- a/src/lib/access/plan.ts
+++ b/src/lib/access/plan.ts
@@ -1,0 +1,12 @@
+import type { Limits, PlanInfo } from './types';
+
+/**
+ * Contrato para obter plano e limites (fonte única = Supabase view/RPC).
+ * Implementação real virá depois. Aqui é apenas assinatura.
+ */
+export async function fetchPlanAndLimits(
+  _account_id: string,
+): Promise<{ plan: PlanInfo; limits: Limits }> {
+  // TODO: chamar view/RPC no Supabase (RLS ON)
+  throw new Error('fetchPlanAndLimits() não implementado.');
+}

--- a/src/lib/access/types.ts
+++ b/src/lib/access/types.ts
@@ -1,0 +1,54 @@
+/**
+ * Tipos centrais do Contexto de Acesso
+ * Alinhado ao Doc Principal v6 + Anexo: Account Dashboard v3
+ */
+
+export type MemberStatus = 'active' | 'pending' | 'inactive' | 'revoked';
+export type Role = 'owner' | 'admin' | 'editor' | 'viewer';
+
+export type AccessErrorCode =
+  | 'UNRESOLVED_TENANT'
+  | 'FORBIDDEN_ACCOUNT'
+  | 'INACTIVE_MEMBER'
+  | 'NO_OWNER_GUARD';
+
+export interface PlanInfo {
+  id: string;
+  name: string;
+}
+
+export interface Limits {
+  max_lps: number;
+  max_conversions: number;
+  max_domains: number;
+  // Fallback para outros limites/flags vindos do backend
+  [key: string]: number | boolean;
+}
+
+export interface AccessContext {
+  account_id: string;
+  account_slug: string; // subdomínio ou slug de rota
+  role: Role;
+  status: MemberStatus;
+  is_super_admin: boolean;
+  acting_as: boolean;
+  plan: PlanInfo;
+  limits: Limits;
+}
+
+/** Entrada padrão para resolução de contexto (usada pelo middleware e server actions) */
+export interface AccessInput {
+  host?: string;
+  pathname?: string;
+  params?: { account?: string }; // fallback de rota: /a/[account]/...
+}
+
+/** Erro tipado para padronizar UX e logs */
+export class AccessError extends Error {
+  code: AccessErrorCode;
+  constructor(code: AccessErrorCode, message?: string) {
+    super(message ?? code);
+    this.code = code;
+    this.name = 'AccessError';
+  }
+}

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,0 +1,12 @@
+/**
+ * Placeholder do cliente Supabase server-side.
+ * Não expõe segredos nem cria dependência de lib agora.
+ * Trocar por implementação real depois (ex.: criarClientServer()).
+ */
+
+export type ServerSupabaseClient = unknown;
+
+export function getServerSupabase(): ServerSupabaseClient {
+  // TODO: retornar cliente real (auth-helpers ou fetch c/ headers)
+  throw new Error('getServerSupabase() não implementado.');
+}

--- a/src/providers/AccessProvider.tsx
+++ b/src/providers/AccessProvider.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import React, { createContext, useContext } from 'react';
+import type { AccessContext } from '../lib/access/types';
+
+/**
+ * Provider leve para expor dados não-sensíveis do contexto na UI.
+ * A resolução real virá do servidor; aqui só o contêiner e os hooks.
+ */
+
+const AccessContextReact = createContext<Partial<AccessContext> | null>(null);
+
+export function AccessProvider({
+  value,
+  children,
+}: {
+  value: Partial<AccessContext> | null;
+  children: React.ReactNode;
+}) {
+  return (
+    <AccessContextReact.Provider value={value}>
+      {children}
+    </AccessContextReact.Provider>
+  );
+}
+
+export function useAccessContext(): Partial<AccessContext> {
+  const ctx = useContext(AccessContextReact);
+  return ctx ?? {};
+}


### PR DESCRIPTION
## Summary
- add middleware stub for tenant resolution
- scaffold server-side Supabase client and access context types
- add access provider and permission guard helpers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Next.js ESLint plugin recommendation prompt)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6897f0205e608329a975518041c740ab