### PR TITLE
feat(auth): aprimora fluxos de recuperação de senha

### DIFF
--- a/src/components/auth/auth-forms/LoginForm.tsx
+++ b/src/components/auth/auth-forms/LoginForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
@@ -12,25 +13,59 @@ type Props = {
 };
 
 export default function LoginForm({ onSuccess, onForgotClick }: Props) {
+  const router = useRouter();
   const [email, setEmail] = useState("");
   const [pwd, setPwd] = useState("");
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
+  // Throttle progressivo
+  const [fails, setFails] = useState(0);
+  const wait = useMemo(() => (fails >= 5 ? 10 : fails >= 3 ? 3 : 0), [fails]);
+  const [cooldown, setCooldown] = useState(0);
+
+  useEffect(() => {
+    if (!cooldown) return;
+    const t = setInterval(() => setCooldown((c) => Math.max(0, c - 1)), 1000);
+    return () => clearInterval(t);
+  }, [cooldown]);
+
+  // Já logado → pular modal
+  useEffect(() => {
+    (async () => {
+      const { data } = await supabase.auth.getSession();
+      if (data.session) {
+        onSuccess?.() ?? router.push("/a");
+      }
+    })();
+  }, [onSuccess, router]);
+
   async function submit(e: React.FormEvent) {
     e.preventDefault();
+    if (cooldown > 0) return;
     setLoading(true);
     setErr(null);
-    const { error } = await supabase.auth.signInWithPassword({
-      email,
-      password: pwd,
-    });
-    if (error) {
-      setErr("E-mail ou senha incorretos.");
-    } else {
-      onSuccess?.();
+
+    try {
+      const { error } = await supabase.auth.signInWithPassword({
+        email,
+        password: pwd,
+      });
+      if (error) {
+        // Erro de credencial (mensagem genérica)
+        setErr("E-mail ou senha incorretos.");
+        setPwd("");
+        setFails((n) => n + 1);
+        if (wait > 0) setCooldown(wait);
+        return;
+      }
+      // Sucesso
+      onSuccess?.() ?? router.push("/a");
+    } catch {
+      setErr("Erro de conexão. Tente novamente.");
+    } finally {
+      setLoading(false);
     }
-    setLoading(false);
   }
 
   return (
@@ -43,6 +78,7 @@ export default function LoginForm({ onSuccess, onForgotClick }: Props) {
           required
           value={email}
           onChange={(e) => setEmail(e.target.value)}
+          autoFocus
         />
       </div>
 
@@ -57,10 +93,14 @@ export default function LoginForm({ onSuccess, onForgotClick }: Props) {
         />
       </div>
 
-      {err && <p className="text-sm text-red-600">{err}</p>}
+      {err && (
+        <p className="text-sm text-red-600">
+          {cooldown > 0 ? `Aguarde ${cooldown}s antes de tentar novamente.` : err}
+        </p>
+      )}
 
-      <Button type="submit" disabled={loading} className="w-full">
-        {loading ? "Entrando..." : "Entrar"}
+      <Button type="submit" disabled={loading || cooldown > 0} className="w-full">
+        {loading ? "Entrando..." : cooldown > 0 ? `Aguarde ${cooldown}s` : "Entrar"}
       </Button>
 
       <div className="text-sm text-center">
@@ -75,3 +115,4 @@ export default function LoginForm({ onSuccess, onForgotClick }: Props) {
     </form>
   );
 }
+


### PR DESCRIPTION
## Summary
- implementa página de redefinição com validação de código, reenvio e comunicação entre abas
- adiciona formulário de recuperação com mensagens neutras, cooldown e escuta de eventos
- inclui throttle progressivo no login e redirecionamento caso já autenticado

## Testing
- `npm run lint` *(falhou: solicitou configuração interativa do ESLint)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68ace9b766d08329851a02a52929b184