### PR TITLE
feat(auth-app): cria estrutura inicial do sub-app de autenticação

### DIFF
--- a/app/auth-app/README.md
+++ b/app/auth-app/README.md
@@ -1,0 +1,11 @@
+# Sub-app Auth
+
+Mini-aplicativo dedicado à autenticação (login + reset de senha).
+
+## Rotas
+- `/auth-app/login` — Tela de login
+- `/auth-app/reset` — Tela de reset de senha
+- `/auth-app/catch` — Normalizador de token
+
+## Redirect final
+Após sucesso, o fluxo retorna sempre para `/a`.

--- a/app/auth-app/catch/page.tsx
+++ b/app/auth-app/catch/page.tsx
@@ -1,0 +1,6 @@
+"use client"
+
+// TODO: Implementar normalizador de token (code, token_hash, access_token)
+export default function CatchPage() {
+  return <div>Normalizador de token (sub-app auth)</div>
+}

--- a/app/auth-app/layout.tsx
+++ b/app/auth-app/layout.tsx
@@ -1,0 +1,7 @@
+export default function AuthAppLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/app/auth-app/login/page.tsx
+++ b/app/auth-app/login/page.tsx
@@ -1,0 +1,6 @@
+"use client"
+
+// TODO: Implementar tela de login do sub-app
+export default function LoginPage() {
+  return <div>Login (sub-app auth)</div>
+}

--- a/app/auth-app/reset/page.tsx
+++ b/app/auth-app/reset/page.tsx
@@ -1,0 +1,6 @@
+"use client"
+
+// TODO: Implementar tela de reset do sub-app
+export default function ResetPage() {
+  return <div>Reset de senha (sub-app auth)</div>
+}


### PR DESCRIPTION
## Summary
- adiciona sub-app de autenticação com rotas de login, reset e catch
- inclui layout isolado e README com instruções

## Testing
- `npm run lint` *(falhou: solicitou configuração do ESLint)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68af2ad1f8608329bf6aff095c5038b9