### PR TITLE
docs: atualizar roadmap e schema para versões de 09/04/2026

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data: 01/04/2026
-• Versão: v1.5.35
+• Data: 09/04/2026
+• Versão: v1.5.36
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -634,7 +634,7 @@
 • Alterar escopo de campos do onboarding (somente consistência de validação).
 
 10.5 Pós-setup persuasivo sem entitlements (active — conversão)
-• Status: Briefing
+• Status: Em evolução
 • Escopo: UX/CTAs para conta em `accounts.status=active` quando **não há plano/trial (sem entitlements)**, imediatamente após o E10.4 (pós-setup). Deve orientar próximos passos e conversão **sem retornar** ao fluxo de “Primeiros passos”.
 • DoD mínimo (MVP):
 • Renderizar uma tela pós-setup (não pode ficar “em branco”) com:
@@ -646,7 +646,7 @@
 • “Primeiros passos” renderiza **somente** se `accounts.status=pending_setup`.
 • Conta `active` **não** implica permissão de criar LP; liberar “Criar LP” apenas com trial/plano (entitlement).
 • Nota: não usa `setup_completed_at` nem `account_setup_completed_at` (não usar em lugar nenhum; manter no DB apenas por segurança).
-• Dependências: E10.4.6 (setup status-based + pós-save com redirect/refresh), E9.8.1 (trial/entitlements), E10.5.1 (enforcement server-side; hardening).
+• Dependências: E10.4.6 (setup status-based + pós-save com redirect/refresh), E9.8.1 (trial/entitlements), E10.5.1 (enforcement server-side; hardening), E10.5.2 (base estrutural admin/interna de taxonomia, templates e guides).
 
 10.5.1 Matriz “preparação vs produtivo” + enforcement (SSR + actions)
 • Status: Briefing
@@ -663,6 +663,27 @@
 10.5.1.4 Dependências
 • E9.8.1 (trial/entitlements).
 • E10.5 (UX pós-setup para reutilizar CTAs/mensagens).
+
+10.5.2 Base estrutural admin/interna de taxonomia, templates e guides
+• Status: Concluído (exec) (09/04/2026)
+• Objetivo: criar a base estrutural de BD para sustentar a evolução do E10.5 com taxonomia, templates, pesquisa e guides, ainda sem exposição ao tenant/app nesta etapa.
+• Implementado/Definido:
+• criadas 8 tabelas do E10.5.2 no Supabase, com PK, FK, `CHECK`, índices e RLS admin-only
+• aplicado `supa#52` nesta etapa via `business_taxon_aliases.alias_text_normalized` como generated column
+• as 8 tabelas nascem como admin/internas nesta etapa, sem exposição a tenant/app, fora de auditoria e fora de Trigger Hub
+• contratos de domínio fechados com `text` + `CHECK`, sem texto solto
+• migration histórica final preparada no formato do repositório: `supabase/migrations/0006__e10_5_2_taxonomy_content_base.sql`
+• ARTEFATOS_REPO:
+• Criados: `supabase/migrations/0006__e10_5_2_taxonomy_content_base.sql`
+• Pendências:
+• `docs/schema.md` ainda não atualizado nesta conversa para refletir as 8 tabelas novas
+• Q1, Q2 e Q3 da conferência estrutural não foram validados até o fim, embora Q4, Q5, Q6 e Q7 tenham sido aprovados
+• a migration histórica final foi entregue em conteúdo, mas ainda não foi commitada no repositório nesta conversa
+
+10.5.3 Popular base inicial de taxons, aliases, templates e vínculos
+• Status: Planejado
+• Objetivo: popular a base inicial criada no E10.5.2 com os primeiros taxons, aliases, templates e vínculos necessários para evolução do E10.5.
+
 
 11. E11 — Gestão de Usuários e Convites
 
@@ -960,6 +981,10 @@
 • Definir o primeiro recorte funcional do LP Builder no roadmap
 
 99. Changelog
+v1.5.36 (09/04/2026)
+• 10.5 ajustado para “Em evolução”, com dependência explícita de 10.5.2.
+• 10.5.2 adicionado como concluído (exec): base estrutural admin/interna de taxonomia, templates e guides, com migration `0006__e10_5_2_taxonomy_content_base.sql`.
+• 10.5.3 adicionado como planejado para popular a base inicial de taxons, aliases, templates e vínculos.
 v1.5.35 (01/04/2026)
 • Adicionado **E19 — LP Builder** como nova seção do Core, no mesmo nível estrutural de Account Dashboard, Admin Dashboard e Partner Dashboard.
 v1.5.34 (31/03/2026)

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data da última atualização: 24/03/2026
-• Documento: LP Factory 10 — Schema (DB Contract) v1.0.9
+• Data da última atualização: 09/04/2026
+• Documento: LP Factory 10 — Schema (DB Contract) v1.0.10
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -134,6 +134,223 @@
 • Schema: public (USAGE)
 • Tabelas existentes em public: GRANT SELECT
 • Novas tabelas em public: default privileges com GRANT SELECT
+
+1.10 business_taxons
+
+1.10.1 Chaves, constraints e relacionamentos
+• PK: id uuid
+• UNIQUE: slug
+• CHECK: business_taxons_level_chk (level IN ('segment', 'niche', 'ultra_niche'))
+• FK: parent_id → business_taxons(id) ON UPDATE CASCADE ON DELETE SET NULL
+
+1.10.2 Campos
+• parent_id uuid null
+• level text not null
+• name text not null
+• slug text not null
+• is_active boolean not null default true
+
+1.10.3 Segurança
+• Trigger Hub: não
+• RLS: ativo (enable row level security)
+
+1.10.4 Policies
+• business_taxons_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
+• business_taxons_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
+• business_taxons_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
+• business_taxons_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
+
+1.11 business_taxon_aliases
+
+1.11.1 Chaves, constraints e relacionamentos
+• PK: id uuid
+• UNIQUE: (taxon_id, alias_text_normalized)
+• FK: taxon_id → business_taxons(id) ON UPDATE CASCADE ON DELETE RESTRICT
+• Generated column: alias_text_normalized (normalização derivada de alias_text)
+
+1.11.2 Campos
+• taxon_id uuid not null
+• alias_text text not null
+• alias_text_normalized text generated always as stored
+• is_active boolean not null default true
+
+1.11.3 Segurança
+• Trigger Hub: não
+• RLS: ativo (enable row level security)
+
+1.11.4 Policies
+• business_taxon_aliases_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
+• business_taxon_aliases_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
+• business_taxon_aliases_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
+• business_taxon_aliases_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
+
+1.12 account_taxonomy
+
+1.12.1 Chaves, constraints e relacionamentos
+• PK: id uuid
+• UNIQUE: (account_id, taxon_id)
+• CHECK: account_taxonomy_status_chk (status IN ('active', 'inactive'))
+• CHECK: account_taxonomy_source_type_chk (source_type IN ('manual', 'taxonomy_match'))
+• FK: account_id → accounts(id) ON UPDATE CASCADE ON DELETE CASCADE
+• FK: taxon_id → business_taxons(id) ON UPDATE CASCADE ON DELETE RESTRICT
+
+1.12.2 Campos
+• account_id uuid not null
+• taxon_id uuid not null
+• is_primary boolean not null default false
+• status text not null
+• source_type text not null
+• created_at timestamptz not null default now()
+• updated_at timestamptz not null default now()
+
+1.12.3 Segurança
+• Trigger Hub: não
+• RLS: ativo (enable row level security)
+
+1.12.4 Policies
+• account_taxonomy_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
+• account_taxonomy_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
+• account_taxonomy_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
+• account_taxonomy_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
+
+1.13 content_templates
+
+1.13.1 Chaves, constraints e relacionamentos
+• PK: id uuid
+• UNIQUE: template_key
+• UNIQUE: slug
+• CHECK: content_templates_template_family_chk (template_family IN ('commercial_activation', 'landing_page'))
+• CHECK: content_templates_template_scope_chk (template_scope IN ('page', 'section'))
+• CHECK: content_templates_status_chk (status IN ('draft', 'active', 'archived'))
+
+1.13.2 Campos
+• template_key text not null
+• name text not null
+• slug text not null
+• template_family text not null
+• template_scope text not null
+• status text not null
+• version integer not null default 1
+• is_active boolean not null default true
+• payload_json jsonb not null
+• notes text null
+• created_at timestamptz not null default now()
+• updated_at timestamptz not null default now()
+
+1.13.3 Segurança
+• Trigger Hub: não
+• RLS: ativo (enable row level security)
+
+1.13.4 Policies
+• content_templates_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
+• content_templates_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
+• content_templates_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
+• content_templates_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
+
+1.14 content_template_taxons
+
+1.14.1 Chaves, constraints e relacionamentos
+• PK: id uuid
+• CHECK: content_template_taxons_resolution_level_chk (resolution_level IN ('generic', 'segment', 'niche', 'ultra_niche'))
+• FK: template_id → content_templates(id) ON UPDATE CASCADE ON DELETE CASCADE
+• FK: taxon_id → business_taxons(id) ON UPDATE CASCADE ON DELETE RESTRICT
+
+1.14.2 Campos
+• template_id uuid not null
+• taxon_id uuid not null
+• resolution_level text not null
+• priority integer not null default 0
+• is_primary boolean not null default false
+• is_active boolean not null default true
+• created_at timestamptz not null default now()
+• updated_at timestamptz not null default now()
+
+1.14.3 Segurança
+• Trigger Hub: não
+• RLS: ativo (enable row level security)
+
+1.14.4 Policies
+• content_template_taxons_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
+• content_template_taxons_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
+• content_template_taxons_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
+• content_template_taxons_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
+
+1.15 taxon_market_research
+
+1.15.1 Chaves, constraints e relacionamentos
+• PK: id uuid
+• CHECK: taxon_market_research_status_chk (status IN ('draft', 'active', 'archived'))
+• FK: taxon_id → business_taxons(id) ON UPDATE CASCADE ON DELETE RESTRICT
+
+1.15.2 Campos
+• taxon_id uuid not null
+• version integer not null default 1
+• status text not null
+• base_summary text not null
+• created_at timestamptz not null default now()
+• updated_at timestamptz not null default now()
+
+1.15.3 Segurança
+• Trigger Hub: não
+• RLS: ativo (enable row level security)
+
+1.15.4 Policies
+• taxon_market_research_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
+• taxon_market_research_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
+• taxon_market_research_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
+• taxon_market_research_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
+
+1.16 taxon_market_research_items
+
+1.16.1 Chaves, constraints e relacionamentos
+• PK: id uuid
+• FK: research_id → taxon_market_research(id) ON UPDATE CASCADE ON DELETE CASCADE
+
+1.16.2 Campos
+• research_id uuid not null
+• item_tag text not null
+• item_text text not null
+• priority integer not null default 0
+• is_active boolean not null default true
+• created_at timestamptz not null default now()
+• updated_at timestamptz not null default now()
+
+1.16.3 Segurança
+• Trigger Hub: não
+• RLS: ativo (enable row level security)
+
+1.16.4 Policies
+• taxon_market_research_items_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
+• taxon_market_research_items_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
+• taxon_market_research_items_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
+• taxon_market_research_items_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
+
+1.17 taxon_message_guides
+
+1.17.1 Chaves, constraints e relacionamentos
+• PK: id uuid
+• CHECK: taxon_message_guides_context_type_chk (context_type IN ('e10_5', 'landing_page', 'email', 'whatsapp'))
+• FK: research_id → taxon_market_research(id) ON UPDATE CASCADE ON DELETE CASCADE
+
+1.17.2 Campos
+• research_id uuid not null
+• context_type text not null
+• guide_payload_json jsonb not null
+• version integer not null default 1
+• is_active boolean not null default true
+• created_at timestamptz not null default now()
+• updated_at timestamptz not null default now()
+
+1.17.3 Segurança
+• Trigger Hub: não
+• RLS: ativo (enable row level security)
+
+1.17.4 Policies
+• taxon_message_guides_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
+• taxon_message_guides_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
+• taxon_message_guides_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
+• taxon_message_guides_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
+
 
 2. Views
 
@@ -286,6 +503,12 @@
 • Nota: accounts.status não aceita trial (CHECK accounts_status_chk). No estado atual, views não contêm trial e o runtime/tipos (PATH) não incluem trial (drift resolvido).
 
 99. Changelog
+v1.0.10 (09/04/2026) — E10.5.2: base estrutural de taxonomia, templates e guides
+• Adicionadas as tabelas: `business_taxons`, `business_taxon_aliases`, `account_taxonomy`, `content_templates`, `content_template_taxons`, `taxon_market_research`, `taxon_market_research_items` e `taxon_message_guides`.
+• Todas nascem com RLS ativo e policies CRUD admin-only (`is_super_admin()` OU `is_platform_admin()`).
+• `business_taxon_aliases.alias_text_normalized` registrado como generated column.
+• Nesta etapa, as 8 tabelas ficam fora de auditoria e fora de Trigger Hub.
+
 v1.0.9 (24/03/2026) — Remoção de referências ao repo-inv
 • Removidas referências a docs/repo-inv.md em consumidores e apontamentos de app/runtime, alinhando o Schema aos documentos canônicos ativos.
 


### PR DESCRIPTION
### Motivation
- Atualizar a documentação para refletir avanços do E10.5 e a criação da base estrutural necessária para taxonomia, templates e guides. 
- Registrar versões e changelogs consistentes para `docs/roadmap.md` e `docs/schema.md` com data de 09/04/2026. 

### Description
- Atualizei o cabeçalho de `docs/roadmap.md` para `v1.5.36` (09/04/2026) e alterei o bloco `10.5` para `Status: Em evolução` com dependência explícita de `E10.5.2`. 
- Adicionei em `docs/roadmap.md` o bloco `10.5.2` (concluído, com artefatos e pendências) e o bloco `10.5.3` (planejado) e incluí a entrada `v1.5.36` no changelog. 
- Atualizei o cabeçalho de `docs/schema.md` para `v1.0.10` (09/04/2026) e inseri as seções `1.10` a `1.17` descrevendo as 8 tabelas (`business_taxons`, `business_taxon_aliases`, `account_taxonomy`, `content_templates`, `content_template_taxons`, `taxon_market_research`, `taxon_market_research_items`, `taxon_message_guides`) com chaves, constraints, campos, RLS e policies, incluindo `business_taxon_aliases.alias_text_normalized` como generated column. 
- Adicionei a entrada `v1.0.10` ao changelog do schema e mantive o escopo restrito a documentação (migrations/artefatos mencionados como referência). 

### Testing
- Rodei `npm ci` com sucesso para instalar dependências. 
- Rodei `npm run check` com sucesso; o `typecheck` passou e o lint retornou apenas warnings (sem erros). 
- Verifiquei os diffs dos arquivos `docs/roadmap.md` e `docs/schema.md` para confirmar as alterações aplicadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7e16e4d988329b68aa658ba13c0b2)