### PR TITLE
docs: mover classificação do negócio para início e renumerar seção 6 do README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@
 • Escopo: visão geral do produto + estratégia empresarial (alto nível) + referências oficiais do projeto
 
 1. O que é
+1.1. Classificação do negócio
+• Segmento: Marketing digital.
+• Nicho: SaaS de landing pages e conversão.
+• Ultranicho: não usar agora.
+
+1.2. Descrição
 • LP Factory 10 é uma plataforma SaaS de landing pages por nicho, com dashboards de análise para acompanhar e otimizar a performance.
 • O foco atual é validar a oferta, o processo e a repetibilidade antes de escalar.
 • O produto foi pensado para atender múltiplos nichos, com priorização orientada pela demanda captada no uso real.
@@ -36,13 +42,10 @@
 • Planos em camadas (Starter → Lite → Pro → Ultra), com capacidades escalando ao longo do tempo.
 
 6. Pendências estratégicas (em aberto)
-6.1. Nicho inicial
-• A prioridade inicial dos nichos será definida por demanda.
-
-6.2. Definições do MVP
+6.1. Definições do MVP
 • Starter mínimo • Tracking mínimo • Atendimento no MVP • Primeira recomendação concreta da IA
 
-6.3. Padrões de entrega
+6.2. Padrões de entrega
 • Definir regra de “o que é uma LP entregue”, com checklist.
 
 7. Referências oficiais


### PR DESCRIPTION
### Motivation
- Trazer a classificação do negócio para o início do documento para facilitar leitura e alinhamento estratégico. 
- Remover o bloco obsoleto `6.1. Nicho inicial` que duplicava decisão já consolidada. 
- Ajustar a numeração das subseções para manter consistência após a remoção.

### Description
- Adiciona a subseção `1.1. Classificação do negócio` com o conteúdo exato solicitado (`Segmento`, `Nicho`, `Ultranicho`) no início de `1. O que é` no arquivo `README.md`.
- Renomeia o conteúdo original da seção `1. O que é` para `1.2. Descrição`, preservando os bullets originais sem reescrita.
- Remove completamente o bloco `6.1. Nicho inicial` e renumera as entradas da seção 6 para `6.1. Definições do MVP` e `6.2. Padrões de entrega` mantendo o texto restante inalterado.
- Mantém formatação Markdown limpa e não altera outras seções do arquivo `README.md`.

### Testing
- Executei `npm ci` com sucesso para instalar dependências.
- Executei `npm run check` (que roda `lint` + `typecheck`) e o processo terminou sem erros funcionais, com `tsc` sem problemas e `eslint` emitindo apenas warnings conhecidos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daa83a96a083299e6af3878f44f178)