### PR TITLE
feat: add E10.5.3 Grupo A operational investigation kit

### DIFF
--- a/docs/e10-5-3-grupo-a-investigacao.md
+++ b/docs/e10-5-3-grupo-a-investigacao.md
@@ -95,7 +95,7 @@ Tarefas:
 5. proponha apenas o que realmente parece faltar
 6. não gere SQL
 7. entregue apenas análise e proposta preliminar
-````
+```
 
 ## 7. Prompt de proposta
 

--- a/docs/e10-5-3-grupo-a-investigacao.md
+++ b/docs/e10-5-3-grupo-a-investigacao.md
@@ -1,0 +1,173 @@
+# E10.5.3 — Grupo A — Guia operacional de investigação, proposta, carga e validação
+
+## 1. Objetivo
+
+Este documento padroniza o processo manual do Grupo A para evitar drift entre chats.
+
+O Grupo A cobre apenas:
+
+- `business_taxons`
+- `business_taxon_aliases`
+
+Este guia existe para orientar:
+
+1. investigação anti-duplicidade
+2. proposta de novos taxons e aliases
+3. formatação canônica da saída aprovada
+4. carga via SQL canônico
+5. validação pós-carga
+
+## 2. Fora do escopo
+
+Não entram neste processo:
+
+- `account_taxonomy`
+- templates comerciais
+- base estratégica por taxon
+- classificação automática do nicho
+- runtime do E10.5
+- migrations
+- mudanças estruturais de BD
+
+## 3. Arquivos operacionais da etapa
+
+### 3.1 Guia humano
+
+- `docs/e10-5-3-grupo-a-investigacao.md`
+
+### 3.2 Snippet read-only
+
+- `supabase/snippets/e10_5_3_grupo_a_investigacao_validacao.sql`
+
+### 3.3 Snippet de carga
+
+- `supabase/snippets/e10_5_3_grupo_a_carga.sql`
+
+## 4. Fluxo operacional obrigatório
+
+1. Ler este guia.
+2. Rodar o snippet read-only de investigação.
+3. Verificar o que já existe em `business_taxons` e `business_taxon_aliases`.
+4. Só depois disso montar a proposta.
+5. Submeter a proposta em formato canônico.
+6. Aguardar aprovação humana.
+7. Só após aprovação preencher e rodar o SQL de carga.
+8. Rodar a validação pós-carga.
+9. Confirmar se o lote carregado bate com o lote aprovado.
+
+## 5. Regras fixas do processo
+
+1. Nenhum novo taxon deve ser proposto sem investigação prévia.
+2. Nenhum alias deve ser proposto sem verificar colisões e duplicidades.
+3. O SQL final de carga deve sair apenas do lote aprovado.
+4. O SQL de carga deve ser idempotente.
+5. O processo deve preservar a hierarquia pai-filho por `parent_slug`.
+6. O slug é a chave operacional estável do taxon neste processo.
+7. O vínculo de alias deve apontar para o `slug` aprovado do taxon-alvo.
+
+## 6. Prompt de investigação anti-duplicidade
+
+Use o texto abaixo em outro chat operacional quando precisar investigar antes da proposta:
+
+```text
+Você vai investigar o Grupo A do E10.5.3.
+
+Escopo:
+- business_taxons
+- business_taxon_aliases
+
+Objetivo:
+- identificar o que já existe
+- evitar duplicidade de taxons
+- evitar colisão de slug
+- evitar alias redundante
+- evitar propor hierarquia incoerente
+
+Tarefas:
+1. leia a saída do SQL read-only de investigação
+2. liste taxons já existentes que podem conflitar com a proposta
+3. liste aliases já existentes que podem conflitar com a proposta
+4. aponte possíveis duplicidades por:
+   4.1 nome muito próximo
+   4.2 slug igual
+   4.3 alias_text_normalized igual
+   4.4 mesma ideia distribuída em taxons diferentes
+5. proponha apenas o que realmente parece faltar
+6. não gere SQL
+7. entregue apenas análise e proposta preliminar
+````
+
+## 7. Prompt de proposta
+
+Use o texto abaixo no chat que vai preparar novos dados:
+
+```text
+Você vai propor novos dados do Grupo A do E10.5.3.
+
+Escopo:
+- business_taxons
+- business_taxon_aliases
+
+Regras:
+1. use a investigação prévia como base
+2. não repita taxons já existentes
+3. não repita aliases já existentes
+4. respeite a hierarquia:
+   4.1 segment
+   4.2 niche
+   4.3 ultra_niche
+5. use slug estável e legível
+6. não gere SQL
+7. entregue exatamente no template canônico pedido
+
+Saída esperada:
+- taxons propostos
+- aliases propostos
+- justificativas curtas
+- observações de risco ou ambiguidade
+```
+
+## 8. Template canônico de saída
+
+Copiar e preencher exatamente neste formato:
+
+```md
+## Taxons propostos
+
+| level | name | slug | parent_slug | justificativa_curta |
+|---|---|---|---|---|
+| segment |  |  |  |  |
+| niche |  |  |  |  |
+| ultra_niche |  |  |  |  |
+
+## Aliases propostos
+
+| target_slug | alias_text | justificativa_curta |
+|---|---|---|
+|  |  |  |
+
+## Observações
+
+- [listar ambiguidades, riscos ou dependências]
+```
+
+## 9. Checklist de validação pós-carga
+
+Após rodar a carga, conferir:
+
+1. os taxons esperados existem
+2. os níveis estão corretos
+3. os `parent_slug` esperados batem com a hierarquia real
+4. os aliases esperados existem
+5. não houve duplicidade operacional inesperada
+6. o lote carregado corresponde ao lote aprovado
+7. não entrou item fora do lote aprovado por engano
+8. o processo continua reaplicável sem drift
+
+## 10. Resultado esperado da etapa
+
+Ao final, este caso deve deixar:
+
+1. um guia humano único em `docs/`
+2. um snippet read-only para investigar e validar
+3. um snippet SQL canônico para carga idempotente

--- a/supabase/snippets/e10_5_3_grupo_a_carga.sql
+++ b/supabase/snippets/e10_5_3_grupo_a_carga.sql
@@ -1,0 +1,209 @@
+-- E10.5.3 — Grupo A — Carga canônica idempotente
+-- Uso:
+-- 1) preencher staged_taxons
+-- 2) preencher staged_aliases
+-- 3) rodar somente após aprovação humana do lote
+-- Observações:
+-- - este arquivo não deve conter dados reais por padrão
+-- - por padrão ele nasce em modo no-op até preenchimento
+-- - a carga é baseada em slug como chave operacional do taxon
+
+begin;
+
+-- =========================================================
+-- 1) STAGING DO LOTE APROVADO
+-- Preencher apenas após aprovação humana.
+-- =========================================================
+
+with staged_taxons(input_order, level, name, slug, parent_slug, is_active) as (
+  select *
+  from (
+    values
+      -- (10, 'segment', 'Marketing digital', 'marketing-digital', null, true),
+      -- (20, 'niche', 'SaaS de landing pages e conversão', 'saas-de-landing-pages-e-conversao', 'marketing-digital', true)
+      (0::int, ''::text, ''::text, ''::text, null::text, true::boolean)
+  ) as v(input_order, level, name, slug, parent_slug, is_active)
+  where slug <> ''
+)
+insert into public.business_taxons (
+  level,
+  name,
+  slug,
+  parent_id,
+  is_active
+)
+select
+  st.level,
+  st.name,
+  st.slug,
+  null::uuid as parent_id,
+  st.is_active
+from staged_taxons st
+where st.level = 'segment'
+on conflict (slug) do update
+set
+  level = excluded.level,
+  name = excluded.name,
+  is_active = excluded.is_active;
+
+with staged_taxons(input_order, level, name, slug, parent_slug, is_active) as (
+  select *
+  from (
+    values
+      -- (10, 'segment', 'Marketing digital', 'marketing-digital', null, true),
+      -- (20, 'niche', 'SaaS de landing pages e conversão', 'saas-de-landing-pages-e-conversao', 'marketing-digital', true)
+      (0::int, ''::text, ''::text, ''::text, null::text, true::boolean)
+  ) as v(input_order, level, name, slug, parent_slug, is_active)
+  where slug <> ''
+)
+insert into public.business_taxons (
+  level,
+  name,
+  slug,
+  parent_id,
+  is_active
+)
+select
+  st.level,
+  st.name,
+  st.slug,
+  parent.id as parent_id,
+  st.is_active
+from staged_taxons st
+join public.business_taxons parent
+  on parent.slug = st.parent_slug
+where st.level = 'niche'
+on conflict (slug) do update
+set
+  level = excluded.level,
+  name = excluded.name,
+  parent_id = excluded.parent_id,
+  is_active = excluded.is_active;
+
+with staged_taxons(input_order, level, name, slug, parent_slug, is_active) as (
+  select *
+  from (
+    values
+      -- (10, 'segment', 'Marketing digital', 'marketing-digital', null, true),
+      -- (20, 'niche', 'SaaS de landing pages e conversão', 'saas-de-landing-pages-e-conversao', 'marketing-digital', true)
+      (0::int, ''::text, ''::text, ''::text, null::text, true::boolean)
+  ) as v(input_order, level, name, slug, parent_slug, is_active)
+  where slug <> ''
+)
+insert into public.business_taxons (
+  level,
+  name,
+  slug,
+  parent_id,
+  is_active
+)
+select
+  st.level,
+  st.name,
+  st.slug,
+  parent.id as parent_id,
+  st.is_active
+from staged_taxons st
+join public.business_taxons parent
+  on parent.slug = st.parent_slug
+where st.level = 'ultra_niche'
+on conflict (slug) do update
+set
+  level = excluded.level,
+  name = excluded.name,
+  parent_id = excluded.parent_id,
+  is_active = excluded.is_active;
+
+with staged_aliases(target_slug, alias_text, is_active) as (
+  select *
+  from (
+    values
+      -- ('marketing-digital', 'agência de marketing digital', true),
+      -- ('saas-de-landing-pages-e-conversao', 'fábrica de landing pages', true)
+      (''::text, ''::text, true::boolean)
+  ) as v(target_slug, alias_text, is_active)
+  where target_slug <> ''
+    and alias_text <> ''
+)
+insert into public.business_taxon_aliases (
+  taxon_id,
+  alias_text,
+  is_active
+)
+select
+  bt.id as taxon_id,
+  sa.alias_text,
+  sa.is_active
+from staged_aliases sa
+join public.business_taxons bt
+  on bt.slug = sa.target_slug
+on conflict (taxon_id, alias_text_normalized) do update
+set
+  alias_text = excluded.alias_text,
+  is_active = excluded.is_active;
+
+commit;
+
+-- =========================================================
+-- 2) SANITY CHECKS PÓS-CARGA
+-- =========================================================
+
+with staged_taxons(input_order, level, name, slug, parent_slug, is_active) as (
+  select *
+  from (
+    values
+      -- (10, 'segment', 'Marketing digital', 'marketing-digital', null, true),
+      -- (20, 'niche', 'SaaS de landing pages e conversão', 'saas-de-landing-pages-e-conversao', 'marketing-digital', true)
+      (0::int, ''::text, ''::text, ''::text, null::text, true::boolean)
+  ) as v(input_order, level, name, slug, parent_slug, is_active)
+  where slug <> ''
+)
+select
+  st.slug,
+  st.level,
+  st.parent_slug,
+  bt.id as actual_taxon_id,
+  parent.slug as actual_parent_slug,
+  bt.is_active as actual_is_active
+from staged_taxons st
+left join public.business_taxons bt
+  on bt.slug = st.slug
+left join public.business_taxons parent
+  on parent.id = bt.parent_id
+order by st.input_order;
+
+with staged_aliases(target_slug, alias_text, is_active) as (
+  select *
+  from (
+    values
+      -- ('marketing-digital', 'agência de marketing digital', true),
+      -- ('saas-de-landing-pages-e-conversao', 'fábrica de landing pages', true)
+      (''::text, ''::text, true::boolean)
+  ) as v(target_slug, alias_text, is_active)
+  where target_slug <> ''
+    and alias_text <> ''
+)
+select
+  sa.target_slug,
+  sa.alias_text,
+  bta.id as actual_alias_id,
+  bta.alias_text_normalized,
+  bta.is_active as actual_is_active
+from staged_aliases sa
+join public.business_taxons bt
+  on bt.slug = sa.target_slug
+left join public.business_taxon_aliases bta
+  on bta.taxon_id = bt.id
+ and bta.alias_text_normalized = btrim(
+   regexp_replace(
+     translate(
+       lower(sa.alias_text),
+       'áàãâäéèêëíìîïóòõôöúùûüçñ',
+       'aaaaaeeeeiiiiooooouuuucn'
+     ),
+     '\s+',
+     ' ',
+     'g'
+   )
+ )
+order by sa.target_slug, sa.alias_text;

--- a/supabase/snippets/e10_5_3_grupo_a_investigacao_validacao.sql
+++ b/supabase/snippets/e10_5_3_grupo_a_investigacao_validacao.sql
@@ -1,0 +1,199 @@
+-- E10.5.3 — Grupo A — Investigação e validação pós-carga
+-- Uso:
+-- 1) Rodar a seção A antes de qualquer proposta.
+-- 2) Rodar a seção B depois da carga, preenchendo os CTEs expected_* quando necessário.
+-- Regras:
+-- - arquivo read-only
+-- - apenas SELECT / WITH
+-- - sem mutações
+
+-- =========================================================
+-- A) INVESTIGAÇÃO PRÉVIA
+-- =========================================================
+
+-- A1) Taxons existentes com hierarquia
+select
+  bt.id,
+  bt.level,
+  bt.name,
+  bt.slug,
+  bt.parent_id,
+  parent.level as parent_level,
+  parent.name as parent_name,
+  parent.slug as parent_slug,
+  bt.is_active
+from public.business_taxons bt
+left join public.business_taxons parent
+  on parent.id = bt.parent_id
+order by
+  case bt.level
+    when 'segment' then 1
+    when 'niche' then 2
+    when 'ultra_niche' then 3
+    else 99
+  end,
+  coalesce(parent.slug, ''),
+  bt.slug
+limit 300;
+
+-- A2) Aliases existentes com taxon alvo
+select
+  bta.id,
+  bt.level,
+  bt.name as taxon_name,
+  bt.slug as taxon_slug,
+  bta.alias_text,
+  bta.alias_text_normalized,
+  bta.is_active
+from public.business_taxon_aliases bta
+join public.business_taxons bt
+  on bt.id = bta.taxon_id
+order by
+  bt.slug,
+  bta.alias_text_normalized
+limit 500;
+
+-- A3) Sanity check de duplicidade de slug
+select
+  bt.slug,
+  count(*) as total
+from public.business_taxons bt
+group by bt.slug
+having count(*) > 1
+order by total desc, bt.slug
+limit 50;
+
+-- A4) Sanity check de duplicidade por (taxon_id, alias_text_normalized)
+select
+  bta.taxon_id,
+  bt.slug as taxon_slug,
+  bta.alias_text_normalized,
+  count(*) as total
+from public.business_taxon_aliases bta
+join public.business_taxons bt
+  on bt.id = bta.taxon_id
+group by
+  bta.taxon_id,
+  bt.slug,
+  bta.alias_text_normalized
+having count(*) > 1
+order by total desc, bt.slug, bta.alias_text_normalized
+limit 50;
+
+-- A5) Mesmos aliases normalizados usados em taxons diferentes
+select
+  bta.alias_text_normalized,
+  count(distinct bt.slug) as total_taxons,
+  string_agg(distinct bt.slug, ' | ' order by bt.slug) as taxon_slugs
+from public.business_taxon_aliases bta
+join public.business_taxons bt
+  on bt.id = bta.taxon_id
+group by bta.alias_text_normalized
+having count(distinct bt.slug) > 1
+order by total_taxons desc, bta.alias_text_normalized
+limit 100;
+
+-- =========================================================
+-- B) VALIDAÇÃO PÓS-CARGA
+-- Preencher os CTEs abaixo com o lote aprovado.
+-- Se mantidos vazios, as queries retornam vazio por padrão.
+-- =========================================================
+
+with expected_taxons(expected_slug, expected_level, expected_parent_slug) as (
+  select *
+  from (
+    values
+      -- ('marketing-digital', 'segment', null),
+      -- ('saas-de-landing-pages-e-conversao', 'niche', 'marketing-digital')
+      (null::text, null::text, null::text)
+  ) as v(expected_slug, expected_level, expected_parent_slug)
+  where expected_slug is not null
+),
+actual_taxons as (
+  select
+    bt.slug,
+    bt.level,
+    parent.slug as parent_slug,
+    bt.name,
+    bt.is_active
+  from public.business_taxons bt
+  left join public.business_taxons parent
+    on parent.id = bt.parent_id
+)
+select
+  et.expected_slug,
+  et.expected_level,
+  et.expected_parent_slug,
+  at.level as actual_level,
+  at.parent_slug as actual_parent_slug,
+  at.name as actual_name,
+  at.is_active as actual_is_active,
+  case
+    when at.slug is null then 'missing'
+    when at.level <> et.expected_level then 'level_mismatch'
+    when coalesce(at.parent_slug, '') <> coalesce(et.expected_parent_slug, '') then 'parent_mismatch'
+    else 'ok'
+  end as validation_status
+from expected_taxons et
+left join actual_taxons at
+  on at.slug = et.expected_slug
+order by et.expected_slug
+limit 200;
+
+with expected_aliases(expected_target_slug, expected_alias_text) as (
+  select *
+  from (
+    values
+      -- ('marketing-digital', 'agência de marketing digital'),
+      -- ('saas-de-landing-pages-e-conversao', 'fábrica de landing pages')
+      (null::text, null::text)
+  ) as v(expected_target_slug, expected_alias_text)
+  where expected_target_slug is not null
+),
+actual_aliases as (
+  select
+    bt.slug as target_slug,
+    bta.alias_text,
+    bta.alias_text_normalized,
+    bta.is_active
+  from public.business_taxon_aliases bta
+  join public.business_taxons bt
+    on bt.id = bta.taxon_id
+),
+normalized_expected as (
+  select
+    expected_target_slug,
+    expected_alias_text,
+    btrim(
+      regexp_replace(
+        translate(
+          lower(expected_alias_text),
+          'áàãâäéèêëíìîïóòõôöúùûüçñ',
+          'aaaaaeeeeiiiiooooouuuucn'
+        ),
+        '\s+',
+        ' ',
+        'g'
+      )
+    ) as expected_alias_text_normalized
+  from expected_aliases
+)
+select
+  ne.expected_target_slug,
+  ne.expected_alias_text,
+  ne.expected_alias_text_normalized,
+  aa.target_slug as actual_target_slug,
+  aa.alias_text as actual_alias_text,
+  aa.is_active as actual_is_active,
+  case
+    when aa.target_slug is null then 'missing'
+    else 'ok'
+  end as validation_status
+from normalized_expected ne
+left join actual_aliases aa
+  on aa.target_slug = ne.expected_target_slug
+ and aa.alias_text_normalized = ne.expected_alias_text_normalized
+order by
+  ne.expected_target_slug,
+  ne.expected_alias_text_normalized
+limit 300;


### PR DESCRIPTION
### Motivation

- Fornecer um kit operacional versionado para o caso `E10.5.3 — Grupo A` focado em processos manuais de investigação, proposta, aprovação, carga e validação.
- Materializar os snippets operacionais em `supabase/snippets/` e um guia humano em `docs/` para padronizar o fluxo e evitar drift entre chats.
- Garantir segurança para versionamento criando um snippet read-only de investigação/validação e um snippet de carga idempotente que nasce em modo no-op até preenchimento humano.

### Description

- Criei o guia operacional `docs/e10-5-3-grupo-a-investigacao.md` com objetivo, fluxo obrigatório, prompts operacionais, template canônico e checklist de validação pós-carga.
- Adicionei o snippet read-only `supabase/snippets/e10_5_3_grupo_a_investigacao_validacao.sql` contendo apenas `SELECT`/`WITH` para investigação prévia e validação pós-carga com CTEs `expected_*` vazios por padrão.
- Adicionei o snippet de carga `supabase/snippets/e10_5_3_grupo_a_carga.sql` como template idempotente e no-op por padrão, com `ON CONFLICT` por `slug`, lógica de parent lookup e sanity checks pós-carga.
- Mantive o escopo restrito às tabelas `business_taxons` e `business_taxon_aliases`, sem migrations, sem alterações de schema/RLS/policies/adapters ou código de runtime e sem mudanças em `docs/roadmap.md`.

### Testing

- Rodei `npm ci` com sucesso (dependências instaladas). 
- Rodei `npm run check` com sucesso; a rotina executou `eslint` e `tsc` e terminou sem erros, observando apenas warnings de lint pré-existentes não relacionados aos arquivos adicionados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dce16d28c8832981cae936d5112d32)