### PR TITLE
Allow nullable parent_slug in Group A load snippet (niche/ultra_niche)

### DIFF
--- a/supabase/snippets/e10_5_3_grupo_a_carga.sql
+++ b/supabase/snippets/e10_5_3_grupo_a_carga.sql
@@ -10,6 +10,31 @@
 
 begin;
 
+do $$
+begin
+  if exists (
+    with staged_taxons(input_order, level, name, slug, parent_slug, is_active) as (
+      select *
+      from (
+        values
+          -- (10, 'segment', 'Marketing digital', 'marketing-digital', null, true),
+          -- (20, 'niche', 'SaaS de landing pages e conversão', 'saas-de-landing-pages-e-conversao', 'marketing-digital', true)
+          (0::int, ''::text, ''::text, ''::text, null::text, true::boolean)
+      ) as v(input_order, level, name, slug, parent_slug, is_active)
+      where slug <> ''
+    )
+    select 1
+    from staged_taxons st
+    left join public.business_taxons parent
+      on parent.slug = st.parent_slug
+    where st.level in ('niche', 'ultra_niche')
+      and st.parent_slug is not null
+      and parent.id is null
+  ) then
+    raise exception 'parent_slug informado não encontrado em business_taxons para niche/ultra_niche';
+  end if;
+end $$;
+
 -- =========================================================
 -- 1) STAGING DO LOTE APROVADO
 -- Preencher apenas após aprovação humana.
@@ -70,9 +95,10 @@ select
   parent.id as parent_id,
   st.is_active
 from staged_taxons st
-join public.business_taxons parent
+left join public.business_taxons parent
   on parent.slug = st.parent_slug
 where st.level = 'niche'
+  and (st.parent_slug is null or parent.id is not null)
 on conflict (slug) do update
 set
   level = excluded.level,
@@ -104,9 +130,10 @@ select
   parent.id as parent_id,
   st.is_active
 from staged_taxons st
-join public.business_taxons parent
+left join public.business_taxons parent
   on parent.slug = st.parent_slug
 where st.level = 'ultra_niche'
+  and (st.parent_slug is null or parent.id is not null)
 on conflict (slug) do update
 set
   level = excluded.level,


### PR DESCRIPTION
### Motivation

- The existing load snippet assumed `parent_slug` was always present for `niche` and `ultra_niche`, but the `business_taxons.parent_id` contract allows null parents so the operational snippet must reflect that flexibility.
- Prevent silent loss of parent linkage when a `parent_slug` is provided but does not resolve to an existing taxon by failing early instead.

### Description

- Updated `supabase/snippets/e10_5_3_grupo_a_carga.sql` to add a lightweight preflight validation (`DO $$ ... $$`) that raises an exception if any `niche` or `ultra_niche` row has a non-null `parent_slug` that cannot be resolved to an existing `business_taxons.slug`.
- Switched the `JOIN` to `LEFT JOIN` for `niche` and `ultra_niche` parent resolution and added the guard `and (st.parent_slug is null or parent.id is not null)` so rows with `parent_slug = NULL` are allowed and store `parent_id = NULL`, while rows with a filled `parent_slug` must resolve to a parent.
- Left `segment` handling unchanged (explicit `parent_id = null`) and preserved the post-load sanity checks and existing `INSERT ... ON CONFLICT ... DO UPDATE` idempotent behavior.

### Testing

- Ran `npm ci` successfully to install dependencies. 
- Ran `npm run check` successfully; the check completed and returned success while reporting unrelated lint warnings in other files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd3f8678c0832995aa774d96847935)