### PR TITLE
docs: reforça diretriz de aliases enxutos no Grupo A (E10.5.3)

### DIFF
--- a/docs/e10-5-3-grupo-a-investigacao.md
+++ b/docs/e10-5-3-grupo-a-investigacao.md
@@ -27,6 +27,13 @@ Nesta rodada do Grupo A, a investigação inicial existe primeiro para:
 
 Ela não precisa virar validação estrutural exaustiva antes da proposta e da aprovação humana.
 
+Nesta etapa, a curadoria de aliases deve ser enxuta e pragmática:
+
+1. evitar inflar aliases para cobrir microvariações meramente textuais
+2. não transformar grafias muito próximas, singular/plural óbvio ou pequenas diferenças de escrita em lista extensa de aliases
+3. priorizar aliases com valor semântico/comercial real (sigla, termo popular, sinônimo de mercado ou forma comercial realmente distinta)
+4. manter coerência com a estratégia documentada de similaridade textual leve no caso de taxonomia (item 51 de `docs/supa-up.md`), sem presumir implementação atual de `pg_trgm`
+
 ## 2. Fora do escopo
 
 Não entram neste processo:
@@ -76,6 +83,9 @@ Não entram neste processo:
 7. O vínculo de alias deve apontar para o `slug` aprovado do taxon-alvo.
 8. O processo deve evitar os dois extremos: permissividade excessiva e rigor excessivo que paralisa a proposta inicial.
 9. `ultra_niche` é permitido quando fizer sentido, mas não é obrigatório nesta proposta inicial.
+10. A lista de aliases desta rodada deve ser enxuta, priorizando cobertura semântica/comercial real.
+11. Não inflar aliases para microvariações textuais (grafias muito próximas, singular/plural óbvio e pequenas diferenças de escrita).
+12. O papel de similaridade textual leve documentado no item 51 de `docs/supa-up.md` é compatível com essa curadoria enxuta de aliases, sem afirmar adoção já implementada de `pg_trgm`.
 
 ## 6. Prompt de investigação anti-duplicidade
 
@@ -94,6 +104,8 @@ Objetivo:
 - evitar duplicidade evidente de taxons
 - evitar colisão evidente de slug
 - evitar alias evidentemente redundante
+- evitar inflar alias por microvariação textual
+- priorizar lacunas semânticas/comerciais reais na proposta de alias
 - evitar propor hierarquia claramente incoerente
 - apoiar proposta prática do que falta
 
@@ -106,10 +118,13 @@ Tarefas:
    4.2 slug igual
    4.3 alias_text_normalized igual
    4.4 mesma ideia distribuída em taxons diferentes
-5. proponha apenas o que realmente parece faltar nesta rodada
-6. não gere SQL
-7. não transforme esta etapa em auditoria estrutural exaustiva
-8. entregue apenas análise e proposta preliminar para aprovação humana
+5. ao analisar aliases faltantes, separe:
+   5.1 aliases semânticos/comerciais relevantes (sigla, termo popular, sinônimo de mercado, forma comercial distinta)
+   5.2 microvariações textuais que não justificam novo alias nesta rodada
+6. proponha apenas o que realmente parece faltar nesta rodada
+7. não gere SQL
+8. não transforme esta etapa em auditoria estrutural exaustiva
+9. entregue apenas análise e proposta preliminar para aprovação humana
 ```
 
 ## 7. Prompt de proposta
@@ -132,8 +147,12 @@ Regras:
    4.2 niche
    4.3 ultra_niche
 5. use slug estável e legível
-6. não gere SQL
-7. entregue exatamente no template canônico pedido
+6. proponha aliases em lista enxuta, priorizando valor semântico/comercial real
+7. não crie alias só para microvariações textuais (grafia muito próxima, singular/plural óbvio, pequenas diferenças de escrita)
+8. considere como prioritários aliases de sigla, termo popular, sinônimo de mercado e forma comercial realmente distinta
+9. mantenha essa curadoria coerente com a estratégia de similaridade textual leve documentada para taxonomia, sem afirmar implementação atual de `pg_trgm`
+10. não gere SQL
+11. entregue exatamente no template canônico pedido
 
 Saída esperada:
 - taxons propostos


### PR DESCRIPTION
### Motivation
- Tornar explícita a diretriz operacional do Grupo A para curadoria enxuta de aliases, evitando inflação por microvariações textuais.
- Alinhar essa diretriz com o papel documentado de similaridade textual leve (item 51 de `docs/supa-up.md`) sem afirmar adoção ou implementação de `pg_trgm` no projeto.

### Description
- Edita apenas `docs/e10-5-3-grupo-a-investigacao.md` para inserir orientações de que a lista de aliases deve ser enxuta e pragmática, priorizando valor semântico/comercial real.
- Em `## 1. Objetivo` foi adicionada a orientação sobre evitar inflar aliases por microvariações textuais e priorizar siglas, termos populares, sinônimos de mercado e formas comerciais distintas.
- Em `## 5. Regras fixas do processo` foram incluídas regras explícitas para não criar aliases para microvariações textuais e para priorizar cobertura semântica/comercial; foi registrada coerência com o item 51 sem afirmar implementação de `pg_trgm`.
- Em `## 6. Prompt de investigação anti-duplicidade` e `## 7. Prompt de proposta` foram atualizados os objetivos e tarefas para separar aliases semânticos relevantes de microvariações que não justificam novo alias nesta rodada e exigir propostas de aliases em lista enxuta.

### Testing
- Executed `npm ci` which completed successfully. 
- Executed `npm run check` which completed successfully; lint reported warnings (no errors) and TypeScript `tsc` passed without emitting errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de5c5b9dac832992ca03e318e0bc7c)