### PR TITLE
docs: inserção de 3.1.1 sobre presets opcionais do supabase-inspect

### DIFF
--- a/docs/automacoes.md
+++ b/docs/automacoes.md
@@ -212,6 +212,18 @@ Workflow: `.github/workflows/pipeline-supabase-inspect.yml`
 Runtime: `automations/supabase-inspect/`
 Referência estrutural: `docs/base-tecnica.md`
 
+3.1.1 Supabase Inspect — presets opcionais de verificação
+
+Objetivo:
+Registrar a possibilidade futura de presets opcionais no `supabase-inspect` para reduzir SQL manual recorrente e apoiar a verificação do estado real do BD, sem substituir o modo livre por SQL nem o contrato canônico de `docs/schema.md`.
+
+Status:
+Proposto
+
+Observações:
+Exemplos futuros de presets: `schema_columns`, `rls_policies`, `indexes`, `triggers`, `functions`, `views`.
+A necessidade real desses presets deve ser avaliada antes de implementação.
+
 3.2 Pipeline Docs Apply Report
 Objetivo:
 Aplicar reports JSON em documentos Markdown e automatizar branch, commit e Pull Request para revisão humana.


### PR DESCRIPTION
### Motivation
- Registrar, de forma curta e não compromissiva, a possibilidade futura de presets opcionais no `supabase-inspect`, mantendo `docs/schema.md` como fonte canônica do contrato do DB e evitando duplicação do inventário de banco.

### Description
- Inserida a subseção `3.1.1 Supabase Inspect — presets opcionais de verificação` imediatamente após `3.1` em `docs/automacoes.md` com o texto fornecido, sem modificar outros arquivos nem prometer implementação existente.

### Testing
- Executados `npm ci` (sucesso) e `npm run check` (primeira execução falhou por dependência transitória `call-bind`, segunda execução passou com warnings de lint e sem erros).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df97073b9883298ca50f19fbf5bad9)