### PR TITLE
docs: registrar boundary operacional do projeto lpf-10-services

### DIFF
--- a/docs/base-tecnica.md
+++ b/docs/base-tecnica.md
@@ -2,8 +2,8 @@
 
 0.1. Cabeçalho
 • Documento: Base Técnica LP Factory 10
-• Versão: v2.0.26
-• Data: 13/04/2026
+• Versão: v2.0.27
+• Data: 15/04/2026
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -27,6 +27,7 @@
 • Deploy: Vercel (preview + produção)
 • Projeto Vercel do app (Core): `lp-factory-10`
 • Projeto Vercel de serviços: `lpf-10-services`
+• Nota operacional (services): deploy isolado no projeto `lpf-10-services` com `Root Directory = services/mcp-supabase-inspect`, `Include files outside the root directory in the Build Step = OFF` e `Ignored Build Step` customizado para reduzir builds desnecessários fora do escopo do service
 • Domínio oficial do app (produção): https://lp-factory-10.vercel.app
 • Base URL das API routes do app: https://lp-factory-10.vercel.app/api
 • Endpoint canônico da MCP Supabase Inspect (serviço dedicado): https://lpf-10-services.vercel.app/api/mcp
@@ -457,6 +458,9 @@ Regra: qualquer novo arquivo em app/auth/ não pode importar @supabase/* até se
 • Adapters vNext: seguir 3.14
 
 99. Changelog
+v2.0.27 (15/04/2026) — Ajuste operacional Vercel do projeto de services
+• Registrada nota operacional do projeto `lpf-10-services` com boundary de deploy por `Root Directory = services/mcp-supabase-inspect`.
+• Registradas as regras operacionais `Include files outside the root directory in the Build Step = OFF` e `Ignored Build Step` customizado para reduzir builds desnecessários fora do escopo do service.
 v2.0.26 (13/04/2026) — Limpeza documental pós-remoção do legado de tokens
 • Removidas referências ao onboarding consultivo por token no contrato técnico/runtime, incluindo menções de adapters e operações legadas.
 • Atualizada a seção de rate limit administrativo para refletir que o limite específico de tokens não faz parte do estado atual e será redefinido no novo Admin Dashboard (E12).

--- a/docs/services.md
+++ b/docs/services.md
@@ -1,9 +1,9 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data: 29/03/2026
-• Versão: v1.0
-• Status: Estrutura inicial criada
+• Data: 15/04/2026
+• Versão: v1.1
+• Status: Atualizado com boundary operacional de deploy do service MCP
 
 0.2 Função do documento
 Registrar a camada `services` do LP Factory 10 como referência oficial e amigável para humano para services implantáveis, MCPs, endpoints e infraestrutura reutilizável com identidade própria, sem expor segredos.
@@ -28,6 +28,12 @@ Registrar a camada `services` do LP Factory 10 como referência oficial e amigá
 1.1.3 Onde acessar
 • Projeto Vercel: `lpf-10-services`
 • Endpoint canônico: `https://lpf-10-services.vercel.app/api/mcp`
+
+1.1.3.1 Boundary operacional de deploy
+• Projeto Vercel: `lpf-10-services`
+• `Root Directory`: `services/mcp-supabase-inspect`
+• `Include files outside the root directory in the Build Step`: OFF
+• `Ignored Build Step`: customizado para reduzir builds desnecessários quando não houver mudança no service
 
 1.1.4 Status
 • implementado em serviço dedicado
@@ -58,7 +64,12 @@ Registrar a camada `services` do LP Factory 10 como referência oficial e amigá
 • `docs/services.md` passa a ser a referência oficial e amigável para humano da camada `services`
 • detalhes técnicos expandidos devem permanecer no README local de cada service
 • novos services devem seguir o mesmo padrão documental: catálogo curto em `docs/services.md` + README técnico local no diretório do service
+• quando um service compartilhado com o Core tiver deploy independente no mesmo repositório, registrar explicitamente a boundary operacional (projeto Vercel, Root Directory e regras de build) para evitar drift documental e builds desnecessários
 
 99. Changelog
+v1.1 (15/04/2026)
+• registrada a boundary operacional de deploy do `LPF Supabase Inspect MCP` no projeto Vercel `lpf-10-services`
+• adicionadas as regras operacionais `Root Directory`, `Include files outside the root directory in the Build Step = OFF` e `Ignored Build Step` customizado
+• atualizada a observação de manutenção para exigir boundary operacional explícita em novos services com deploy independente e repositório compartilhado
 v1.0 (29/03/2026)
 • criado `docs/services.md` como documento oficial da camada `services`


### PR DESCRIPTION
### Motivation
- Registrar no repositório o ajuste operacional já aplicado na Vercel para o projeto de services `lpf-10-services` e evitar drift documental entre Vercel e docs. 
- Manter a Base Técnica concisa e a seção `services` com a boundary mínima necessária para operações de deploy independentes.

### Description
- Atualizados `docs/base-tecnica.md` (versão `v2.0.27`, `15/04/2026`) para incluir uma nota operacional curta que registra o isolamento de deploy do service em `lpf-10-services` com `Root Directory = services/mcp-supabase-inspect`, `Include files outside the root directory in the Build Step = OFF` e o `Ignored Build Step` customizado.  
- Atualizados `docs/services.md` (versão `v1.1`, `15/04/2026`) adicionando a subseção `Boundary operacional de deploy` à entrada `LPF Supabase Inspect MCP` com o projeto Vercel, endpoint canônico (`https://lpf-10-services.vercel.app/api/mcp`), `Root Directory`, flag de inclusão de arquivos fora do root e nota sobre o `Ignored Build Step`.  
- Ajustada a observação de manutenção em `docs/services.md` para exigir registro explícito de boundary operacional em novos services implantáveis que compartilhem repositório com o Core.  
- Atualizados os changelogs de ambos os documentos seguindo a lógica já presente nos arquivos (nova versão/data e entrada de changelog). 

### Testing
- Executed `npm ci` at repo root and it completed successfully. 
- Executed `npm run check` (which runs `eslint .` and `tsc -p tsconfig.json --noEmit`) and it completed with no errors; ESLint reported 32 warnings (preexisting) and TypeScript typecheck passed with no emit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfb728762c832983875df3445354ff)