### PR TITLE
docs: corrigir drift do E6.4 em roadmap (remover referência obsoleta)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -188,7 +188,6 @@
 • `components/layout/Header.tsx`
 • `components/layout/UserMenu.tsx`
 • `components/features/account-switcher/AccountSwitcherList.tsx`
-• `app/admin/layout.tsx`
 • Pendências:
 • asset oficial de logo ainda não versionado no repo
 • formulários/componentes-base ainda não padronizados pelo design system


### PR DESCRIPTION
### Motivation
- Corrigir drift documental em `docs/roadmap.md` que listava `app/admin/layout.tsx` como artefato ajustado no E6.4 apesar do arquivo não existir mais no repositório.

### Description
- Removeu a linha que referenciava `app/admin/layout.tsx` na seção "E6.4 → ARTEFATOS_REPO / Ajustados" de `docs/roadmap.md`, mantendo a alteração mínima e sem tocar outros arquivos.

### Testing
- Executados `npm ci` e `npm run check`, ambos concluíram com sucesso; `check` exibiu apenas avisos de lint pré-existentes e nenhum erro.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2982b484c8329bea338110aa1b1a1)