### PR TITLE
feat(admin): add protected /admin layout, header and admin user menu (E12.5.1)

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -14,6 +14,10 @@ export default async function AdminLayout({ children }: AdminLayoutProps) {
   const gate = await requirePlatformAdmin();
 
   if (!gate.allowed) {
+    if (gate.redirect === '/auth/login') {
+      redirect('/auth/login?next=%2Fadmin');
+    }
+
     redirect(gate.redirect ?? '/auth/confirm/info');
   }
 

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,0 +1,28 @@
+import { redirect } from 'next/navigation';
+import { requirePlatformAdmin } from '@/lib/access/guards';
+import { getUserEmail } from '@/lib/auth/authAdapter';
+import { AdminHeader } from '@/components/admin/AdminHeader';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+type AdminLayoutProps = {
+  children: React.ReactNode;
+};
+
+export default async function AdminLayout({ children }: AdminLayoutProps) {
+  const gate = await requirePlatformAdmin();
+
+  if (!gate.allowed) {
+    redirect(gate.redirect ?? '/auth/confirm/info');
+  }
+
+  const userEmail = await getUserEmail();
+
+  return (
+    <>
+      <AdminHeader userEmail={userEmail} />
+      <main className="mx-auto max-w-6xl px-4 py-6">{children}</main>
+    </>
+  );
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,15 @@
+export default function AdminPage() {
+  return (
+    <section className="rounded-2xl border border-border bg-card p-6 shadow-sm">
+      <div className="space-y-1">
+        <h1 className="text-lg font-semibold text-card-foreground">
+          Admin Dashboard
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          Superfície inicial do administrativo pronta para evolução dos próximos
+          subcasos.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -1,10 +1,13 @@
 import { LoginForm } from '@/components/login-form'
+import { Suspense } from 'react'
 
 export default function Page() {
   return (
     <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
       <div className="w-full max-w-sm">
-        <LoginForm />
+        <Suspense fallback={null}>
+          <LoginForm />
+        </Suspense>
       </div>
     </div>
   )

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -1,20 +1,10 @@
 import { LoginForm } from '@/components/login-form'
 
-type LoginSearchParams = {
-  next?: string
-}
-
-export default async function Page(props: any) {
-  const searchParams = (props.searchParams
-    ? await props.searchParams
-    : undefined) as LoginSearchParams | undefined
-
-  const nextValue = searchParams?.next ?? null
-
+export default function Page() {
   return (
     <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
       <div className="w-full max-w-sm">
-        <LoginForm next={nextValue} />
+        <LoginForm />
       </div>
     </div>
   )

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -1,10 +1,20 @@
 import { LoginForm } from '@/components/login-form'
 
-export default function Page() {
+type LoginSearchParams = {
+  next?: string
+}
+
+export default async function Page(props: any) {
+  const searchParams = (props.searchParams
+    ? await props.searchParams
+    : undefined) as LoginSearchParams | undefined
+
+  const nextValue = searchParams?.next ?? null
+
   return (
     <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
       <div className="w-full max-w-sm">
-        <LoginForm />
+        <LoginForm next={nextValue} />
       </div>
     </div>
   )

--- a/components/admin/AdminHeader.tsx
+++ b/components/admin/AdminHeader.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link';
+import { AdminUserMenu } from '@/components/admin/AdminUserMenu';
+
+type AdminHeaderProps = {
+  userEmail?: string | null;
+};
+
+export function AdminHeader({ userEmail }: AdminHeaderProps) {
+  return (
+    <header className="border-b border-border bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/85">
+      <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4">
+        <Link
+          href="/admin"
+          aria-label="Ir para o Admin Dashboard"
+          className="inline-flex items-center rounded-md border border-brand-600/20 bg-brand-50 px-2.5 py-1 text-sm font-semibold tracking-wide text-brand-700 transition-colors hover:border-brand-600/35 hover:bg-brand-50/70"
+        >
+          LP Factory Administrativo
+        </Link>
+
+        {userEmail ? <AdminUserMenu userEmail={userEmail} /> : null}
+      </div>
+    </header>
+  );
+}

--- a/components/admin/AdminUserMenu.tsx
+++ b/components/admin/AdminUserMenu.tsx
@@ -76,7 +76,7 @@ export function AdminUserMenu({ userEmail }: AdminUserMenuProps) {
             <div className="truncate text-sm font-medium text-popover-foreground">
               {safeEmail}
             </div>
-            <div className="text-xs text-muted-foreground">platform_admin</div>
+            <div className="text-xs text-muted-foreground">Administrador</div>
           </div>
 
           <div className="my-1 h-px w-full bg-border" />

--- a/components/admin/AdminUserMenu.tsx
+++ b/components/admin/AdminUserMenu.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { LogoutButton } from '@/components/logout-button';
+
+type AdminUserMenuProps = {
+  userEmail?: string | null;
+};
+
+export function AdminUserMenu({ userEmail }: AdminUserMenuProps) {
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const btnRef = useRef<HTMLButtonElement | null>(null);
+
+  const safeEmail = userEmail?.trim() || '—';
+
+  const initials = useMemo(() => {
+    const first = safeEmail.charAt(0).toUpperCase();
+    return /[A-Z0-9]/i.test(first) ? first : 'U';
+  }, [safeEmail]);
+
+  useEffect(() => {
+    function handleClickOutside(ev: MouseEvent) {
+      if (!open) return;
+
+      const target = ev.target as Node | null;
+
+      if (
+        menuRef.current &&
+        !menuRef.current.contains(target) &&
+        btnRef.current &&
+        !btnRef.current.contains(target)
+      ) {
+        setOpen(false);
+      }
+    }
+
+    function handleEscape(ev: KeyboardEvent) {
+      if (ev.key === 'Escape') {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [open]);
+
+  return (
+    <div className="relative">
+      <button
+        ref={btnRef}
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="Abrir menu do administrador"
+        onClick={() => setOpen((value) => !value)}
+        className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-brand-600/20 bg-brand-50 text-sm font-medium text-brand-700 transition-colors hover:bg-brand-50/70"
+        title={safeEmail}
+      >
+        {initials}
+      </button>
+
+      {open ? (
+        <div
+          ref={menuRef}
+          role="menu"
+          aria-label="Menu do administrador"
+          className="absolute right-0 z-50 mt-2 w-72 overflow-hidden rounded-lg border border-border bg-popover shadow-lg"
+        >
+          <div className="px-4 py-3">
+            <div className="truncate text-sm font-medium text-popover-foreground">
+              {safeEmail}
+            </div>
+            <div className="text-xs text-muted-foreground">platform_admin</div>
+          </div>
+
+          <div className="my-1 h-px w-full bg-border" />
+
+          <div className="px-2 pb-2">
+            <LogoutButton />
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -7,12 +7,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { FormField, FormFieldError, FormFieldLabel } from '@/components/ui/form-field'
 import { Input } from '@/components/ui/input'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
+import { useSearchParams } from 'next/navigation'
 import { useState } from 'react'
-
-type LoginFormProps = React.ComponentPropsWithoutRef<'div'> & {
-  next?: string | null
-}
 
 function sanitizeNext(next?: string | null): string {
   if (!next) return '/a/home'
@@ -21,12 +17,12 @@ function sanitizeNext(next?: string | null): string {
   return next
 }
 
-export function LoginForm({ className, next, ...props }: LoginFormProps) {
+export function LoginForm({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
-  const router = useRouter()
+  const searchParams = useSearchParams()
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -40,8 +36,8 @@ export function LoginForm({ className, next, ...props }: LoginFormProps) {
         password,
       })
       if (error) throw error
-      const safeNext = sanitizeNext(next)
-      router.push(safeNext)
+      const safeNext = sanitizeNext(searchParams.get('next'))
+      window.location.assign(safeNext)
     } catch (error: unknown) {
       setError(error instanceof Error ? error.message : 'Ocorreu um erro')
     } finally {

--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -10,7 +10,18 @@ import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 
-export function LoginForm({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) {
+type LoginFormProps = React.ComponentPropsWithoutRef<'div'> & {
+  next?: string | null
+}
+
+function sanitizeNext(next?: string | null): string {
+  if (!next) return '/a/home'
+  if (!next.startsWith('/')) return '/a/home'
+  if (next.startsWith('//')) return '/a/home'
+  return next
+}
+
+export function LoginForm({ className, next, ...props }: LoginFormProps) {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
@@ -29,8 +40,8 @@ export function LoginForm({ className, ...props }: React.ComponentPropsWithoutRe
         password,
       })
       if (error) throw error
-      // Update this route to redirect to an authenticated route. The user already has an active session.
-      router.push('/a/home')
+      const safeNext = sanitizeNext(next)
+      router.push(safeNext)
     } catch (error: unknown) {
       setError(error instanceof Error ? error.message : 'Ocorreu um erro')
     } finally {


### PR DESCRIPTION
### Motivation
- Entregar a primeira superfície real e protegida de `/admin` conforme o caso E12.5.1. 
- Reutilizar a base de auth/sessão já existente e aplicar uma camada de autorização própria para a seção Admin. 
- Manter separação clara entre o Admin e o contexto de Account Dashboard, sem acoplar menus ou switchers de conta.

### Description
- Adiciona `app/admin/layout.tsx` que aplica o guard SSR `requirePlatformAdmin()`, faz `redirect` quando necessário e injeta `AdminHeader` passando `getUserEmail()` como prop. 
- Cria `app/admin/page.tsx` com conteúdo neutro e minimalista para a primeira página do Admin. 
- Cria `components/admin/AdminHeader.tsx` com a identidade textual "LP Factory Administrativo" e composição independente do contexto de conta. 
- Cria `components/admin/AdminUserMenu.tsx` como client component próprio que mostra iniciais, email, papel `platform_admin` e inclui `LogoutButton`, sem usar `useAccessContext`, `UserMenu` ou `AccountSwitcher` e sem alterar BD/migrations/SQL.

### Testing
- Executado `npm ci` com sucesso. 
- Executado `npm run check` com sucesso; `eslint` reportou warnings preexistentes (32 warnings) e `tsc` concluiu sem erros. 
- Resultado dos checks: passagem (warnings não bloqueantes no lint, sem erros de typecheck).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e377f2f820832992b18f9911027ba5)