### PR TITLE
docs: fechar campos mínimos e governança do Grupo C em 6.3.4

### DIFF
--- a/docs/lousa-estrategista-E10-5.md
+++ b/docs/lousa-estrategista-E10-5.md
@@ -426,7 +426,9 @@ Ela registra o caso de uso atual, suas decisões, ambiguidades, propostas, fluxo
 
 * esta etapa recorta a modelagem mínima final de `taxon_market_research_items`
 * a tabela deve ser ajustada neste recorte antes da primeira carga real do Grupo C
-* o objetivo é permitir diferenciação segura por tipo amplo do item, chave semântica, escopo de público, conteúdo, ordem e observação opcional
+* fechar os campos mínimos: `item_type`, `item_key`, `audience_scope`, `item_text`, `priority`, `sort_order`, `is_active`, `notes`
+* fechar valores iniciais de `audience_scope`: `end_customer` e `business_buyer`
+* governança: `item_key` novo descoberto na pesquisa não entra automaticamente no BD; só entra após aprovação humana e, se necessário, após ajuste do `docs/prompt-E10-5-4-consolidacao-pesquisa-nicho.md`
 
 #### 6.3.5 Processo manual desta etapa
 


### PR DESCRIPTION
### Motivation
- Fechar a modelagem mínima de `taxon_market_research_items` no recorte do Grupo C para viabilizar a primeira carga real e explicitar regras de governança.

### Description
- Atualiza apenas `docs/lousa-estrategista-E10-5.md` na seção `6.3.4` para fechar os campos mínimos (`item_type`, `item_key`, `audience_scope`, `item_text`, `priority`, `sort_order`, `is_active`, `notes`), definir valores iniciais de `audience_scope` (`end_customer`, `business_buyer`) e adicionar a regra de governança para novos `item_key` (não entram automaticamente no BD; só após aprovação humana e possível ajuste do `docs/prompt-E10-5-4-consolidacao-pesquisa-nicho.md`).

### Testing
- Rodei `npm ci` e `npm run check`, ambos concluíram com sucesso; o `eslint` exibiu warnings preexistentes e o `tsc` não retornou erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6569e783883298d9fa4d7a100efd2)