### PR TITLE
docs: adicionar itens de governança Supabase em docs/supa-up.md

### DIFF
--- a/docs/supa-up.md
+++ b/docs/supa-up.md
@@ -1763,3 +1763,106 @@ Generated columns do PostgreSQL permitem manter **colunas derivadas automaticame
 - Observação: documentar como capacidade futura, sem induzir implementação imediata.
 
 ---
+
+## 55 — GitHub Integration (Schema CI/CD) *(🟦 Estável)*  
+
+2026-04-20  
+
+### Status no Projeto
+
+- Status: Não implementado
+- Evidência: diretório `supabase/` ainda sem baseline consolidado para adoção do fluxo completo de migrations + preview/produção no projeto
+
+
+### Descrição  
+
+Integração de governança e CI/CD de schema com GitHub no Supabase, permitindo sincronizar branches e aplicar migrations versionadas de `supabase/migrations`, além de apoiar deploy declarativo de recursos do projeto.  
+
+### Valor para o Projeto  
+
+- Reduz drift entre repositório e banco em fluxos com migrations versionadas.  
+
+- Fortalece governança de mudanças de schema com checks de integração antes de merge.  
+
+- Não resolve baseline sozinho; depende da organização prévia do diretório `supabase/`.  
+
+### Valor para o Usuário  
+
+- Menor risco de regressões silenciosas por divergência de schema em produção.  
+
+### Ações Recomendadas  
+
+1. Consolidar baseline do diretório `supabase/` (migrations, config e convenções).  
+
+2. Conectar repositório ao projeto Supabase e configurar required checks no GitHub.  
+
+3. Validar pipeline em branch de preview antes de ativação em produção.  
+
+---
+
+## 56 — Push Protection para `supabase_secret_key` *(🟦 Estável)*  
+
+2026-04-20  
+
+### Status no Projeto
+
+- Status: Não implementado
+- Evidência: não há registro no repositório de política operacional formalizada de push protection específica para `supabase_secret_key`
+
+
+### Descrição  
+
+Recurso de segurança/governança para bloquear push acidental de chaves secretas Supabase detectadas pelo GitHub (push protection para `supabase_secret_key`).  
+
+### Valor para o Projeto  
+
+- Reforça a política de não exposição de segredos e o uso controlado de `SUPABASE_SECRET_KEY`.  
+
+- Reduz risco operacional de vazamento por erro humano em commits/pushes.  
+
+### Valor para o Usuário  
+
+- Maior proteção indireta de dados e continuidade do serviço.  
+
+### Ações Recomendadas  
+
+1. Habilitar/validar push protection no repositório GitHub do projeto.  
+
+2. Revisar documentação interna de segredos para refletir o controle automático.  
+
+3. Incluir checagem em onboarding técnico para reduzir recorrência de incidentes.  
+
+---
+
+## 57 — Schema Visualiser Improvements *(🟦 Estável)*  
+
+2026-04-20  
+
+### Status no Projeto
+
+- Status: Não implementado
+- Evidência: sem procedimento registrado no projeto para uso recorrente do visualizador como etapa de revisão de modelagem
+
+
+### Descrição  
+
+Melhorias do Schema Visualiser para inspeção de modelagem (relações clicáveis, ações de contexto em tabelas/colunas e navegação com popovers entre objetos conectados).  
+
+### Valor para o Projeto  
+
+- Apoia revisão operacional de modelagem em frentes de evolução de dados (ex.: E10.5 e Grupo C).  
+
+- Complementa documentação técnica (`docs/schema.md`), sem substituí-la.  
+
+### Valor para o Usuário  
+
+- Melhora indireta na consistência estrutural das funcionalidades dependentes de dados.  
+
+### Ações Recomendadas  
+
+1. Adotar o visualizador como apoio em revisões de schema e PRs com migrations.  
+
+2. Registrar no playbook quando usar inspeção visual versus revisão textual em `docs/schema.md`.  
+
+---
+

--- a/docs/supa-up.md
+++ b/docs/supa-up.md
@@ -1798,6 +1798,14 @@ Integração de governança e CI/CD de schema com GitHub no Supabase, permitindo
 
 3. Validar pipeline em branch de preview antes de ativação em produção.  
 
+### Registro (Tipo A — Plataforma)
+
+- Status: PENDENTE
+- Verificado em: —
+- Ambiente: Supabase Dashboard / GitHub Integration / Branching
+- Evidência: —
+- Observação: recurso de governança e CI/CD de schema; depende de baseline consolidado no diretório `supabase/` antes de adoção prática no projeto.
+
 ---
 
 ## 56 — Push Protection para `supabase_secret_key` *(🟦 Estável)*  
@@ -1832,6 +1840,14 @@ Recurso de segurança/governança para bloquear push acidental de chaves secreta
 
 3. Incluir checagem em onboarding técnico para reduzir recorrência de incidentes.  
 
+### Registro (Tipo A — Plataforma)
+
+- Status: PENDENTE
+- Verificado em: —
+- Ambiente: GitHub / Secret Scanning / Push Protection
+- Evidência: —
+- Observação: recurso de segurança e governança; reforça a política do projeto de uso controlado de `SUPABASE_SECRET_KEY` e prevenção de vazamento por push acidental.
+
 ---
 
 ## 57 — Schema Visualiser Improvements *(🟦 Estável)*  
@@ -1864,5 +1880,12 @@ Melhorias do Schema Visualiser para inspeção de modelagem (relações clicáve
 
 2. Registrar no playbook quando usar inspeção visual versus revisão textual em `docs/schema.md`.  
 
----
+### Registro (Tipo A — Plataforma)
 
+- Status: PENDENTE
+- Verificado em: —
+- Ambiente: Supabase Studio / Schema Visualiser
+- Evidência: —
+- Observação: recurso de apoio operacional de modelagem e inspeção visual; complementa `docs/schema.md`, sem substituí-lo.
+
+---


### PR DESCRIPTION
### Motivation

- Registrar no documento as atualizações de plataforma/governança anunciadas pela Supabase (GitHub integration, Push Protection e Schema Visualiser) para manter o repositório alinhado ao estado de mercado.  
- Fornecer recomendações operacionais e um estado explícito no projeto (`Status no Projeto`) para cada recurso novo, preservando o padrão editorial do arquivo.  
- Evitar expandir o escopo de produto ao classificar os itens como recursos de governança/plataforma com impacto operacional (tipo A) quando aplicável.  

### Description

- Acrescentei três blocos padronizados em `docs/supa-up.md` para os itens: `GitHub Integration (Schema CI/CD)`, `Push Protection para supabase_secret_key` e `Schema Visualiser Improvements`.  
- Mantive a estrutura editorial existente em cada bloco com `Status no Projeto`, `Descrição`, `Valor para o Projeto`, `Valor para o Usuário` e `Ações Recomendadas`.  
- Ajustei a numeração dos novos registros para `55`, `56` e `57` e preservei o status `Não implementado` com evidências operacionais específicas do projeto.  

### Testing

- Rodei `npm ci` com sucesso (instalação concluída sem erros).  
- Rodei `npm run check` com sucesso; a verificação executou `eslint` e `tsc` sem erros, produzindo 32 avisos de lint reportados (0 erros).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6583e49c083298ea076478c7068f5)