### PR TITLE
docs: atualiza definição do prompt de pesquisa na lousa E10.5

### DIFF
--- a/docs/lousa-estrategista-E10-5.md
+++ b/docs/lousa-estrategista-E10-5.md
@@ -437,12 +437,13 @@ A) Definido
 * o prompt de pesquisa desta etapa deve ficar em `docs/prompt-E10-5-4-pesquisa-completa-nicho.md`
 * ele deve funcionar como prompt mestre do nicho
 * ele deve permitir selecionar um, vários ou todos os `research_block`
-* os `research_block` previstos para cada rodada de pesquisa serão definidos no próprio prompt
+* os quatro blocos iniciais desta fase ficam: `strategic_core`, `lp_overview`, `lp_sections`, `seo`
 * a pesquisa pode ter liberdade controlada, mas deve entregar apenas conteúdo útil à estrutura da tabela
 
 B) Ambiguidades / A definir
 
-* sem ambiguidades relevantes nesta etapa
+* definir os `item_key` iniciais de cada `research_block`
+* definir os entregáveis obrigatórios mínimos de cada `research_block`
 
 ##### 6.3.3.3 Prompt de consolidação
 


### PR DESCRIPTION
### Motivation

- Especificar com mais detalhe o prompt de pesquisa da etapa E10.5.4 para garantir consistência na produção da pesquisa por nicho. 
- Fixar os blocos iniciais de pesquisa e transformar a seção de ambiguidades em itens concretos a definir para orientar próximas iterações.

### Description

- Substituí a subseção `6.3.3.2 Prompt de pesquisa` em `docs/lousa-estrategista-E10-5.md` mantendo o formato A) Definido / B) Ambiguidades. 
- Adicionei a lista dos quatro `research_block` iniciais: `strategic_core`, `lp_overview`, `lp_sections`, `seo`. 
- Removi a linha genérica sobre definir blocos no próprio prompt e passei a listar como pendências operacionais a definição dos `item_key` iniciais por `research_block` e os entregáveis mínimos obrigatórios por `research_block`. 
- O arquivo modificado foi `docs/lousa-estrategista-E10-5.md`.

### Testing

- Executei `npm ci` com sucesso para instalar dependências. 
- Executei `npm run check`, que rodou `lint` e `typecheck`; o `lint` reportou 32 avisos e nenhum erro, e o `typecheck` concluiu sem erros. 
- A rotina seguiu as instruções do repositório para sandbox (`npm ci` e `npm run check`, sem `npm run build`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecaa4ed2388329871075db798eb738)