### PR TITLE
docs: atualizar blocos de status no supa-up conforme briefing

### DIFF
--- a/docs/supa-up.md
+++ b/docs/supa-up.md
@@ -138,7 +138,8 @@ Permite consultas diretas a fontes externas (Data Lakes e BIs).
 ### Status no Projeto
 
 - Status: Em implementação por casos de uso
-- Evidência: docs/base-tecnica.md + docs/roadmap.md (E5.4/E10.4.6; logs estruturados com request_id/rid)
+- Evidência: docs/roadmap.md (E5.4, E10.4.6) + docs/base-tecnica.md (logs estruturados com request_id/rid)
+
 
 
 ### Descrição  
@@ -625,7 +626,8 @@ Sistema de tracking nativo de eventos, medindo comportamento e conversão com se
 ### Status no Projeto
 
 - Status: Em implementação por casos de uso
-- Evidência: docs/roadmap.md (E9.x; model_grants/grants em evolução por casos)
+- Evidência: docs/roadmap.md (E9.4, E9.8; grants/model_grants/get_feature em evolução por casos)
+
 
 
 
@@ -660,7 +662,8 @@ Modelo de controle dinâmico de recursos e permissões por plano, utilizando bun
 ### Status no Projeto
 
 - Status: Implementado globalmente no projeto
-- Evidência: docs/base-tecnica.md + docs/schema.md (views com security_invoker = true)
+- Evidência: docs/base-tecnica.md + docs/schema.md (views com security_invoker = true); sem seção E específica suficiente no roadmap para atribuição única.
+
 
 
 ### Descrição  
@@ -904,7 +907,8 @@ Define um padrão unificado para rastrear mudanças em triggers, policies e fun�
 ### Status no Projeto
 
 - Status: Em implementação por casos de uso
-- Evidência: docs/base-tecnica.md + docs/roadmap.md (templates de Auth já absorvidos parcialmente)
+- Evidência: docs/roadmap.md (E5.4, E5.6) + docs/base-tecnica.md (templates de Auth e SMTP via Resend)
+
 
 
 ### Descrição  
@@ -1094,7 +1098,9 @@ Recurso/integração do **index_advisor** para ajudar a identificar índices fal
 ### Status no Projeto
 
 - Status: Implementado globalmente no projeto
-- Evidência: docs/base-tecnica.md (ambiente atual PostgREST 14.1)
+- Evidência: docs/base-tecnica.md (ambiente atual PostgREST 14.1); docs/roadmap.md (E3.4 como update externo a considerar)
+- Observação: uso específico de FTS no E10.5 ainda está previsto em docs/lousa-estrategista-E10-5.md (E10.5.6), não implementado.
+
 
 
 ### Descrição  
@@ -1219,8 +1225,9 @@ A extensão **pg_graphql** passa a vir **desativada por padrão** em novos proje
 
 ### Status no Projeto
 
-- Status: Não implementado
-- Evidência: docs/roadmap.md (sem adoção definida no escopo atual)
+- Status: Em implementação por casos de uso
+- Evidência: docs/lousa-estrategista-E10-5.md (E10.5.3 implementado com snippets do Grupo A; E10.5.4 planejado com snippets do Grupo C)
+
 
 
 ### Descrição
@@ -1649,9 +1656,9 @@ A extensão `pg_trgm` do PostgreSQL fornece operadores e índices para **similar
 
 ### Status no Projeto
 
-- Status: Não implementado
-- Evidência: não há uso explícito de generated columns registrado na base atual do projeto.
-- Observação: candidato forte para normalização automática em taxonomias e chaves auxiliares de busca.
+- Status: Em implementação por casos de uso
+- Evidência: docs/lousa-estrategista-E10-5.md (E10.5.2 implementado; `business_taxon_aliases.alias_text_normalized` aplicado como generated column)
+
 
 ### Descrição
 


### PR DESCRIPTION
### Motivation

- Alinhar os blocos de status de itens selecionados em `docs/supa-up.md` às referências determinísticas do briefing (docs/roadmap.md, docs/base-tecnica.md e docs/lousa-estrategista-E10-5.md). 
- Garantir que apenas os blocos `### Status no Projeto` sejam substituídos sem alterar títulos, descrições, valores do projeto ou ações recomendadas.

### Description

- Atualiza exclusivamente os blocos `### Status no Projeto` em `docs/supa-up.md` para os itens 5, 20, 21, 30, 36, 40 e 52. 
- Padroniza as evidências e o texto de status conforme o briefing (por exemplo `E5.4, E10.4.6` e `docs/base-tecnica.md` para Unified Logs; `E9.4, E9.8` e `grants/model_grants/get_feature` para Bundles; observação adicional sobre FTS no item 36; anotação sobre `security_invoker` no item 21). 
- Mantém intactos títulos, descrições, valores para o projeto, valores para o usuário e ações recomendadas fora do bloco de status.

### Testing

- Executado `npm ci` com sucesso. 
- Executado `npm run check`, que rodou `lint` e `typecheck` com sucesso; não houve erros, apenas warnings pré-existentes do ESLint.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecc52d28bc832988ae07b9645774d9)