### PR TITLE
docs: add universal outcome-first prompt template

### DIFF
--- a/docs/template-prompts.md
+++ b/docs/template-prompts.md
@@ -1,0 +1,40 @@
+# Template geral de prompts — LP Factory 10
+
+## 1. Objetivo
+
+Descreva o resultado esperado.
+
+## 2. Fontes / contexto disponível
+
+Informe quais fontes ou contexto devem ser usados:
+
+- chat
+- trecho
+- arquivo
+- repositório
+- web
+- print
+
+## 3. Critérios de sucesso
+
+Liste o que precisa estar verdadeiro para a resposta ser considerada boa.
+
+## 4. Limites
+
+Declare o que não pode ser inferido, alterado, removido ou criado.
+
+## 5. Entrega esperada
+
+Defina o formato final e o nível de detalhe:
+
+- análise curta
+- relatório
+- lousa
+- briefing para Codex
+- prompt pronto
+- checklist
+- decisão
+
+## 6. Regras de parada
+
+Informe quando parar, pedir fonte, declarar limite ou não prosseguir.

--- a/docs/template-prompts.md
+++ b/docs/template-prompts.md
@@ -1,5 +1,9 @@
 # Template geral de prompts — LP Factory 10
 
+A nova abordagem de prompts do LP Factory 10 segue o princípio outcome-first: começar pelo resultado esperado, informar fontes/contexto, definir critérios de sucesso, declarar limites, especificar a entrega esperada e parar quando faltar fonte ou houver limite.
+
+Fonte conceitual: https://developers.openai.com/api/docs/guides/prompt-guidance
+
 ## 1. Objetivo
 
 Descreva o resultado esperado.


### PR DESCRIPTION
### Motivation

- Add a short, universal outcome-first prompt template in `docs/` to standardize prompt briefings, following `AGENTS.md` and the existing `docs/template-briefing-codex.md`.

### Description

- Create `docs/template-prompts.md` with the exact six-section template requested (Objetivo; Fontes / contexto disponível; Critérios de sucesso; Limites; Entrega esperada; Regras de parada) and no other project files changed.

### Testing

- Ran `npm ci` and `npm run check`; installation succeeded and `npm run check` completed with TypeScript passing and ESLint producing warnings but no errors, so automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed55ae0804832988eda4caa817fc41)