### PR TITLE
docs: atualizar schema e roadmap para ajuste de audience_scope do Grupo C (v1.0.13 / v1.5.43)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data: 23/04/2026
-• Versão: v1.5.42
+• Data: 26/04/2026
+• Versão: v1.5.43
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -667,17 +667,22 @@
 • Q1, Q2 e Q3 da conferência estrutural não foram validados até o fim, embora Q4, Q5, Q6 e Q7 tenham sido aprovados
 • a migration histórica final foi entregue em conteúdo, mas ainda não foi commitada no repositório nesta conversa
 
-10.5.2.1 Ajustar taxon_market_research e taxon_market_research_items no BD
-• Status: Concluído (23/04/2026)
-• Escopo final:
-• taxon_market_research: remoção de base_summary; inclusão de research_block; unicidade por (taxon_id, research_block, version); índice único parcial para no máximo 1 versão active por (taxon_id, research_block)
-• taxon_market_research_items: substituição da estrutura baseada em item_tag por item_key, audience_scope, item_text, priority, sort_order, is_active, notes
-• audience_scope com CHECK ('end_customer', 'business_buyer')
-• sem unicidade extra na tabela-filha nesta etapa
-• sort_order como NOT NULL DEFAULT 999
-• Artefatos:
-• supabase/migrations/0007__e10_5_2_1_group_c_research_adjust.sql
-• supabase/rollbacks/20260423__e10_5_2_1_group_c_research_adjust.rollback.sql
+10.5.2.1 Ajustar `taxon_market_research` e `taxon_market_research_items` no BD
+• Status: Concluído (exec) (26/04/2026)
+• Objetivo: corrigir a modelagem do Grupo C para separar o público da pesquisa no registro-pai, evitando mistura de `end_customer` e `business_buyer` no mesmo consolidado.
+• Implementado:
+• `taxon_market_research`: adicionada coluna `audience_scope` com CHECK restrito a `end_customer` e `business_buyer`.
+• `taxon_market_research`: unicidade ajustada para `(taxon_id, research_block, audience_scope, version)`.
+• `taxon_market_research`: ativo único ajustado para `(taxon_id, research_block, audience_scope) WHERE status = 'active'`.
+• `taxon_market_research_items`: removida coluna `audience_scope`; itens passam a herdar o público pelo `research_id`.
+• `taxon_market_research_items.item_key`: consolidado como `NOT NULL`.
+• Decisão operacional: a carga do Grupo C deve criar 1 registro pai por `taxon + research_block + audience_scope`.
+• Fora do escopo: carga real do Grupo C, prompts operacionais, runtime, adapters, `taxon_message_guides`, nova tabela e mudanças em RLS/policies.
+• ARTEFATOS_REPO:
+• Criados:
+• `supabase/migrations/0008__e10_5_2_1_research_audience_scope_parent.sql`
+• `supabase/rollbacks/20260426__e10_5_2_1_research_audience_scope_parent.rollback.sql`
+• Ajustados: N/A
 
 10.5.3 Kit operacional de expansão do Grupo A
 • Status: Concluído (exec) (15/04/2026)
@@ -971,6 +976,9 @@
 • Definir o primeiro recorte funcional do LP Builder no roadmap
 
 99. Changelog
+v1.5.43 (26/04/2026) — 10.5.2.1: ajuste corretivo do Grupo C
+• Registrado o estado final do ajuste de `audience_scope`: público da pesquisa no registro-pai, itens herdando público por `research_id`, unicidade por `taxon_id + research_block + audience_scope + version` e artefatos de migration/rollback.
+
 v1.5.42 (23/04/2026)
 • Adicionado 10.5.2.1 com o ajuste estrutural de taxon_market_research e taxon_market_research_items no BD.
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data da última atualização: 23/04/2026
-• Documento: LP Factory 10 — Schema (DB Contract) v1.0.12
+• Data da última atualização: 26/04/2026
+• Documento: LP Factory 10 — Schema (DB Contract) v1.0.13
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -265,21 +265,25 @@
 
 1.15.1 Chaves, constraints e relacionamentos
 • PK: id uuid
-• UNIQUE: (taxon_id, research_block, version)
+• UNIQUE: (taxon_id, research_block, audience_scope, version)
 • CHECK: taxon_market_research_status_chk (status IN ('draft', 'active', 'archived'))
+• CHECK: taxon_market_research_audience_scope_chk (audience_scope IN ('end_customer', 'business_buyer'))
 • FK: taxon_id → business_taxons(id) ON UPDATE CASCADE ON DELETE RESTRICT
 
 1.15.2 Campos
 • taxon_id uuid not null
 • research_block text not null
 • Regra: texto governado por processo operacional; sem CHECK fechado nesta etapa
+• audience_scope text not null
+• Regra: audience_scope define o público homogêneo da pesquisa-pai; valores permitidos: end_customer | business_buyer
 • version integer not null default 1
 • status text not null
 • created_at timestamptz not null default now()
 • updated_at timestamptz not null default now()
 
 1.15.3 Índices
-• uq_taxon_market_research_active_per_block (UNIQUE parcial em (taxon_id, research_block) WHERE status = 'active')
+• taxon_market_research_taxon_block_audience_version_uidx (UNIQUE em taxon_id, research_block, audience_scope, version)
+• taxon_market_research_one_active_per_block_audience_uidx (UNIQUE parcial em taxon_id, research_block, audience_scope WHERE status = 'active')
 
 1.15.4 Segurança
 • Trigger Hub: não
@@ -295,14 +299,12 @@
 
 1.16.1 Chaves, constraints e relacionamentos
 • PK: id uuid
-• CHECK: taxon_market_research_items_audience_scope_chk (audience_scope IN ('end_customer', 'business_buyer'))
 • FK: research_id → taxon_market_research(id) ON UPDATE CASCADE ON DELETE CASCADE
 • UNIQUE adicional: nenhuma nesta etapa
 
 1.16.2 Campos
 • research_id uuid not null
 • item_key text not null
-• audience_scope text not null
 • item_text text not null
 • priority integer not null default 0
 • sort_order integer not null default 999
@@ -486,6 +488,11 @@
 • Nota: accounts.status não aceita trial (CHECK accounts_status_chk). No estado atual, views não contêm trial e o runtime/tipos (PATH) não incluem trial (drift resolvido).
 
 99. Changelog
+v1.0.13 (26/04/2026) — E10.5.2.1: ajuste corretivo de audience_scope no Grupo C
+• taxon_market_research: adicionado audience_scope no registro-pai; registrada unicidade por (taxon_id, research_block, audience_scope, version) e índice único parcial para no máximo 1 versão active por (taxon_id, research_block, audience_scope).
+• taxon_market_research_items: removido audience_scope; itens passam a herdar o público pelo research_id.
+• taxon_market_research_items.item_key: registrado como NOT NULL conforme estado validado no Supabase.
+
 v1.0.12 (23/04/2026) — E10.5.2.1: ajuste estrutural das tabelas do Grupo C
 • taxon_market_research: removido base_summary; adicionado research_block; registrada unicidade por (taxon_id, research_block, version) e índice único parcial para no máximo 1 versão active por (taxon_id, research_block).
 • taxon_market_research_items: substituída a estrutura baseada em item_tag por item_key, audience_scope, item_text, priority, sort_order, is_active e notes.


### PR DESCRIPTION
### Motivation
- Corrigir a modelagem do Grupo C para separar o público da pesquisa no registro-pai e evitar mistura de `end_customer` e `business_buyer` no mesmo consolidado.
- Atualizar os documentos canônicos do projeto para refletir o estado final da mudança e registrar os artefatos de migration/rollback correspondentes.

### Description
- Atualiza o cabeçalho em `docs/schema.md` para `v1.0.13` (26/04/2026) e substitui as seções `1.15` e `1.16` com a nova modelagem: `audience_scope` passou para o pai `taxon_market_research` (com `CHECK` fechado) e foi removido de `taxon_market_research_items` enquanto `item_key` permanece `NOT NULL`.
- Ajusta unicidade e índices em `taxon_market_research` para `(taxon_id, research_block, audience_scope, version)` e adiciona índice parcial para garantir no máximo uma versão `active` por `(taxon_id, research_block, audience_scope)`.
- Atualiza `docs/roadmap.md` para `v1.5.43` (26/04/2026) substituindo a seção `10.5.2.1` pelo estado final concluído e registrando os artefatos `supabase/migrations/0008__e10_5_2_1_research_audience_scope_parent.sql` e `supabase/rollbacks/20260426__e10_5_2_1_research_audience_scope_parent.rollback.sql`.
- Adiciona entradas de changelog correspondentes em ambos os documentos para registrar a alteração (schema `v1.0.13` e roadmap `v1.5.43`).

### Testing
- Rodei `npm ci` com sucesso no workspace, instalando as dependências necessárias.
- Rodei `npm run check` com sucesso; o processo completou sem erros de build/typecheck e retornou apenas warnings de lint preexistentes no repositório.
- Não foram executados testes automatizados adicionais além dos checks acima; ambos os comandos concluíram sem falhas bloqueantes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee4f3a374c8329b017dc03c5490cbe)