### PR TITLE
docs: adiciona item 22 sobre GPT-5.5 / latest-model em auto-agentes-up

### DIFF
--- a/docs/auto-agentes-up.md
+++ b/docs/auto-agentes-up.md
@@ -411,3 +411,26 @@ Recurso da OpenAI para forçar respostas aderentes a um schema estruturado, redu
 1. Usar Structured Outputs em automações assistidas que precisem gerar resposta estruturada para o sistema.
 2. Priorizar esse recurso em classificações, recomendações e validações que afetem decisões do produto.
 3. Evitar geração livre quando o resultado precisar ser persistido ou usado por lógica de negócio.
+
+---
+
+## 22 — GPT-5.5 / latest-model para automações e IA no produto *(🍾 Estável)*
+2026-04-28
+
+### Descrição
+Guia oficial da OpenAI sobre uso de GPT-5.5 como modelo de referência para tarefas complexas, multi-etapas, com tools, raciocínio, Structured Outputs, critérios de sucesso, testes e automações assistidas.
+
+### Valor para o Projeto
+- Reforça o uso de GPT-5.5 em tarefas de maior complexidade, como investigação, planejamento, Codex, análise de repositório e automações com múltiplas etapas.
+- Orienta planos base mais objetivos, com foco em resultado, fontes, restrições, evidência e critérios de sucesso.
+- Apoia decisões futuras sobre IA dentro do SaaS, especialmente quando houver uso de Responses API, tools e Structured Outputs.
+
+### Valor para o Usuário
+- Favorece experiências assistidas mais úteis, previsíveis e inteligentes dentro dos dashboards.
+- Ajuda a transformar IA em valor percebido no produto, não apenas em apoio interno de desenvolvimento.
+
+### Ações Recomendadas
+1. Usar GPT-5.5 como referência para automações complexas, análises multi-etapas e fluxos com tools.
+2. Aplicar a diretriz outcome-first em planos base, briefings e prompts operacionais.
+3. Usar Responses API e Structured Outputs quando a IA gerar dados que serão persistidos ou usados por lógica de negócio.
+4. Priorizar IA dentro do produto apenas quando houver usuário, entrada, saída esperada, ganho prático e controle de risco definidos.


### PR DESCRIPTION
### Motivation
- Inserir referência ao guia oficial da OpenAI `latest-model` (GPT-5.5) no catálogo de agentes para orientar uso do modelo em automações complexas, tools e Structured Outputs.
- Manter o padrão visual e a estrutura do documento existente sem renumerar ou alterar itens prévios.

### Description
- Adiciona ao final de `docs/auto-agentes-up.md` o item "22 — GPT-5.5 / latest-model para automações e IA no produto" com seções `Descrição`, `Valor para o Projeto`, `Valor para o Usuário` e `Ações Recomendadas` conforme o texto fornecido.
- A alteração é local e restrita ao arquivo `docs/auto-agentes-up.md`, posicionada após o item 21 e preservando cabeçalho, versão, data e demais itens.

### Testing
- Executed `npm ci` successfully to install dependencies. 
- Executed `npm run check` successfully; the run completed with no errors though existing lint warnings unrelated to this change were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0bb6ac7408329b82924b656c47567)