### PR TITLE
fix(account-dashboard): gate pending_setup only by account status

### DIFF
--- a/app/a/[account]/page.tsx
+++ b/app/a/[account]/page.tsx
@@ -53,10 +53,8 @@ export default function Page(props: any) {
       | "suspended"
       | null;
 
-    const setupCompletedAt = (ctx?.account?.setupCompletedAt ?? null) as string | null;
-
-    // E10.4: pending_setup + setup incompleto → Primeiros passos (form inline)
-    if (accountStatus === "pending_setup" && !setupCompletedAt) {
+    // E10.4: pending_setup → Primeiros passos (form inline)
+    if (accountStatus === "pending_setup") {
       return <PendingSetupFirstSteps accountSubdomain={params.account} ctx={ctx} />;
     }
 


### PR DESCRIPTION
### Motivation
- Remove runtime dependency on `setup_completed_at` / `account_setup_completed_at` / `setupCompletedAt` when deciding the `pending_setup` flow in the Account Dashboard.
- Ensure the `pending_setup` UI is determined solely by `accounts.status` to avoid drift between DB contract and runtime rendering.

### Description
- Updated `app/a/[account]/page.tsx` to stop reading `ctx?.account?.setupCompletedAt` and removed the `&& !setupCompletedAt` condition.
- The `PendingSetupFirstSteps` form is now rendered whenever `accountStatus === "pending_setup"` and the adjacent comment was updated to reflect the status-based rule.
- No other files, schemas, adapters, server actions, or UX/copy were modified; the change is minimal and localized to the page component.

### Testing
- Ran `npm ci` and it completed successfully in the sandbox environment.
- Ran `npm run check` (which runs `eslint` and `tsc`) and it completed successfully with only existing lint warnings and no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e72c64c483298cc77e8548bf39c1)