### PR TITLE
fix(validador-final): make Playwright login step resilient to timing/race conditions

### DIFF
--- a/automations/validador-final/login-playwright.mjs
+++ b/automations/validador-final/login-playwright.mjs
@@ -324,16 +324,34 @@ export async function login({ page, email, password }) {
     return { passed: false, authenticated: false, detail: "botão de login não encontrado", finalUrl: page.url() };
   }
 
-  await page.waitForTimeout(1800);
-  const finalUrl = page.url();
-  const uiError = await detectUiError(page);
-  const authenticated = hasAuthSuccessUrl(finalUrl);
+  const OUTCOME_TIMEOUT_MS = 12000;
+  const POLL_INTERVAL_MS = 300;
+  const startedAt = Date.now();
+  let finalUrl = page.url();
+  let uiError = null;
+  let authenticated = hasAuthSuccessUrl(finalUrl);
+
+  while (Date.now() - startedAt <= OUTCOME_TIMEOUT_MS) {
+    finalUrl = page.url();
+    uiError = await detectUiError(page);
+    authenticated = hasAuthSuccessUrl(finalUrl);
+
+    if (authenticated) break;
+    if (uiError) break;
+
+    await page.waitForTimeout(POLL_INTERVAL_MS);
+  }
+
+  const elapsedMs = Date.now() - startedAt;
+  const timingSuffix = `(elapsed=${elapsedMs}ms, finalUrl=${finalUrl})`;
 
   return {
     passed: authenticated,
     authenticated,
     uiError,
-    detail: authenticated ? "login autenticado" : `login sem autenticação: ${uiError ?? "sem erro explícito"}`,
+    detail: authenticated
+      ? `login autenticado ${timingSuffix}`
+      : `login sem autenticação: ${uiError ?? "sem erro explícito"} ${timingSuffix}`,
     finalUrl,
   };
 }


### PR DESCRIPTION
### Motivation
- The `login_correct_password` step was intermittently failing with `login sem autenticação: sem erro explícito`, likely due to a timing/race condition when the automation sampled the page state too early. 
- The goal is to harden the validator automation (not the app) by making the `login()` check tolerant to delayed redirects/hydration/session establishment.

### Description
- Replaced the single fixed `await page.waitForTimeout(1800)` read in `login()` with a bounded polling loop (up to 12s, poll interval 300ms) that re-evaluates `page.url()` and UI error signals. 
- The loop exits early when an auth success URL (`/a/`) is observed or when an explicit UI error is detected, preserving the original success/failure semantics. 
- Added timing and final-URL diagnostics to the returned `detail` message to improve observability on future failures. 
- File changed: `automations/validador-final/login-playwright.mjs` (only automation code; no app changes).

### Testing
- Ran dependency install with `npm ci` and project checks with `npm run check`. 
- `npm run check` completed successfully (TypeScript check passed), while ESLint reported existing warnings (32 warnings) unrelated to this change. 
- No runtime app changes were made; the change is limited to the validator automation and increases robustness and observability of the `login_correct_password` step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0fdaa19908329a9fa46dbea704957)