### PR TITLE
docs: atualiza roadmap v1.5.45 e base-tecnica v2.0.29 (convenção route-local)

### DIFF
--- a/docs/base-tecnica.md
+++ b/docs/base-tecnica.md
@@ -2,8 +2,8 @@
 
 0.1. Cabeçalho
 • Documento: Base Técnica LP Factory 10
-• Versão: v2.0.28
-• Data: 18/04/2026
+• Versão: v2.0.29
+• Data: 29/04/2026
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -145,6 +145,8 @@
 • Seções do Core: Account Dashboard, Admin Dashboard, Partner Dashboard, LP Builder  
 
 3.3.2 Paths canônicos e anti-drift de localização
+
+• Regra: componentes específicos de rota que dependem de Server Action, estado ou boundary da própria rota devem nascer como route-local em `app/.../_components`; não promover para `components/features` sem boundary compartilhada real.
 • Regra: path é contrato operacional  
 • Regra: não inventar path nem assumir localização por padrão genérico  
 • Regra: em dúvida, confirmar no repositório real (GitHub/conectores/fontes acessíveis)  
@@ -565,3 +567,5 @@ v1.9.2 (23/12/2025) — Infra/Auth/PostgREST (estado atual)
 • Atualizado 3.12 Compatibilidade PostgREST 14.1: registrado FTS (fts/plfts/phfts/wfts) (disponível; sem escopo de telas) + preferência por wfts e índices GIN conforme necessidade.
 • Atualizado 3.12 Compatibilidade PostgREST 14.1: UX de paginação — HTTP 416 / PGRST103 = fim da lista (não erro de sistema).
 • Atualizado 5.3.4 Observabilidade: server-timing/proxy-status não observados nos requests testados via DevTools; diretriz de instrumentação/logs/APM se necessário.
+
+v2.0.29 (29/04/2026) — Registra convenção route-local para componentes específicos de rota que dependem da própria boundary da rota.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data: 27/04/2026
-• Versão: v1.5.44
+• Data: 29/04/2026
+• Versão: v1.5.45
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -449,6 +449,12 @@
 • UX Partner Dashboard
 
 10.4 Primeiros passos (pending_setup — status-based)
+
+• Arquitetura runtime atual: `app/a/[account]/page.tsx` atua como orquestrador da rota; o formulário `PendingSetupFirstSteps` reside em `app/a/[account]/_components/PendingSetupFirstSteps.tsx` como componente route-local.
+• ARTEFATOS_REPO:
+• Criado: `app/a/[account]/_components/PendingSetupFirstSteps.tsx`
+• Ajustado: `app/a/[account]/page.tsx`
+• Checks/QA (reportado): `npm ci` ok; `npm run check` ok; Security Checks ok; Preview Vercel Ready; Validador Final passou; QA manual confirmou `pending_setup → active`.
 
 • Status: Concluído (exec) (13/02/2026)
 • Escopo: Entregar o fluxo ponta a ponta de “Primeiros passos” no dashboard da conta (/a/[account]) quando `accounts.status=pending_setup`: exibir formulário inline, validar campos (incl. regras condicionais), salvar com estados/erros (loading, validação inline, erro sistêmico com retry), persistir perfil v1, promover status (`pending_setup → active`) e redirecionar para o fluxo pós-setup.
@@ -1072,3 +1078,5 @@ v1.5.6 (27/01/2026) — F2: Auto 1ª conta (pending_setup) e atualização do fl
 v1.5.3 (21/01/2026) — Gate SSR: UX de bloqueio por status (membership/conta)
 • E4: Gate SSR roteia bloqueios de membership para rotas dedicadas e diferencia fallback de conta bloqueada por status (inactive/suspended) com páginas específicas.
 • E15: Detalhada a UX/CTAs e rotas por status de membership, incluindo tratamento de usuário autenticado sem membership (clear_last).
+
+v1.5.45 (29/04/2026) — E10.4: registra extração route-local do formulário `PendingSetupFirstSteps` e QA do fluxo `pending_setup → active`.


### PR DESCRIPTION
### Motivation
- Registrar a extração route-local do formulário `PendingSetupFirstSteps` e documentar o resultado do QA do fluxo `pending_setup → active` no roadmap. 
- Formalizar a convenção técnica de que componentes específicos de rota que dependem de Server Action/estado/boundary nasçam como route-local em `app/.../_components` para evitar drift de localização.
- Atualizar metadados dos documentos para refletir as versões e datas atuais.

### Description
- Atualizado o cabeçalho de `docs/roadmap.md` para `v1.5.45` com `Data: 29/04/2026` e inserido o trecho em `10.4 Primeiros passos (pending_setup — status-based)` descrevendo arquitetura route-local, artefatos criados/ajustados e checks/QA reportados. 
- Atualizado o cabeçalho de `docs/base-tecnica.md` para `v2.0.29` com `Data: 29/04/2026` e adicionada, em `3.3.2 Paths canônicos e anti-drift de localização`, a regra que exige `app/.../_components` para componentes route-local dependentes da própria boundary. 
- Incluídas entradas de changelog para `v1.5.45` (roadmap) e `v2.0.29` (base técnica). 
- Arquivos modificados: `docs/roadmap.md`, `docs/base-tecnica.md`.

### Testing
- Executado `npm ci` com sucesso. 
- Executado `npm run check` com sucesso; o check retornou 0 erros e 32 warnings (lint warnings), e o `tsc --noEmit` passou.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20da8dbf88329953cc329512f525a)