### PR TITLE
docs: clarify template prompt guidance

### DIFF
--- a/docs/template-prompts.md
+++ b/docs/template-prompts.md
@@ -1,6 +1,6 @@
 # Template geral de prompts — LP Factory 10
 
-A nova abordagem de prompts do LP Factory 10 segue o princípio outcome-first: começar pelo resultado esperado, informar fontes/contexto, definir critérios de sucesso, declarar limites, especificar a entrega esperada e parar quando faltar fonte ou houver limite.
+A nova abordagem de prompts do LP Factory 10 segue o princípio outcome-first: começar pelo resultado esperado, informar fontes/contexto, definir critérios de sucesso, declarar limites e especificar a entrega esperada. Ela orienta parar quando faltar fonte ou houver limite.
 
 Fonte conceitual: https://developers.openai.com/api/docs/guides/prompt-guidance
 


### PR DESCRIPTION
## Summary
- Split the opening prompt guidance into two shorter sentences for clarity.
- Kept sections, numbering, and scope unchanged.

## Validation
- npm ci
- npm run check