### PR TITLE
docs: shorten template prompt intro

### DIFF
--- a/docs/template-prompts.md
+++ b/docs/template-prompts.md
@@ -1,6 +1,6 @@
 # Template geral de prompts — LP Factory 10
 
-A nova abordagem de prompts do LP Factory 10 segue o princípio outcome-first: começar pelo resultado esperado, informar fontes/contexto, definir critérios de sucesso, declarar limites e especificar a entrega esperada. Ela orienta parar quando faltar fonte ou houver limite.
+A abordagem de prompts do LP Factory 10 é outcome-first: começar pelo resultado esperado, informar fontes/contexto, definir critérios de sucesso, declarar limites e especificar a entrega esperada. Ela orienta parar quando faltar fonte ou houver limite.
 
 Fonte conceitual: https://developers.openai.com/api/docs/guides/prompt-guidance
 


### PR DESCRIPTION
## Summary
- Shorten the opening sentence in `docs/template-prompts.md` without changing its meaning.
- Keep sections, numbering, and scope unchanged.

## Validation
- npm ci
- npm run check

## Notes
- Local Git branch and commit were created successfully.
- Local push failed due Windows/Git credentials (`SEC_E_NO_CREDENTIALS`), so the PR branch was published through the GitHub connector with the same one-file change.