### PR TITLE
docs: reference AGENTS.md for standard checks in template briefing

### DIFF
--- a/docs/template-briefing-codex.md
+++ b/docs/template-briefing-codex.md
@@ -15,7 +15,7 @@ Todo briefing deve ser outcome-first e informar, de forma objetiva:
 
 ### Código
 
-- incluir `npm ci` e `npm run check`;
+- seguir a rotina padrão de checks definida no `AGENTS.md`;
 - entregar arquivos novos com conteúdo completo;
 - em arquivos existentes, orientar alteração mínima dentro do escopo definido;
 - evitar reestruturação ampla sem pedido explícito.


### PR DESCRIPTION
### Motivation
- Avoid duplication by making `AGENTS.md` the single source of truth for the repository's standard check routine instead of hardcoding `npm ci`/`npm run check` in the briefing template.

### Description
- Replace the fixed instruction "incluir `npm ci` e `npm run check`" with "seguir a rotina padrão de checks definida no `AGENTS.md`" in `docs/template-briefing-codex.md`, while preserving the existing conditional gate guidance for sensitive code.

### Testing
- Ran `npm ci` and `npm run check`, where lint completed with 32 warnings and 0 errors and `tsc` typecheck completed with no errors, so automated checks passed (warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f65bf2c5f8832984dea9c0d75df763)