### PR TITLE
docs: ajustar prompt-nicho-identificacao para formato enxuto

### DIFF
--- a/docs/prompt-nicho-identificacao.md
+++ b/docs/prompt-nicho-identificacao.md
@@ -1,61 +1,46 @@
-Prompt — Identificação de nicho/taxon
-Objetivo
+# Prompt — Identificação de nicho/taxon
 
-Identificar o taxon cadastrado, definir o público da pesquisa e registrar os research_block que serão pesquisados.
+## Objetivo
 
-Contexto
+Identificar o taxon cadastrado, definir o público da pesquisa e registrar os `research_blocks` que serão pesquisados.
 
-Use o SQL de apoio:
-
-supabase/snippets/e10_5_4_nicho_identificacao_taxon_lookup.sql
-
-O SQL localiza o taxon em:
-
-business_taxons
-business_taxon_aliases
-Entrada
+## Entrada
 
 Peça ao humano:
 
-Nome do nicho/taxon:
-Público da pesquisa: business_buyer ou end_customer
-research_block e ordem desejada:
-strategic_core
-lp_overview
-lp_sections
-seo
+- Nome do nicho/taxon:
+- Público da pesquisa: `business_buyer` ou `end_customer`
+- `research_blocks` e ordem:
+  - `strategic_core`
+  - `lp_overview`
+  - `lp_sections`
+  - `seo`
 
-Exemplo:
+Aceite apenas um público por pesquisa.
 
-Nome do nicho/taxon: Harmonização Facial
-Público da pesquisa: end_customer
-research_block: 1. strategic_core, 2. lp_overview
+Aceite apenas `research_blocks` da lista acima.
 
-Ação 1 — Localizar taxon
+## Ação
 
-Oriente o humano a executar o SQL de apoio no Supabase usando o nome informado.
+Use o snippet:
 
-Depois, peça que cole o resultado no chat.
+`supabase/snippets/e10_5_4_nicho_identificacao_taxon_lookup.sql`
 
-Ação 2 — Confirmar taxon
+Peça ao humano para executar o SQL no Supabase com o nome informado e colar o resultado no chat.
 
-Ao receber o resultado do SQL, apresente os dados encontrados:
+Ao receber o resultado:
 
-taxon_id
-taxon_name
-taxon_slug
-taxon_level
-parent_id
-parent_name
-is_active
-match_source
+- apresente os taxons encontrados
+- peça confirmação do taxon correto
+- se houver mais de um resultado possível, peça ao humano para escolher
+- se não houver resultado, pare e oriente cadastrar o taxon antes da pesquisa
+- se `is_active = false`, peça confirmação explícita antes de continuar
 
-Se houver mais de um resultado possível, peça ao humano para escolher o taxon correto.
-
-Entrega final
+## Entrega final
 
 Após a confirmação humana, entregue exatamente este bloco:
 
+```md
 # Entrada confirmada para pesquisa profunda
 
 taxon_id:
@@ -81,6 +66,8 @@ modo_de_execucao:
 - após todos os blocos, aguardar comando humano para consolidar
 - após a consolidação, aguardar comando humano para gerar SQL de carregamento
 - após o carregamento, gerar SQL de verificação
-Parada
+```
+
+## Parada
 
 Depois de entregar a entrada confirmada para pesquisa profunda, pare.


### PR DESCRIPTION
### Motivation

- Tornar `docs/prompt-nicho-identificacao.md` mais curto, claro e compatível com a nova diretriz de prompts operacionais enxutos.
- Padronizar a estrutura do prompt para as cinco seções obrigatórias: `Objetivo`, `Entrada`, `Ação`, `Entrega final` e `Parada`.
- Garantir que as validações essenciais (resultados múltiplos, ausência de resultado, `is_active = false`) estejam dentro de `Ação`.
- Manter referência explícita ao snippet de lookup usado pelo fluxo: `supabase/snippets/e10_5_4_nicho_identificacao_taxon_lookup.sql`.

### Description

- Substitui integralmente o conteúdo de `docs/prompt-nicho-identificacao.md` pelo formato enxuto solicitado com as cinco seções obrigatórias.
- Movi a referência ao snippet para a seção `Ação` e instruí a execução do SQL no Supabase para colagem do resultado no chat.
- Incorporei as validações essenciais na seção `Ação`: apresentação dos taxons, confirmação humana, escolha em caso de múltiplos resultados, orientação quando não houver resultado e confirmação explícita quando `is_active = false`.
- Preservei o bloco final de saída exatamente no formato pedido para `Entrada confirmada para pesquisa profunda` e incluí instruções de `modo_de_execucao`.

### Testing

- Rodei `npm ci` com sucesso.
- Rodei `npm run check` com sucesso, retornando apenas warnings de lint existentes fora do escopo desta alteração.
- Não foram introduzidos erros de typechecking ao executar `tsc -p tsconfig.json --noEmit` durante a rotina de `check`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f743da09a083298442193d1a4a9a40)