### PR TITLE
docs: adicionar referências de briefing no AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,3 +8,9 @@ Rodar, nesta ordem:
 
 ## Observação
 - No sandbox do Codex, não incluir `npm run build` na rotina de `check`.
+
+## Referências de briefing
+
+- Para estruturar pedidos incompletos em padrão outcome-first, usar `docs/template-prompts.md`.
+- Para tarefas gerais do Codex, usar `docs/template-briefing-codex.md`.
+- Para tarefas com impacto visual/frontend, usar também `docs/template-briefing-codex-frontend.md`.


### PR DESCRIPTION
### Motivation

- Adicionar um bloco curto de referências de briefing em `AGENTS.md` para servir como índice operacional enxuto apontando para os templates relevantes sem transformar o arquivo em um playbook extenso.

### Description

- Inserido `## Referências de briefing` imediatamente após a observação existente em `AGENTS.md` com três bullets vinculando a `docs/template-prompts.md`, `docs/template-briefing-codex.md` e `docs/template-briefing-codex-frontend.md`, e nenhum outro arquivo foi alterado.

### Testing

- Executado `npm ci` e `npm run check`, onde `npm run check` concluiu com sucesso apresentando apenas warnings de lint preexistentes e sem erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b8efbb9c83298aeba2eebbebf7d2)