### PR TITLE
docs: adicionar observação de Prompt guidance no item 22

### DIFF
--- a/docs/auto-agentes-up.md
+++ b/docs/auto-agentes-up.md
@@ -434,3 +434,13 @@ Guia oficial da OpenAI sobre uso de GPT-5.5 como modelo de referência para tare
 2. Aplicar a diretriz outcome-first em planos base, briefings e prompts operacionais.
 3. Usar Responses API e Structured Outputs quando a IA gerar dados que serão persistidos ou usados por lógica de negócio.
 4. Priorizar IA dentro do produto apenas quando houver usuário, entrada, saída esperada, ganho prático e controle de risco definidos.
+
+### Observação futura — prompt guidance para automações
+
+- planos base e planos de implementação devem ser rastreáveis, com objetivo, fontes, arquivos/sistemas envolvidos, validações, comportamento de falha, riscos e dúvidas abertas;
+- prompts complexos devem seguir abordagem outcome-first, com menos processo repetido e mais resultado esperado, restrições, evidência e formato de saída;
+- agentes e automações devem validar o resultado antes de declarar pronto, usando testes, checks, logs, summaries ou evidência equivalente quando aplicável;
+- updates intermediários devem ser curtos, úteis e sem virar log operacional excessivo;
+- tools devem ser passadas como tools, com nomes e descrições claras, evitando simular ferramentas apenas por texto no prompt;
+- em agentes próprios com contexto longo, avaliar compaction apenas quando houver histórico extenso ou múltiplas etapas relevantes;
+- evitar instruções repetidas, contraditórias ou excessivamente processuais.


### PR DESCRIPTION
### Motivation
- Incluir uma observação curta no final do item `22 — GPT-5.5 / latest-model para automações e IA no produto` para referenciar pontos relevantes do guia oficial `Prompt guidance` sobre planos de implementação, prompts outcome-first, validação, preambles, compaction e uso de tools.

### Description
- Inserida a seção `### Observação futura — prompt guidance para automações` ao final do item 22 em `docs/auto-agentes-up.md`, com sete bullets cobrindo planos rastreáveis, abordagem outcome-first, validação antes de declarar pronto, updates intermediários enxutos, passagem de tools como ferramentas, avaliação de compaction em contextos longos e evitar instruções repetitivas/contraditórias; alteração estritamente documental e restrita a esse arquivo.

### Testing
- Executados `npm ci` e `npm run check`, ambos concluídos com sucesso; o `npm run check` retornou warnings de lint preexistentes mas sem erros bloqueantes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7c9077c888329acd7fc926c6fefc6)