### PR TITLE
docs: add 'Papel / função' section to prompt template

### DIFF
--- a/docs/template-prompts.md
+++ b/docs/template-prompts.md
@@ -4,11 +4,17 @@ A abordagem de prompts do LP Factory 10 é outcome-first: começar pelo resultad
 
 Fonte conceitual: https://developers.openai.com/api/docs/guides/prompt-guidance
 
-## 1. Objetivo
+## 1. Papel / função
+
+Defina, em 1 ou 2 frases, qual função o modelo deve assumir na tarefa.
+
+Exemplos: Estrategista de produto, Gestor de UX, Designer de Produto UI, Especialista Codex.
+
+## 2. Objetivo
 
 Descreva o resultado esperado.
 
-## 2. Fontes / contexto disponível
+## 3. Fontes / contexto disponível
 
 Informe quais fontes ou contexto devem ser usados:
 
@@ -19,15 +25,15 @@ Informe quais fontes ou contexto devem ser usados:
 - web
 - print
 
-## 3. Critérios de sucesso
+## 4. Critérios de sucesso
 
 Liste o que precisa estar verdadeiro para a resposta ser considerada boa.
 
-## 4. Limites
+## 5. Limites
 
 Declare o que não pode ser inferido, alterado, removido ou criado.
 
-## 5. Entrega esperada
+## 6. Entrega esperada
 
 Defina o formato final e o nível de detalhe:
 
@@ -39,14 +45,14 @@ Defina o formato final e o nível de detalhe:
 - checklist
 - decisão
 
-## 6. Regras de parada
+## 7. Regras de parada
 
 Informe quando parar, pedir fonte, declarar limite ou não prosseguir.
 
-## 7. Evidência / validação
+## 8. Evidência / validação
 
 Informe como a resposta deve demonstrar que usou as fontes corretas ou validou o resultado esperado.
 
-## 8. Regra de concisão
+## 9. Regra de concisão
 
 Evitar instruções repetidas, excesso de processo e detalhamento que não ajude na entrega final.


### PR DESCRIPTION
### Motivation
- Alinhar o template de prompts à estrutura sugerida pela OpenAI adicionando a seção de papel/função sem inflar o documento. 
- Permitir que o autor defina, de forma explícita e curta, qual função o modelo deve assumir antes de `Objetivo`.

### Description
- Adiciona em `docs/template-prompts.md` a seção `## 1. Papel / função` com orientação curta (1–2 frases) e exemplos breves de função do modelo. 
- Renumera as seções subsequentes (por exemplo, `Objetivo` → `## 2. Objetivo`, `Fontes / contexto disponível` → `## 3. Fontes / contexto disponível`, etc.).
- Não há outras mudanças de conteúdo ou reestruturação no template e nenhum outro arquivo foi alterado. 

### Testing
- Executei `npm ci` com sucesso. 
- Executei `npm run check` com sucesso; o processo mostrou apenas warnings de lint pré-existentes e sem erros bloqueantes. 
- Segui a rotina mínima definida em `AGENTS.md` e confirmei que somente `docs/template-prompts.md` foi modificado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7d0dc0c58832999d36340124a0a8f)