### PR TITLE
docs: ajustar fontes por research_block em prompt-nicho-pesquisa

### DIFF
--- a/docs/prompt-nicho-pesquisa.md
+++ b/docs/prompt-nicho-pesquisa.md
@@ -36,11 +36,7 @@ Use a entrada confirmada como fonte de verdade para:
 - Faça apenas pesquisa, sem SQL de carga.
 - Faça consolidação final somente com comando humano.
 
-## 5. Fontes de pesquisa
-
-Use web, SERP, páginas reais do nicho, concorrentes, avaliações públicas e fontes adequadas ao mercado brasileiro.
-
-## 6. strategic_core
+## 5. strategic_core
 
 
 Entregue uma tabela sobre o núcleo estratégico do taxon confirmado para o audience_scope recebido na entrada confirmada.
@@ -63,6 +59,11 @@ Atenção: em `priority`, número maior = maior força; em `sort_order`, número
 
 Para cada linha: `item_key` = um dos itens acima; `item_text` = achado específico e útil; `priority` = força do achado (`3` forte, `2` relevante, `1` secundário/condicional); `sort_order` = ordem de relevância dentro do mesmo `item_key` e reinicia em cada `item_key`; `notes` = contexto, nuance, limite ou cuidado; `evidência` = fonte, padrão observado ou inferência marcada.
 
-Use web, SERP, páginas reais do nicho, concorrentes e avaliações públicas do mercado brasileiro.
+Fontes específicas para `strategic_core`:
+- reviews públicas, como Google, Doctoralia e Reclame Aqui
+- comunidades, fóruns e perguntas reais do nicho
+- conteúdo de mercado, como páginas de clínicas, profissionais, prestadores ou infoprodutores
+- fontes oficiais ou regulatórias quando houver risco, segurança, regra profissional ou alegação técnica
+- inferência marcada em `evidência` quando não houver fonte direta
 
 Limites: não incluir dados locais de cliente, não escrever copy final, usar apenas o audience_scope recebido na entrada confirmada, não criar `item_key` fora da lista acima e não inventar quando faltar fonte.


### PR DESCRIPTION
### Motivation

- Remover a seção genérica de fontes e fazer com que cada `research_block` declare suas próprias fontes específicas para aumentar a aderência ao formato esperado. 
- Especificamente, ajustar as orientações do bloco `strategic_core` para fontes mais relevantes e operacionais. 

### Description

- Removi a seção `## 5. Fontes de pesquisa` de `docs/prompt-nicho-pesquisa.md` e renumerei `strategic_core` para `## 5. strategic_core`.
- Substituí a orientação genérica por uma lista de fontes específicas para `strategic_core`: reviews públicas (Google, Doctoralia, Reclame Aqui), comunidades/fóruns, conteúdo de mercado (páginas de clínicas/profissionais/prestadores/infoprodutores), fontes oficiais/regulatórias quando aplicável e inferência marcada em `evidência` quando não houver fonte direta.
- Mantive todos os limites e regras existentes do arquivo (não alterar `item_key`, coluna `evidência`, `priority`, `sort_order`, `notes`, `hidden_desire`, nem criar novos arquivos). 

### Testing

- Rodei `npm ci` com sucesso. 
- Rodei a rotina `npm run check`, que executa `eslint` e `tsc`, e concluiu sem erros; `eslint` reportou `32` warnings e o `tsc` passou sem erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8bbc458a88329a20447b99843d4c7)