### PR TITLE
docs: ajustar prompt-nicho-pesquisa com critérios de sucesso e travas de entrega

### DIFF
--- a/docs/prompt-nicho-pesquisa.md
+++ b/docs/prompt-nicho-pesquisa.md
@@ -4,11 +4,11 @@
 
 Pesquisar o taxon confirmado recebido no relatório-instrução de `docs/prompt-nicho-identificacao.md`, um `research_block` por vez.
 
-## Papel / função
+## 2. Papel / função
 
 Atuar como pesquisador de nicho orientado por execução em blocos, com saída estritamente no formato do `research_block` solicitado.
 
-## 2. Entrada obrigatória
+## 3. Entrada obrigatória
 
 Receba o relatório-instrução gerado por `docs/prompt-nicho-identificacao.md`.
 
@@ -24,7 +24,7 @@ Use a entrada confirmada como fonte de verdade para:
 - `audience_scope`
 - `research_blocks_order`
 
-## 3. Regras de execução
+## 4. Regras de execução
 
 - Pesquise apenas o próximo `research_block` da ordem definida.
 - Entregue o resultado desse bloco separadamente.
@@ -32,14 +32,14 @@ Use a entrada confirmada como fonte de verdade para:
 - Quando o humano mandar continuar, pesquise o próximo `research_block` pendente.
 - Quando todos os blocos forem pesquisados, informe que a pesquisa foi concluída e aguarde comando humano para consolidar.
 
-## 3.1 Critérios de sucesso
+## 4.1 Critérios de sucesso
 
 - Executar somente o próximo `research_block` pendente.
 - Seguir estritamente o formato definido para o `research_block` executado.
 - Não entregar overview de nicho, definição introdutória ou texto educativo fora do formato do `research_block`.
 - Encerrar a resposta imediatamente após a entrega do bloco.
 
-## 4. Limites
+## 5. Limites
 
 - Use a entrada confirmada como fonte de verdade.
 - Mantenha o `audience_scope` recebido.
@@ -48,7 +48,7 @@ Use a entrada confirmada como fonte de verdade para:
 - Faça consolidação final somente com comando humano.
 - Não entregar overview genérico do nicho, definição introdutória ou explicação educativa fora do formato do `research_block`.
 
-## 5. strategic_core
+## 6. strategic_core
 
 Entregue uma tabela sobre o núcleo estratégico do taxon confirmado para o audience_scope recebido na entrada confirmada.
 

--- a/docs/prompt-nicho-pesquisa.md
+++ b/docs/prompt-nicho-pesquisa.md
@@ -4,6 +4,10 @@
 
 Pesquisar o taxon confirmado recebido no relatório-instrução de `docs/prompt-nicho-identificacao.md`, um `research_block` por vez.
 
+## Papel / função
+
+Atuar como pesquisador de nicho orientado por execução em blocos, com saída estritamente no formato do `research_block` solicitado.
+
 ## 2. Entrada obrigatória
 
 Receba o relatório-instrução gerado por `docs/prompt-nicho-identificacao.md`.
@@ -28,6 +32,13 @@ Use a entrada confirmada como fonte de verdade para:
 - Quando o humano mandar continuar, pesquise o próximo `research_block` pendente.
 - Quando todos os blocos forem pesquisados, informe que a pesquisa foi concluída e aguarde comando humano para consolidar.
 
+## 3.1 Critérios de sucesso
+
+- Executar somente o próximo `research_block` pendente.
+- Seguir estritamente o formato definido para o `research_block` executado.
+- Não entregar overview de nicho, definição introdutória ou texto educativo fora do formato do `research_block`.
+- Encerrar a resposta imediatamente após a entrega do bloco.
+
 ## 4. Limites
 
 - Use a entrada confirmada como fonte de verdade.
@@ -35,9 +46,9 @@ Use a entrada confirmada como fonte de verdade para:
 - Mantenha a ordem dos `research_blocks`.
 - Faça apenas pesquisa, sem SQL de carga.
 - Faça consolidação final somente com comando humano.
+- Não entregar overview genérico do nicho, definição introdutória ou explicação educativa fora do formato do `research_block`.
 
 ## 5. strategic_core
-
 
 Entregue uma tabela sobre o núcleo estratégico do taxon confirmado para o audience_scope recebido na entrada confirmada.
 


### PR DESCRIPTION
### Motivation

- Clarificar o papel e reforçar execução por blocos para evitar entregas fora do formato `research_block` e garantir comportamento previsível de parada após cada bloco. 
- Incluir critérios explícitos de sucesso para evitar overviews/definições/explicações educativas fora do formato solicitado. 
- Fazer limpeza visual mínima em `strategic_core` sem alterar seu conteúdo nem remover `evidência`.

### Description

- Atualizado `docs/prompt-nicho-pesquisa.md` para adicionar a seção `## Papel / função` logo após o objetivo, definindo o papel como pesquisador orientado por blocos. 
- Inserida a seção `## 3.1 Critérios de sucesso` com os critérios: executar somente o próximo `research_block`, seguir estritamente o formato do bloco, não entregar overview/definição/texto educativo fora do formato e encerrar a resposta após a entrega do bloco. 
- Estendida a seção `## 4. Limites` para incluir a trava que proíbe overviews genéricos, definições introdutórias ou explicações educativas fora do formato do `research_block`. 
- Removida a linha vazia dupla abaixo de `## 5. strategic_core` como limpeza visual, preservando todo o conteúdo de `strategic_core` e a entrada `evidência`.

### Testing

- Executed `npm ci` successfully with no install errors. 
- Executed `npm run check` (which runs lint and `tsc`) and it completed with no errors; only pre-existing ESLint warnings were reported. 
- No new files were created and the repository typecheck/lint status remains without new failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8d0e527048329a302454c1ce723cb)