### PR TITLE
docs: add pre-edit branch gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,15 @@ Rodar, nesta ordem:
 
 - Nunca aplicar alterações diretamente na `main`.
 
+### Gate pré-edição no Codex App
+
+Antes de editar arquivos no workspace local, verificar a branch ativa.
+
+- Se estiver em `main`, parar imediatamente.
+- Não editar arquivos diretamente na working tree da `main`.
+- Usar o conector GitHub para criar uma branch de trabalho e aplicar as alterações.
+- Se o conector GitHub não estiver disponível, reportar bloqueio antes de editar.
+
 - Se o conector GitHub não estiver disponível ou falhar, parar e informar o bloqueio. Não tentar substituir por Git remoto local dentro do sandbox.
 
 - Comandos Git locais continuam permitidos quando úteis:

--- a/docs/template-briefing-codex.md
+++ b/docs/template-briefing-codex.md
@@ -13,6 +13,15 @@ Todo briefing deve ser outcome-first e informar, de forma objetiva:
 
 ## B) Regras por tipo de entrega
 
+### Checklist pré-edição
+
+Antes de editar arquivos no Codex App:
+
+- verificar a branch ativa;
+- se estiver em `main`, parar e não editar a working tree local;
+- usar o conector GitHub para criar branch de trabalho e aplicar alterações;
+- se o conector GitHub não estiver disponível, reportar bloqueio antes de editar.
+
 ### Código
 
 - seguir a rotina padrão de checks definida no `AGENTS.md`;


### PR DESCRIPTION
### Motivation

- Prevent the Codex App from editing the local working tree when the active branch is `main` by adding an explicit pre-edit gate. 
- Ensure briefings require a branch check so the connector GitHub flow is used for creating work branches before edits.

### Description

- Added a `Gate pré-edição no Codex App` section to `AGENTS.md` that requires verifying the active branch, stopping if on `main`, using the GitHub connector to create a work branch, and reporting a block if the connector is unavailable. 
- Added a `Checklist pré-edição` to `docs/template-briefing-codex.md` that instructs briefs to verify the branch and follow the same stop-and-use-connector rule. 
- Changes are limited to `AGENTS.md` and `docs/template-briefing-codex.md` (18 lines added) with no code, workflow, or package modifications.

### Testing

- Ran `npm ci`, which completed successfully and installed dependencies. 
- Ran `npm run check`, which finished with exit code 0; `eslint` reported 32 warnings and no errors and `tsc` completed without errors. 
- Verified with `git status`/`git diff --stat` that the active branch was `work` and only the two Markdown files were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fca2d7591c83298dab89229363049a)