### PR TITLE
docs: roadmap v1.5.46 — E10.4: registrar refinamento técnico (PR #226)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data: 29/04/2026
-• Versão: v1.5.45
+• Data: 07/05/2026
+• Versão: v1.5.46
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -449,6 +449,12 @@
 • UX Partner Dashboard
 
 10.4 Primeiros passos (pending_setup — status-based)
+
+• Refinamento técnico pós-PR #226: a mutação `pending_setup → active` passou a residir em `lib/access/adapters/accountAdapter.ts`; `app/a/[account]/actions.ts` permanece como orquestrador do fluxo.
+• ARTEFATOS_REPO:
+• Ajustados: `app/a/[account]/actions.ts`
+• Ajustados: `lib/access/adapters/accountAdapter.ts`
+• Checks/QA (reportado): Preview Vercel Ready e acessível; Validador Final passou; QA manual confirmou ativação `pending_setup → active`.
 
 • Arquitetura runtime atual: `app/a/[account]/page.tsx` atua como orquestrador da rota; o formulário `PendingSetupFirstSteps` reside em `app/a/[account]/_components/PendingSetupFirstSteps.tsx` como componente route-local.
 • ARTEFATOS_REPO:
@@ -965,6 +971,8 @@
 • Definir o primeiro recorte funcional do LP Builder no roadmap
 
 99. Changelog
+v1.5.46 (07/05/2026) — E10.4: registra refinamento técnico do PR #226, movendo a mutação `pending_setup → active` para `accountAdapter` e preservando a action como orquestradora do fluxo.
+
 v1.5.44 (27/04/2026) — Simplificada a seção 10.5.2 do roadmap, fundindo 10.5.2 e 10.5.2.1 no estado final único da base do BD do E10.5.
 
 v1.5.43 (26/04/2026) — 10.5.2.1: ajuste corretivo do Grupo C


### PR DESCRIPTION
### Motivation
- Atualizar o `docs/roadmap.md` para registrar a mudança de versão/data e documentar o refinamento técnico introduzido pelo PR #226 que altera onde a mutação `pending_setup → active` reside. 
- Manter o roadmap alinhado ao estado real do repositório e incluir um registro de changelog para auditoria histórica.

### Description
- Atualizado o cabeçalho em `docs/roadmap.md` para `• Data: 07/05/2026` e `• Versão: v1.5.46`. 
- Inserido em `10.4 Primeiros passos (pending_setup — status-based)` o texto que registra que a mutação `pending_setup → active` passou para `lib/access/adapters/accountAdapter.ts` e que `app/a/[account]/actions.ts` permanece como orquestrador. 
- Adicionada a entrada de changelog `v1.5.46 (07/05/2026)` descrevendo o refinamento técnico do PR #226. 
- Apenas o arquivo `docs/roadmap.md` foi alterado no PR.

### Testing
- `npm ci` foi executado e passou com sucesso. 
- `npm run check` foi executado e passou; o linter (`eslint`) reportou 33 warnings e 0 errors, e o `tsc` (typecheck) concluiu sem erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcda55d0408329a5d70bb66627cfe0)