### PR TITLE
docs: registrar proposta 3.5 "Resolver IA de Nicho no pending_setup"

### DIFF
--- a/docs/automacoes.md
+++ b/docs/automacoes.md
@@ -330,6 +330,35 @@ Workflow: `.github/workflows/automation-validador-final.yml`
 Runtime: `automations/validador-final/`
 Estado persistido: `automations/validador-final/state/test-account.json`
 
+3.5 Resolver IA de Nicho no pending_setup
+
+Objetivo:
+Interpretar o nicho bruto informado pelo lead no `pending_setup`, sugerir o taxon/slug correspondente com saída estruturada, acionar microdiálogo quando necessário e registrar fallback/revisão sem bloquear o fluxo.
+
+Status:
+Proposto
+
+Acesso:
+Produto LP Factory 10 — fluxo `pending_setup` / onboarding inicial.
+
+Como usar:
+A automação deve ser acionada quando o lead informar o nicho bruto do negócio e o sistema precisar resolver esse valor contra a taxonomia existente.
+
+Resposta esperada:
+Saída estruturada com sugestão de taxon/slug, nível de confiança, justificativa curta, indicação de necessidade de revisão e fallback seguro quando não houver confiança suficiente.
+
+Referências / dependências:
+`docs/auto-agentes-up.md` — GPT-5.5 / latest-model, Responses API e Structured Outputs.
+`docs/schema.md` — taxonomia, aliases, vínculo de conta com taxon e demais estruturas de DB aplicáveis.
+Lousa do Gestor de Automações — `7.6 Resolver IA de Nicho no pending_setup`.
+
+Observações:
+- não criar taxon automaticamente sem regra aprovada;
+- se a confiança for alta, o sistema pode sugerir ou vincular o taxon correspondente conforme regra futura;
+- se a confiança for média, pode haver microdiálogo de confirmação;
+- se a confiança for baixa, o fluxo deve salvar o valor bruto, usar fallback seguro e registrar revisão futura;
+- a automação não deve bloquear o avanço do lead.
+
 4. Aprendizados operacionais
 4.1 Princípios identificados
 Integração entre plataformas não garante utilidade real.


### PR DESCRIPTION
### Motivation
- Registrar no catálogo de automações operacionais um caso proposto para resolver semanticamente o campo `niche` em `pending_setup` e evitar fallbacks genéricos por correspondência exata.
- Documentar objetivo, status, acesso, modo de uso, saída esperada e dependências sem afirmar implementação existente, conforme limites do escopo fornecido.

### Description
- Inserida a seção `3.5 Resolver IA de Nicho no pending_setup` em `docs/automacoes.md` imediatamente após `3.4 Validador Final` e antes de `4. Aprendizados operacionais` com o texto solicitado (objetivo, status, acesso, como usar, resposta esperada, referências/dependências e observações).
- Referências registradas: `docs/auto-agentes-up.md`, `docs/schema.md` e a lousa do Gestor de Automações (`7.6 Resolver IA de Nicho no pending_setup`).
- A alteração é exclusivamente documental, não implementa código, não altera cabeçalho/versionamento/changelog e não renumera itens existentes.
- Somente o arquivo `docs/automacoes.md` foi modificado.

### Testing
- `npm ci` foi executado com sucesso (dependências instaladas); portanto a validação de instalação é aplicável e passou.
- `npm run check` foi executado com sucesso; o lint retornou 33 warnings e 0 errors, e o `tsc` typecheck concluiu com exit code 0.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce82133908329b23d12dce9c88829)