### PR TITLE
docs: add Supabase migrations automation catalog entries

### DIFF
--- a/docs/automations.md
+++ b/docs/automations.md
@@ -359,6 +359,68 @@ Observações:
 - se a confiança for baixa, o fluxo deve salvar o valor bruto, usar fallback seguro e registrar revisão futura;
 - a automação não deve bloquear o avanço do lead.
 
+3.6 Apply automático de migrations no Supabase
+
+Objetivo:
+Preparar o fluxo para que migrations versionadas no repositório possam ser aplicadas ao Supabase por automação, depois que o baseline oficial do banco estiver concluído e o histórico remoto estiver alinhado.
+
+Status:
+Proposto / bloqueado por baseline oficial
+
+Acesso:
+GitHub Actions / Supabase, após liberação controlada do fluxo.
+
+Como usar:
+O fluxo só deve ser usado depois que a fase baseline estiver concluída, o legado atual estiver fora do fluxo oficial e houver smoke manual com evidência em logs e Summary.
+
+Resposta esperada:
+Aplicação controlada de migrations versionadas no Supabase, com evidência clara de sucesso ou falha, sem depender de copiar e colar SQL manualmente no painel.
+
+Referências / dependências:
+`docs/lousa-automations3-6.md`
+`docs/lousa-automations3-6-1.md`
+`docs/base-tecnica.md`
+`docs/schema.md`
+`supabase/migrations/`
+
+Observações:
+- o banco remoto atual é a fonte de verdade para a transição;
+- o histórico atual em `supabase/migrations/` é tratado como legado técnico transitório;
+- o legado atual não deve ser considerado histórico oficial futuro;
+- o workflow de apply só pode ser liberado após baseline oficial, histórico remoto alinhado, legado fora do fluxo ativo e smoke manual concluído;
+- enquanto a baseline não estiver concluída, o apply automático permanece bloqueado como fluxo confiável.
+
+3.6.1 Baseline de migrations no Supabase
+
+Objetivo:
+Extrair o baseline real do banco remoto atual, transformá-lo no novo histórico oficial de migrations e preparar a retirada segura do legado atual de `supabase/migrations/`.
+
+Status:
+Proposto / pendente
+
+Acesso:
+Supabase CLI / ambiente externo do banco, com apoio do repositório para versionamento posterior do baseline oficial.
+
+Como usar:
+A fase baseline deve ser executada antes da liberação do workflow de apply automático. A extração e o alinhamento remoto dependem de ação externa controlada no Supabase CLI ou ambiente equivalente.
+
+Resposta esperada:
+Baseline oficial extraído do banco remoto atual, migration baseline tecnicamente aceita, histórico remoto alinhado ao baseline, legado retirado do fluxo oficial e workflow liberado apenas após smoke manual.
+
+Referências / dependências:
+`docs/lousa-automations3-6-1.md`
+`docs/lousa-automations3-6.md`
+`docs/schema.md`
+`supabase/migrations/`
+
+Observações:
+- o histórico remoto de migrations está ausente;
+- o conjunto atual de `supabase/migrations/` cobre apenas parte do banco;
+- o conjunto atual deve permanecer apenas como apoio transitório durante a fase baseline;
+- não fazer limpeza patch por patch no escuro;
+- a remoção do legado só deve acontecer depois de baseline oficial versionado, histórico remoto alinhado e transição segura concluída;
+- o workflow de apply está preparado, mas não liberado como fluxo confiável até a conclusão da baseline.
+
 4. Aprendizados operacionais
 4.1 Princípios identificados
 Integração entre plataformas não garante utilidade real.


### PR DESCRIPTION
### Motivation
- Registrar no catálogo operacional os casos `3.6 Apply automático de migrations no Supabase` e `3.6.1 Baseline de migrations no Supabase` para formalizar o estado, dependências e gates de liberação do fluxo de apply.
- Deixar claro que o workflow de apply está preparado mas permanece bloqueado até a extração/versionamento do baseline oficial e alinhamento do histórico remoto.
- Preservar o legado atual em `supabase/migrations/` como apoio transitório e documentar as condições necessárias para sua remoção segura.

### Description
- Inserida a seção `3.6 Apply automático de migrations no Supabase` em `docs/automations.md` com objetivo, status, acesso, como usar, resposta esperada, referências/dependências e observações, posicionada após `3.5` e antes de `4. Aprendizados operacionais`.
- Inserida a seção `3.6.1 Baseline de migrations no Supabase` em `docs/automations.md` com objetivo, status, acesso, como usar, resposta esperada, referências/dependências e observações, enfatizando que a extração/alinhamento do baseline é ação externa e pré-requisito para liberar o apply automático.
- As referências listadas apontam para `docs/lousa-automations3-6.md`, `docs/lousa-automations3-6-1.md`, `docs/schema.md`, `docs/base-tecnica.md` e `supabase/migrations/` e nenhum outro arquivo foi alterado.
- Não há renumeração de itens existentes nem alterações no cabeçalho, data, versão ou changelog, e o workflow não foi implementado nem tratado como liberado.

### Testing
- `npm ci` foi executado com sucesso. 
- `npm run check` foi executado e terminou com exit code 0, com lint reporting 33 warnings and 0 errors and `tsc` typecheck passing (no emit).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fde8fee5448329a6554ace44d10194)