### PR TITLE
docs: consolidate A3.6.1 baseline guidance

### DIFF
--- a/docs/automations.md
+++ b/docs/automations.md
@@ -362,64 +362,32 @@ Observações:
 3.6 Apply automático de migrations no Supabase
 
 Objetivo:
-Preparar o fluxo para que migrations versionadas no repositório possam ser aplicadas ao Supabase por automação, depois que o baseline oficial do banco estiver concluído e o histórico remoto estiver alinhado.
+Manter o apply automático como fluxo preparado, mas bloqueado até a conclusão da baseline oficial de migrations e do alinhamento remoto.
 
 Status:
 Proposto / bloqueado por baseline oficial
 
-Acesso:
-GitHub Actions / Supabase, após liberação controlada do fluxo.
-
-Como usar:
-O fluxo só deve ser usado depois que a fase baseline estiver concluída, o legado atual estiver fora do fluxo oficial e houver smoke manual com evidência em logs e Summary.
-
-Resposta esperada:
-Aplicação controlada de migrations versionadas no Supabase, com evidência clara de sucesso ou falha, sem depender de copiar e colar SQL manualmente no painel.
+Resumo de controle:
+O workflow de apply não deve ser tratado como liberado enquanto a baseline A3.6.1 estiver pendente. A orientação operacional detalhada fica centralizada nas lousas de referência, sem duplicação neste índice.
 
 Referências / dependências:
 `docs/lousa-automations3-6.md`
 `docs/lousa-automations3-6-1.md`
-`docs/base-tecnica.md`
-`docs/schema.md`
-`supabase/migrations/`
-
-Observações:
-- o banco remoto atual é a fonte de verdade para a transição;
-- o histórico atual em `supabase/migrations/` é tratado como legado técnico transitório;
-- o legado atual não deve ser considerado histórico oficial futuro;
-- o workflow de apply só pode ser liberado após baseline oficial, histórico remoto alinhado, legado fora do fluxo ativo e smoke manual concluído;
-- enquanto a baseline não estiver concluída, o apply automático permanece bloqueado como fluxo confiável.
 
 3.6.1 Baseline de migrations no Supabase
 
 Objetivo:
-Extrair o baseline real do banco remoto atual, transformá-lo no novo histórico oficial de migrations e preparar a retirada segura do legado atual de `supabase/migrations/`.
+Consolidar o baseline real do banco remoto atual como novo histórico oficial de migrations antes de liberar o apply automático.
 
 Status:
 Proposto / pendente
 
-Acesso:
-Supabase CLI / ambiente externo do banco, com apoio do repositório para versionamento posterior do baseline oficial.
-
-Como usar:
-A fase baseline deve ser executada antes da liberação do workflow de apply automático. A extração e o alinhamento remoto dependem de ação externa controlada no Supabase CLI ou ambiente equivalente.
-
-Resposta esperada:
-Baseline oficial extraído do banco remoto atual, migration baseline tecnicamente aceita, histórico remoto alinhado ao baseline, legado retirado do fluxo oficial e workflow liberado apenas após smoke manual.
+Resumo de controle:
+A lousa operacional principal da baseline é `docs/lousa-automations3-6-1.md`. O contexto de controle do apply automático permanece em `docs/lousa-automations3-6.md`.
 
 Referências / dependências:
-`docs/lousa-automations3-6-1.md`
 `docs/lousa-automations3-6.md`
-`docs/schema.md`
-`supabase/migrations/`
-
-Observações:
-- o histórico remoto de migrations está ausente;
-- o conjunto atual de `supabase/migrations/` cobre apenas parte do banco;
-- o conjunto atual deve permanecer apenas como apoio transitório durante a fase baseline;
-- não fazer limpeza patch por patch no escuro;
-- a remoção do legado só deve acontecer depois de baseline oficial versionado, histórico remoto alinhado e transição segura concluída;
-- o workflow de apply está preparado, mas não liberado como fluxo confiável até a conclusão da baseline.
+`docs/lousa-automations3-6-1.md`
 
 4. Aprendizados operacionais
 4.1 Princípios identificados

--- a/docs/lousa-automations3-6-1.md
+++ b/docs/lousa-automations3-6-1.md
@@ -100,14 +100,22 @@ A baseline só pode ser tratada como concluída quando os itens abaixo estiverem
 ## 9) Execução segura no repositório
 
 * O baseline real não deve ser improvisado no repositório.
-* `supabase/migrations/` continua como legado transitório até a extração externa devolver o baseline.
-* O workflow de apply não deve ser tratado como liberado antes da baseline oficial.
+* `supabase/migrations/` continua como legado transitório até a extração externa devolver o baseline bruto.
+* O workflow de apply não deve ser tratado como fluxo liberado antes da baseline oficial.
+* A liberação futura do workflow só pode acontecer depois de:
+
+  * baseline oficial versionado
+  * histórico remoto alinhado
+  * legado fora do fluxo ativo
+  * smoke manual autorizado
 
 ## 10) Leitura operacional do legado atual
 
-* Os arquivos legados atuais representam só parte do histórico.
-* Arquivos fora do padrão esperado do Supabase CLI devem ser tratados como apoio legado.
+* `0001__baseline_e7.sql` não deve ser tratado como baseline real do banco.
+* Os arquivos legados atuais em `supabase/migrations/` representam apenas parte do histórico do banco remoto.
+* Arquivos fora do padrão esperado do Supabase CLI devem ser tratados como apoio legado, não como histórico oficial novo.
 * A ausência de `supabase/config.toml` continua como observação operacional.
+* O destino técnico do legado é sair do fluxo ativo quando o baseline oficial entrar, permanecendo apenas como apoio transitório até a transição segura.
 
 ## 11) Ações externas necessárias
 

--- a/docs/lousa-automations3-6-1.md
+++ b/docs/lousa-automations3-6-1.md
@@ -96,3 +96,20 @@ A baseline só pode ser tratada como concluída quando os itens abaixo estiverem
 * legado removido do fluxo oficial: pendente
 * workflow de apply: preparado, mas não liberado como fluxo confiável
 * bloqueio central atual: baseline
+
+## 9) Execução segura no repositório
+
+* O baseline real não deve ser improvisado no repositório.
+* `supabase/migrations/` continua como legado transitório até a extração externa devolver o baseline.
+* O workflow de apply não deve ser tratado como liberado antes da baseline oficial.
+
+## 10) Leitura operacional do legado atual
+
+* Os arquivos legados atuais representam só parte do histórico.
+* Arquivos fora do padrão esperado do Supabase CLI devem ser tratados como apoio legado.
+* A ausência de `supabase/config.toml` continua como observação operacional.
+
+## 11) Ações externas necessárias
+
+* A extração do baseline e o alinhamento do histórico remoto dependem de execução externa.
+* Se for necessário detalhar o passo a passo externo, isso deve ser pedido em execução separada.


### PR DESCRIPTION
### Motivation
- Centralize the operational baseline for A3.6.1 so the repository no longer depends on an old feature branch for guidance. 
- Keep `docs/lousa-automations3-6-1.md` as the primary operational lousa and avoid duplicating the detailed plan in the main index. 
- Provide concise control-level references in `docs/automations.md` for items 3.6 and 3.6.1 that point to the lousas for the full operational procedure.

### Description
- Added three short sections to the end of `docs/lousa-automations3-6-1.md`: `## 9) Execução segura no repositório`, `## 10) Leitura operacional do legado atual`, and `## 11) Ações externas necessárias`, recording repo-safety, legacy interpretation, and external-action constraints. 
- Replaced the full text of items `3.6` and `3.6.1` in `docs/automations.md` with compact control summaries that explicitly reference `docs/lousa-automations3-6.md` and `docs/lousa-automations3-6-1.md`. 
- Did not modify `docs/lousa-automations3-6.md`, workflows, `docs/schema.md`, or create new files, per scope limits. 
- Changes are limited to `docs/lousa-automations3-6-1.md` and `docs/automations.md` only.

### Testing
- Executed `npm ci` which completed successfully and installed dependencies. 
- Executed `npm run check`; linting produced warnings (33 warnings, 0 errors) and `tsc` completed with no type errors, so the check step succeeded. 
- No additional automated tests were run because the change is documentation-only and the required validation commands passed as described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdfaf25c2c83299a6e1b76c50396c2)