### PR TITLE
Require niche during pending setup

### DIFF
--- a/app/a/[account]/_components/PendingSetupFirstSteps.tsx
+++ b/app/a/[account]/_components/PendingSetupFirstSteps.tsx
@@ -70,6 +70,7 @@ export function PendingSetupFirstSteps({
   }, [serverState]);
 
   const nameRef = useRef<HTMLInputElement | null>(null);
+  const nicheRef = useRef<HTMLInputElement | null>(null);
   const channelRef = useRef<HTMLSelectElement | null>(null);
   const whatsappRef = useRef<HTMLInputElement | null>(null);
   const siteRef = useRef<HTMLInputElement | null>(null);
@@ -107,7 +108,7 @@ export function PendingSetupFirstSteps({
     const clientErrors: any = { ...(validation.fieldErrors ?? {}) };
     const out: any = { ...serverErrors, ...clientErrors };
 
-    const keys = ["name", "preferred_channel", "whatsapp", "site_url"] as const;
+    const keys = ["name", "niche", "preferred_channel", "whatsapp", "site_url"] as const;
     for (const k of keys) {
       if (dirty[k] && !clientErrors[k]) {
         delete out[k];
@@ -118,7 +119,7 @@ export function PendingSetupFirstSteps({
   }, [serverState?.fieldErrors, validation.fieldErrors, dirty]);
 
   const isNameValidNow = !mergedFieldErrors?.name;
-  const canSubmitByName = isNameValidNow && !isPending;
+  const canSubmit = validation.ok && !isPending;
 
   const canRevealAfterName = isMobile && nameValidatedOnce && isNameValidNow;
   const shouldShowChannel = !isMobile || canRevealAfterName;
@@ -139,11 +140,12 @@ export function PendingSetupFirstSteps({
     return null;
   };
 
-  const focusFirstInvalid = () => {
-    if (mergedFieldErrors?.name) return nameRef.current?.focus();
-    if (mergedFieldErrors?.preferred_channel) return channelRef.current?.focus();
-    if (mergedFieldErrors?.whatsapp) return whatsappRef.current?.focus();
-    if (mergedFieldErrors?.site_url) return siteRef.current?.focus();
+  const focusFirstInvalid = (errors = mergedFieldErrors) => {
+    if (errors?.name) return nameRef.current?.focus();
+    if (errors?.niche) return nicheRef.current?.focus();
+    if (errors?.preferred_channel) return channelRef.current?.focus();
+    if (errors?.whatsapp) return whatsappRef.current?.focus();
+    if (errors?.site_url) return siteRef.current?.focus();
   };
 
   const onSubmit = (e: FormEvent<HTMLFormElement>) => {
@@ -160,7 +162,7 @@ export function PendingSetupFirstSteps({
 
     if (!v.ok) {
       e.preventDefault();
-      focusFirstInvalid();
+      focusFirstInvalid(v.fieldErrors);
     }
   };
 
@@ -221,20 +223,26 @@ export function PendingSetupFirstSteps({
           </FormField>
 
           <FormField>
-            <FormFieldLabel htmlFor="niche">Nicho (opcional)</FormFieldLabel>
+            <FormFieldLabel htmlFor="niche" required>Nicho</FormFieldLabel>
             <Input
               id="niche"
               name="niche"
+              ref={nicheRef}
               value={niche}
               onChange={(e) => {
                 setNiche(e.target.value);
+                setTouched((t) => ({ ...t, niche: true }));
                 setDirty((d) => ({ ...d, niche: true }));
               }}
+              onBlur={() => setTouched((t) => ({ ...t, niche: true }))}
               disabled={isPending}
               placeholder="Ex.: Harmonização facial"
               autoComplete="off"
               enterKeyHint={isMobile ? "next" : undefined}
             />
+            {showFieldError("niche") ? (
+              <FormFieldError>{showFieldError("niche")}</FormFieldError>
+            ) : null}
           </FormField>
 
           {shouldShowChannel ? (
@@ -322,7 +330,7 @@ export function PendingSetupFirstSteps({
             </FormField>
           ) : null}
 
-          <Button type="submit" disabled={!canSubmitByName}>
+          <Button type="submit" disabled={!canSubmit}>
             {isPending ? "Salvando…" : "Salvar e continuar"}
           </Button>
         </form>

--- a/app/a/[account]/actions.ts
+++ b/app/a/[account]/actions.ts
@@ -24,6 +24,7 @@ export type SetupSaveState = {
   ok: boolean;
   fieldErrors?: Partial<{
     name: string;
+    niche: string;
     preferred_channel: string;
     whatsapp: string;
     site_url: string;

--- a/lib/onboarding/e10_4_setup_validation.ts
+++ b/lib/onboarding/e10_4_setup_validation.ts
@@ -4,6 +4,7 @@ export type PreferredChannel = "email" | "whatsapp";
 
 export type SetupFieldErrors = Partial<{
   name: string;
+  niche: string;
   preferred_channel: string;
   whatsapp: string;
   site_url: string;
@@ -11,7 +12,7 @@ export type SetupFieldErrors = Partial<{
 
 export type SetupValidatedValues = {
   name: string;
-  niche: string | null;
+  niche: string;
   preferred_channel: PreferredChannel;
   whatsapp: string | null;
   site_url: string | null; // normalizado; inclui esquema quando presente
@@ -98,6 +99,12 @@ function nameErrorMessage(code: string): string {
   return "Informe um nome válido.";
 }
 
+function validateNicheForSetup(input: unknown): string {
+  const trimmed = normalizeText(input);
+  if (!trimmed) throw new Error("niche_required");
+  return trimmed;
+}
+
 function whatsappErrorMessage(code: string): string {
   return code === "whatsapp_required_when_channel"
     ? "WhatsApp é obrigatório quando o canal é WhatsApp."
@@ -138,6 +145,13 @@ export function validateE10_4SetupForm(args: {
     fieldErrors.name = nameErrorMessage(code);
   }
 
+  let niche = normalizeText(args.niche);
+  try {
+    niche = validateNicheForSetup(args.niche);
+  } catch {
+    fieldErrors.niche = "Informe o nicho do projeto.";
+  }
+
   let whatsapp: string | null = normalizeText(args.whatsapp) || null;
   try {
     whatsapp = validateWhatsappIfNeeded(preferred, args.whatsapp);
@@ -153,10 +167,9 @@ export function validateE10_4SetupForm(args: {
     fieldErrors.site_url = siteUrlErrorMessage();
   }
 
-  const niche = normalizeText(args.niche) || null;
-
   const ok =
     !fieldErrors.name &&
+    !fieldErrors.niche &&
     !fieldErrors.preferred_channel &&
     !fieldErrors.whatsapp &&
     !fieldErrors.site_url;


### PR DESCRIPTION
### Motivation
- Tornar o campo `niche` obrigatório no fluxo de `pending_setup` para impedir que o usuário avance sem informar o nicho do projeto. 
- Garantir validação consistente em dois níveis: client-side e server-side (server action) usando o validador compartilhado.

### Description
- Atualiza o validador em `lib/onboarding/e10_4_setup_validation.ts` para incluir `niche` em `SetupFieldErrors`, tornar `niche` um `string` validado, adicionar `validateNicheForSetup` que usa `normalizeText` e preencher `fieldErrors.niche` com a mensagem exata `Informe o nicho do projeto.` quando vazio; `niche` também entra no cálculo de `ok` e é retornado em `values`.
- Ajusta o componente em `app/a/[account]/_components/PendingSetupFirstSteps.tsx` para adicionar `nicheRef`, marcar o `FormFieldLabel` como `required`, marcar `niche` como `touched`/`dirty`, exibir `FormFieldError` quando aplicável, incluir `niche` nas chaves de limpeza (`mergedFieldErrors`) e alterar o fluxo de submissão para bloquear o envio quando `validateE10_4SetupForm` retornar erro de `niche` (submit agora usa `validation.ok` para habilitar o botão e foca o primeiro campo inválido incluindo `niche`).
- Atualiza a tipagem de `SetupSaveState['fieldErrors']` em `app/a/[account]/actions.ts` para aceitar `niche`, permitindo que a server action retorne o novo erro tipado sem alterar sua lógica de persistência.

### Testing
- `npm ci`: executado com sucesso (instalação concluída).
- `npm run check`: executado com sucesso; o script passou (ESLint emitiu avisos existentes, mas não houve erros e o `tsc` não reportou problemas).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe07c2539883299b2d193987a95e1e)