### PR TITLE
docs: ajusta 3.1.3 e adiciona 3.1.3.1 (formato SQL Supabase Inspect)

### DIFF
--- a/docs/prompt-executor.md
+++ b/docs/prompt-executor.md
@@ -20,7 +20,21 @@ Status: em desenvolvimento nesta lousa.Referência no repositório: docs/prompt-
 
 3.1.3 Investigação BD
 
-• Em caso de BD, investigar apenas se os docs canônicos não forem suficientes.• Em criação de estrutura nova, investigar apenas o entorno do BD, se necessário.• Em ajuste estrutural do BD, investigar as estruturas a serem ajustadas e o entorno necessário.• A investigação de BD deve ser feita por meio da entrega de SQLs de inspeção para execução pelo Gestor.• Os SQLs de inspeção devem ser read-only, usar apenas SELECT ou WITH, ter LIMIT obrigatório, ser separados por --- e ter até 20 queries por execução.• Analisar os outputs retornados pelo Gestor.• Só deve bloquear a execução quando houver conflito concreto, drift relevante ou dependência não resolvida.
+• Em caso de BD, investigar apenas se os docs canônicos não forem suficientes.
+• Em criação de estrutura nova, investigar apenas o entorno do BD, se necessário.
+• Em ajuste estrutural do BD, investigar as estruturas a serem ajustadas e o entorno necessário.
+• A investigação de BD deve ser feita por meio da entrega de SQLs de inspeção para execução pelo Gestor.
+• Os SQLs de inspeção devem seguir o formato obrigatório definido em 3.1.3.1.
+• Só deve bloquear a execução quando houver conflito concreto, drift relevante ou dependência não resolvida.
+
+3.1.3.1 Formato dos SQLs para Supabase Inspect
+
+• Entregar bloco pronto para colar no input `briefing` do workflow.
+• Usar apenas SELECT ou WITH read-only.
+• Cada query deve ter LIMIT obrigatório de até 50.
+• Não usar ponto e vírgula (`;`) ao final das queries.
+• Separar queries com `---`, preferencialmente em linha própria.
+• Usar no máximo 20 queries por execução.
 
 3.2 Etapa 2 — Plano de implementação
 


### PR DESCRIPTION
### Motivation
- Tornar explícito quando e como investigar bancos de dados no fluxo do executor, evitando investigações desnecessárias.
- Padronizar o formato dos SQLs de inspeção usados no workflow `Supabase Inspect` para garantir consultas read-only e segura execução pelo Gestor.

### Description
- Substitui o conteúdo da seção `3.1.3 Investigação BD` em `docs/prompt-executor.md` para referenciar o formato obrigatório de SQLs e clarificar quando investigar e quando bloquear a execução.
- Adiciona a nova seção `3.1.3.1 Formato dos SQLs para Supabase Inspect` com as regras: bloco pronto para colar no `briefing`, apenas `SELECT` ou `WITH` read-only, `LIMIT` obrigatório (até 50), sem `;` no final, queries separadas por `---` e máximo de 20 queries por execução.
- Arquivo modificado: `docs/prompt-executor.md`.

### Testing
- `npm ci`: executado com sucesso (dependências instaladas).
- `npm run check`: executado com sucesso; o pipeline terminou com sucesso, o `eslint` reportou 33 warnings (0 errors) e o `tsc` não retornou erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe3f1e9d0083299de1a631616a74e5)