### PR TITLE
docs: register deterministic taxonomy matching

### DIFF
--- a/docs/base-tecnica.md
+++ b/docs/base-tecnica.md
@@ -2,8 +2,8 @@
 
 0.1. Cabeçalho
 • Documento: Base Técnica LP Factory 10
-• Versão: v2.0.29
-• Data: 29/04/2026
+• Versão: v2.0.30
+• Data: 09/05/2026
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -291,6 +291,13 @@
 • Enums: proibido fallback silencioso.
 • Gate adapters: pode retornar null, mas logs devem diferenciar deny vs error.
 
+3.14.1 Matching de taxonomia via adapter server-side
+• Regra: consumo de matching determinístico de taxonomia deve ocorrer somente via camada server/adapter do app.
+• Regra: não chamar RPC de matching diretamente do client/UI.
+• Regra: adapter deve retornar DTO final com candidatos oficiais; UI não normaliza nem interpreta rows crus do banco.
+• Regra: não logar nicho bruto, `p_query`, aliases digitados ou valores de formulário.
+• Regra: quando criado, o adapter deve nascer em path canônico de domínio, preferencialmente `lib/onboarding/niche-resolution/`, salvo decisão explícita diferente baseada no repositório real.
+
 4. DB Contract - Fonte única: PATH: docs/schema.md
 • Este documento não lista mais tabelas/views/functions/triggers/policies; isso está em PATH: docs/schema.md.
 • Trigger Hub é regra do contrato de DB (governança/auditoria). Fonte única e detalhes: PATH: docs/schema.md (seções 3.5 e 4.1).
@@ -366,6 +373,7 @@
 • Server Actions críticas devem emitir logs estruturados (JSON) com request_id e latency_ms (padrão mínimo).
 • Regra (logs sem PII): não logar valores de formulário (ex.: name, whatsapp, site_url).
 • Onboarding pós-save (E10.4.6): revalidatePath(route) antes do redirect para evitar UI stale.
+• Matching de taxonomia: quando a RPC determinística for consumida em runtime, observability mínima deve registrar apenas metadados não sensíveis, como request_id, latency_ms, candidates_count, top_match_source e top_score; não logar nicho bruto, `p_query`, aliases digitados ou valores identificáveis do usuário.
 
 5.3.5 Signup
 • Entrada: /auth/sign-up (SignUpForm usa supabase.auth.signUp) (PATH: components/sign-up-form.tsx).
@@ -434,6 +442,11 @@ Fonte normativa da allowlist SULB para exceções de Auth. Qualquer novo arquivo
 • Tipos canônicos e adapters vNext: validar por 3.6 e 3.14.
 
 99. Changelog
+v2.0.30 (09/05/2026) — E10.5.6: regras técnicas para consumo runtime do matching de taxonomia
+• Registrada regra de consumo server-side via adapter para matching determinístico de taxonomia.
+• Registrada restrição contra consumo direto pelo client/UI.
+• Registrada observability mínima sem PII para futura integração runtime da RPC de matching.
+
 v2.0.29 (29/04/2026) — Registra convenção route-local para componentes específicos de rota que dependem da própria boundary da rota.
 v2.0.28 (18/04/2026) — E12.5.1: primeira superfície ativa do Admin + retorno administrativo no login
 • Atualizada 5.2.2 para registrar a seção Admin ativa no runtime via `app/admin/layout.tsx`, protegida por guard SSR administrativo reaproveitando `requirePlatformAdmin()`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data: 08/05/2026
-• Versão: v1.5.47
+• Data: 09/05/2026
+• Versão: v1.5.48
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -725,6 +725,27 @@
 • E10.5.3
 • E10.5.6
 
+10.5.6 Classificação da conta e resolução do template
+• Status: Parcialmente concluído (BD determinístico inicial) (09/05/2026)
+• Escopo implementado: camada determinística inicial de matching de taxonomia para resolver texto livre de nicho contra taxons oficiais.
+• Implementado:
+• `pg_trgm` habilitado no schema `extensions`.
+• Função `public.normalize_taxon_match_text(text)` criada para normalização textual.
+• RPC read-only `public.match_business_taxons_deterministic(text, integer)` criada para retornar candidatos oficiais com `taxon_id`, `name`, `slug`, `level`, `parent_id`, `parent_name`, `matched_aliases`, `match_source` e `score`.
+• Índices criados para match exato/normalizado, FTS e trigram em `business_taxons` e `business_taxon_aliases`.
+• Estratégia determinística coberta: `alias_exact`, `alias_normalized`, `taxon_name_exact`, `taxon_name_normalized`, `taxon_slug_normalized`, `fts`, `trgm`.
+• Segurança: funções sem `SECURITY DEFINER`; grants restritos a `service_role`; consumo previsto via camada server/adapter, sem consumo direto pelo client nesta etapa.
+• ARTEFATOS_REPO:
+• Criado: `supabase/migrations/0009__e10_5_6_deterministic_taxon_matching.sql`
+• Criado: `supabase/rollbacks/20260509__e10_5_6_deterministic_taxon_matching.rollback.sql`
+• Validação: SQL aplicado no Supabase; `pg_trgm`, 8 índices e 2 funções confirmados; testes de nome exato, nome normalizado, alias, trigram, FTS e input vazio aprovados.
+• Fora do escopo mantido: IA, fallback final, `account_taxonomy`, `account_niche_resolutions`, microdiálogo, escolha de template e alteração no onboarding.
+• Pendências:
+• Criar adapter server-side para consumir a RPC.
+• Integrar a resolução determinística ao fluxo pós-save do `pending_setup`.
+• Definir regra de confiança mínima e etapa posterior de resolvedor IA/fallback.
+• Definir persistência futura em `account_taxonomy`.
+
 
 11. E11 — Gestão de Usuários e Convites
 
@@ -980,6 +1001,8 @@
 • Definir o primeiro recorte funcional do LP Builder no roadmap
 
 99. Changelog
+v1.5.48 — 09/05/2026 — E10.5.6: registrado matching determinístico inicial de taxonomia, com `pg_trgm`, normalização textual, FTS, trigram, RPC read-only, migration/rollback e validação funcional no Supabase.
+
 v1.5.47 (08/05/2026) — E10.4: registrado `niche` obrigatório no `pending_setup`, com artefatos ajustados, validação client/server e QA funcional aprovado.
 
 v1.5.46 (07/05/2026) — E10.4: registra refinamento técnico do PR #226, movendo a mutação `pending_setup → active` para `accountAdapter` e preservando a action como orquestradora do fluxo.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data da última atualização: 26/04/2026
-• Documento: LP Factory 10 — Schema (DB Contract) v1.0.13
+• Data da última atualização: 09/05/2026
+• Documento: LP Factory 10 — Schema (DB Contract) v1.0.14
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -146,6 +146,13 @@
 • business_taxons_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
 • business_taxons_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
 
+1.10.5 Índices
+• business_taxons_name_normalized_idx (btree em normalize_taxon_match_text(name))
+• business_taxons_slug_normalized_idx (btree em normalize_taxon_match_text(replace(slug, '-', ' ')))
+• business_taxons_name_slug_fts_gin_idx (GIN em to_tsvector('portuguese', normalize_taxon_match_text(name) + slug normalizado))
+• business_taxons_name_normalized_trgm_gin_idx (GIN trigram em normalize_taxon_match_text(name))
+• business_taxons_slug_normalized_trgm_gin_idx (GIN trigram em slug normalizado)
+
 1.11 business_taxon_aliases
 
 1.11.1 Chaves, constraints e relacionamentos
@@ -169,6 +176,11 @@
 • business_taxon_aliases_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
 • business_taxon_aliases_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
 • business_taxon_aliases_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
+
+1.11.5 Índices
+• business_taxon_aliases_alias_text_normalized_idx (btree em alias_text_normalized)
+• business_taxon_aliases_alias_text_normalized_fts_gin_idx (GIN em to_tsvector('portuguese', alias_text_normalized))
+• business_taxon_aliases_alias_text_normalized_trgm_gin_idx (GIN trigram em alias_text_normalized)
 
 1.12 account_taxonomy
 
@@ -460,6 +472,25 @@
 • fn_event_bus_publish(table text, kind text, payload jsonb)
 • jsonb_diff_val(old jsonb, new jsonb) → jsonb
 
+
+3.6 Matching determinístico de taxonomia
+3.6.1 normalize_taxon_match_text(input text) → text
+• Segurança: invoker; SECURITY DEFINER = false
+• search_path: public, extensions
+• Volatilidade: immutable
+• Grants: EXECUTE somente para service_role
+• Efeito: normaliza texto para matching determinístico com lower, remoção de acentos, compactação de espaços e trim
+
+3.6.2 match_business_taxons_deterministic(p_query text, p_limit integer default 10) → table
+• Segurança: invoker; SECURITY DEFINER = false
+• search_path: public, extensions
+• Volatilidade: stable
+• Grants: EXECUTE somente para service_role
+• Retorno: taxon_id, name, slug, level, parent_id, parent_name, matched_aliases, match_source, score
+• Estratégias cobertas: alias_exact, alias_normalized, taxon_name_exact, taxon_name_normalized, taxon_slug_normalized, fts, trgm
+• Consumidor previsto: camada server/adapter do app; sem consumo direto pelo client nesta etapa
+• Fora do escopo: writes, IA, fallback final, account_taxonomy, account_niche_resolutions e escolha de template
+
 4. Triggers 
 
 4.1 Trigger Hub (governança)
@@ -487,7 +518,21 @@
 • MemberRole: owner | admin | editor | viewer
 • Nota: accounts.status não aceita trial (CHECK accounts_status_chk). No estado atual, views não contêm trial e o runtime/tipos (PATH) não incluem trial (drift resolvido).
 
+
+6. Extensões
+6.1 pg_trgm
+• Schema: extensions
+• Uso atual: suporte a índices e scoring trigram no matching determinístico de taxonomia
+• Migration de origem: supabase/migrations/0009__e10_5_6_deterministic_taxon_matching.sql
+• Rollback: não remove automaticamente a extensão, pois pode ser reutilizada por outros recursos
+
 99. Changelog
+v1.0.14 (09/05/2026) — E10.5.6: matching determinístico inicial de taxonomia
+• Registrada a extensão `pg_trgm` no schema `extensions`.
+• Registrados índices auxiliares em `business_taxons` e `business_taxon_aliases` para normalização, FTS e trigram.
+• Registradas as funções `normalize_taxon_match_text(text)` e `match_business_taxons_deterministic(text, integer)`, com SECURITY DEFINER=false e grants restritos a `service_role`.
+• Registrado o contrato de retorno da RPC com candidatos oficiais, `match_source` e `score`.
+
 v1.0.13 (26/04/2026) — E10.5.2.1: ajuste corretivo de audience_scope no Grupo C
 • taxon_market_research: adicionado audience_scope no registro-pai; registrada unicidade por (taxon_id, research_block, audience_scope, version) e índice único parcial para no máximo 1 versão active por (taxon_id, research_block, audience_scope).
 • taxon_market_research_items: removido audience_scope; itens passam a herdar o público pelo research_id.


### PR DESCRIPTION
### Motivation
- Document the initial deterministic taxonomy matching implementation and its validation artifacts so the roadmap reflects the DB work completed for E10.5.6. 
- Record DB-level contract changes (indexes, functions/RPC signature, extension) in the schema reference to avoid drift between migrations and docs. 
- Add runtime rules and observability guidance to the technical base to mandate server-side adapter consumption and PII-safe logging for the new RPC. 

### Description
- Updated `docs/roadmap.md` to `v1.5.48` (09/05/2026) and added section `10.5.6 Classificação da conta e resolução do template` documenting the deterministic matching status, artifacts (`supabase/migrations/0009__e10_5_6_deterministic_taxon_matching.sql` and `supabase/rollbacks/20260509__e10_5_6_deterministic_taxon_matching.rollback.sql`), validation results and pending follow-ups. 
- Updated `docs/schema.md` to `v1.0.14` (09/05/2026) adding `1.10.5` and `1.11.5` index descriptions, a `3.6` section describing `normalize_taxon_match_text` and `match_business_taxons_deterministic` (contract, security, volatility, grants, return columns and covered strategies), `6.1 pg_trgm` extension notes, and the changelog entry. 
- Updated `docs/base-tecnica.md` to `v2.0.30` (09/05/2026) adding `3.14.1 Matching de taxonomia via adapter server-side` rules enforcing server/adapter consumption (no direct client RPC calls), DTO/adapter placement guidance, and an observability guideline to log only non-sensitive metadata for RPC consumption. 
- Committed the three updated docs in a single change with commit message `docs: register deterministic taxonomy matching` and prepared a PR with the same title and a summary of changes. 

### Testing
- `npm ci` was executed successfully in the workspace and completed (packages installed). 
- `npm run check` was executed and completed successfully (lint reported warnings but no errors, and `tsc --noEmit` passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffb3849ce88329aa6b7ceaebf8760d)