### PR TITLE
Add deterministic taxon match adapter

### DIFF
--- a/lib/onboarding/niche-resolution/adapters/taxonMatchAdapter.ts
+++ b/lib/onboarding/niche-resolution/adapters/taxonMatchAdapter.ts
@@ -1,0 +1,90 @@
+import "server-only";
+
+import { createServiceClient } from "@/lib/supabase/service";
+import type {
+  TaxonLevel,
+  TaxonMatchCandidate,
+} from "../contracts";
+
+type TaxonMatchRpcRow = {
+  taxon_id: string;
+  name: string;
+  slug: string;
+  level: string;
+  parent_id: string | null;
+  parent_name: string | null;
+  matched_aliases: string[] | null;
+  match_source: string;
+  score: number | string | null;
+};
+
+const TAXON_LEVELS = new Set<TaxonLevel>(["segment", "niche", "ultra_niche"]);
+
+function normalizeLimit(limit: number): number {
+  const finiteLimit = Number.isFinite(limit) ? limit : 10;
+  return Math.min(50, Math.max(1, Math.floor(finiteLimit)));
+}
+
+function normalizeTaxonLevel(level: string): TaxonLevel | null {
+  return TAXON_LEVELS.has(level as TaxonLevel) ? (level as TaxonLevel) : null;
+}
+
+function mapTaxonMatchRpcRow(
+  row: TaxonMatchRpcRow
+): TaxonMatchCandidate | null {
+  const level = normalizeTaxonLevel(row.level);
+
+  if (!level) return null;
+
+  const score = Number(row.score ?? 0);
+
+  return {
+    taxonId: row.taxon_id,
+    name: row.name,
+    slug: row.slug,
+    level,
+    parentId: row.parent_id,
+    parentName: row.parent_name,
+    matchedAliases: Array.isArray(row.matched_aliases) ? row.matched_aliases : [],
+    matchSource: row.match_source,
+    score: Number.isFinite(score) ? score : 0,
+  };
+}
+
+export async function matchBusinessTaxonsDeterministic(
+  query: string,
+  limit = 10
+): Promise<TaxonMatchCandidate[]> {
+  const normalizedQuery = query.trim();
+
+  if (!normalizedQuery) return [];
+
+  const safeLimit = normalizeLimit(limit);
+  const supabase = createServiceClient();
+
+  try {
+    const { data, error } = await supabase.rpc("match_business_taxons_deterministic", {
+      p_query: normalizedQuery,
+      p_limit: safeLimit,
+    });
+
+    if (error) {
+      console.error("matchBusinessTaxonsDeterministic failed:", {
+        code: error?.code,
+        message: error?.message,
+      });
+      return [];
+    }
+
+    const rows = (Array.isArray(data) ? data : []) as TaxonMatchRpcRow[];
+    return rows
+      .map(mapTaxonMatchRpcRow)
+      .filter((candidate): candidate is TaxonMatchCandidate => candidate !== null);
+  } catch (error) {
+    console.error("matchBusinessTaxonsDeterministic failed:", {
+      code: error instanceof Error ? error.name : undefined,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return [];
+  }
+}

--- a/lib/onboarding/niche-resolution/contracts.ts
+++ b/lib/onboarding/niche-resolution/contracts.ts
@@ -1,0 +1,13 @@
+export type TaxonLevel = "segment" | "niche" | "ultra_niche";
+
+export type TaxonMatchCandidate = {
+  taxonId: string;
+  name: string;
+  slug: string;
+  level: TaxonLevel;
+  parentId: string | null;
+  parentName: string | null;
+  matchedAliases: string[];
+  matchSource: string;
+  score: number;
+};


### PR DESCRIPTION
### Motivation
- Provide a server-side adapter to consume the `match_business_taxons_deterministic` RPC and return typed, camelCase taxon candidates for the onboarding niche resolver.
- Enforce server-only usage and security/observability rules from the technical docs (no logging of raw user input, use service client). 

### Description
- Added `lib/onboarding/niche-resolution/contracts.ts` with `TaxonLevel` and `TaxonMatchCandidate` types in camelCase for downstream use.
- Added server-only adapter `lib/onboarding/niche-resolution/adapters/taxonMatchAdapter.ts` that implements `matchBusinessTaxonsDeterministic(query: string, limit = 10): Promise<TaxonMatchCandidate[]>` using `createServiceClient()`.
- Adapter behavior: trims `query`, returns `[]` for empty input without calling the RPC, clamps `limit` safely to `1..50`, calls `supabase.rpc('match_business_taxons_deterministic', { p_query, p_limit })`, maps snake_case RPC rows to camelCase DTOs, accepts only `segment | niche | ultra_niche` levels (rows with unexpected levels are discarded), and on RPC/error returns `[]` while logging only safe technical metadata (`code`, `message`).
- No existing files were altered outside the new module tree.

### Testing
- Executed `npm ci`: succeeded (packages installed).
- Executed `npm run check`: succeeded (both `eslint` and `tsc` ran and `tsc` passed); ESLint reported warnings only (no errors).
- No runtime call to the Supabase RPC was performed in the sandbox, so integration with the live RPC was not validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffba4b860083299aecdbb6610fb63e)