### PR TITLE
docs: register deterministic taxon adapter

### DIFF
--- a/docs/base-tecnica.md
+++ b/docs/base-tecnica.md
@@ -296,7 +296,8 @@
 • Regra: não chamar RPC de matching diretamente do client/UI.
 • Regra: adapter deve retornar DTO final com candidatos oficiais; UI não normaliza nem interpreta rows crus do banco.
 • Regra: não logar nicho bruto, `p_query`, aliases digitados ou valores de formulário.
-• Regra: quando criado, o adapter deve nascer em path canônico de domínio, preferencialmente `lib/onboarding/niche-resolution/`, salvo decisão explícita diferente baseada no repositório real.
+• Adapter canônico: PATH: `lib/onboarding/niche-resolution/adapters/taxonMatchAdapter.ts`.
+• Contrato público: PATH: `lib/onboarding/niche-resolution/contracts.ts`.
 
 4. DB Contract - Fonte única: PATH: docs/schema.md
 • Este documento não lista mais tabelas/views/functions/triggers/policies; isso está em PATH: docs/schema.md.
@@ -328,6 +329,7 @@
 5.2 Adapters, Guards, Providers
 
 5.2.1 Adapters
+• taxonMatchAdapter (PATH: lib/onboarding/niche-resolution/adapters/taxonMatchAdapter.ts): consumo server-side da RPC `match_business_taxons_deterministic`, com retorno DTO camelCase de candidatos oficiais de taxonomia e tratamento seguro de erro sem PII.
 • accountAdapter (PATH: lib/access/adapters/accountAdapter.ts): operações de conta e status no runtime, com normalização de status e mutações idempotentes quando aplicável.
 • accountProfileAdapter (PATH: lib/access/adapters/accountProfileAdapter.ts): persistência/atualização do perfil operacional da conta (E10.4.6).
 • accessContextAdapter (PATH: lib/access/adapters/accessContextAdapter.ts): leitura do contexto em v_access_context_v2, decisão de acesso (allow/deny), fallback de primeira conta via RPC quando não há membership e observabilidade de deny vs error.
@@ -442,6 +444,11 @@ Fonte normativa da allowlist SULB para exceções de Auth. Qualquer novo arquivo
 • Tipos canônicos e adapters vNext: validar por 3.6 e 3.14.
 
 99. Changelog
+v2.0.31 (09/05/2026) — E10.5.6: adapter server-side do matching determinístico de taxonomia
+• Registrado o path canônico do adapter `taxonMatchAdapter`.
+• Registrado o contrato público `TaxonMatchCandidate`.
+• Registrada a regra de consumo server-side da RPC de matching, com DTO camelCase e erro sem PII.
+
 v2.0.30 (09/05/2026) — E10.5.6: regras técnicas para consumo runtime do matching de taxonomia
 • Registrada regra de consumo server-side via adapter para matching determinístico de taxonomia.
 • Registrada restrição contra consumo direto pelo client/UI.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -726,25 +726,29 @@
 • E10.5.6
 
 10.5.6 Classificação da conta e resolução do template
-• Status: Parcialmente concluído (BD determinístico inicial) (09/05/2026)
-• Escopo implementado: camada determinística inicial de matching de taxonomia para resolver texto livre de nicho contra taxons oficiais.
+• Status: Parcialmente concluído (BD determinístico inicial + adapter server-side) (09/05/2026)
+• Escopo implementado: camada determinística inicial de matching de taxonomia para resolver texto livre de nicho contra taxons oficiais, com adapter server-side tipado para consumo futuro pelo resolvedor de nicho.
 • Implementado:
 • `pg_trgm` habilitado no schema `extensions`.
 • Função `public.normalize_taxon_match_text(text)` criada para normalização textual.
 • RPC read-only `public.match_business_taxons_deterministic(text, integer)` criada para retornar candidatos oficiais com `taxon_id`, `name`, `slug`, `level`, `parent_id`, `parent_name`, `matched_aliases`, `match_source` e `score`.
 • Índices criados para match exato/normalizado, FTS e trigram em `business_taxons` e `business_taxon_aliases`.
+• Adapter server-side `matchBusinessTaxonsDeterministic(query, limit)` criado para consumir a RPC via `createServiceClient()`.
+• Contrato TypeScript criado para retorno em camelCase com `taxonId`, `name`, `slug`, `level`, `parentId`, `parentName`, `matchedAliases`, `matchSource` e `score`.
 • Estratégia determinística coberta: `alias_exact`, `alias_normalized`, `taxon_name_exact`, `taxon_name_normalized`, `taxon_slug_normalized`, `fts`, `trgm`.
 • Segurança: funções sem `SECURITY DEFINER`; grants restritos a `service_role`; consumo previsto via camada server/adapter, sem consumo direto pelo client nesta etapa.
 • ARTEFATOS_REPO:
 • Criado: `supabase/migrations/0009__e10_5_6_deterministic_taxon_matching.sql`
 • Criado: `supabase/rollbacks/20260509__e10_5_6_deterministic_taxon_matching.rollback.sql`
-• Validação: SQL aplicado no Supabase; `pg_trgm`, 8 índices e 2 funções confirmados; testes de nome exato, nome normalizado, alias, trigram, FTS e input vazio aprovados.
+• Criado: `lib/onboarding/niche-resolution/contracts.ts`
+• Criado: `lib/onboarding/niche-resolution/adapters/taxonMatchAdapter.ts`
+• Validação: SQL aplicado no Supabase; `pg_trgm`, 8 índices e 2 funções confirmados; testes de nome exato, nome normalizado, alias, trigram, FTS e input vazio aprovados; `npm ci` e `npm run check` aprovados na criação do adapter.
 • Fora do escopo mantido: IA, fallback final, `account_taxonomy`, `account_niche_resolutions`, microdiálogo, escolha de template e alteração no onboarding.
 • Pendências:
-• Criar adapter server-side para consumir a RPC.
 • Integrar a resolução determinística ao fluxo pós-save do `pending_setup`.
 • Definir regra de confiança mínima e etapa posterior de resolvedor IA/fallback.
 • Definir persistência futura em `account_taxonomy`.
+• Executar teste runtime contra a RPC real quando o adapter for integrado ao fluxo.
 
 
 11. E11 — Gestão de Usuários e Convites
@@ -1001,6 +1005,8 @@
 • Definir o primeiro recorte funcional do LP Builder no roadmap
 
 99. Changelog
+v1.5.49 — 09/05/2026 — E10.5.6: registrado adapter server-side `matchBusinessTaxonsDeterministic` e contrato TypeScript para consumo futuro da RPC de matching determinístico de taxonomia.
+
 v1.5.48 — 09/05/2026 — E10.5.6: registrado matching determinístico inicial de taxonomia, com `pg_trgm`, normalização textual, FTS, trigram, RPC read-only, migration/rollback e validação funcional no Supabase.
 
 v1.5.47 (08/05/2026) — E10.4: registrado `niche` obrigatório no `pending_setup`, com artefatos ajustados, validação client/server e QA funcional aprovado.


### PR DESCRIPTION
### Motivation

- Document the creation of a server-side adapter and TypeScript contract for the deterministic taxon matching work (E10.5.6) and record the change in both roadmap and technical baseline. 
- Make the canonical path and public contract explicit so future implementations follow the repository conventions for adapters and DTOs.

### Description

- Updated `docs/roadmap.md` section 10.5.6 to mark the status as "BD determinístico inicial + adapter server-side", to list the adapter `matchBusinessTaxonsDeterministic(query, limit)` and the TypeScript contract, and to add the `v1.5.49` changelog entry. 
- Updated `docs/base-tecnica.md` section 3.14.1 to register the canonical adapter path `lib/onboarding/niche-resolution/adapters/taxonMatchAdapter.ts` and the public contract path `lib/onboarding/niche-resolution/contracts.ts`, added `taxonMatchAdapter` to the adapters list, and added the `v2.0.31` changelog entry. 
- The doc text records repository artefacts and validation status (including the migration/rollback SQL and claims about adapter/contract creation) for future integration work. 

### Testing

- `npm ci` was executed and completed successfully. 
- `npm run check` was executed and completed successfully with no errors and 33 lint warnings. 
- `git diff --check` was run and reported no whitespace/conflict errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffc1fe2f888329b8fda217bccaa102)