### PR TITLE
Add deterministic taxon confidence helper

### DIFF
--- a/lib/onboarding/niche-resolution/contracts.ts
+++ b/lib/onboarding/niche-resolution/contracts.ts
@@ -11,3 +11,29 @@ export type TaxonMatchCandidate = {
   matchSource: string;
   score: number;
 };
+
+export type DeterministicMatchConfidence = "high" | "medium" | "low";
+
+export type AiEscalationMode =
+  | "none"
+  | "rerank_candidates"
+  | "infer_existing_segment"
+  | "suggest_alias_for_review"
+  | "suggest_new_taxon_for_review";
+
+export type DeterministicMatchReason =
+  | "no_candidates"
+  | "high_confidence_strong_match"
+  | "medium_confidence_close_candidates"
+  | "medium_confidence_weak_match_source"
+  | "low_confidence_insufficient_score";
+
+export type DeterministicMatchDecision = {
+  confidence: DeterministicMatchConfidence;
+  selectedCandidate: TaxonMatchCandidate | null;
+  shouldUseDeterministicMatch: boolean;
+  shouldEscalateToAi: boolean;
+  aiEscalationMode: AiEscalationMode;
+  needsAdminReview: boolean;
+  reason: DeterministicMatchReason;
+};

--- a/lib/onboarding/niche-resolution/contracts.ts
+++ b/lib/onboarding/niche-resolution/contracts.ts
@@ -25,6 +25,7 @@ export type DeterministicMatchReason =
   | "no_candidates"
   | "high_confidence_strong_match"
   | "medium_confidence_close_candidates"
+  | "medium_confidence_below_high_threshold"
   | "medium_confidence_weak_match_source"
   | "low_confidence_insufficient_score";
 

--- a/lib/onboarding/niche-resolution/deterministicConfidence.ts
+++ b/lib/onboarding/niche-resolution/deterministicConfidence.ts
@@ -71,10 +71,9 @@ export function evaluateDeterministicTaxonMatch(
     };
   }
 
-  if (
-    best.score >= HIGH_CONFIDENCE_SCORE &&
-    hasStrongMatchSource(best.matchSource)
-  ) {
+  const strongMatchSource = hasStrongMatchSource(best.matchSource);
+
+  if (best.score >= HIGH_CONFIDENCE_SCORE && strongMatchSource) {
     return {
       confidence: "high",
       selectedCandidate: best,
@@ -83,6 +82,18 @@ export function evaluateDeterministicTaxonMatch(
       aiEscalationMode: "none",
       needsAdminReview: false,
       reason: "high_confidence_strong_match",
+    };
+  }
+
+  if (strongMatchSource) {
+    return {
+      confidence: "medium",
+      selectedCandidate: best,
+      shouldUseDeterministicMatch: false,
+      shouldEscalateToAi: true,
+      aiEscalationMode: "rerank_candidates",
+      needsAdminReview: true,
+      reason: "medium_confidence_below_high_threshold",
     };
   }
 

--- a/lib/onboarding/niche-resolution/deterministicConfidence.ts
+++ b/lib/onboarding/niche-resolution/deterministicConfidence.ts
@@ -1,0 +1,98 @@
+import type {
+  DeterministicMatchDecision,
+  TaxonMatchCandidate,
+} from "./contracts";
+
+const HIGH_CONFIDENCE_SCORE = 0.92;
+const MIN_RELEVANT_SCORE = 0.7;
+const CLOSE_CANDIDATE_DELTA = 0.05;
+
+const STRONG_MATCH_SOURCES = new Set([
+  "alias_exact",
+  "alias_normalized",
+  "taxon_name_exact",
+  "taxon_name_normalized",
+  "taxon_slug_normalized",
+]);
+
+function hasStrongMatchSource(matchSource: string): boolean {
+  return matchSource
+    .split("+")
+    .some((source) => STRONG_MATCH_SOURCES.has(source.trim()));
+}
+
+function hasCloseSecondCandidate(
+  best: TaxonMatchCandidate,
+  second: TaxonMatchCandidate | undefined
+): boolean {
+  return second !== undefined && best.score - second.score <= CLOSE_CANDIDATE_DELTA;
+}
+
+export function evaluateDeterministicTaxonMatch(
+  candidates: TaxonMatchCandidate[]
+): DeterministicMatchDecision {
+  if (candidates.length === 0) {
+    return {
+      confidence: "low",
+      selectedCandidate: null,
+      shouldUseDeterministicMatch: false,
+      shouldEscalateToAi: true,
+      aiEscalationMode: "suggest_new_taxon_for_review",
+      needsAdminReview: true,
+      reason: "no_candidates",
+    };
+  }
+
+  const [best, second] = [...candidates].sort((a, b) => b.score - a.score);
+
+  if (best.score < MIN_RELEVANT_SCORE) {
+    return {
+      confidence: "low",
+      selectedCandidate: best,
+      shouldUseDeterministicMatch: false,
+      shouldEscalateToAi: true,
+      aiEscalationMode: "rerank_candidates",
+      needsAdminReview: true,
+      reason: "low_confidence_insufficient_score",
+    };
+  }
+
+  const closeSecondCandidate = hasCloseSecondCandidate(best, second);
+
+  if (closeSecondCandidate) {
+    return {
+      confidence: "medium",
+      selectedCandidate: best,
+      shouldUseDeterministicMatch: false,
+      shouldEscalateToAi: true,
+      aiEscalationMode: "rerank_candidates",
+      needsAdminReview: true,
+      reason: "medium_confidence_close_candidates",
+    };
+  }
+
+  if (
+    best.score >= HIGH_CONFIDENCE_SCORE &&
+    hasStrongMatchSource(best.matchSource)
+  ) {
+    return {
+      confidence: "high",
+      selectedCandidate: best,
+      shouldUseDeterministicMatch: true,
+      shouldEscalateToAi: false,
+      aiEscalationMode: "none",
+      needsAdminReview: false,
+      reason: "high_confidence_strong_match",
+    };
+  }
+
+  return {
+    confidence: "medium",
+    selectedCandidate: best,
+    shouldUseDeterministicMatch: false,
+    shouldEscalateToAi: true,
+    aiEscalationMode: "rerank_candidates",
+    needsAdminReview: true,
+    reason: "medium_confidence_weak_match_source",
+  };
+}


### PR DESCRIPTION
### Motivation

- Implement a pure helper to evaluate taxon match candidates and produce a deterministic, typed decision that drives whether to use a deterministic match or escalate to AI/human review.
- Expose a stable decision payload and new contract types so downstream code can rely on a single, deterministic rule set without external calls or side effects.

### Description

- Add `lib/onboarding/niche-resolution/deterministicConfidence.ts` with `evaluateDeterministicTaxonMatch(candidates)` implementing the decision rules (empty list, weak scores, close second candidate, weak match sources, and high-confidence strong-source match) and parsing `matchSource` composed with `+`.
- Add constants `HIGH_CONFIDENCE_SCORE = 0.92`, `MIN_RELEVANT_SCORE = 0.7`, `CLOSE_CANDIDATE_DELTA = 0.05` and a `STRONG_MATCH_SOURCES` set used by the helper.
- Extend `lib/onboarding/niche-resolution/contracts.ts` with typed exports `DeterministicMatchConfidence`, `AiEscalationMode`, `DeterministicMatchReason` and `DeterministicMatchDecision` (includes `confidence`, `selectedCandidate`, `shouldUseDeterministicMatch`, `shouldEscalateToAi`, `aiEscalationMode`, `needsAdminReview`, `reason`).
- Implementation is pure: it does not call Supabase, does not log, does not mutate the input array, and returns a stable typed decision.

### Testing

- `npm ci` — executed successfully without errors.
- `npm run check` — executed successfully (lint + typecheck), with lint reporting `33` warnings and `0` errors and `tsc` completing with no type errors, and the warnings are preexisting outside the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffcd4e97a0832985c97c9229bd6c4d)