### PR TITLE
Harden Supabase Inspect SQL batch errors

### DIFF
--- a/automations/supabase-inspect/README.md
+++ b/automations/supabase-inspect/README.md
@@ -95,10 +95,26 @@ SELECT ... LIMIT 10 --- SELECT ... LIMIT 10
 
 - máximo de 20 queries
 
+No modo SQL batch, o pipeline pré-valida todas as queries antes de executar. Se qualquer query falhar nos guardrails, o batch inteiro é bloqueado e nenhuma query é executada. Se todas passarem nos guardrails, erros runtime SQL de uma query são registrados no relatório e não impedem a execução das próximas queries.
+
+**Taxonomia de erros**
+
+- Guardrail errors: bloqueiam o pipeline e retornam exit 1.
+- Runtime SQL errors: são registrados por query, não interrompem o batch e retornam exit 0 com status `completed_with_query_errors`.
+- Infra errors: bloqueiam o pipeline e retornam exit 1.
+
+**Status do batch**
+
+- `completed`: todas as queries válidas executaram sem erro runtime SQL.
+- `completed_with_query_errors`: uma ou mais queries válidas falharam em runtime SQL, mas o batch continuou até o fim.
+
 No Job Summary, o modo batch inclui:
 
 - lista das queries executadas
-- output por query com `rowCount`, `columns` e sample de `rows` (truncado)
+- status individual por query (`ok` ou `error`)
+- se `ok`: output por query com `rowCount`, `columns` e sample de `rows` (truncado)
+- se `error`: mensagem, SQLSTATE e campos úteis disponíveis do erro
+- resumo final com totais, sucessos, erros runtime, guardrail errors e status do batch
 
 Exemplo de output no Job Summary (1 query):
 
@@ -113,7 +129,7 @@ SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' L
 - columns: table_name
 
 ```json
-{ "rowCount": 2, "columns": ["table_name"], "rows": [{ "table_name": "accounts" }, { "table_name": "profiles" }] }
+{ "status": "ok", "queryNumber": 1, "rowCount": 2, "columns": ["table_name"], "rows": [{ "table_name": "accounts" }, { "table_name": "profiles" }] }
 ```
 ````
 

--- a/automations/supabase-inspect/run.mjs
+++ b/automations/supabase-inspect/run.mjs
@@ -155,6 +155,7 @@ function serializeQueryError(err) {
     severity: err?.severity ?? null,
     position: err?.position ?? null,
     routine: err?.routine ?? null,
+    where: err?.where ?? null,
     detail: err?.detail ?? null,
     hint: err?.hint ?? null,
     schema: err?.schema ?? null,

--- a/automations/supabase-inspect/run.mjs
+++ b/automations/supabase-inspect/run.mjs
@@ -148,6 +148,62 @@ function writeSummary(md) {
   }
 }
 
+function serializeQueryError(err) {
+  return {
+    message: err?.message || String(err),
+    code: err?.code ?? null,
+    severity: err?.severity ?? null,
+    position: err?.position ?? null,
+    routine: err?.routine ?? null,
+    detail: err?.detail ?? null,
+    hint: err?.hint ?? null,
+    schema: err?.schema ?? null,
+    table: err?.table ?? null,
+    column: err?.column ?? null,
+    dataType: err?.dataType ?? null,
+    constraint: err?.constraint ?? null,
+  };
+}
+
+function isRuntimeSqlError(err) {
+  const code = err?.code;
+  if (typeof code !== "string" || !/^[0-9A-Z]{5}$/.test(code)) {
+    return false;
+  }
+
+  // Classes de erro do PostgreSQL ligadas a conexão/recursos/sistema são tratadas como infraestrutura.
+  const infraClasses = ["08", "53", "57", "58"];
+  return !infraClasses.includes(code.slice(0, 2));
+}
+
+function writeBatchOkSummary({ queryNumber, safeSql, payload, summaryOutputLimit }) {
+  let summaryJson = JSON.stringify(payload, null, 2);
+  summaryJson = trunc(summaryJson, summaryOutputLimit);
+
+  writeSummary(`\n### Query ${queryNumber} — ok\n`);
+  writeSummary(`\`\`\`sql\n${safeSql}\n\`\`\`\n`);
+  writeSummary(`**Output (truncado)**\n`);
+  writeSummary(`- status: ok`);
+  writeSummary(`- rowCount: ${payload.rowCount}`);
+  writeSummary(`- columns: ${payload.columns.join(", ") || "(sem colunas)"}\n`);
+  writeSummary(`\`\`\`json\n${summaryJson}\n\`\`\`\n`);
+}
+
+function writeBatchErrorSummary({ queryNumber, safeSql, payload, summaryOutputLimit }) {
+  let summaryJson = JSON.stringify(payload, null, 2);
+  summaryJson = trunc(summaryJson, summaryOutputLimit);
+
+  writeSummary(`\n### Query ${queryNumber} — error\n`);
+  writeSummary(`\`\`\`sql\n${safeSql}\n\`\`\`\n`);
+  writeSummary(`**Erro runtime SQL**\n`);
+  writeSummary(`- status: error`);
+  writeSummary(`- message: ${payload.error.message}`);
+  writeSummary(`- code: ${payload.error.code || "(sem SQLSTATE)"}`);
+  writeSummary(`- severity: ${payload.error.severity || "(sem severity)"}`);
+  writeSummary(`- routine: ${payload.error.routine || "(sem routine)"}\n`);
+  writeSummary(`\`\`\`json\n${summaryJson}\n\`\`\`\n`);
+}
+
 function loadBriefing() {
   const inline = (process.env.BRIEFING || "").trim();
   const path = (process.env.BRIEFING_PATH || "").trim();
@@ -189,43 +245,108 @@ async function executeSqlBatch(db, briefing) {
     throw new Error(`SQL batch excede max_queries (${MAX_QUERIES}).`);
   }
 
-  let queryCount = 0;
-  const executed = [];
+  const safeQueries = [];
+  const guardrailErrors = [];
 
-  for (const raw of queries) {
-    const safeSql = enforceGuard(raw);
-
-    queryCount += 1;
-
-    console.log(`\n--- QUERY ${queryCount} ---`);
-    console.log(safeSql);
-
-    const res = await db.query(safeSql);
-
-    const rows = summarizeRows(res.rows || []);
-
-    const payload = {
-      rowCount: res.rowCount ?? rows.length,
-      columns: (res.fields || []).map((f) => f.name),
-      rows,
-    };
-
-    let summaryJson = JSON.stringify(payload, null, 2);
-    summaryJson = trunc(summaryJson, summaryOutputLimit);
-
-    writeSummary(`\n### Query ${queryCount}\n`);
-    writeSummary(`\`\`\`sql\n${safeSql}\n\`\`\`\n`);
-    writeSummary(`**Output (truncado)**\n`);
-    writeSummary(`- rowCount: ${payload.rowCount}`);
-    writeSummary(`- columns: ${payload.columns.join(", ") || "(sem colunas)"}\n`);
-    writeSummary(`\`\`\`json\n${summaryJson}\n\`\`\`\n`);
-
-    console.log(`Rows (sample <= ${MAX_ROWS}): ${rows.length}`);
-
-    executed.push({ sql: safeSql, result: payload });
+  for (let i = 0; i < queries.length; i++) {
+    try {
+      safeQueries.push(enforceGuard(queries[i]));
+    } catch (err) {
+      guardrailErrors.push({
+        queryNumber: i + 1,
+        error: err?.message || String(err),
+      });
+    }
   }
 
-  return executed;
+  if (guardrailErrors.length) {
+    writeSummary(`
+## Execução (SQL batch)
+`);
+    writeSummary(`Guardrail errors: ${guardrailErrors.length}
+`);
+    for (const item of guardrailErrors) {
+      writeSummary(`- Query ${item.queryNumber}: ${item.error}`);
+    }
+    throw new Error(
+      `SQL batch bloqueado por guardrail em ${guardrailErrors.length} query(s). Nenhuma query foi executada.`,
+    );
+  }
+
+  const results = [];
+
+  writeSummary(`
+## Execução (SQL batch)
+`);
+
+  for (let i = 0; i < safeQueries.length; i++) {
+    const queryNumber = i + 1;
+    const safeSql = safeQueries[i];
+
+    console.log(`\n--- QUERY ${queryNumber} ---`);
+    console.log(safeSql);
+
+    try {
+      const res = await db.query(safeSql);
+      const rows = summarizeRows(res.rows || []);
+      const payload = {
+        status: "ok",
+        queryNumber,
+        rowCount: res.rowCount ?? rows.length,
+        columns: (res.fields || []).map((f) => f.name),
+        rows,
+      };
+
+      writeBatchOkSummary({ queryNumber, safeSql, payload, summaryOutputLimit });
+
+      console.log(`Status: ok`);
+      console.log(`Rows (sample <= ${MAX_ROWS}): ${rows.length}`);
+      console.log(trunc(JSON.stringify(payload), 2000));
+
+      results.push({ sql: safeSql, ...payload });
+    } catch (err) {
+      if (!isRuntimeSqlError(err)) {
+        throw err;
+      }
+
+      const payload = {
+        status: "error",
+        queryNumber,
+        error: serializeQueryError(err),
+      };
+
+      writeBatchErrorSummary({ queryNumber, safeSql, payload, summaryOutputLimit });
+
+      console.error(`Status: error`);
+      console.error(payload.error.message);
+      console.error(trunc(JSON.stringify(payload), 2000));
+
+      results.push({ sql: safeSql, ...payload });
+    }
+  }
+
+  const successCount = results.filter((item) => item.status === "ok").length;
+  const runtimeErrorCount = results.filter((item) => item.status === "error").length;
+  const status = runtimeErrorCount ? "completed_with_query_errors" : "completed";
+
+  writeSummary(`
+## Resumo do batch
+
+`);
+  writeSummary(`Queries totais: ${safeQueries.length}`);
+  writeSummary(`Sucesso: ${successCount}`);
+  writeSummary(`Erros runtime: ${runtimeErrorCount}`);
+  writeSummary(`Guardrail errors: 0`);
+  writeSummary(`Status: ${status}\n`);
+
+  return {
+    status,
+    totalQueries: safeQueries.length,
+    successCount,
+    runtimeErrorCount,
+    guardrailErrorCount: 0,
+    results,
+  };
 }
 
 async function main() {
@@ -258,169 +379,175 @@ async function main() {
     connectionString: dbUrl,
     ssl: { rejectUnauthorized: false }, // piloto
   });
+  let dbConnected = false;
 
-  await db.connect();
+  try {
+    await db.connect();
+    dbConnected = true;
 
-  if (batchMode) {
-    console.log("Modo SQL batch detectado.");
+    if (batchMode) {
+      console.log("Modo SQL batch detectado.");
 
-    const executed = await executeSqlBatch(db, briefing);
+      const batchResult = await executeSqlBatch(db, briefing);
 
-    writeSummary(`
-## Execução (SQL batch)
-`);
-    writeSummary(`Queries executadas: ${executed.length}\n`);
+      console.log("\n=== RESUMO DO BATCH ===");
+      console.log(`Queries totais: ${batchResult.totalQueries}`);
+      console.log(`Sucesso: ${batchResult.successCount}`);
+      console.log(`Erros runtime: ${batchResult.runtimeErrorCount}`);
+      console.log(`Guardrail errors: ${batchResult.guardrailErrorCount}`);
+      console.log(`Status: ${batchResult.status}`);
 
-    await db.end();
-    process.exit(0);
-  }
-
-  let queryCount = 0;
-  const executed = [];
-
-  async function runSqlReadonly({ sql }) {
-    if (queryCount >= MAX_QUERIES) {
-      throw new Error(`max_queries atingido (${MAX_QUERIES}).`);
+      return;
     }
 
-    const safeSql = enforceGuard(sql);
+    let queryCount = 0;
+    const executed = [];
 
-    queryCount += 1;
-    console.log(`\n--- QUERY ${queryCount} ---`);
-    console.log(safeSql);
+    async function runSqlReadonly({ sql }) {
+      if (queryCount >= MAX_QUERIES) {
+        throw new Error(`max_queries atingido (${MAX_QUERIES}).`);
+      }
 
-    const res = await db.query(safeSql);
-    const rows = summarizeRows(res.rows || []);
-    const payload = {
-      rowCount: res.rowCount ?? rows.length,
-      columns: (res.fields || []).map((f) => f.name),
-      rows,
-    };
+      const safeSql = enforceGuard(sql);
 
-    let out = JSON.stringify(payload);
-    out = trunc(out, MAX_QUERY_OUTPUT_CHARS);
+      queryCount += 1;
+      console.log(`\n--- QUERY ${queryCount} ---`);
+      console.log(safeSql);
 
-    console.log(`Rows (sample <= ${MAX_ROWS}): ${rows.length}`);
-    console.log(trunc(out, 2000));
+      const res = await db.query(safeSql);
+      const rows = summarizeRows(res.rows || []);
+      const payload = {
+        rowCount: res.rowCount ?? rows.length,
+        columns: (res.fields || []).map((f) => f.name),
+        rows,
+      };
 
-    executed.push({ sql: safeSql, result: payload });
-    return out;
-  }
+      let out = JSON.stringify(payload);
+      out = trunc(out, MAX_QUERY_OUTPUT_CHARS);
 
-  const tools = [
-    {
-      type: "function",
-      name: "run_sql_readonly",
-      description:
-        "Executa uma query SQL read-only (apenas WITH/SELECT com LIMIT obrigatório). Retorna JSON com colunas e amostras truncadas.",
-      parameters: {
-        type: "object",
-        properties: {
-          sql: { type: "string", description: "SQL (WITH/SELECT) com LIMIT <= 50." },
+      console.log(`Rows (sample <= ${MAX_ROWS}): ${rows.length}`);
+      console.log(trunc(out, 2000));
+
+      executed.push({ sql: safeSql, result: payload });
+      return out;
+    }
+
+    const tools = [
+      {
+        type: "function",
+        name: "run_sql_readonly",
+        description:
+          "Executa uma query SQL read-only (apenas WITH/SELECT com LIMIT obrigatório). Retorna JSON com colunas e amostras truncadas.",
+        parameters: {
+          type: "object",
+          properties: {
+            sql: { type: "string", description: "SQL (WITH/SELECT) com LIMIT <= 50." },
+          },
+          required: ["sql"],
+          additionalProperties: false,
         },
-        required: ["sql"],
-        additionalProperties: false,
+        strict: true,
       },
-      strict: true,
-    },
-  ];
+    ];
 
-  // Prompt inicial (regras + briefing)
-  let input = [
-    {
-      role: "user",
-      content: [
-        "Você é um inspetor read-only do banco (Supabase Postgres).",
-        "",
-        "REGRAS OBRIGATÓRIAS:",
-        "- Você só pode chamar a ferramenta run_sql_readonly.",
-        "- Gere apenas SQL WITH/SELECT.",
-        "- LIMIT é obrigatório (<= 50).",
-        "- Nunca use ; (single statement).",
-        "- Evite scans pesados; comece por discovery (information_schema) quando necessário.",
-        "- O escopo do piloto é schema public (pode usar information_schema/pg_catalog para discovery).",
-        "",
-        "ROTEIRO INTERNO (sempre):",
-        "1) O que preciso saber? (checklist curto)",
-        "2) Quais tabelas/entidades suspeitas?",
-        "3) Discovery de schema se necessário",
-        "4) Queries nas tabelas reais",
-        "5) Encerrar com achados, riscos e próximos passos (sem mudanças)",
-        "",
-        `BRIEFING:\n${briefing}`,
-      ].join("\n"),
-    },
-  ];
+    // Prompt inicial (regras + briefing)
+    let input = [
+      {
+        role: "user",
+        content: [
+          "Você é um inspetor read-only do banco (Supabase Postgres).",
+          "",
+          "REGRAS OBRIGATÓRIAS:",
+          "- Você só pode chamar a ferramenta run_sql_readonly.",
+          "- Gere apenas SQL WITH/SELECT.",
+          "- LIMIT é obrigatório (<= 50).",
+          "- Nunca use ; (single statement).",
+          "- Evite scans pesados; comece por discovery (information_schema) quando necessário.",
+          "- O escopo do piloto é schema public (pode usar information_schema/pg_catalog para discovery).",
+          "",
+          "ROTEIRO INTERNO (sempre):",
+          "1) O que preciso saber? (checklist curto)",
+          "2) Quais tabelas/entidades suspeitas?",
+          "3) Discovery de schema se necessário",
+          "4) Queries nas tabelas reais",
+          "5) Encerrar com achados, riscos e próximos passos (sem mudanças)",
+          "",
+          `BRIEFING:\n${briefing}`,
+        ].join("\n"),
+      },
+    ];
 
-  let response = await callResponsesApi({
-    apiKey: openaiKey,
-    model,
-    tools,
-    input,
-  });
-
-  // Loop de tool-calling
-  while (true) {
-    const calls = (response.output || []).filter((it) => it.type === "function_call" && it.name === "run_sql_readonly");
-
-    // sempre anexar output no input para manter estado
-    input.push(...(response.output || []));
-
-    if (!calls.length) break;
-    if (queryCount >= MAX_QUERIES) break;
-
-    for (const call of calls) {
-      if (queryCount >= MAX_QUERIES) break;
-
-      let args = call.arguments;
-      if (typeof args === "string") {
-        try {
-          args = JSON.parse(args);
-        } catch {
-          args = { sql: String(args) };
-        }
-      }
-
-      let toolOut;
-      try {
-        toolOut = await runSqlReadonly(args);
-      } catch (e) {
-        toolOut = JSON.stringify({ error: e?.message || String(e) });
-      }
-
-      input.push({
-        type: "function_call_output",
-        call_id: call.call_id,
-        output: toolOut,
-      });
-    }
-
-    response = await callResponsesApi({
+    let response = await callResponsesApi({
       apiKey: openaiKey,
       model,
       tools,
       input,
     });
+
+    // Loop de tool-calling
+    while (true) {
+      const calls = (response.output || []).filter((it) => it.type === "function_call" && it.name === "run_sql_readonly");
+
+      // sempre anexar output no input para manter estado
+      input.push(...(response.output || []));
+
+      if (!calls.length) break;
+      if (queryCount >= MAX_QUERIES) break;
+
+      for (const call of calls) {
+        if (queryCount >= MAX_QUERIES) break;
+
+        let args = call.arguments;
+        if (typeof args === "string") {
+          try {
+            args = JSON.parse(args);
+          } catch {
+            args = { sql: String(args) };
+          }
+        }
+
+        let toolOut;
+        try {
+          toolOut = await runSqlReadonly(args);
+        } catch (e) {
+          toolOut = JSON.stringify({ error: e?.message || String(e) });
+        }
+
+        input.push({
+          type: "function_call_output",
+          call_id: call.call_id,
+          output: toolOut,
+        });
+      }
+
+      response = await callResponsesApi({
+        apiKey: openaiKey,
+        model,
+        tools,
+        input,
+      });
+    }
+
+    const finalText = (response.output_text || "").trim();
+
+    console.log("\n=== RELATÓRIO FINAL ===\n");
+    console.log(finalText || "(sem output_text)");
+
+    // Job Summary (compacto)
+    writeSummary(`\n## Execução\n\n- Queries executadas: \`${queryCount}\`\n`);
+    writeSummary(`\n## Queries (lista)\n`);
+    for (let i = 0; i < executed.length; i++) {
+      const q = executed[i];
+      writeSummary(`\n### Query ${i + 1}\n\n\`\`\`sql\n${trunc(q.sql, 2000)}\n\`\`\`\n`);
+    }
+    writeSummary(`\n## Relatório\n\n${finalText || "_(sem output)_"}\n`);
+
+    // Se o modelo não devolveu nada, ainda assim finalizar ok
+  } finally {
+    if (dbConnected) {
+      await db.end();
+    }
   }
-
-  const finalText = (response.output_text || "").trim();
-
-  console.log("\n=== RELATÓRIO FINAL ===\n");
-  console.log(finalText || "(sem output_text)");
-
-  // Job Summary (compacto)
-  writeSummary(`\n## Execução\n\n- Queries executadas: \`${queryCount}\`\n`);
-  writeSummary(`\n## Queries (lista)\n`);
-  for (let i = 0; i < executed.length; i++) {
-    const q = executed[i];
-    writeSummary(`\n### Query ${i + 1}\n\n\`\`\`sql\n${trunc(q.sql, 2000)}\n\`\`\`\n`);
-  }
-  writeSummary(`\n## Relatório\n\n${finalText || "_(sem output)_"}\n`);
-
-  await db.end();
-
-  // Se o modelo não devolveu nada, ainda assim finalizar ok
-  process.exit(0);
 }
 
 main().catch((err) => {

--- a/docs/prompt-executor.md
+++ b/docs/prompt-executor.md
@@ -35,6 +35,7 @@ Status: em desenvolvimento nesta lousa.Referência no repositório: docs/prompt-
 • Não usar ponto e vírgula (`;`) ao final das queries.
 • Separar queries com `---`, preferencialmente em linha própria.
 • Usar no máximo 20 queries por execução.
+• Em funções, views e retornos compostos, evitar `SELECT *`; preferir colunas explícitas quando o objetivo for validar retorno.
 
 3.2 Etapa 2 — Plano de implementação
 


### PR DESCRIPTION
### Motivation

- Make SQL batch mode more robust so a PostgreSQL runtime error on one query does not abort the whole batch while preserving guardrail and infra blocking semantics.
- Ensure per-query runtime errors are captured and surfaced in the Job Summary with a clear batch-level status.
- Guarantee the DB client is always closed even on error to avoid leaked connections.

### Description

- Updated `automations/supabase-inspect/run.mjs` to pre-validate all batch queries with `enforceGuard` and block the entire batch if any guardrail fails, and to execute validated queries sequentially with a `try/catch` per query that records runtime SQL errors instead of exiting the process. 
- Added helpers in `run.mjs`: `serializeQueryError`, `isRuntimeSqlError`, `writeBatchOkSummary`, and `writeBatchErrorSummary`, and changed `executeSqlBatch` to return a structured result with `status` set to either `completed` or `completed_with_query_errors` and per-query `ok`/`error` entries. 
- Ensured DB client lifecycle uses a `try/finally` (`dbConnected` flag) so `await db.end()` runs when the connection was opened. 
- Documented the new batch behavior and error taxonomy in `automations/supabase-inspect/README.md` and added an executor guidance line to `docs/prompt-executor.md` advising to avoid `SELECT *` in functions/views/composite returns (recommendation only). 

### Testing

- Ran `npm ci` in `automations/supabase-inspect` and it completed successfully. 
- Ran `npm run check` (i.e. `node --check run.mjs`) in `automations/supabase-inspect` and it completed without syntax errors. 
- Executed a mocked batch validation (using a fake `db.query`) with inputs `ok / error / ok` and asserted the function returned `status: "completed_with_query_errors"`, `totalQueries: 3`, `successCount: 2`, `runtimeErrorCount: 1`, and per-query statuses `ok,error,ok`, which succeeded. 
- Executed a mocked guardrail validation (including a denied statement) and asserted the batch was blocked with zero DB calls, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a007ece03b08329a3e9de82034b86f9)