### PR TITLE
docs: register deterministic taxon confidence helper

### DIFF
--- a/docs/base-tecnica.md
+++ b/docs/base-tecnica.md
@@ -2,8 +2,8 @@
 
 0.1. Cabeçalho
 • Documento: Base Técnica LP Factory 10
-• Versão: v2.0.30
-• Data: 09/05/2026
+• Versão: v2.0.31
+• Data: 10/05/2026
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -298,6 +298,10 @@
 • Regra: não logar nicho bruto, `p_query`, aliases digitados ou valores de formulário.
 • Adapter canônico: PATH: `lib/onboarding/niche-resolution/adapters/taxonMatchAdapter.ts`.
 • Contrato público: PATH: `lib/onboarding/niche-resolution/contracts.ts`.
+• Decisão de confiança determinística para taxon match deve usar o helper puro `evaluateDeterministicTaxonMatch` (PATH: `lib/onboarding/niche-resolution/deterministicConfidence.ts`).
+• Contrato tipado da decisão determinística e de `aiEscalationMode` fica em `lib/onboarding/niche-resolution/contracts.ts`.
+• Regra: não embutir avaliação de confiança, thresholds ou reasons semânticos inline em UI, route ou server action; reutilizar helper + contrato.
+• `aiEscalationMode` é preparação contratual para evolução futura e não autoriza IA no runtime atual sem caso específico.
 
 4. DB Contract - Fonte única: PATH: docs/schema.md
 • Este documento não lista mais tabelas/views/functions/triggers/policies; isso está em PATH: docs/schema.md.
@@ -444,6 +448,9 @@ Fonte normativa da allowlist SULB para exceções de Auth. Qualquer novo arquivo
 • Tipos canônicos e adapters vNext: validar por 3.6 e 3.14.
 
 99. Changelog
+v2.0.31 (10/05/2026)
+• Registrada a regra de confiança determinística para taxon match via helper puro `evaluateDeterministicTaxonMatch`, com contrato tipado em `lib/onboarding/niche-resolution/contracts.ts` e uso obrigatório sem lógica inline em UI/route/server action.
+
 v2.0.31 (09/05/2026) — E10.5.6: adapter server-side do matching determinístico de taxonomia
 • Registrado o path canônico do adapter `taxonMatchAdapter`.
 • Registrado o contrato público `TaxonMatchCandidate`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data: 09/05/2026
-• Versão: v1.5.48
+• Data: 10/05/2026
+• Versão: v1.5.49
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -714,6 +714,27 @@
 • Pendências:
 • Nenhuma pendência obrigatória aberta neste recorte
 
+
+10.5.4 Helper puro de confiança determinística para taxon match
+• Status: Concluído (exec) (10/05/2026)
+• Natureza: repo-only (sem Supabase, sem logs, sem side effects, sem onboarding e sem mutation).
+• Objetivo: preparar a avaliação determinística de candidatos de taxonomia para evolução futura do E10.5, sem implementar IA nesta etapa.
+• Implementado/Definido:
+• criado helper puro `evaluateDeterministicTaxonMatch` para avaliar candidatos de taxonomia
+• adicionado contrato tipado para decisão de confiança determinística
+• adicionado `aiEscalationMode` para preparar evolução futura de IA sem implementar IA agora
+• corrigido reason semântico para fonte forte abaixo do threshold: `medium_confidence_below_high_threshold`
+• ARTEFATOS_REPO:
+• Criados: `lib/onboarding/niche-resolution/deterministicConfidence.ts`
+• Ajustados: `lib/onboarding/niche-resolution/contracts.ts`
+• Checks/QA (reportado): QA feito; smoke feito com `npm ci` e `npm run check` aprovados pelo Codex; evidência funcional por código + checks.
+• Pendências:
+• branch ainda não foi mergeada
+• helper ainda não está integrado ao pós-save do `pending_setup`
+• sem teste runtime porque ainda não há consumo em fluxo real
+• sem persistência em `account_taxonomy`
+• sem IA, microdiálogo, fallback final ou escolha de template comercial
+
 10.5.3.1 Curadoria operacional de aliases enxutos vs microvariações textuais
 • Status: Briefing
 • Objetivo: definir o critério operacional de curadoria de aliases no Grupo A, separando o que deve ser cadastrado manualmente como alias do que deve ficar para matching textual leve futuro.
@@ -1005,6 +1026,9 @@
 • Definir o primeiro recorte funcional do LP Builder no roadmap
 
 99. Changelog
+v1.5.49 (10/05/2026)
+• Adicionado 10.5.4 como concluído (exec): helper puro de confiança determinística para taxon match, com contrato tipado, `aiEscalationMode` e artefatos em `lib/onboarding/niche-resolution/`, mantendo escopo repo-only e pendência explícita de branch sem merge e sem integração ao `pending_setup`.
+
 v1.5.49 — 09/05/2026 — E10.5.6: registrado adapter server-side `matchBusinessTaxonsDeterministic` e contrato TypeScript para consumo futuro da RPC de matching determinístico de taxonomia.
 
 v1.5.48 — 09/05/2026 — E10.5.6: registrado matching determinístico inicial de taxonomia, com `pg_trgm`, normalização textual, FTS, trigram, RPC read-only, migration/rollback e validação funcional no Supabase.


### PR DESCRIPTION
### Motivation
- Registrar no roadmap e na Base Técnica a entrega do helper puro de avaliação determinística de confiança para taxon match e documentar seu escopo repo-only e pendências.
- Padronizar a regra técnica para que decisões de confiança reutilizem um helper tipado e o `aiEscalationMode` em vez de lógica inline em UI/route/server action.

### Description
- Atualizado o cabeçalho de `docs/roadmap.md` para `v1.5.49` com data `10/05/2026` e inserida a seção `10.5.4` descrevendo o helper `evaluateDeterministicTaxonMatch`, artefatos e pendências (arquivo modificado: `docs/roadmap.md`).
- Atualizado o cabeçalho de `docs/base-tecnica.md` para `v2.0.31` com data `10/05/2026` e acrescentadas regras que obrigam o uso do helper puro `evaluateDeterministicTaxonMatch` e do contrato tipado em `lib/onboarding/niche-resolution/contracts.ts` (arquivo modificado: `docs/base-tecnica.md`).
- Adicionadas entradas de changelog correspondentes em ambos os documentos e documentada a natureza repo-only, paths de artefatos (`lib/onboarding/niche-resolution/deterministicConfidence.ts` e `lib/onboarding/niche-resolution/contracts.ts`) e o preparo para evolução com `aiEscalationMode`.

### Testing
- `npm ci` foi executado com sucesso no workspace e instalou dependências sem erros.
- `npm run check` foi executado com sucesso; o lint retornou 33 avisos (0 erros) e o `tsc` finalizou sem erros, encerrando o comando com exit code 0.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a008edb02848329bd0a76dcb0de556a)