### PR TITLE
Integrate deterministic taxonomy matching in saveSetupAndContinueAction

### DIFF
--- a/app/a/[account]/actions.ts
+++ b/app/a/[account]/actions.ts
@@ -14,6 +14,8 @@ import {
 } from '@/lib/access/adapters/accountAdapter';
 import { upsertAccountProfileV1 } from '@/lib/access/adapters/accountProfileAdapter';
 import { validateE10_4SetupForm } from '@/lib/onboarding/e10_4_setup_validation';
+import { matchBusinessTaxonsDeterministic } from '../../../lib/onboarding/niche-resolution/adapters/taxonMatchAdapter';
+import { evaluateDeterministicTaxonMatch } from '../../../lib/onboarding/niche-resolution/deterministicConfidence';
 
 export type RenameAccountState = {
   ok: boolean;
@@ -284,6 +286,45 @@ export async function saveSetupAndContinueAction(
     // Status (fonte de verdade)
     const okStatus = await setAccountStatusActiveIfPending(accountId);
     if (!okStatus) throw new Error('status_update_failed');
+
+    try {
+      const taxonomyMatchStartedAt = Date.now();
+      const candidates = await matchBusinessTaxonsDeterministic(validated.values.niche, 10);
+      const decision = evaluateDeterministicTaxonMatch(candidates);
+      const topCandidate = candidates[0] ?? null;
+
+      console.log(
+        JSON.stringify({
+          scope: 'onboarding',
+          event: 'setup_taxonomy_match_evaluated',
+          candidates_count: candidates.length,
+          confidence: decision.confidence,
+          should_use_deterministic_match: decision.shouldUseDeterministicMatch,
+          should_escalate_to_ai: decision.shouldEscalateToAi,
+          ai_escalation_mode: decision.aiEscalationMode,
+          needs_admin_review: decision.needsAdminReview,
+          reason: decision.reason,
+          top_match_source: topCandidate?.matchSource ?? null,
+          top_score: topCandidate?.score ?? null,
+          account_id: accountId,
+          request_id: requestId,
+          latency_ms: Date.now() - taxonomyMatchStartedAt,
+          ts: new Date().toISOString(),
+        })
+      );
+    } catch (err: unknown) {
+      console.warn(
+        JSON.stringify({
+          scope: 'onboarding',
+          event: 'setup_taxonomy_match_failed',
+          error_type: 'non_blocking_taxonomy_match',
+          error: err instanceof Error ? err.message : String(err),
+          request_id: requestId,
+          latency_ms: Date.now() - t0,
+          ts: new Date().toISOString(),
+        })
+      );
+    }
 
     const latency = Date.now() - t0;
 

--- a/app/a/[account]/actions.ts
+++ b/app/a/[account]/actions.ts
@@ -291,7 +291,7 @@ export async function saveSetupAndContinueAction(
       const taxonomyMatchStartedAt = Date.now();
       const candidates = await matchBusinessTaxonsDeterministic(validated.values.niche, 10);
       const decision = evaluateDeterministicTaxonMatch(candidates);
-      const topCandidate = candidates[0] ?? null;
+      const topCandidate = decision.selectedCandidate;
 
       console.log(
         JSON.stringify({


### PR DESCRIPTION
### Motivation

- Add deterministic taxonomy matching to the onboarding post-save flow so we can evaluate a candidate taxon after the core persist steps without blocking the lead progress. 
- Keep matching non-blocking and log only safe observability fields to avoid PII leakage and preserve the current activation flow.

### Description

- Imported matching helpers and evaluator into `app/a/[account]/actions.ts` and called them using relative imports (`matchBusinessTaxonsDeterministic`, `evaluateDeterministicTaxonMatch`).
- Integrated a degradable matching block immediately after `setAccountStatusActiveIfPending(...)` and before the `setup_completed` logging, `revalidatePath(route)` and `redirect(route)` operations.
- Within the block the code calls `matchBusinessTaxonsDeterministic(validated.values.niche, 10)`, runs `evaluateDeterministicTaxonMatch(candidates)`, extracts `topCandidate`, and logs a JSON object with only allowed fields (`candidates_count`, `confidence`, decision flags, `ai_escalation_mode`, `needs_admin_review`, `reason`, `top_match_source`, `top_score`, `account_id`, `request_id`, `latency_ms`, `ts`).
- Any error in matching is caught and logged as a non-blocking warning so the flow continues and the user is redirected; no persistence to `account_taxonomy`, no AI calls, no DB migrations or UI changes were added.
- Used relative imports because the requested alias imports triggered `tsc` resolution errors in this workspace; functionality and module usage remain the same.

### Testing

- Ran `npm ci` which completed successfully.
- Ran `npm run check` which executed `eslint` and `tsc`; the run completed successfully with lint warnings only (no errors) and typecheck passed.
- No automated tests failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00963cab388329b78a03b2b0aa1c6f)