### PR TITLE
Relax ai_readonly permissions for MVP Supabase Inspect

### DIFF
--- a/automations/supabase-inspect/README.md
+++ b/automations/supabase-inspect/README.md
@@ -59,6 +59,8 @@ Durante o MVP, o role `ai_readonly` usado pelo Supabase Inspect opera com permis
 
 - `SELECT` em tabelas do schema `public`;
 - `EXECUTE` em funções do schema `public`;
+- `USAGE` no schema `extensions`;
+- `EXECUTE` em funções do schema `extensions`, para funções auxiliares de extensões como `similarity()` do `pg_trgm`;
 - `BYPASSRLS`;
 - `statement_timeout = 5s`.
 

--- a/automations/supabase-inspect/README.md
+++ b/automations/supabase-inspect/README.md
@@ -53,6 +53,17 @@ Escopo:
 - Role `ai_readonly` com acesso apenas ao schema `public`
 - Discovery pode usar `information_schema` / `pg_catalog`
 
+## Permissões do role `ai_readonly` no MVP
+
+Durante o MVP, o role `ai_readonly` usado pelo Supabase Inspect opera com permissões temporariamente ampliadas para acelerar inspeções:
+
+- `SELECT` em tabelas do schema `public`;
+- `EXECUTE` em funções do schema `public`;
+- `BYPASSRLS`;
+- `statement_timeout = 5s`.
+
+Essa decisão é operacional e temporária. Não usa `service_role`, não concede escrita direta e não libera grants amplos em `auth`. Deve ser revisada antes de ampliar acesso do workflow para equipe/funcionários.
+
 ## Saída
 Nos logs do workflow:
 - Plano / decisões do modelo

--- a/docs/automations.md
+++ b/docs/automations.md
@@ -153,7 +153,7 @@ Escopo: role/usuário read-only
 Role ai_readonly com login permitido, statement_timeout de 5s, USAGE no schema public, GRANT SELECT nas tabelas existentes em public e default privileges para novas tabelas em public.
 Migration relacionada: supabase/migrations/0005__ai_readonly.sql
 
-Durante o MVP, a migration supabase/migrations/0010__ai_readonly_mvp_inspect_relaxation.sql amplia temporariamente o role ai_readonly para acelerar inspeções do Supabase Inspect: SELECT em tabelas public, EXECUTE em funções public, BYPASSRLS e statement_timeout de 5s. A decisão não usa service_role, não concede escrita direta e não libera grants amplos em auth. Deve ser revisada antes de ampliar acesso do workflow para equipe/funcionários.
+Durante o MVP, a migration supabase/migrations/0010__ai_readonly_mvp_inspect_relaxation.sql amplia temporariamente o role ai_readonly para acelerar inspeções do Supabase Inspect: SELECT em tabelas public, EXECUTE em funções public, USAGE no schema extensions, EXECUTE em funções extensions para auxiliares como similarity() do pg_trgm, BYPASSRLS e statement_timeout de 5s. A decisão não usa service_role, não concede escrita direta e não libera grants amplos em auth. Deve ser revisada antes de ampliar acesso do workflow para equipe/funcionários.
 
 2.3.4 Observações
 O pipeline atual executa apenas SQL read-only.

--- a/docs/automations.md
+++ b/docs/automations.md
@@ -153,6 +153,8 @@ Escopo: role/usuário read-only
 Role ai_readonly com login permitido, statement_timeout de 5s, USAGE no schema public, GRANT SELECT nas tabelas existentes em public e default privileges para novas tabelas em public.
 Migration relacionada: supabase/migrations/0005__ai_readonly.sql
 
+Durante o MVP, a migration supabase/migrations/0010__ai_readonly_mvp_inspect_relaxation.sql amplia temporariamente o role ai_readonly para acelerar inspeções do Supabase Inspect: SELECT em tabelas public, EXECUTE em funções public, BYPASSRLS e statement_timeout de 5s. A decisão não usa service_role, não concede escrita direta e não libera grants amplos em auth. Deve ser revisada antes de ampliar acesso do workflow para equipe/funcionários.
+
 2.3.4 Observações
 O pipeline atual executa apenas SQL read-only.
 Discovery pode usar information_schema e pg_catalog.

--- a/supabase/migrations/0010__ai_readonly_mvp_inspect_relaxation.sql
+++ b/supabase/migrations/0010__ai_readonly_mvp_inspect_relaxation.sql
@@ -22,6 +22,8 @@ $$;
 grant usage on schema public to ai_readonly;
 grant select on all tables in schema public to ai_readonly;
 grant execute on all functions in schema public to ai_readonly;
+grant usage on schema extensions to ai_readonly;
+grant execute on all functions in schema extensions to ai_readonly;
 
 alter default privileges in schema public
 grant select on tables to ai_readonly;
@@ -29,7 +31,10 @@ grant select on tables to ai_readonly;
 alter default privileges in schema public
 grant execute on functions to ai_readonly;
 
+alter default privileges in schema extensions
+grant execute on functions to ai_readonly;
+
 comment on role ai_readonly is
-  'MVP read-only inspection role for Supabase Inspect. Temporarily uses BYPASSRLS and EXECUTE on public functions; no service_role/no write grants. Review before team access.';
+  'MVP read-only inspection role for Supabase Inspect. Temporarily uses BYPASSRLS and EXECUTE on public/extensions functions; no service_role/no write grants. Review before team access.';
 
 commit;

--- a/supabase/migrations/0010__ai_readonly_mvp_inspect_relaxation.sql
+++ b/supabase/migrations/0010__ai_readonly_mvp_inspect_relaxation.sql
@@ -1,0 +1,35 @@
+-- 0010__ai_readonly_mvp_inspect_relaxation.sql
+-- Supabase Inspect MVP — afrouxamento temporário do role ai_readonly
+-- Idempotente.
+-- Objetivo: acelerar inspeções read-only no MVP sem usar service_role e sem conceder escrita direta.
+-- Revisar antes de liberar acesso do workflow para equipe/funcionários.
+
+begin;
+
+do $$
+begin
+  if not exists (select 1 from pg_roles where rolname = 'ai_readonly') then
+    execute 'create role ai_readonly login';
+  end if;
+
+  execute 'alter role ai_readonly login';
+  execute 'alter role ai_readonly nocreatedb nocreaterole noreplication';
+  execute 'alter role ai_readonly set statement_timeout = ''5s''';
+  execute 'alter role ai_readonly bypassrls';
+end
+$$;
+
+grant usage on schema public to ai_readonly;
+grant select on all tables in schema public to ai_readonly;
+grant execute on all functions in schema public to ai_readonly;
+
+alter default privileges in schema public
+grant select on tables to ai_readonly;
+
+alter default privileges in schema public
+grant execute on functions to ai_readonly;
+
+comment on role ai_readonly is
+  'MVP read-only inspection role for Supabase Inspect. Temporarily uses BYPASSRLS and EXECUTE on public functions; no service_role/no write grants. Review before team access.';
+
+commit;

--- a/supabase/rollbacks/20260510__ai_readonly_mvp_inspect_relaxation.rollback.sql
+++ b/supabase/rollbacks/20260510__ai_readonly_mvp_inspect_relaxation.rollback.sql
@@ -13,8 +13,13 @@ end
 $$;
 
 revoke execute on all functions in schema public from ai_readonly;
+revoke execute on all functions in schema extensions from ai_readonly;
+revoke usage on schema extensions from ai_readonly;
 
 alter default privileges in schema public
+revoke execute on functions from ai_readonly;
+
+alter default privileges in schema extensions
 revoke execute on functions from ai_readonly;
 
 comment on role ai_readonly is

--- a/supabase/rollbacks/20260510__ai_readonly_mvp_inspect_relaxation.rollback.sql
+++ b/supabase/rollbacks/20260510__ai_readonly_mvp_inspect_relaxation.rollback.sql
@@ -1,0 +1,23 @@
+-- 20260510__ai_readonly_mvp_inspect_relaxation.rollback.sql
+-- Rollback do afrouxamento temporário do ai_readonly para Supabase Inspect MVP.
+-- Mantém os grants básicos originais de leitura definidos em 0005__ai_readonly.sql.
+
+begin;
+
+do $$
+begin
+  if exists (select 1 from pg_roles where rolname = 'ai_readonly') then
+    execute 'alter role ai_readonly nobypassrls';
+  end if;
+end
+$$;
+
+revoke execute on all functions in schema public from ai_readonly;
+
+alter default privileges in schema public
+revoke execute on functions from ai_readonly;
+
+comment on role ai_readonly is
+  'Read-only automation role. Password must be set per environment (not stored in migrations).';
+
+commit;


### PR DESCRIPTION
### Motivation
- Enable the Supabase Inspect pipeline to run necessary read-only inspections (including calling public functions) during MVP by temporarily widening the `ai_readonly` role permissions to avoid permission-denied runtime errors.
- Keep the change reversible, limited in scope and timeboxed for MVP while preserving the project's guardrails: no `service_role`, no write grants, no broad grants in `auth`/`storage`.

### Description
- Add idempotent migration `supabase/migrations/0010__ai_readonly_mvp_inspect_relaxation.sql` that ensures `ai_readonly` exists, sets `statement_timeout = '5s'`, enables `BYPASSRLS`, grants `USAGE` and `SELECT` on `public` tables, and grants `EXECUTE` on `public` functions, plus default privileges for future objects.
- Add rollback `supabase/rollbacks/20260510__ai_readonly_mvp_inspect_relaxation.rollback.sql` that removes `BYPASSRLS` and revokes `EXECUTE` on public functions while preserving baseline read-only grants from `0005__ai_readonly.sql`.
- Update operational docs: `automations/supabase-inspect/README.md` to document the temporary MVP permissions and `docs/automations.md` to reference the new migration and its temporary nature.
- Preserve constraints: migration does not create or use `service_role`, does not add write grants, and keeps `statement_timeout = 5s` as required.

### Testing
- Ran `npm ci` at repo root, which completed successfully.
- Ran `npm run check` at repo root, which completed successfully with ESLint warnings but no errors (typecheck passed); overall `check` succeeded.
- Ran `cd automations/supabase-inspect && npm ci && npm run check`, which completed successfully.
- Ran `git diff --check` to validate diff hygiene with no reported issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00a273a6d48329923424a9c45933b7)