### PR TITLE
docs: clarify A3.6 status and block automatic Supabase apply

### DIFF
--- a/docs/lousa-automations3-6-1.md
+++ b/docs/lousa-automations3-6-1.md
@@ -90,11 +90,13 @@ A baseline só pode ser tratada como concluída quando os itens abaixo estiverem
 
 ## 8) Status atual
 
+* risco imediato de apply automático: mitigado pelo bloqueio no workflow atual
 * baseline oficial: pendente
 * extração real do baseline: pendente
 * histórico remoto alinhado: pendente
 * legado removido do fluxo oficial: pendente
-* workflow de apply: preparado, mas não liberado como fluxo confiável
+* workflow de apply: preparado, mas bloqueado por padrão e não liberado como fluxo confiável
+* A3.6.1: frente estrutural futura, sem execução urgente neste momento
 * bloqueio central atual: baseline
 
 ## 9) Execução segura no repositório
@@ -102,6 +104,7 @@ A baseline só pode ser tratada como concluída quando os itens abaixo estiverem
 * O baseline real não deve ser improvisado no repositório.
 * `supabase/migrations/` continua como legado transitório até a extração externa devolver o baseline bruto.
 * O workflow de apply não deve ser tratado como fluxo liberado antes da baseline oficial.
+* Como o apply automático está bloqueado no workflow atual, a baseline segue pendente sem exigir execução urgente de A3.6.1 neste momento.
 * A liberação futura do workflow só pode acontecer depois de:
 
   * baseline oficial versionado

--- a/docs/lousa-automations3-6.md
+++ b/docs/lousa-automations3-6.md
@@ -41,13 +41,15 @@ O workflow de apply só pode ser tratado como liberado quando os itens abaixo es
 
 ## 6) Dependência operacional
 
-* O detalhamento completo da fase baseline fica em `docs/lousa-automations3-5-1.md`.
-* Enquanto a baseline não estiver concluída, o caso 3.5 permanece bloqueado.
+* O detalhamento completo da fase baseline fica em `docs/lousa-automations3-6-1.md`.
+* Enquanto a baseline não estiver concluída, o caso A3.6 permanece bloqueado.
 
 ## 7) Status consolidado
 
 * workflow de apply: preparado
+* apply automático: bloqueado por padrão no workflow atual
 * baseline oficial: pendente
+* `supabase/migrations/`: tratado no momento como histórico auxiliar, não como fluxo oficial confiável de apply
 * legado atual: transitório e marcado para remoção após a transição segura
-* bloqueio central do caso: baseline
-* próximo passo: executar o plano descrito em `docs/lousa-automations3-5-1.md`
+* bloqueio central do caso A3.6: baseline
+* próximo passo: executar o plano descrito em `docs/lousa-automations3-6-1.md`


### PR DESCRIPTION
### Motivation

- Atualizar a documentação para refletir o estado atual do caso A3.6, apontando para o documento de baseline correto e deixando explícito que o apply automático está bloqueado por padrão. 
- Registrar que `supabase/migrations/` é atualmente um histórico auxiliar/legado e não o fluxo oficial confiável de apply até a extração do baseline.

### Description

- Em `docs/lousa-automations3-6.md` substituí referências a `docs/lousa-automations3-5-1.md` por `docs/lousa-automations3-6-1.md` e ajustei menções de “caso 3.5” para “caso A3.6”.
- Atualizei o bloco de status em `docs/lousa-automations3-6.md` para declarar que o workflow de apply está preparado, que o `apply automático` está bloqueado por padrão e que `supabase/migrations/` é tratado como histórico auxiliar no momento.
- Mantive a estrutura de `docs/lousa-automations3-6-1.md` e ajustei apenas o bloco de status para registrar que o risco imediato de apply automático foi mitigado pelo bloqueio, que a baseline segue pendente e que A3.6.1 é uma frente estrutural futura sem execução urgente.
- Arquivos modificados: `docs/lousa-automations3-6.md` e `docs/lousa-automations3-6-1.md`.

### Testing

- `npm ci` foi executado com sucesso e instalou dependências (adicionou packages sem erro). 
- `npm run check` foi executado com sucesso; o pipeline completou com `eslint` emitindo 33 warnings e `tsc` concluindo sem erros. 
- Resultado geral dos checks: ambos comandos concluíram com exit code 0, com apenas avisos de lint existentes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00cdb3a75883299188dfba41a4ce6d)