### PR TITLE
docs: update taxonomy matching in roadmap (v1.5.50) and base-tecnica (v2.0.32)

### DIFF
--- a/docs/base-tecnica.md
+++ b/docs/base-tecnica.md
@@ -2,7 +2,7 @@
 
 0.1. Cabeçalho
 • Documento: Base Técnica LP Factory 10
-• Versão: v2.0.31
+• Versão: v2.0.32
 • Data: 10/05/2026
 
 0.2 Contrato do documento (consulta)
@@ -292,6 +292,9 @@
 • Gate adapters: pode retornar null, mas logs devem diferenciar deny vs error.
 
 3.14.1 Matching de taxonomia via adapter server-side
+• No pós-save do `pending_setup`, a integração determinística deve ocorrer server-side em `saveSetupAndContinueAction`, depois de salvar perfil, atualizar nome e promover a conta para `active`.
+• Regra: `matchBusinessTaxonsDeterministic(validated.values.niche, 10)` pode ser chamado no fluxo server-side após validação do onboarding, mas falha no matching não pode bloquear o lead, `revalidatePath(route)` ou `redirect(route)`.
+• Regra: a decisão observável do matching determinístico deve usar `evaluateDeterministicTaxonMatch(candidates)` e registrar somente metadados seguros.
 • Regra: consumo de matching determinístico de taxonomia deve ocorrer somente via camada server/adapter do app.
 • Regra: não chamar RPC de matching diretamente do client/UI.
 • Regra: adapter deve retornar DTO final com candidatos oficiais; UI não normaliza nem interpreta rows crus do banco.
@@ -379,7 +382,7 @@
 • Server Actions críticas devem emitir logs estruturados (JSON) com request_id e latency_ms (padrão mínimo).
 • Regra (logs sem PII): não logar valores de formulário (ex.: name, whatsapp, site_url).
 • Onboarding pós-save (E10.4.6): revalidatePath(route) antes do redirect para evitar UI stale.
-• Matching de taxonomia: quando a RPC determinística for consumida em runtime, observability mínima deve registrar apenas metadados não sensíveis, como request_id, latency_ms, candidates_count, top_match_source e top_score; não logar nicho bruto, `p_query`, aliases digitados ou valores identificáveis do usuário.
+• Matching de taxonomia: quando a RPC determinística for consumida em runtime, observability mínima deve registrar apenas metadados não sensíveis, como request_id, latency_ms, candidates_count, top_match_source e top_score; eventos canônicos: `setup_taxonomy_match_evaluated` e `setup_taxonomy_match_failed`; não logar nicho bruto, `p_query`, query, aliases digitados, dados de formulário ou valores identificáveis do usuário.
 
 5.3.5 Signup
 • Entrada: /auth/sign-up (SignUpForm usa supabase.auth.signUp) (PATH: components/sign-up-form.tsx).
@@ -448,6 +451,8 @@ Fonte normativa da allowlist SULB para exceções de Auth. Qualquer novo arquivo
 • Tipos canônicos e adapters vNext: validar por 3.6 e 3.14.
 
 99. Changelog
+v2.0.32 — 10/05/2026 — Base técnica atualizada com contrato runtime do matching determinístico de taxonomia no pós-save do `pending_setup`, regra não bloqueante e observability segura com eventos canônicos.
+
 v2.0.31 (10/05/2026)
 • Registrada a regra de confiança determinística para taxon match via helper puro `evaluateDeterministicTaxonMatch`, com contrato tipado em `lib/onboarding/niche-resolution/contracts.ts` e uso obrigatório sem lógica inline em UI/route/server action.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 0.1 Cabeçalho
 • Data: 10/05/2026
-• Versão: v1.5.49
+• Versão: v1.5.50
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -449,6 +449,19 @@
 • UX Partner Dashboard
 
 10.4 Primeiros passos (pending_setup — status-based)
+
+• Integração de matching determinístico de taxonomia no pós-save do `pending_setup` (10/05/2026): após salvar perfil, atualizar nome e promover a conta para `active`, `saveSetupAndContinueAction` chama `matchBusinessTaxonsDeterministic(validated.values.niche, 10)` server-side e avalia os candidatos com `evaluateDeterministicTaxonMatch(candidates)` para log seguro de decisão.
+• Regra de fluxo: falha no matching não bloqueia o lead nem impede `revalidatePath(route)` e `redirect(route)`.
+• Observability mínima: logs seguros `setup_taxonomy_match_evaluated` e `setup_taxonomy_match_failed`, sem nicho bruto, query, aliases ou dados de formulário.
+• ARTEFATOS_REPO:
+• Ajustado: `app/a/[account]/actions.ts`
+• Checks/QA (reportado): QA feito; smoke feito; caso de uso funcionando; evidência funcional apresentada.
+• Pendências:
+• Branch ainda não mergeada.
+• Logs runtime da Vercel não apresentados no chat; observability validada por código, não por captura de log.
+• Adapter ainda trata falha da RPC como lista vazia; melhoria futura pode diferenciar “sem candidatos” de “falha técnica da RPC”.
+• Ainda não há persistência em `account_taxonomy`.
+• Ainda não há IA, microdiálogo, fallback final ou escolha de template comercial.
 
 • Atualização de obrigatoriedade do nicho no `pending_setup` (08/05/2026): `niche` passou a ser obrigatório no formulário “Primeiros passos”, com validação client-side e server-side, `trim` e erro `Informe o nicho do projeto.` para valor vazio ou apenas espaços.
 • ARTEFATOS_REPO:
@@ -1027,6 +1040,8 @@
 • Definir o primeiro recorte funcional do LP Builder no roadmap
 
 99. Changelog
+v1.5.50 — 10/05/2026 — Roadmap atualizado com o estado final da integração de matching determinístico de taxonomia no pós-save do `pending_setup`, incluindo artefato ajustado, regra não bloqueante, observability segura e pendências explícitas.
+
 v1.5.49 (10/05/2026)
 • Adicionado 10.5.4 como concluído (exec): helper puro de confiança determinística para taxon match, com contrato tipado, `aiEscalationMode` e artefatos em `lib/onboarding/niche-resolution/`, mantendo escopo repo-only e pendência explícita de branch sem merge e sem integração ao `pending_setup`.
 


### PR DESCRIPTION
### Motivation

- Document the final state of the deterministic taxonomy matching integration triggered after saving `pending_setup` so product and engineering share the runtime contract and known limitations. 
- Align the technical contract with the runtime change by adding the server-side adapter usage, the deterministic-evaluation helper and safe observability rules. 

### Description

- Updated `docs/roadmap.md` header to `v1.5.50` and added a detailed entry under `10.4 Primeiros passos (pending_setup — status-based)` describing the post-save deterministic taxonomy matching flow, artifacts touched, QA status and explicit pendências. 
- Updated `docs/base-tecnica.md` header to `v2.0.32` and extended `3.14.1 Matching de taxonomia via adapter server-side` to require invocation in `saveSetupAndContinueAction` with `matchBusinessTaxonsDeterministic(validated.values.niche, 10)` and decision via `evaluateDeterministicTaxonMatch(candidates)`. 
- Augmented `5.3.4 Observabilidade` to require canonical events `setup_taxonomy_match_evaluated` and `setup_taxonomy_match_failed` and to restate the prohibition on logging sensitive form/niche values. 
- Added corresponding changelog entries to both documents describing the version bumps and the new guidance. 

### Testing

- `npm ci`: executed successfully (packages installed). 
- `npm run check`: executed successfully; `tsc` returned no errors and ESLint returned 0 errors and 33 warnings (warnings are preexisting and non-blocking). 
- `git diff --check` / local workspace checks: files staged for doc update and no diff-check failures were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00d03521288329ba5ba286879f6e53)