### PR TITLE
Persist operational niche resolutions after deterministic match

### DIFF
--- a/app/a/[account]/actions.ts
+++ b/app/a/[account]/actions.ts
@@ -14,6 +14,10 @@ import {
 } from '@/lib/access/adapters/accountAdapter';
 import { upsertAccountProfileV1 } from '@/lib/access/adapters/accountProfileAdapter';
 import { validateE10_4SetupForm } from '@/lib/onboarding/e10_4_setup_validation';
+import {
+  mapDecisionToResolutionStatus,
+  upsertAccountNicheResolution,
+} from '../../../lib/onboarding/niche-resolution/adapters/accountNicheResolutionAdapter';
 import { matchBusinessTaxonsDeterministic } from '../../../lib/onboarding/niche-resolution/adapters/taxonMatchAdapter';
 import { evaluateDeterministicTaxonMatch } from '../../../lib/onboarding/niche-resolution/deterministicConfidence';
 
@@ -293,6 +297,34 @@ export async function saveSetupAndContinueAction(
       const decision = evaluateDeterministicTaxonMatch(candidates);
       const topCandidate = decision.selectedCandidate;
 
+      const resolutionSaved = await upsertAccountNicheResolution({
+        accountId,
+        rawInput: validated.values.niche,
+        selectedTaxonId: topCandidate?.taxonId ?? null,
+        confidence: decision.confidence,
+        shouldUseDeterministicMatch: decision.shouldUseDeterministicMatch,
+        shouldEscalateToAi: decision.shouldEscalateToAi,
+        aiEscalationMode: decision.aiEscalationMode,
+        needsAdminReview: decision.needsAdminReview,
+        reason: decision.reason,
+        resolutionStatus: mapDecisionToResolutionStatus(decision),
+        matchSource: topCandidate?.matchSource ?? null,
+        score: topCandidate?.score ?? null,
+      });
+
+      if (!resolutionSaved) {
+        console.warn(
+          JSON.stringify({
+            scope: 'onboarding',
+            event: 'setup_taxonomy_resolution_persist_failed',
+            error_type: 'non_blocking_niche_resolution_persist',
+            request_id: requestId,
+            latency_ms: Date.now() - taxonomyMatchStartedAt,
+            ts: new Date().toISOString(),
+          })
+        );
+      }
+
       console.log(
         JSON.stringify({
           scope: 'onboarding',
@@ -304,6 +336,7 @@ export async function saveSetupAndContinueAction(
           ai_escalation_mode: decision.aiEscalationMode,
           needs_admin_review: decision.needsAdminReview,
           reason: decision.reason,
+          resolution_saved: resolutionSaved,
           top_match_source: topCandidate?.matchSource ?? null,
           top_score: topCandidate?.score ?? null,
           account_id: accountId,

--- a/lib/onboarding/niche-resolution/adapters/accountNicheResolutionAdapter.ts
+++ b/lib/onboarding/niche-resolution/adapters/accountNicheResolutionAdapter.ts
@@ -42,7 +42,6 @@ export async function upsertAccountNicheResolution(
     resolution_status: input.resolutionStatus,
     match_source: input.matchSource,
     score: input.score,
-    updated_at: new Date().toISOString(),
   };
 
   try {

--- a/lib/onboarding/niche-resolution/adapters/accountNicheResolutionAdapter.ts
+++ b/lib/onboarding/niche-resolution/adapters/accountNicheResolutionAdapter.ts
@@ -1,0 +1,73 @@
+import "server-only";
+
+import { createServiceClient } from "@/lib/supabase/service";
+import type {
+  AccountNicheResolutionStatus,
+  DeterministicMatchDecision,
+  UpsertAccountNicheResolutionInput,
+} from "../contracts";
+
+export function mapDecisionToResolutionStatus(
+  decision: Pick<
+    DeterministicMatchDecision,
+    "confidence" | "shouldUseDeterministicMatch"
+  >,
+): AccountNicheResolutionStatus {
+  if (decision.confidence === "high" && decision.shouldUseDeterministicMatch) {
+    return "deterministic_high_confidence";
+  }
+
+  if (decision.confidence === "medium") {
+    return "review_required";
+  }
+
+  return "unclassified";
+}
+
+export async function upsertAccountNicheResolution(
+  input: UpsertAccountNicheResolutionInput,
+): Promise<boolean> {
+  const supabase = createServiceClient();
+
+  const payload = {
+    account_id: input.accountId,
+    raw_input: input.rawInput,
+    selected_taxon_id: input.selectedTaxonId,
+    confidence: input.confidence,
+    should_use_deterministic_match: input.shouldUseDeterministicMatch,
+    should_escalate_to_ai: input.shouldEscalateToAi,
+    ai_escalation_mode: input.aiEscalationMode,
+    needs_admin_review: input.needsAdminReview,
+    reason: input.reason,
+    resolution_status: input.resolutionStatus,
+    match_source: input.matchSource,
+    score: input.score,
+    updated_at: new Date().toISOString(),
+  };
+
+  try {
+    let q: any = supabase
+      .from("account_niche_resolutions")
+      .upsert(payload, { onConflict: "account_id" });
+
+    if (typeof q?.maxAffected === "function") q = q.maxAffected(1);
+
+    const { error } = await q;
+
+    if (error) {
+      console.error("upsertAccountNicheResolution failed:", {
+        code: (error as any)?.code,
+        message: (error as any)?.message ?? String(error),
+      });
+      return false;
+    }
+
+    return true;
+  } catch (error) {
+    console.error("upsertAccountNicheResolution failed:", {
+      code: error instanceof Error ? error.name : undefined,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+}

--- a/lib/onboarding/niche-resolution/contracts.ts
+++ b/lib/onboarding/niche-resolution/contracts.ts
@@ -38,3 +38,23 @@ export type DeterministicMatchDecision = {
   needsAdminReview: boolean;
   reason: DeterministicMatchReason;
 };
+
+export type AccountNicheResolutionStatus =
+  | "deterministic_high_confidence"
+  | "review_required"
+  | "unclassified";
+
+export type UpsertAccountNicheResolutionInput = {
+  accountId: string;
+  rawInput: string;
+  selectedTaxonId: string | null;
+  confidence: DeterministicMatchConfidence;
+  shouldUseDeterministicMatch: boolean;
+  shouldEscalateToAi: boolean;
+  aiEscalationMode: AiEscalationMode;
+  needsAdminReview: boolean;
+  reason: DeterministicMatchReason;
+  resolutionStatus: AccountNicheResolutionStatus;
+  matchSource: string | null;
+  score: number | null;
+};

--- a/supabase/migrations/0011__e10_5_6_account_niche_resolutions.sql
+++ b/supabase/migrations/0011__e10_5_6_account_niche_resolutions.sql
@@ -1,0 +1,248 @@
+begin;
+
+create table if not exists public.account_niche_resolutions (
+  account_id uuid not null,
+  raw_input text not null,
+  selected_taxon_id uuid null,
+  confidence text not null,
+  should_use_deterministic_match boolean not null default false,
+  should_escalate_to_ai boolean not null default false,
+  ai_escalation_mode text not null,
+  needs_admin_review boolean not null default false,
+  reason text not null,
+  resolution_status text not null,
+  match_source text null,
+  score numeric null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'account_niche_resolutions_pkey'
+      and conrelid = 'public.account_niche_resolutions'::regclass
+  ) then
+    alter table public.account_niche_resolutions
+      add constraint account_niche_resolutions_pkey
+      primary key (account_id);
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'account_niche_resolutions_account_id_fkey'
+      and conrelid = 'public.account_niche_resolutions'::regclass
+  ) then
+    alter table public.account_niche_resolutions
+      add constraint account_niche_resolutions_account_id_fkey
+      foreign key (account_id)
+      references public.accounts(id)
+      on update cascade
+      on delete cascade;
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'account_niche_resolutions_selected_taxon_id_fkey'
+      and conrelid = 'public.account_niche_resolutions'::regclass
+  ) then
+    alter table public.account_niche_resolutions
+      add constraint account_niche_resolutions_selected_taxon_id_fkey
+      foreign key (selected_taxon_id)
+      references public.business_taxons(id)
+      on update cascade
+      on delete set null;
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'account_niche_resolutions_raw_input_chk'
+      and conrelid = 'public.account_niche_resolutions'::regclass
+  ) then
+    alter table public.account_niche_resolutions
+      add constraint account_niche_resolutions_raw_input_chk
+      check (btrim(raw_input) <> '');
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'account_niche_resolutions_confidence_chk'
+      and conrelid = 'public.account_niche_resolutions'::regclass
+  ) then
+    alter table public.account_niche_resolutions
+      add constraint account_niche_resolutions_confidence_chk
+      check (confidence in ('high', 'medium', 'low'));
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'account_niche_resolutions_ai_escalation_mode_chk'
+      and conrelid = 'public.account_niche_resolutions'::regclass
+  ) then
+    alter table public.account_niche_resolutions
+      add constraint account_niche_resolutions_ai_escalation_mode_chk
+      check (
+        ai_escalation_mode in (
+          'none',
+          'rerank_candidates',
+          'infer_existing_segment',
+          'suggest_alias_for_review',
+          'suggest_new_taxon_for_review'
+        )
+      );
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'account_niche_resolutions_reason_chk'
+      and conrelid = 'public.account_niche_resolutions'::regclass
+  ) then
+    alter table public.account_niche_resolutions
+      add constraint account_niche_resolutions_reason_chk
+      check (
+        reason in (
+          'no_candidates',
+          'high_confidence_strong_match',
+          'medium_confidence_close_candidates',
+          'medium_confidence_below_high_threshold',
+          'medium_confidence_weak_match_source',
+          'low_confidence_insufficient_score'
+        )
+      );
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'account_niche_resolutions_resolution_status_chk'
+      and conrelid = 'public.account_niche_resolutions'::regclass
+  ) then
+    alter table public.account_niche_resolutions
+      add constraint account_niche_resolutions_resolution_status_chk
+      check (
+        resolution_status in (
+          'deterministic_high_confidence',
+          'review_required',
+          'unclassified'
+        )
+      );
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'account_niche_resolutions_score_chk'
+      and conrelid = 'public.account_niche_resolutions'::regclass
+  ) then
+    alter table public.account_niche_resolutions
+      add constraint account_niche_resolutions_score_chk
+      check (score is null or (score >= 0 and score <= 1));
+  end if;
+end;
+$$;
+
+create index if not exists account_niche_resolutions_selected_taxon_id_idx
+  on public.account_niche_resolutions using btree (selected_taxon_id);
+
+alter table public.account_niche_resolutions enable row level security;
+
+drop policy if exists account_niche_resolutions_select_admin_only
+  on public.account_niche_resolutions;
+
+create policy account_niche_resolutions_select_admin_only
+  on public.account_niche_resolutions
+  for select
+  to public
+  using (is_super_admin() or is_platform_admin());
+
+drop policy if exists account_niche_resolutions_insert_admin_only
+  on public.account_niche_resolutions;
+
+create policy account_niche_resolutions_insert_admin_only
+  on public.account_niche_resolutions
+  for insert
+  to public
+  with check (is_super_admin() or is_platform_admin());
+
+drop policy if exists account_niche_resolutions_update_admin_only
+  on public.account_niche_resolutions;
+
+create policy account_niche_resolutions_update_admin_only
+  on public.account_niche_resolutions
+  for update
+  to public
+  using (is_super_admin() or is_platform_admin())
+  with check (is_super_admin() or is_platform_admin());
+
+drop policy if exists account_niche_resolutions_delete_admin_only
+  on public.account_niche_resolutions;
+
+create policy account_niche_resolutions_delete_admin_only
+  on public.account_niche_resolutions
+  for delete
+  to public
+  using (is_super_admin() or is_platform_admin());
+
+drop trigger if exists account_niche_resolutions_set_updated_at
+  on public.account_niche_resolutions;
+
+create trigger account_niche_resolutions_set_updated_at
+  before update on public.account_niche_resolutions
+  for each row
+  execute function public.tg_set_updated_at();
+
+grant usage on schema public to service_role;
+
+grant execute on function public.match_business_taxons_deterministic(text, integer) to service_role;
+grant execute on function public.normalize_taxon_match_text(text) to service_role;
+
+grant select on table public.business_taxons to service_role;
+grant select on table public.business_taxon_aliases to service_role;
+
+revoke all on table public.account_niche_resolutions from public;
+revoke all on table public.account_niche_resolutions from anon;
+revoke all on table public.account_niche_resolutions from authenticated;
+
+grant select, insert, update on table public.account_niche_resolutions to service_role;
+
+commit;

--- a/supabase/rollbacks/20260511__e10_5_6_account_niche_resolutions.rollback.sql
+++ b/supabase/rollbacks/20260511__e10_5_6_account_niche_resolutions.rollback.sql
@@ -1,0 +1,38 @@
+-- 20260511__e10_5_6_account_niche_resolutions.rollback.sql
+-- E10.5.6 / 20.6 — rollback da persistência da resolução operacional atual
+-- Escopo:
+-- - remove a tabela operacional account_niche_resolutions
+-- - remove trigger, policies, índice, constraints e grants ligados à tabela
+-- Regra:
+-- - não usa CASCADE
+-- - não remove nem altera account_taxonomy
+-- - não remove nem altera business_taxons ou business_taxon_aliases
+-- - não revoga grants de service_role em business_taxons/business_taxon_aliases, pois eles suportam a RPC de matching determinístico já existente
+
+begin;
+
+drop trigger if exists account_niche_resolutions_set_updated_at
+  on public.account_niche_resolutions;
+
+drop policy if exists account_niche_resolutions_delete_admin_only
+  on public.account_niche_resolutions;
+
+drop policy if exists account_niche_resolutions_update_admin_only
+  on public.account_niche_resolutions;
+
+drop policy if exists account_niche_resolutions_insert_admin_only
+  on public.account_niche_resolutions;
+
+drop policy if exists account_niche_resolutions_select_admin_only
+  on public.account_niche_resolutions;
+
+revoke all on table public.account_niche_resolutions from service_role;
+revoke all on table public.account_niche_resolutions from public;
+revoke all on table public.account_niche_resolutions from anon;
+revoke all on table public.account_niche_resolutions from authenticated;
+
+drop index if exists public.account_niche_resolutions_selected_taxon_id_idx;
+
+drop table if exists public.account_niche_resolutions;
+
+commit;


### PR DESCRIPTION
### Motivation

- Persist the post-matching operational resolution for an account so the system records the deterministic match decision without creating account_taxonomy links or introducing AI logic.
- Keep the persistence non-blocking for onboarding flow and follow repo conventions for server-only adapters and safe observability (no PII logging).

### Description

- Added a server-only adapter `lib/onboarding/niche-resolution/adapters/accountNicheResolutionAdapter.ts` that uses `createServiceClient()` to `upsert` into `public.account_niche_resolutions` using `account_id` as the conflict key and returns `true | false` on success/failure. The adapter logs only safe metadata (`code`, `message`) on errors and never logs raw input or other PII.
- Introduced small typed contracts in `lib/onboarding/niche-resolution/contracts.ts`: `AccountNicheResolutionStatus` and `UpsertAccountNicheResolutionInput` to model the persisted payload.
- Implemented `mapDecisionToResolutionStatus` in the adapter to map deterministic decision to one of `deterministic_high_confidence`, `review_required`, or `unclassified` per the specified rules.
- Integrated persistence into `saveSetupAndContinueAction` in `app/a/[account]/actions.ts` immediately after `matchBusinessTaxonsDeterministic(...)` and `evaluateDeterministicTaxonMatch(...)`, calling the adapter and recording a safe `resolution_saved: true|false` field in the existing `setup_taxonomy_match_evaluated` event; on adapter failure the flow continues (non-blocking) and emits a `setup_taxonomy_resolution_persist_failed` event with non-sensitive metadata.
- Persisted fields include: `account_id`, `raw_input`, `selected_taxon_id`, `confidence`, deterministic/AI flags, `ai_escalation_mode`, `reason`, `resolution_status`, `match_source`, `score` and `updated_at`.

### Testing

- Ran `npm ci` which completed successfully and installed dependencies.
- Ran `npm run check` which runs `eslint` and `tsc`; TypeScript typecheck passed and ESLint finished with warnings but no errors, so `npm run check` exited successfully.
- Lint warnings are pre-existing repository warnings (did not block this change) and do not affect the acceptance criteria for this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01dce6ddd88329a5a40984debac91a)