### PR TITLE
docs: atualiza resolução operacional de nicho

### DIFF
--- a/docs/base-tecnica.md
+++ b/docs/base-tecnica.md
@@ -2,8 +2,8 @@
 
 0.1. Cabeçalho
 • Documento: Base Técnica LP Factory 10
-• Versão: v2.0.32
-• Data: 10/05/2026
+• Versão: v2.0.33
+• Data: 11/05/2026
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -305,6 +305,11 @@
 • Contrato tipado da decisão determinística e de `aiEscalationMode` fica em `lib/onboarding/niche-resolution/contracts.ts`.
 • Regra: não embutir avaliação de confiança, thresholds ou reasons semânticos inline em UI, route ou server action; reutilizar helper + contrato.
 • `aiEscalationMode` é preparação contratual para evolução futura e não autoriza IA no runtime atual sem caso específico.
+• Resolução operacional: após avaliar o matching determinístico no pós-save do `pending_setup`, o runtime pode persistir a resolução atual da conta via adapter server-side canônico em `lib/onboarding/niche-resolution/adapters/accountNicheResolutionAdapter.ts`.
+• Regra: `account_niche_resolutions` registra a resolução operacional atual; `account_taxonomy` continua reservado para vínculo oficial futuro.
+• Regra: falha de matching ou persistência da resolução não pode bloquear o lead, `revalidatePath(route)` ou `redirect(route)`.
+• Regra: logs do fluxo devem permanecer sem PII e não devem registrar `raw_input`, nicho bruto, query, aliases, candidatos completos ou dados de formulário.
+• Regra: timestamps da resolução operacional devem ser controlados pelo banco.
 
 4. DB Contract - Fonte única: PATH: docs/schema.md
 • Este documento não lista mais tabelas/views/functions/triggers/policies; isso está em PATH: docs/schema.md.
@@ -451,6 +456,8 @@ Fonte normativa da allowlist SULB para exceções de Auth. Qualquer novo arquivo
 • Tipos canônicos e adapters vNext: validar por 3.6 e 3.14.
 
 99. Changelog
+v2.0.33 — 11/05/2026 — Base técnica atualizada com contrato mínimo de runtime para persistência operacional de resolução em `account_niche_resolutions`, sem gravação de `account_taxonomy`, com fluxo não bloqueante e logs sem PII.
+
 v2.0.32 — 10/05/2026 — Base técnica atualizada com contrato runtime do matching determinístico de taxonomia no pós-save do `pending_setup`, regra não bloqueante e observability segura com eventos canônicos.
 
 v2.0.31 (10/05/2026)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data: 10/05/2026
-• Versão: v1.5.50
+• Data: 11/05/2026
+• Versão: v1.5.51
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -449,6 +449,23 @@
 • UX Partner Dashboard
 
 10.4 Primeiros passos (pending_setup — status-based)
+
+• Persistência da resolução operacional de nicho no pós-save do `pending_setup` (11/05/2026): após o matching determinístico, o fluxo passou a registrar a resolução atual da conta em `account_niche_resolutions`.
+• Decisão: `account_niche_resolutions` registra a resolução operacional atual; `account_taxonomy` permanece reservado para vínculo oficial futuro.
+• Regra de fluxo: falhas de matching ou persistência não bloqueiam a conclusão do setup nem o redirecionamento.
+• Fora do escopo: IA, microdiálogo, fallback final, vínculo oficial em `account_taxonomy` e escolha de template comercial.
+• ARTEFATOS_REPO:
+• Criado: `lib/onboarding/niche-resolution/adapters/accountNicheResolutionAdapter.ts`
+• Criado: `supabase/migrations/0011__e10_5_6_account_niche_resolutions.sql`
+• Criado: `supabase/rollbacks/20260511__e10_5_6_account_niche_resolutions.rollback.sql`
+• Ajustado: `lib/onboarding/niche-resolution/contracts.ts`
+• Ajustado: `app/a/[account]/actions.ts`
+• Checks/QA (reportado): `npm ci` ok; `npm run check` ok; runtime validado em deployment correto com caso forte, caso alias e caso sem candidato claro.
+• Status de entrega: PR da implementação 20.6 mergeado; 20.6 concluído.
+• Pendências futuras:
+• Definir quando `account_taxonomy` será gravado como vínculo oficial.
+• Decidir se haverá histórico/versionamento de resoluções.
+• Implementar IA/microdiálogo apenas em recorte futuro.
 
 • Integração de matching determinístico de taxonomia no pós-save do `pending_setup` (10/05/2026): após salvar perfil, atualizar nome e promover a conta para `active`, `saveSetupAndContinueAction` chama `matchBusinessTaxonsDeterministic(validated.values.niche, 10)` server-side e avalia os candidatos com `evaluateDeterministicTaxonMatch(candidates)` para log seguro de decisão.
 • Regra de fluxo: falha no matching não bloqueia o lead nem impede `revalidatePath(route)` e `redirect(route)`.
@@ -1040,6 +1057,8 @@
 • Definir o primeiro recorte funcional do LP Builder no roadmap
 
 99. Changelog
+v1.5.51 — 11/05/2026 — Roadmap atualizado com o estado final da implementação 20.6: persistência da resolução operacional em `account_niche_resolutions`, decisão sobre `account_taxonomy`, artefatos, QA e pendências futuras.
+
 v1.5.50 — 10/05/2026 — Roadmap atualizado com o estado final da integração de matching determinístico de taxonomia no pós-save do `pending_setup`, incluindo artefato ajustado, regra não bloqueante, observability segura e pendências explícitas.
 
 v1.5.49 (10/05/2026)

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data da última atualização: 09/05/2026
-• Documento: LP Factory 10 — Schema (DB Contract) v1.0.14
+• Data da última atualização: 11/05/2026
+• Documento: LP Factory 10 — Schema (DB Contract) v1.0.15
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -139,6 +139,7 @@
 1.10.3 Segurança
 • Trigger Hub: não
 • RLS: ativo (enable row level security)
+• service_role: SELECT
 
 1.10.4 Policies
 • business_taxons_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
@@ -170,6 +171,7 @@
 1.11.3 Segurança
 • Trigger Hub: não
 • RLS: ativo (enable row level security)
+• service_role: SELECT
 
 1.11.4 Policies
 • business_taxon_aliases_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
@@ -361,6 +363,42 @@
 • taxon_message_guides_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
 • taxon_message_guides_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
 
+1.18 account_niche_resolutions
+
+1.18.1 Chaves, constraints e relacionamentos
+• PK: account_id uuid
+• FK: account_id → accounts(id)
+• FK: selected_taxon_id → business_taxons(id)
+• CHECK: raw_input não vazio
+• CHECK: confidence
+• CHECK: ai_escalation_mode
+• CHECK: reason
+• CHECK: resolution_status
+• CHECK: score entre 0 e 1 ou NULL
+
+1.18.2 Campos
+• account_id uuid not null
+• raw_input text not null
+• selected_taxon_id uuid null
+• confidence text not null
+• should_use_deterministic_match boolean not null
+• should_escalate_to_ai boolean not null
+• ai_escalation_mode text not null
+• needs_admin_review boolean not null
+• reason text not null
+• resolution_status text not null
+• match_source text null
+• score numeric null
+• created_at timestamptz not null default now()
+• updated_at timestamptz not null default now()
+
+1.18.3 Segurança
+• Trigger Hub: não
+• RLS: ativo
+• Policies: admin-only
+• Acesso direto removido de public, anon e authenticated
+• service_role: SELECT, INSERT e UPDATE
+
 
 2. Views
 
@@ -510,6 +548,7 @@
 4.2 Fora do Hub
 • plans: sem trigger
 • partners: sem trigger hub
+• account_niche_resolutions_set_updated_at: trigger de atualização de updated_at em account_niche_resolutions
 
 5. Tipos canônicos
 • Fonte única: PATH: lib/types/status.ts
@@ -527,6 +566,12 @@
 • Rollback: não remove automaticamente a extensão, pois pode ser reutilizada por outros recursos
 
 99. Changelog
+v1.0.15 (11/05/2026) — E10.5.6: account_niche_resolutions
+• Registrada a tabela `account_niche_resolutions` como persistência operacional da resolução atual da conta.
+• Registradas PK/FKs, constraints principais, RLS, policies admin-only e permissões operacionais de `service_role`.
+• Registrado o trigger `account_niche_resolutions_set_updated_at`.
+• Registrado `service_role` com SELECT em `business_taxons` e `business_taxon_aliases`.
+
 v1.0.14 (09/05/2026) — E10.5.6: matching determinístico inicial de taxonomia
 • Registrada a extensão `pg_trgm` no schema `extensions`.
 • Registrados índices auxiliares em `business_taxons` e `business_taxon_aliases` para normalização, FTS e trigram.


### PR DESCRIPTION
### Motivation
- Formalizar o contrato runtime para persistência operacional da resolução de nicho após o `pending_setup` e registrar decisão de não gravar em `account_taxonomy` por enquanto. 
- Atualizar os cabeçalhos e changelogs das docs afetadas para as novas versões/datas de 11/05/2026. 
- Refletir no `docs/schema.md` a nova tabela/contrato e permissões necessárias para o fluxo operacional. 

### Description
- Atualiza o cabeçalho de `docs/base-tecnica.md` para `v2.0.33` e adiciona a seção em `3.14.1` que documenta a persistência operacional via adapter server-side (`lib/onboarding/niche-resolution/adapters/accountNicheResolutionAdapter.ts`) e regras de não bloqueio e logs sem PII. 
- Atualiza o cabeçalho de `docs/roadmap.md` para `v1.5.51` e insere no `10.4` o resumo da decisão operacional, artefatos criados/ajustados e status/pendências da implementação 20.6. 
- Atualiza `docs/schema.md` para `v1.0.15`, adiciona a especificação de `1.18 account_niche_resolutions` (chaves, campos e segurança), registra `service_role: SELECT` onde aplicável e documenta o trigger `account_niche_resolutions_set_updated_at`, além de incluir a entrada de changelog correspondente. 
- Arquivos modificados: `docs/base-tecnica.md`, `docs/roadmap.md`, `docs/schema.md`, commit aplicado com a mensagem `docs: atualiza contratos de resolução operacional de nicho` e PR criado. 

### Testing
- Executei `npm ci` que concluiu com sucesso (`added 485 packages in 16s`). 
- Executei `npm run check` que passou sem errors; ESLint reportou 33 warnings (0 errors) e `tsc` retornou sem erros. 
- Verificação de diff e `git diff --check` mostraram apenas as alterações de documentação adicionadas e nenhuma verificação falhou.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a021bc4c1b0832981a92a1bbdf59fbc)