### PR TITLE
Add deterministic account taxonomy linking

### DIFF
--- a/app/a/[account]/actions.ts
+++ b/app/a/[account]/actions.ts
@@ -18,6 +18,10 @@ import {
   mapDecisionToResolutionStatus,
   upsertAccountNicheResolution,
 } from '../../../lib/onboarding/niche-resolution/adapters/accountNicheResolutionAdapter';
+import {
+  linkAccountTaxonomyFromDeterministicDecision,
+  shouldLinkAccountTaxonomyFromDecision,
+} from '../../../lib/onboarding/niche-resolution/adapters/accountTaxonomyAdapter';
 import { matchBusinessTaxonsDeterministic } from '../../../lib/onboarding/niche-resolution/adapters/taxonMatchAdapter';
 import { evaluateDeterministicTaxonMatch } from '../../../lib/onboarding/niche-resolution/deterministicConfidence';
 
@@ -325,6 +329,67 @@ export async function saveSetupAndContinueAction(
         );
       }
 
+      const shouldLinkAccountTaxonomy = shouldLinkAccountTaxonomyFromDecision(decision);
+      let accountTaxonomyLinkStatus: string = shouldLinkAccountTaxonomy
+        ? 'not_attempted'
+        : 'skipped_not_high_confidence';
+
+      console.log(
+        JSON.stringify({
+          scope: 'onboarding',
+          event: 'setup_account_taxonomy_link_evaluated',
+          account_id: accountId,
+          taxon_id: topCandidate?.taxonId ?? null,
+          source_type: 'taxonomy_match',
+          status: accountTaxonomyLinkStatus,
+          reason: decision.reason,
+          request_id: requestId,
+          latency_ms: Date.now() - taxonomyMatchStartedAt,
+          ts: new Date().toISOString(),
+        })
+      );
+
+      if (shouldLinkAccountTaxonomy) {
+        const linkResult = await linkAccountTaxonomyFromDeterministicDecision({
+          accountId,
+          decision,
+        });
+        accountTaxonomyLinkStatus = linkResult.status;
+
+        const linkLogEvent =
+          linkResult.status === 'saved'
+            ? 'setup_account_taxonomy_link_saved'
+            : linkResult.status === 'failed'
+              ? 'setup_account_taxonomy_link_failed'
+              : 'setup_account_taxonomy_link_skipped';
+
+        const linkLogReason =
+          linkResult.status === 'skipped_conflicting_primary'
+            ? 'conflicting_primary'
+            : linkResult.status === 'skipped_not_high_confidence'
+              ? 'not_high_confidence'
+              : linkResult.status;
+
+        const linkLogPayload: Record<string, unknown> = {
+          scope: 'onboarding',
+          event: linkLogEvent,
+          account_id: accountId,
+          taxon_id: linkResult.taxonId,
+          source_type: 'taxonomy_match',
+          status: linkResult.status,
+          reason: linkLogReason,
+          request_id: requestId,
+          latency_ms: Date.now() - taxonomyMatchStartedAt,
+          ts: new Date().toISOString(),
+        };
+
+        if (linkResult.status === 'failed') {
+          console.warn(JSON.stringify(linkLogPayload));
+        } else {
+          console.log(JSON.stringify(linkLogPayload));
+        }
+      }
+
       console.log(
         JSON.stringify({
           scope: 'onboarding',
@@ -337,6 +402,7 @@ export async function saveSetupAndContinueAction(
           needs_admin_review: decision.needsAdminReview,
           reason: decision.reason,
           resolution_saved: resolutionSaved,
+          account_taxonomy_link_status: accountTaxonomyLinkStatus,
           top_match_source: topCandidate?.matchSource ?? null,
           top_score: topCandidate?.score ?? null,
           account_id: accountId,

--- a/lib/onboarding/niche-resolution/adapters/accountTaxonomyAdapter.ts
+++ b/lib/onboarding/niche-resolution/adapters/accountTaxonomyAdapter.ts
@@ -1,0 +1,153 @@
+import "server-only";
+
+import { createServiceClient } from "@/lib/supabase/service";
+import type { DeterministicMatchDecision } from "../contracts";
+
+const ACCOUNT_TAXONOMY_SOURCE_TYPE = "taxonomy_match" as const;
+const ACCOUNT_TAXONOMY_STATUS = "active" as const;
+
+type AccountTaxonomyPrimaryLinkRow = {
+  account_id: string;
+  taxon_id: string;
+  is_primary: boolean;
+  status: typeof ACCOUNT_TAXONOMY_STATUS;
+  source_type: typeof ACCOUNT_TAXONOMY_SOURCE_TYPE;
+};
+
+export type AccountTaxonomyLinkResult =
+  | { status: "saved"; taxonId: string }
+  | { status: "skipped_not_high_confidence"; taxonId: string | null }
+  | { status: "skipped_conflicting_primary"; taxonId: string; existingPrimaryTaxonId: string }
+  | { status: "failed"; taxonId: string | null };
+
+export function shouldLinkAccountTaxonomyFromDecision(
+  decision: DeterministicMatchDecision,
+): boolean {
+  return (
+    decision.confidence === "high" &&
+    decision.shouldUseDeterministicMatch === true &&
+    decision.selectedCandidate !== null &&
+    Boolean(decision.selectedCandidate.taxonId) &&
+    decision.needsAdminReview === false
+  );
+}
+
+export async function linkAccountTaxonomyFromDeterministicDecision(input: {
+  accountId: string;
+  decision: DeterministicMatchDecision;
+}): Promise<AccountTaxonomyLinkResult> {
+  const taxonId = input.decision.selectedCandidate?.taxonId ?? null;
+
+  if (!shouldLinkAccountTaxonomyFromDecision(input.decision) || !taxonId) {
+    return { status: "skipped_not_high_confidence", taxonId };
+  }
+
+  return upsertPrimaryAccountTaxonomyLink({
+    accountId: input.accountId,
+    taxonId,
+  });
+}
+
+async function upsertPrimaryAccountTaxonomyLink(input: {
+  accountId: string;
+  taxonId: string;
+}): Promise<AccountTaxonomyLinkResult> {
+  const supabase = createServiceClient();
+
+  try {
+    const { data: existingPrimary, error: existingPrimaryError } = await supabase
+      .from("account_taxonomy")
+      .select("taxon_id")
+      .eq("account_id", input.accountId)
+      .eq("is_primary", true)
+      .eq("status", ACCOUNT_TAXONOMY_STATUS)
+      .limit(1)
+      .maybeSingle();
+
+    if (existingPrimaryError) {
+      console.error("accountTaxonomyLink primary lookup failed:", {
+        code: (existingPrimaryError as any)?.code,
+        message: (existingPrimaryError as any)?.message ?? String(existingPrimaryError),
+      });
+      return { status: "failed", taxonId: input.taxonId };
+    }
+
+    const existingPrimaryTaxonId = (existingPrimary as { taxon_id?: string } | null)?.taxon_id ?? null;
+
+    if (existingPrimaryTaxonId && existingPrimaryTaxonId !== input.taxonId) {
+      return {
+        status: "skipped_conflicting_primary",
+        taxonId: input.taxonId,
+        existingPrimaryTaxonId,
+      };
+    }
+
+    const payload: AccountTaxonomyPrimaryLinkRow = {
+      account_id: input.accountId,
+      taxon_id: input.taxonId,
+      is_primary: true,
+      status: ACCOUNT_TAXONOMY_STATUS,
+      source_type: ACCOUNT_TAXONOMY_SOURCE_TYPE,
+    };
+
+    const { data: existingLink, error: existingLinkError } = await supabase
+      .from("account_taxonomy")
+      .select("account_id,taxon_id")
+      .eq("account_id", input.accountId)
+      .eq("taxon_id", input.taxonId)
+      .limit(1)
+      .maybeSingle();
+
+    if (existingLinkError) {
+      console.error("accountTaxonomyLink existing link lookup failed:", {
+        code: (existingLinkError as any)?.code,
+        message: (existingLinkError as any)?.message ?? String(existingLinkError),
+      });
+      return { status: "failed", taxonId: input.taxonId };
+    }
+
+    if (existingLink) {
+      let updateQuery: any = supabase
+        .from("account_taxonomy")
+        .update({ ...payload, updated_at: new Date().toISOString() })
+        .eq("account_id", input.accountId)
+        .eq("taxon_id", input.taxonId);
+
+      if (typeof updateQuery?.maxAffected === "function") updateQuery = updateQuery.maxAffected(1);
+
+      const { error: updateError } = await updateQuery;
+
+      if (updateError) {
+        console.error("accountTaxonomyLink update failed:", {
+          code: (updateError as any)?.code,
+          message: (updateError as any)?.message ?? String(updateError),
+        });
+        return { status: "failed", taxonId: input.taxonId };
+      }
+
+      return { status: "saved", taxonId: input.taxonId };
+    }
+
+    let insertQuery: any = supabase.from("account_taxonomy").insert(payload);
+
+    if (typeof insertQuery?.maxAffected === "function") insertQuery = insertQuery.maxAffected(1);
+
+    const { error: insertError } = await insertQuery;
+
+    if (insertError) {
+      console.error("accountTaxonomyLink insert failed:", {
+        code: (insertError as any)?.code,
+        message: (insertError as any)?.message ?? String(insertError),
+      });
+      return { status: "failed", taxonId: input.taxonId };
+    }
+
+    return { status: "saved", taxonId: input.taxonId };
+  } catch (error) {
+    console.error("accountTaxonomyLink failed:", {
+      code: error instanceof Error ? error.name : undefined,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return { status: "failed", taxonId: input.taxonId };
+  }
+}

--- a/supabase/migrations/0012__e10_5_6_account_taxonomy_service_role_grants.sql
+++ b/supabase/migrations/0012__e10_5_6_account_taxonomy_service_role_grants.sql
@@ -1,0 +1,20 @@
+-- 0012__e10_5_6_account_taxonomy_service_role_grants.sql
+-- E10.5.6 / 20.7 — grants para vínculo oficial em account_taxonomy
+-- Objetivo:
+-- - permitir que a camada server/service grave vínculo oficial em account_taxonomy
+-- - manter account_taxonomy sem acesso direto para public, anon e authenticated
+-- - não alterar estrutura da tabela
+-- - não alterar policies/RLS
+-- - não criar nem remover dados
+
+begin;
+
+grant usage on schema public to service_role;
+
+revoke all on table public.account_taxonomy from public;
+revoke all on table public.account_taxonomy from anon;
+revoke all on table public.account_taxonomy from authenticated;
+
+grant select, insert, update on table public.account_taxonomy to service_role;
+
+commit;

--- a/supabase/rollbacks/20260511__e10_5_6_account_taxonomy_service_role_grants.rollback.sql
+++ b/supabase/rollbacks/20260511__e10_5_6_account_taxonomy_service_role_grants.rollback.sql
@@ -1,0 +1,16 @@
+-- 20260511__e10_5_6_account_taxonomy_service_role_grants.rollback.sql
+-- E10.5.6 / 20.7 — rollback dos grants para vínculo oficial em account_taxonomy
+-- Escopo:
+-- - remove permissões operacionais concedidas ao service_role em account_taxonomy
+-- - mantém a tabela e os dados de account_taxonomy intactos
+-- - não altera account_niche_resolutions
+-- - não altera business_taxons
+-- - não altera business_taxon_aliases
+-- - não altera RLS/policies
+-- - não usa CASCADE
+
+begin;
+
+revoke select, insert, update on table public.account_taxonomy from service_role;
+
+commit;


### PR DESCRIPTION
### Motivation

- Persist the official account → taxon link in `account_taxonomy` when the deterministic matching flow yields a high-confidence decision, to promote operational resolutions into an official taxonomy binding. 

### Description

- Added a server-only adapter `lib/onboarding/niche-resolution/adapters/accountTaxonomyAdapter.ts` that exposes `shouldLinkAccountTaxonomyFromDecision` and `linkAccountTaxonomyFromDeterministicDecision` and returns a typed `AccountTaxonomyLinkResult`.
- Adapter uses `createServiceClient()`, explicit columns, `.maxAffected(1)` for 1:1 mutations, and applies the MVP primary-conflict rule: it queries for an active primary and returns `skipped_conflicting_primary` if a different active primary exists, otherwise it upserts (idempotent update or insert) the `is_primary = true, status = "active", source_type = "taxonomy_match"` link and sets `updated_at` on updates.
- Integrated the adapter into `saveSetupAndContinueAction` in `app/a/[account]/actions.ts` after `matchBusinessTaxonsDeterministic`, `evaluateDeterministicTaxonMatch` and `upsertAccountNicheResolution`, calling the adapter only when the decision meets the high-confidence rule and treating failures as degradable (do not block setup, revalidate or redirect).
- Added safe observability events and logs (`setup_account_taxonomy_link_evaluated`, `_saved`, `_skipped`, `_failed`) and included `account_taxonomy_link_status` in the `setup_taxonomy_match_evaluated` payload without leaking PII.

### Testing

- Ran `npm ci` successfully in the workspace (packages installed). 
- Ran `npm run check` successfully and it exited with code 0; lint produced existing unrelated warnings but no errors and TypeScript typecheck passed. 
- No integration tests against a live Supabase instance were executed in this change set (runtime DB scenarios described in the briefing remain to be validated in integration/QA).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02271e0a688329a013a67eb84b0730)