### PR TITLE
test: automate niche runtime validation

### DIFF
--- a/.github/workflows/automation-niche-runtime-tests.yml
+++ b/.github/workflows/automation-niche-runtime-tests.yml
@@ -11,6 +11,14 @@ on:
         description: "Numero inicial para alcinoafonso380+conviteXX@gmail.com"
         required: true
         default: "100"
+      verification_mode:
+        description: "Nivel de verificacao apos preencher o pending_setup"
+        required: true
+        default: "setup_only"
+        type: choice
+        options:
+          - setup_only
+          - niche_resolution_20_6
 
 permissions:
   contents: read
@@ -33,11 +41,14 @@ jobs:
           MAILBOX_EMAIL: ${{ secrets.MAILBOX_EMAIL }}
           MAILBOX_PASSWORD: ${{ secrets.MAILBOX_PASSWORD }}
           SUPABASE_DB_URL_READONLY: ${{ secrets.SUPABASE_DB_URL_READONLY }}
+          VERIFICATION_MODE: ${{ inputs.verification_mode }}
         run: |
           test -n "$APP_URL_OVERRIDE" || (echo "Falta input app_url" && exit 1)
           test -n "$MAILBOX_EMAIL" || (echo "Falta secret MAILBOX_EMAIL" && exit 1)
           test -n "$MAILBOX_PASSWORD" || (echo "Falta secret MAILBOX_PASSWORD" && exit 1)
-          test -n "$SUPABASE_DB_URL_READONLY" || (echo "Falta secret SUPABASE_DB_URL_READONLY" && exit 1)
+          if [ "$VERIFICATION_MODE" != "setup_only" ]; then
+            test -n "$SUPABASE_DB_URL_READONLY" || (echo "Falta secret SUPABASE_DB_URL_READONLY" && exit 1)
+          fi
 
       - name: Setup Node
         uses: actions/setup-node@v5
@@ -69,19 +80,23 @@ jobs:
         run: node run-niche-setup.mjs
 
       - name: Install Supabase inspect deps
+        if: ${{ inputs.verification_mode != 'setup_only' }}
         working-directory: automations/supabase-inspect
         run: npm ci
 
       - name: Check Supabase verifier
+        if: ${{ inputs.verification_mode != 'setup_only' }}
         working-directory: automations/supabase-inspect
         run: |
           npm run check
           node --check verify-niche-runtime.mjs
 
       - name: Verify database evidence
+        if: ${{ inputs.verification_mode != 'setup_only' }}
         working-directory: automations/supabase-inspect
         env:
           NICHE_RUNTIME_INPUT_PATH: ../niche-runtime-results.json
+          NICHE_RUNTIME_VERIFICATION_MODE: ${{ inputs.verification_mode }}
           SUPABASE_DB_URL_READONLY: ${{ secrets.SUPABASE_DB_URL_READONLY }}
         run: node verify-niche-runtime.mjs
 

--- a/.github/workflows/automation-niche-runtime-tests.yml
+++ b/.github/workflows/automation-niche-runtime-tests.yml
@@ -1,0 +1,94 @@
+name: Automation Niche Runtime Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      app_url:
+        description: "URL manual do app/preview para testar o pending_setup"
+        required: true
+        default: ""
+      start_sequence:
+        description: "Numero inicial para alcinoafonso380+conviteXX@gmail.com"
+        required: true
+        default: "100"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: automation-niche-runtime-tests-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Validate required inputs and secrets
+        env:
+          APP_URL_OVERRIDE: ${{ inputs.app_url }}
+          MAILBOX_EMAIL: ${{ secrets.MAILBOX_EMAIL }}
+          MAILBOX_PASSWORD: ${{ secrets.MAILBOX_PASSWORD }}
+          SUPABASE_DB_URL_READONLY: ${{ secrets.SUPABASE_DB_URL_READONLY }}
+        run: |
+          test -n "$APP_URL_OVERRIDE" || (echo "Falta input app_url" && exit 1)
+          test -n "$MAILBOX_EMAIL" || (echo "Falta secret MAILBOX_EMAIL" && exit 1)
+          test -n "$MAILBOX_PASSWORD" || (echo "Falta secret MAILBOX_PASSWORD" && exit 1)
+          test -n "$SUPABASE_DB_URL_READONLY" || (echo "Falta secret SUPABASE_DB_URL_READONLY" && exit 1)
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+
+      - name: Install validador deps
+        working-directory: automations/validador-final
+        run: npm ci
+
+      - name: Check validador scripts
+        working-directory: automations/validador-final
+        run: |
+          npm run check
+          node --check run-niche-setup.mjs
+
+      - name: Install Playwright Chromium
+        working-directory: automations/validador-final
+        run: npx playwright install --with-deps chromium
+
+      - name: Create accounts and submit pending_setup cases
+        working-directory: automations/validador-final
+        env:
+          APP_URL_OVERRIDE: ${{ inputs.app_url }}
+          NICHE_RUNTIME_START_SEQUENCE: ${{ inputs.start_sequence }}
+          NICHE_RUNTIME_OUTPUT_PATH: ../niche-runtime-results.json
+          MAILBOX_EMAIL: ${{ secrets.MAILBOX_EMAIL }}
+          MAILBOX_PASSWORD: ${{ secrets.MAILBOX_PASSWORD }}
+        run: node run-niche-setup.mjs
+
+      - name: Install Supabase inspect deps
+        working-directory: automations/supabase-inspect
+        run: npm ci
+
+      - name: Check Supabase verifier
+        working-directory: automations/supabase-inspect
+        run: |
+          npm run check
+          node --check verify-niche-runtime.mjs
+
+      - name: Verify database evidence
+        working-directory: automations/supabase-inspect
+        env:
+          NICHE_RUNTIME_INPUT_PATH: ../niche-runtime-results.json
+          SUPABASE_DB_URL_READONLY: ${{ secrets.SUPABASE_DB_URL_READONLY }}
+        run: node verify-niche-runtime.mjs
+
+      - name: Upload runtime evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: niche-runtime-results
+          path: automations/niche-runtime-results.json
+          if-no-files-found: ignore

--- a/automations/niche-runtime-tests/README.md
+++ b/automations/niche-runtime-tests/README.md
@@ -10,6 +10,9 @@ Inputs manuais:
 
 - `app_url`: URL do app ou preview a ser validado.
 - `start_sequence`: numero inicial do alias `alcinoafonso380+conviteXX@gmail.com`. Default: `100`.
+- `verification_mode`: nivel de verificacao apos preencher o setup.
+  - `setup_only`: cria as contas, confirma email, preenche `pending_setup` e publica evidencia. Nao consulta o banco.
+  - `niche_resolution_20_6`: executa o preset read-only que valida a expectativa da etapa 20.6 no Supabase.
 
 ## Casos cobertos
 
@@ -19,11 +22,24 @@ O workflow cria e confirma tres contas reais, usando a mailbox programatica do `
 - `convite101`: `hof` -> alias.
 - `convite102`: `Beleza Facial` -> sem candidato claro.
 
-Se `start_sequence` for alterado, os tres casos usam `start_sequence`, `start_sequence + 1` e `start_sequence + 2`.
+Se `start_sequence` for alterado, os tres casos usam `start_sequence`, `start_sequence + 1` e `start_sequence + 2`. Os nomes dos projetos acompanham a sequencia usada.
 
-## Validacao no banco
+## Nucleo estavel
 
-A etapa read-only consulta o Supabase com `SUPABASE_DB_URL_READONLY` e valida:
+O nucleo estavel da automacao e:
+
+- criar conta real;
+- confirmar email;
+- abrir sessao autenticada;
+- preencher `pending_setup`;
+- capturar `subdomain`, `email`, `projectName`, `niche`, `finalUrl` e timestamp;
+- publicar evidencia no Job Summary e no artifact.
+
+Esse nucleo ja funciona como teste de funcionamento do fluxo.
+
+## Preset de validacao no banco
+
+A validacao no banco e opcional porque a expectativa muda por etapa. No preset `niche_resolution_20_6`, a etapa read-only consulta o Supabase com `SUPABASE_DB_URL_READONLY` e valida:
 
 - conta criada e `accounts.status = active`;
 - `account_profiles.niche` igual ao input;
@@ -39,7 +55,7 @@ Valores secretos nao devem ser versionados. O workflow espera os seguintes GitHu
 
 - `MAILBOX_EMAIL`: caixa postal base usada para ler emails de confirmacao.
 - `MAILBOX_PASSWORD`: senha de app da mailbox usada por POP3.
-- `SUPABASE_DB_URL_READONLY`: connection string read-only para verificar evidencia no banco.
+- `SUPABASE_DB_URL_READONLY`: connection string read-only para verificar evidencia no banco quando `verification_mode` nao for `setup_only`.
 
 ## Evidencia
 

--- a/automations/niche-runtime-tests/README.md
+++ b/automations/niche-runtime-tests/README.md
@@ -1,0 +1,50 @@
+# automations/niche-runtime-tests
+
+Piloto de automacao runtime para validar o fluxo real de `pending_setup` com persistencia de resolucao de nicho.
+
+## Workflow
+
+GitHub Actions -> `Automation Niche Runtime Tests`
+
+Inputs manuais:
+
+- `app_url`: URL do app ou preview a ser validado.
+- `start_sequence`: numero inicial do alias `alcinoafonso380+conviteXX@gmail.com`. Default: `100`.
+
+## Casos cobertos
+
+O workflow cria e confirma tres contas reais, usando a mailbox programatica do `validador-final`, e preenche o `pending_setup`:
+
+- `convite100`: `Harmonização Facial` -> match forte.
+- `convite101`: `hof` -> alias.
+- `convite102`: `Beleza Facial` -> sem candidato claro.
+
+Se `start_sequence` for alterado, os tres casos usam `start_sequence`, `start_sequence + 1` e `start_sequence + 2`.
+
+## Validacao no banco
+
+A etapa read-only consulta o Supabase com `SUPABASE_DB_URL_READONLY` e valida:
+
+- conta criada e `accounts.status = active`;
+- `account_profiles.niche` igual ao input;
+- `account_niche_resolutions.raw_input` igual ao input;
+- status esperado em `account_niche_resolutions.resolution_status`;
+- `selected_taxon_id` e `score` preenchidos quando o caso exige match forte;
+- `match_source` contendo `alias` no caso de alias;
+- nenhuma linha criada em `account_taxonomy`.
+
+## Secrets usados
+
+Valores secretos nao devem ser versionados. O workflow espera os seguintes GitHub Actions repository secrets:
+
+- `MAILBOX_EMAIL`: caixa postal base usada para ler emails de confirmacao.
+- `MAILBOX_PASSWORD`: senha de app da mailbox usada por POP3.
+- `SUPABASE_DB_URL_READONLY`: connection string read-only para verificar evidencia no banco.
+
+## Evidencia
+
+O workflow escreve o resumo no Job Summary e publica o artifact `niche-runtime-results` com os subdominios criados e os dados necessarios para auditoria.
+
+## Cleanup
+
+Nao ha cleanup automatico neste piloto. As contas criadas ficam preservadas como evidencia funcional.

--- a/automations/supabase-inspect/verify-niche-runtime.mjs
+++ b/automations/supabase-inspect/verify-niche-runtime.mjs
@@ -1,0 +1,258 @@
+import { appendFileSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import pg from "pg";
+
+const { Client } = pg;
+
+const allowedUnclearStatuses = new Set(["unclassified", "review_required"]);
+
+function die(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function writeSummary(markdown) {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) return;
+  appendFileSync(summaryPath, markdown.endsWith("\n") ? markdown : `${markdown}\n`, "utf-8");
+}
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (typeof value !== "string" || value.trim() === "") {
+    die(`Falta ${name}.`);
+  }
+  return value.trim();
+}
+
+function readInput() {
+  const inputPath = resolve(process.env.NICHE_RUNTIME_INPUT_PATH || "../niche-runtime-results.json");
+  const parsed = JSON.parse(readFileSync(inputPath, "utf-8"));
+
+  if (!parsed || !Array.isArray(parsed.cases) || parsed.cases.length === 0) {
+    die(`Arquivo de entrada invalido: ${inputPath}`);
+  }
+
+  return { inputPath, payload: parsed };
+}
+
+async function fetchAccountEvidence(client, subdomain) {
+  const accountResult = await client.query(
+    `select
+       a.id,
+       a.name,
+       a.subdomain,
+       a.status,
+       ap.niche,
+       anr.raw_input,
+       anr.selected_taxon_id,
+       bt.name as selected_taxon_name,
+       anr.confidence,
+       anr.should_use_deterministic_match,
+       anr.should_escalate_to_ai,
+       anr.ai_escalation_mode,
+       anr.needs_admin_review,
+       anr.reason,
+       anr.resolution_status,
+       anr.match_source,
+       anr.score,
+       anr.created_at,
+       anr.updated_at
+     from public.accounts a
+     left join public.account_profiles ap
+       on ap.account_id = a.id
+     left join public.account_niche_resolutions anr
+       on anr.account_id = a.id
+     left join public.business_taxons bt
+       on bt.id = anr.selected_taxon_id
+     where a.subdomain = $1
+     limit 1`,
+    [subdomain],
+  );
+
+  const taxonomyResult = await client.query(
+    `select count(*)::int as count
+     from public.account_taxonomy at
+     join public.accounts a
+       on a.id = at.account_id
+     where a.subdomain = $1`,
+    [subdomain],
+  );
+
+  return {
+    account: accountResult.rows[0] ?? null,
+    taxonomyRows: Number(taxonomyResult.rows[0]?.count ?? 0),
+  };
+}
+
+function assertCommon(testCase, evidence, failures) {
+  const row = evidence.account;
+
+  if (!row) {
+    failures.push("conta nao encontrada pelo subdomain");
+    return;
+  }
+
+  if (row.status !== "active") {
+    failures.push(`accounts.status esperado active, recebido ${row.status ?? "null"}`);
+  }
+
+  if (row.name !== testCase.projectName) {
+    failures.push(`accounts.name esperado ${testCase.projectName}, recebido ${row.name ?? "null"}`);
+  }
+
+  if (row.niche !== testCase.niche) {
+    failures.push(`account_profiles.niche esperado ${testCase.niche}, recebido ${row.niche ?? "null"}`);
+  }
+
+  if (row.raw_input !== testCase.niche) {
+    failures.push(`account_niche_resolutions.raw_input esperado ${testCase.niche}, recebido ${row.raw_input ?? "null"}`);
+  }
+
+  if (!row.resolution_status) {
+    failures.push("account_niche_resolutions.resolution_status nao preenchido");
+  }
+
+  if (evidence.taxonomyRows !== 0) {
+    failures.push(`account_taxonomy deveria ter 0 linhas, recebeu ${evidence.taxonomyRows}`);
+  }
+}
+
+function assertStrong(row, failures) {
+  if (row.resolution_status !== "deterministic_high_confidence") {
+    failures.push(
+      `resolution_status esperado deterministic_high_confidence, recebido ${row.resolution_status ?? "null"}`,
+    );
+  }
+
+  if (!row.selected_taxon_id) {
+    failures.push("selected_taxon_id deveria estar preenchido");
+  }
+
+  if (row.score === null || row.score === undefined) {
+    failures.push("score deveria estar preenchido");
+  }
+}
+
+function assertAlias(row, failures) {
+  assertStrong(row, failures);
+
+  if (!String(row.match_source ?? "").includes("alias")) {
+    failures.push(`match_source deveria conter alias, recebido ${row.match_source ?? "null"}`);
+  }
+}
+
+function assertUnclear(row, failures) {
+  if (!allowedUnclearStatuses.has(row.resolution_status)) {
+    failures.push(
+      `resolution_status esperado unclassified ou review_required, recebido ${row.resolution_status ?? "null"}`,
+    );
+  }
+}
+
+function evaluateCase(testCase, evidence) {
+  const failures = [];
+  assertCommon(testCase, evidence, failures);
+
+  if (evidence.account) {
+    if (testCase.id === "strong_match") assertStrong(evidence.account, failures);
+    if (testCase.id === "alias") assertAlias(evidence.account, failures);
+    if (testCase.id === "unclear") assertUnclear(evidence.account, failures);
+  }
+
+  return {
+    id: testCase.id,
+    label: testCase.label,
+    email: testCase.email,
+    subdomain: testCase.subdomain,
+    accountId: evidence.account?.id ?? null,
+    accountStatus: evidence.account?.status ?? null,
+    profileNiche: evidence.account?.niche ?? null,
+    rawInput: evidence.account?.raw_input ?? null,
+    selectedTaxonId: evidence.account?.selected_taxon_id ?? null,
+    selectedTaxonName: evidence.account?.selected_taxon_name ?? null,
+    confidence: evidence.account?.confidence ?? null,
+    resolutionStatus: evidence.account?.resolution_status ?? null,
+    matchSource: evidence.account?.match_source ?? null,
+    score: evidence.account?.score ?? null,
+    taxonomyRows: evidence.taxonomyRows,
+    status: failures.length === 0 ? "passed" : "failed",
+    failures,
+  };
+}
+
+function renderSummary({ inputPath, appUrl, results }) {
+  const passed = results.filter((entry) => entry.status === "passed").length;
+  const failed = results.length - passed;
+
+  writeSummary("# Runtime niche resolution verification");
+  writeSummary(`- input_path: \`${inputPath}\``);
+  writeSummary(`- app_url: \`${appUrl ?? "null"}\``);
+  writeSummary(`- status: \`${failed === 0 ? "passed" : "failed"}\``);
+  writeSummary(`- cases: \`${passed}/${results.length} passed\``);
+  writeSummary("");
+  writeSummary("| Caso | Subdomain | Status | Resolution | Taxon | Match source | Taxonomy rows |");
+  writeSummary("| --- | --- | --- | --- | --- | --- | --- |");
+
+  for (const result of results) {
+    writeSummary(
+      `| ${result.label} | \`${result.subdomain}\` | ${result.status} | \`${result.resolutionStatus ?? "null"}\` | \`${result.selectedTaxonName ?? result.selectedTaxonId ?? "null"}\` | \`${result.matchSource ?? "null"}\` | \`${result.taxonomyRows}\` |`,
+    );
+  }
+
+  for (const result of results) {
+    if (result.failures.length === 0) continue;
+    writeSummary(`\n## Falhas - ${result.label}`);
+    for (const failure of result.failures) {
+      writeSummary(`- ${failure}`);
+    }
+  }
+}
+
+async function main() {
+  const connectionString = requireEnv("SUPABASE_DB_URL_READONLY");
+  const { inputPath, payload } = readInput();
+  const client = new Client({ connectionString });
+  const results = [];
+
+  await client.connect();
+  try {
+    for (const testCase of payload.cases) {
+      if (!testCase.subdomain) {
+        results.push({
+          id: testCase.id,
+          label: testCase.label,
+          email: testCase.email,
+          subdomain: null,
+          status: "failed",
+          failures: ["subdomain ausente no arquivo de entrada"],
+        });
+        continue;
+      }
+
+      const evidence = await fetchAccountEvidence(client, testCase.subdomain);
+      results.push(evaluateCase(testCase, evidence));
+    }
+  } finally {
+    await client.end().catch(() => {});
+  }
+
+  const output = {
+    kind: "niche_runtime_verification_results",
+    appUrl: payload.appUrl ?? null,
+    inputPath,
+    completedAt: new Date().toISOString(),
+    results,
+  };
+
+  console.log(JSON.stringify(output, null, 2));
+  renderSummary({ inputPath, appUrl: payload.appUrl, results });
+
+  if (results.some((entry) => entry.status !== "passed")) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  die(`falha na verificacao runtime niche: ${error instanceof Error ? error.message : String(error)}`);
+});

--- a/automations/supabase-inspect/verify-niche-runtime.mjs
+++ b/automations/supabase-inspect/verify-niche-runtime.mjs
@@ -5,6 +5,7 @@ import pg from "pg";
 const { Client } = pg;
 
 const allowedUnclearStatuses = new Set(["unclassified", "review_required"]);
+const supportedVerificationModes = new Set(["niche_resolution_20_6"]);
 
 function die(message) {
   console.error(message);
@@ -34,6 +35,16 @@ function readInput() {
   }
 
   return { inputPath, payload: parsed };
+}
+
+function readVerificationMode() {
+  const mode = process.env.NICHE_RUNTIME_VERIFICATION_MODE || "niche_resolution_20_6";
+
+  if (!supportedVerificationModes.has(mode)) {
+    die(`NICHE_RUNTIME_VERIFICATION_MODE sem preset suportado: ${mode}`);
+  }
+
+  return mode;
 }
 
 async function fetchAccountEvidence(client, subdomain) {
@@ -181,13 +192,14 @@ function evaluateCase(testCase, evidence) {
   };
 }
 
-function renderSummary({ inputPath, appUrl, results }) {
+function renderSummary({ inputPath, appUrl, verificationMode, results }) {
   const passed = results.filter((entry) => entry.status === "passed").length;
   const failed = results.length - passed;
 
   writeSummary("# Runtime niche resolution verification");
   writeSummary(`- input_path: \`${inputPath}\``);
   writeSummary(`- app_url: \`${appUrl ?? "null"}\``);
+  writeSummary(`- verification_mode: \`${verificationMode}\``);
   writeSummary(`- status: \`${failed === 0 ? "passed" : "failed"}\``);
   writeSummary(`- cases: \`${passed}/${results.length} passed\``);
   writeSummary("");
@@ -212,6 +224,7 @@ function renderSummary({ inputPath, appUrl, results }) {
 async function main() {
   const connectionString = requireEnv("SUPABASE_DB_URL_READONLY");
   const { inputPath, payload } = readInput();
+  const verificationMode = readVerificationMode();
   const client = new Client({ connectionString });
   const results = [];
 
@@ -239,6 +252,7 @@ async function main() {
 
   const output = {
     kind: "niche_runtime_verification_results",
+    verificationMode,
     appUrl: payload.appUrl ?? null,
     inputPath,
     completedAt: new Date().toISOString(),
@@ -246,7 +260,7 @@ async function main() {
   };
 
   console.log(JSON.stringify(output, null, 2));
-  renderSummary({ inputPath, appUrl: payload.appUrl, results });
+  renderSummary({ inputPath, appUrl: payload.appUrl, verificationMode, results });
 
   if (results.some((entry) => entry.status !== "passed")) {
     process.exitCode = 1;

--- a/automations/validador-final/run-niche-setup.mjs
+++ b/automations/validador-final/run-niche-setup.mjs
@@ -1,0 +1,316 @@
+import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  createAccount,
+  hasAuthSuccessUrl,
+  openAuth,
+  withBrowserSession,
+} from "./login-playwright.mjs";
+import { findLatestEmailLinkForAlias } from "./mailbox-client.mjs";
+
+const MAILBOX_POLL_TIMEOUT_MS = 120000;
+const MAILBOX_POLL_INTERVAL_MS = 5000;
+const DEFAULT_START_SEQUENCE = 100;
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const defaultOutputPath = resolve(scriptDir, "../niche-runtime-results.json");
+
+const cases = [
+  {
+    id: "strong_match",
+    label: "Caso 1 - Match forte",
+    sequenceOffset: 0,
+    projectName: "Convite teste runtime 100 A",
+    niche: "Harmonização Facial",
+  },
+  {
+    id: "alias",
+    label: "Caso 2 - Alias",
+    sequenceOffset: 1,
+    projectName: "Convite teste runtime 101 B",
+    niche: "hof",
+  },
+  {
+    id: "unclear",
+    label: "Caso 3 - Sem candidato claro",
+    sequenceOffset: 2,
+    projectName: "Convite teste runtime 102 C",
+    niche: "Beleza Facial",
+  },
+];
+
+function die(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function writeSummary(markdown) {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) return;
+  appendFileSync(summaryPath, markdown.endsWith("\n") ? markdown : `${markdown}\n`, "utf-8");
+}
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (typeof value !== "string" || value.trim() === "") {
+    die(`Falta ${name}.`);
+  }
+  return value.trim();
+}
+
+function readStartSequence() {
+  const raw = process.env.NICHE_RUNTIME_START_SEQUENCE;
+  if (typeof raw !== "string" || raw.trim() === "") return DEFAULT_START_SEQUENCE;
+
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    die(`NICHE_RUNTIME_START_SEQUENCE invalido: ${raw}`);
+  }
+
+  return parsed;
+}
+
+function buildAlias(sequence) {
+  return `alcinoafonso380+convite${sequence}@gmail.com`;
+}
+
+function buildPassword(sequence) {
+  return `Convite${sequence}!Aa`;
+}
+
+function extractAccountSubdomain(value) {
+  try {
+    const url = new URL(value);
+    const parts = url.pathname.split("/").filter(Boolean);
+    if (parts[0] !== "a") return null;
+    const subdomain = (parts[1] ?? "").trim().toLowerCase();
+    if (!subdomain || subdomain === "home") return null;
+    return subdomain;
+  } catch {
+    return null;
+  }
+}
+
+function inspectUrlParts(value) {
+  try {
+    const parsed = new URL(value);
+    return {
+      pathname: parsed.pathname,
+      search: parsed.search || "",
+    };
+  } catch {
+    return { pathname: "invalid_url", search: "" };
+  }
+}
+
+async function handleAuthConfirmInterstitial({ page, flowLabel }) {
+  const initialTimeoutMs = 9000;
+  const currentUrl = page.url();
+  if (!currentUrl.includes("/auth/confirm")) {
+    return { ok: true, detail: `${flowLabel}: sem intersticial /auth/confirm` };
+  }
+
+  try {
+    await page.waitForURL((url) => !url.toString().includes("/auth/confirm"), {
+      timeout: initialTimeoutMs,
+    });
+    return { ok: true, detail: `${flowLabel}: saiu automaticamente de /auth/confirm` };
+  } catch {
+    // Some previews render an explicit interstitial form. Submit it as the existing validador-final does.
+  }
+
+  const fallbackSubmitted = await page.evaluate(() => {
+    const primary = document.querySelector("form#f");
+    const secondary = document.querySelector('form[action="/auth/confirm"]');
+    const form = primary || secondary;
+    if (!form) return false;
+    if (typeof form.requestSubmit === "function") {
+      form.requestSubmit();
+      return true;
+    }
+    form.submit();
+    return true;
+  });
+
+  if (fallbackSubmitted) {
+    try {
+      await page.waitForURL((url) => !url.toString().includes("/auth/confirm"), {
+        timeout: initialTimeoutMs,
+      });
+      return { ok: true, detail: `${flowLabel}: saiu de /auth/confirm apos fallback` };
+    } catch {
+      return { ok: false, detail: `${flowLabel}: fallback enviado, mas continuou em /auth/confirm` };
+    }
+  }
+
+  return { ok: false, detail: `${flowLabel}: intersticial /auth/confirm sem form submetivel` };
+}
+
+async function openSignupLink({ page, appOrigin, email }) {
+  const signupMail = await findLatestEmailLinkForAlias({
+    aliasEmail: email,
+    timeoutMs: MAILBOX_POLL_TIMEOUT_MS,
+    intervalMs: MAILBOX_POLL_INTERVAL_MS,
+    linkIncludes: appOrigin,
+    expectedLinkKind: "signup_confirmation",
+  });
+
+  const linkParts = inspectUrlParts(signupMail.matched_link);
+  writeSummary(`- signup_mail_subject: \`${signupMail.matched_subject || "sem assunto"}\``);
+  writeSummary(`- signup_mail_pathname: \`${linkParts.pathname}\``);
+  writeSummary(`- signup_mail_search: \`${linkParts.search || "(empty)"}\``);
+
+  await page.goto(signupMail.matched_link, { waitUntil: "domcontentloaded", timeout: 30000 });
+  const interstitial = await handleAuthConfirmInterstitial({ page, flowLabel: "signup" });
+  if (!interstitial.ok) throw new Error(interstitial.detail);
+}
+
+async function waitForAccountSubdomain(page) {
+  await page.waitForURL((url) => url.pathname.startsWith("/a/"), { timeout: 20000 });
+
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const subdomain = extractAccountSubdomain(page.url());
+    if (subdomain) return subdomain;
+    await page.waitForTimeout(500);
+  }
+
+  throw new Error(`nao foi possivel capturar subdomain a partir de ${page.url()}`);
+}
+
+async function firstVisible(page, locators) {
+  for (const locator of locators) {
+    if ((await locator.count()) > 0 && (await locator.first().isVisible().catch(() => false))) {
+      return locator.first();
+    }
+  }
+  return null;
+}
+
+async function fillPendingSetup(page, testCase) {
+  const nameInput = await firstVisible(page, [
+    page.getByLabel(/nome do projeto/i),
+    page.locator('input[name="name"]'),
+  ]);
+
+  if (!nameInput) {
+    throw new Error(`campo Nome do projeto nao encontrado em ${page.url()}`);
+  }
+
+  const nicheInput = await firstVisible(page, [
+    page.getByLabel(/^nicho$/i),
+    page.locator('input[name="niche"]'),
+  ]);
+
+  if (!nicheInput) {
+    throw new Error(`campo Nicho nao encontrado em ${page.url()}`);
+  }
+
+  await nameInput.fill(testCase.projectName);
+  await nicheInput.fill(testCase.niche);
+
+  const submit = await firstVisible(page, [
+    page.getByRole("button", { name: /salvar e continuar|continuar|salvar/i }),
+    page.locator('button[type="submit"]'),
+  ]);
+
+  if (!submit) {
+    throw new Error(`botao de salvar pending_setup nao encontrado em ${page.url()}`);
+  }
+
+  await Promise.allSettled([
+    page.waitForLoadState("networkidle", { timeout: 12000 }),
+    submit.click(),
+  ]);
+  await page.waitForTimeout(2500);
+
+  if (page.url().includes("/auth") || !hasAuthSuccessUrl(page.url())) {
+    throw new Error(`pending_setup nao concluiu em rota autenticada: ${page.url()}`);
+  }
+}
+
+async function runCase({ appUrl, appOrigin, testCase, sequence }) {
+  const email = buildAlias(sequence);
+  const password = buildPassword(sequence);
+
+  return withBrowserSession(async ({ page }) => {
+    await openAuth({ page, appUrl });
+
+    const signupResult = await createAccount({ page, email, password });
+    if (signupResult.collisionDetected) {
+      throw new Error(`alias ${email} ja existe ou colidiu: ${signupResult.detail}`);
+    }
+    if (!signupResult.passed || signupResult.creationAccepted !== true) {
+      throw new Error(`signup nao aceito para ${email}: ${signupResult.detail}`);
+    }
+
+    await openSignupLink({ page, appOrigin, email });
+    await page.waitForTimeout(1200);
+
+    const subdomain = await waitForAccountSubdomain(page);
+    await fillPendingSetup(page, testCase);
+
+    return {
+      id: testCase.id,
+      label: testCase.label,
+      sequence,
+      email,
+      password,
+      projectName: testCase.projectName,
+      niche: testCase.niche,
+      subdomain,
+      finalUrl: page.url(),
+      status: "setup_submitted",
+    };
+  });
+}
+
+async function main() {
+  const appUrl = requireEnv("APP_URL_OVERRIDE");
+  requireEnv("MAILBOX_EMAIL");
+  requireEnv("MAILBOX_PASSWORD");
+
+  const appOrigin = new URL(appUrl).origin;
+  const startSequence = readStartSequence();
+  const outputPath = resolve(process.env.NICHE_RUNTIME_OUTPUT_PATH || defaultOutputPath);
+  const startedAt = new Date().toISOString();
+  const results = [];
+
+  writeSummary("# Runtime niche setup");
+  writeSummary(`- started_at: \`${startedAt}\``);
+  writeSummary(`- app_url: \`${appUrl}\``);
+  writeSummary(`- start_sequence: \`${startSequence}\``);
+
+  for (const testCase of cases) {
+    const sequence = startSequence + testCase.sequenceOffset;
+    writeSummary(`\n## ${testCase.label}`);
+    writeSummary(`- email: \`${buildAlias(sequence)}\``);
+    writeSummary(`- niche: \`${testCase.niche}\``);
+
+    const result = await runCase({ appUrl, appOrigin, testCase, sequence });
+    results.push(result);
+
+    writeSummary(`- subdomain: \`${result.subdomain}\``);
+    writeSummary(`- final_url: \`${result.finalUrl}\``);
+    writeSummary(`- status: \`${result.status}\``);
+  }
+
+  const payload = {
+    kind: "niche_runtime_setup_results",
+    appUrl,
+    appOrigin,
+    startSequence,
+    startedAt,
+    completedAt: new Date().toISOString(),
+    cases: results,
+  };
+
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, `${JSON.stringify(payload, null, 2)}\n`, "utf-8");
+  console.log(JSON.stringify(payload, null, 2));
+  writeSummary(`\n- output_path: \`${outputPath}\``);
+}
+
+main().catch((error) => {
+  die(`falha no runtime niche setup: ${error instanceof Error ? error.message : String(error)}`);
+});

--- a/automations/validador-final/run-niche-setup.mjs
+++ b/automations/validador-final/run-niche-setup.mjs
@@ -21,21 +21,21 @@ const cases = [
     id: "strong_match",
     label: "Caso 1 - Match forte",
     sequenceOffset: 0,
-    projectName: "Convite teste runtime 100 A",
+    projectSuffix: "A",
     niche: "Harmonização Facial",
   },
   {
     id: "alias",
     label: "Caso 2 - Alias",
     sequenceOffset: 1,
-    projectName: "Convite teste runtime 101 B",
+    projectSuffix: "B",
     niche: "hof",
   },
   {
     id: "unclear",
     label: "Caso 3 - Sem candidato claro",
     sequenceOffset: 2,
-    projectName: "Convite teste runtime 102 C",
+    projectSuffix: "C",
     niche: "Beleza Facial",
   },
 ];
@@ -77,6 +77,10 @@ function buildAlias(sequence) {
 
 function buildPassword(sequence) {
   return `Convite${sequence}!Aa`;
+}
+
+function buildProjectName(sequence, testCase) {
+  return `Convite teste runtime ${sequence} ${testCase.projectSuffix}`;
 }
 
 function extractAccountSubdomain(value) {
@@ -187,7 +191,7 @@ async function firstVisible(page, locators) {
   return null;
 }
 
-async function fillPendingSetup(page, testCase) {
+async function fillPendingSetup(page, { projectName, niche }) {
   const nameInput = await firstVisible(page, [
     page.getByLabel(/nome do projeto/i),
     page.locator('input[name="name"]'),
@@ -206,8 +210,8 @@ async function fillPendingSetup(page, testCase) {
     throw new Error(`campo Nicho nao encontrado em ${page.url()}`);
   }
 
-  await nameInput.fill(testCase.projectName);
-  await nicheInput.fill(testCase.niche);
+  await nameInput.fill(projectName);
+  await nicheInput.fill(niche);
 
   const submit = await firstVisible(page, [
     page.getByRole("button", { name: /salvar e continuar|continuar|salvar/i }),
@@ -232,6 +236,7 @@ async function fillPendingSetup(page, testCase) {
 async function runCase({ appUrl, appOrigin, testCase, sequence }) {
   const email = buildAlias(sequence);
   const password = buildPassword(sequence);
+  const projectName = buildProjectName(sequence, testCase);
 
   return withBrowserSession(async ({ page }) => {
     await openAuth({ page, appUrl });
@@ -248,7 +253,7 @@ async function runCase({ appUrl, appOrigin, testCase, sequence }) {
     await page.waitForTimeout(1200);
 
     const subdomain = await waitForAccountSubdomain(page);
-    await fillPendingSetup(page, testCase);
+    await fillPendingSetup(page, { projectName, niche: testCase.niche });
 
     return {
       id: testCase.id,
@@ -256,7 +261,7 @@ async function runCase({ appUrl, appOrigin, testCase, sequence }) {
       sequence,
       email,
       password,
-      projectName: testCase.projectName,
+      projectName,
       niche: testCase.niche,
       subdomain,
       finalUrl: page.url(),


### PR DESCRIPTION
## Summary

- adds a manual GitHub Actions workflow for runtime niche-resolution validation
- creates three real signup/pending_setup cases from `alcinoafonso380+conviteXX@gmail.com`, defaulting to sequences 100, 101, and 102
- verifies Supabase evidence read-only with `SUPABASE_DB_URL_READONLY`
- documents the pilot workflow and required secrets without storing secret values

## Runtime Flow

1. Create and confirm accounts through the existing mailbox/Playwright helpers.
2. Fill `pending_setup` for:
   - `Harmonização Facial`
   - `hof`
   - `Beleza Facial`
3. Capture each generated subdomain.
4. Query `accounts`, `account_profiles`, `account_niche_resolutions`, `business_taxons`, and `account_taxonomy`.
5. Publish results in the Job Summary and upload `niche-runtime-results` artifact.

## Validation

- Not run locally: the workspace is on `main`, and AGENTS.md blocks local edits/checks on `main`.
- Workflow includes syntax checks for the new scripts before executing runtime steps.
- Full validation requires running `Automation Niche Runtime Tests` manually with `app_url`.

## Notes

No cleanup is included in this pilot. Created accounts are preserved as runtime evidence.