### PR TITLE
docs: add future-facing note about Agents SDK evolution

### DIFF
--- a/docs/auto-agentes-up.md
+++ b/docs/auto-agentes-up.md
@@ -52,6 +52,14 @@ A base atual de agentes é tratada como plataforma composta por Responses API, b
 1. Padronizar novos agentes no stack Responses API + tools + SDK.
 2. Definir trilha mínima de observabilidade por agente (execução, tool calls e falhas).
 
+### Nota futura — Agents SDK com sandbox/harness
+
+A evolução recente do Agents SDK deve ser tratada como caminho futuro para automações programáticas complexas, especialmente fluxos que precisem inspecionar arquivos, executar comandos, editar código, trabalhar em tarefas longas ou operar em sandbox controlado.
+
+Para o A3.5 `Resolver IA de Nicho no pending_setup`, não aplicar Agents SDK neste momento. O caso atual é curto, tem entrada simples e saída estruturada; se a camada de IA for ativada, `Responses API + Structured Outputs` continuam suficientes.
+
+Usar Agents SDK deve ser avaliado apenas quando houver orquestração real com múltiplas etapas, tools, sandbox, geração de patches, PRs ou execução programática mais complexa.
+
 ---
 
 ## 3 — Passagens Eficazes entre Agentes (Handoff Design) *(🟣 Estável)*


### PR DESCRIPTION
### Motivation
- Clarify that the recent Agents SDK evolution (sandbox/harness) is a future path for complex programmatic automations while preserving the current A3.5 approach with `Responses API + Structured Outputs`.

### Description
- Edited `docs/auto-agentes-up.md` to append the section `Nota futura — Agents SDK com sandbox/harness` to item `2 — Agents Platform: Responses API + Tools + Agents SDK`, explicitly positioning Agents SDK as a future option and advising not to apply it to the A3.5 `Resolver IA de Nicho no pending_setup` case.

### Testing
- Executed `npm ci` (success) and `npm run check` (success; lint reported 33 warnings and `tsc` passed, with no errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04854c01508329a01a052bf17ebf39)