### PR TITLE
test: flexibiliza presets de nicho no runtime

### DIFF
--- a/.github/workflows/automation-niche-runtime-tests.yml
+++ b/.github/workflows/automation-niche-runtime-tests.yml
@@ -12,9 +12,13 @@ on:
         required: true
         default: "100"
       case_preset:
-        description: "Arquivo em automations/niche-runtime-tests/cases sem .json"
-        required: true
+        description: "Fallback: arquivo em automations/niche-runtime-tests/cases sem .json"
+        required: false
         default: "niche-resolution-20-6"
+      niches:
+        description: "Opcional: nichos livres separados por ponto e virgula"
+        required: false
+        default: ""
       verification_mode:
         description: "Nivel de verificacao apos preencher o pending_setup"
         required: true
@@ -43,6 +47,7 @@ jobs:
         env:
           APP_URL_OVERRIDE: ${{ inputs.app_url }}
           CASE_PRESET: ${{ inputs.case_preset }}
+          NICHES: ${{ inputs.niches }}
           MAILBOX_EMAIL: ${{ secrets.MAILBOX_EMAIL }}
           MAILBOX_PASSWORD: ${{ secrets.MAILBOX_PASSWORD }}
           SUPABASE_DB_URL_READONLY: ${{ secrets.SUPABASE_DB_URL_READONLY }}
@@ -53,6 +58,7 @@ jobs:
           test -n "$MAILBOX_EMAIL" || (echo "Falta secret MAILBOX_EMAIL" && exit 1)
           test -n "$MAILBOX_PASSWORD" || (echo "Falta secret MAILBOX_PASSWORD" && exit 1)
           if [ "$VERIFICATION_MODE" != "setup_only" ]; then
+            test -z "$NICHES" || (echo "verification_mode com banco exige case_preset, nao niches livres" && exit 1)
             test -n "$SUPABASE_DB_URL_READONLY" || (echo "Falta secret SUPABASE_DB_URL_READONLY" && exit 1)
           fi
 
@@ -81,6 +87,7 @@ jobs:
           APP_URL_OVERRIDE: ${{ inputs.app_url }}
           NICHE_RUNTIME_START_SEQUENCE: ${{ inputs.start_sequence }}
           NICHE_RUNTIME_CASE_PRESET: ${{ inputs.case_preset }}
+          NICHE_RUNTIME_NICHES: ${{ inputs.niches }}
           NICHE_RUNTIME_OUTPUT_PATH: ../niche-runtime-results.json
           MAILBOX_EMAIL: ${{ secrets.MAILBOX_EMAIL }}
           MAILBOX_PASSWORD: ${{ secrets.MAILBOX_PASSWORD }}

--- a/.github/workflows/automation-niche-runtime-tests.yml
+++ b/.github/workflows/automation-niche-runtime-tests.yml
@@ -11,6 +11,10 @@ on:
         description: "Numero inicial para alcinoafonso380+conviteXX@gmail.com"
         required: true
         default: "100"
+      case_preset:
+        description: "Arquivo em automations/niche-runtime-tests/cases sem .json"
+        required: true
+        default: "niche-resolution-20-6"
       verification_mode:
         description: "Nivel de verificacao apos preencher o pending_setup"
         required: true
@@ -38,12 +42,14 @@ jobs:
       - name: Validate required inputs and secrets
         env:
           APP_URL_OVERRIDE: ${{ inputs.app_url }}
+          CASE_PRESET: ${{ inputs.case_preset }}
           MAILBOX_EMAIL: ${{ secrets.MAILBOX_EMAIL }}
           MAILBOX_PASSWORD: ${{ secrets.MAILBOX_PASSWORD }}
           SUPABASE_DB_URL_READONLY: ${{ secrets.SUPABASE_DB_URL_READONLY }}
           VERIFICATION_MODE: ${{ inputs.verification_mode }}
         run: |
           test -n "$APP_URL_OVERRIDE" || (echo "Falta input app_url" && exit 1)
+          test -n "$CASE_PRESET" || (echo "Falta input case_preset" && exit 1)
           test -n "$MAILBOX_EMAIL" || (echo "Falta secret MAILBOX_EMAIL" && exit 1)
           test -n "$MAILBOX_PASSWORD" || (echo "Falta secret MAILBOX_PASSWORD" && exit 1)
           if [ "$VERIFICATION_MODE" != "setup_only" ]; then
@@ -74,6 +80,7 @@ jobs:
         env:
           APP_URL_OVERRIDE: ${{ inputs.app_url }}
           NICHE_RUNTIME_START_SEQUENCE: ${{ inputs.start_sequence }}
+          NICHE_RUNTIME_CASE_PRESET: ${{ inputs.case_preset }}
           NICHE_RUNTIME_OUTPUT_PATH: ../niche-runtime-results.json
           MAILBOX_EMAIL: ${{ secrets.MAILBOX_EMAIL }}
           MAILBOX_PASSWORD: ${{ secrets.MAILBOX_PASSWORD }}

--- a/automations/niche-runtime-tests/README.md
+++ b/automations/niche-runtime-tests/README.md
@@ -10,13 +10,45 @@ Inputs manuais:
 
 - `app_url`: URL do app ou preview a ser validado.
 - `start_sequence`: numero inicial do alias `alcinoafonso380+conviteXX@gmail.com`. Default: `100`.
+- `case_preset`: arquivo em `automations/niche-runtime-tests/cases` sem a extensao `.json`. Default: `niche-resolution-20-6`.
 - `verification_mode`: nivel de verificacao apos preencher o setup.
   - `setup_only`: cria as contas, confirma email, preenche `pending_setup` e publica evidencia. Nao consulta o banco.
   - `niche_resolution_20_6`: executa o preset read-only que valida a expectativa da etapa 20.6 no Supabase.
 
-## Casos cobertos
+## Presets de casos
 
-O workflow cria e confirma tres contas reais, usando a mailbox programatica do `validador-final`, e preenche o `pending_setup`:
+Os nichos ficam fora do script runtime. Cada conjunto de teste deve ser declarado como JSON em:
+
+```text
+automations/niche-runtime-tests/cases/<case_preset>.json
+```
+
+Formato:
+
+```json
+{
+  "cases": [
+    {
+      "id": "strong_match",
+      "label": "Caso 1 - Match forte",
+      "sequenceOffset": 0,
+      "projectSuffix": "A",
+      "niche": "Harmonização Facial"
+    }
+  ]
+}
+```
+
+Campos:
+
+- `niche`: obrigatorio.
+- `id`: opcional, mas recomendado quando houver verificacao posterior.
+- `label`: opcional, usado no summary.
+- `sequenceOffset`: opcional; default e a posicao do caso no array.
+- `projectSuffix`: opcional; default e `A`, `B`, `C`...
+- `projectNameTemplate`: opcional; aceita `{sequence}`, `{suffix}` e `{id}`.
+
+O preset default `niche-resolution-20-6` cria e confirma tres contas reais, usando a mailbox programatica do `validador-final`, e preenche o `pending_setup`:
 
 - `convite100`: `Harmonização Facial` -> match forte.
 - `convite101`: `hof` -> alias.
@@ -39,7 +71,7 @@ Esse nucleo ja funciona como teste de funcionamento do fluxo.
 
 ## Preset de validacao no banco
 
-A validacao no banco e opcional porque a expectativa muda por etapa. No preset `niche_resolution_20_6`, a etapa read-only consulta o Supabase com `SUPABASE_DB_URL_READONLY` e valida:
+A validacao no banco e opcional porque a expectativa muda por etapa. O modo `niche_resolution_20_6` exige o `case_preset` `niche-resolution-20-6`, consulta o Supabase com `SUPABASE_DB_URL_READONLY` e valida:
 
 - conta criada e `accounts.status = active`;
 - `account_profiles.niche` igual ao input;

--- a/automations/niche-runtime-tests/README.md
+++ b/automations/niche-runtime-tests/README.md
@@ -10,14 +10,31 @@ Inputs manuais:
 
 - `app_url`: URL do app ou preview a ser validado.
 - `start_sequence`: numero inicial do alias `alcinoafonso380+conviteXX@gmail.com`. Default: `100`.
-- `case_preset`: arquivo em `automations/niche-runtime-tests/cases` sem a extensao `.json`. Default: `niche-resolution-20-6`.
+- `niches`: lista livre de nichos separada por `;`. Se preenchida, cria uma conta por nicho e ignora `case_preset`.
+- `case_preset`: fallback versionado em `automations/niche-runtime-tests/cases`, sem a extensao `.json`. Default: `niche-resolution-20-6`.
 - `verification_mode`: nivel de verificacao apos preencher o setup.
   - `setup_only`: cria as contas, confirma email, preenche `pending_setup` e publica evidencia. Nao consulta o banco.
   - `niche_resolution_20_6`: executa o preset read-only que valida a expectativa da etapa 20.6 no Supabase.
 
+## Nichos livres
+
+Para testes exploratorios, preencha `niches` diretamente no workflow:
+
+```text
+Marketing Digital; Market Digital; Digital marketing
+```
+
+Com `start_sequence = 103`, esse exemplo cria tres contas:
+
+- `alcinoafonso380+convite103@gmail.com` com nicho `Marketing Digital`;
+- `alcinoafonso380+convite104@gmail.com` com nicho `Market Digital`;
+- `alcinoafonso380+convite105@gmail.com` com nicho `Digital marketing`.
+
+Use `verification_mode = setup_only` para nichos livres. Verificacoes rigidas de banco continuam presas a presets versionados.
+
 ## Presets de casos
 
-Os nichos ficam fora do script runtime. Cada conjunto de teste deve ser declarado como JSON em:
+Para suites repetiveis, cada conjunto de teste pode ser declarado como JSON em:
 
 ```text
 automations/niche-runtime-tests/cases/<case_preset>.json

--- a/automations/niche-runtime-tests/cases/niche-resolution-20-6.json
+++ b/automations/niche-runtime-tests/cases/niche-resolution-20-6.json
@@ -1,0 +1,26 @@
+{
+  "description": "Etapa 20.6 - resolucao de nicho: match forte, alias e sem candidato claro.",
+  "cases": [
+    {
+      "id": "strong_match",
+      "label": "Caso 1 - Match forte",
+      "sequenceOffset": 0,
+      "projectSuffix": "A",
+      "niche": "Harmonização Facial"
+    },
+    {
+      "id": "alias",
+      "label": "Caso 2 - Alias",
+      "sequenceOffset": 1,
+      "projectSuffix": "B",
+      "niche": "hof"
+    },
+    {
+      "id": "unclear",
+      "label": "Caso 3 - Sem candidato claro",
+      "sequenceOffset": 2,
+      "projectSuffix": "C",
+      "niche": "Beleza Facial"
+    }
+  ]
+}

--- a/automations/supabase-inspect/verify-niche-runtime.mjs
+++ b/automations/supabase-inspect/verify-niche-runtime.mjs
@@ -52,6 +52,12 @@ function assertVerificationPreset({ verificationMode, payload }) {
   const expectedPreset = verificationModePresets.get(verificationMode);
   if (!expectedPreset) return;
 
+  if (payload.caseSource !== "preset") {
+    die(
+      `verification_mode ${verificationMode} exige case_source preset; recebido ${payload.caseSource ?? "null"}`,
+    );
+  }
+
   if (payload.casePreset !== expectedPreset) {
     die(
       `verification_mode ${verificationMode} exige case_preset ${expectedPreset}; recebido ${payload.casePreset ?? "null"}`,

--- a/automations/supabase-inspect/verify-niche-runtime.mjs
+++ b/automations/supabase-inspect/verify-niche-runtime.mjs
@@ -6,6 +6,7 @@ const { Client } = pg;
 
 const allowedUnclearStatuses = new Set(["unclassified", "review_required"]);
 const supportedVerificationModes = new Set(["niche_resolution_20_6"]);
+const verificationModePresets = new Map([["niche_resolution_20_6", "niche-resolution-20-6"]]);
 
 function die(message) {
   console.error(message);
@@ -45,6 +46,17 @@ function readVerificationMode() {
   }
 
   return mode;
+}
+
+function assertVerificationPreset({ verificationMode, payload }) {
+  const expectedPreset = verificationModePresets.get(verificationMode);
+  if (!expectedPreset) return;
+
+  if (payload.casePreset !== expectedPreset) {
+    die(
+      `verification_mode ${verificationMode} exige case_preset ${expectedPreset}; recebido ${payload.casePreset ?? "null"}`,
+    );
+  }
 }
 
 async function fetchAccountEvidence(client, subdomain) {
@@ -192,13 +204,14 @@ function evaluateCase(testCase, evidence) {
   };
 }
 
-function renderSummary({ inputPath, appUrl, verificationMode, results }) {
+function renderSummary({ inputPath, appUrl, casePreset, verificationMode, results }) {
   const passed = results.filter((entry) => entry.status === "passed").length;
   const failed = results.length - passed;
 
   writeSummary("# Runtime niche resolution verification");
   writeSummary(`- input_path: \`${inputPath}\``);
   writeSummary(`- app_url: \`${appUrl ?? "null"}\``);
+  writeSummary(`- case_preset: \`${casePreset ?? "null"}\``);
   writeSummary(`- verification_mode: \`${verificationMode}\``);
   writeSummary(`- status: \`${failed === 0 ? "passed" : "failed"}\``);
   writeSummary(`- cases: \`${passed}/${results.length} passed\``);
@@ -225,6 +238,7 @@ async function main() {
   const connectionString = requireEnv("SUPABASE_DB_URL_READONLY");
   const { inputPath, payload } = readInput();
   const verificationMode = readVerificationMode();
+  assertVerificationPreset({ verificationMode, payload });
   const client = new Client({ connectionString });
   const results = [];
 
@@ -254,13 +268,20 @@ async function main() {
     kind: "niche_runtime_verification_results",
     verificationMode,
     appUrl: payload.appUrl ?? null,
+    casePreset: payload.casePreset ?? null,
     inputPath,
     completedAt: new Date().toISOString(),
     results,
   };
 
   console.log(JSON.stringify(output, null, 2));
-  renderSummary({ inputPath, appUrl: payload.appUrl, verificationMode, results });
+  renderSummary({
+    inputPath,
+    appUrl: payload.appUrl,
+    casePreset: payload.casePreset,
+    verificationMode,
+    results,
+  });
 
   if (results.some((entry) => entry.status !== "passed")) {
     process.exitCode = 1;

--- a/automations/validador-final/run-niche-setup.mjs
+++ b/automations/validador-final/run-niche-setup.mjs
@@ -1,4 +1,4 @@
-import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -12,33 +12,11 @@ import { findLatestEmailLinkForAlias } from "./mailbox-client.mjs";
 const MAILBOX_POLL_TIMEOUT_MS = 120000;
 const MAILBOX_POLL_INTERVAL_MS = 5000;
 const DEFAULT_START_SEQUENCE = 100;
+const DEFAULT_CASE_PRESET = "niche-resolution-20-6";
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const defaultOutputPath = resolve(scriptDir, "../niche-runtime-results.json");
-
-const cases = [
-  {
-    id: "strong_match",
-    label: "Caso 1 - Match forte",
-    sequenceOffset: 0,
-    projectSuffix: "A",
-    niche: "Harmonização Facial",
-  },
-  {
-    id: "alias",
-    label: "Caso 2 - Alias",
-    sequenceOffset: 1,
-    projectSuffix: "B",
-    niche: "hof",
-  },
-  {
-    id: "unclear",
-    label: "Caso 3 - Sem candidato claro",
-    sequenceOffset: 2,
-    projectSuffix: "C",
-    niche: "Beleza Facial",
-  },
-];
+const casesDir = resolve(scriptDir, "../niche-runtime-tests/cases");
 
 function die(message) {
   console.error(message);
@@ -71,6 +49,70 @@ function readStartSequence() {
   return parsed;
 }
 
+function readCasePreset() {
+  const raw = process.env.NICHE_RUNTIME_CASE_PRESET;
+  const preset = typeof raw === "string" && raw.trim() !== "" ? raw.trim() : DEFAULT_CASE_PRESET;
+
+  if (!/^[a-zA-Z0-9._-]+$/.test(preset)) {
+    die(`NICHE_RUNTIME_CASE_PRESET invalido: ${preset}`);
+  }
+
+  return preset;
+}
+
+function defaultProjectSuffix(index) {
+  if (index >= 0 && index < 26) return String.fromCharCode(65 + index);
+  return String(index + 1);
+}
+
+function normalizeCase(rawCase, index, preset) {
+  if (!rawCase || typeof rawCase !== "object" || Array.isArray(rawCase)) {
+    die(`Caso ${index + 1} invalido no preset ${preset}.`);
+  }
+
+  const niche = typeof rawCase.niche === "string" ? rawCase.niche.trim() : "";
+  if (!niche) {
+    die(`Caso ${index + 1} do preset ${preset} sem niche.`);
+  }
+
+  const sequenceOffset =
+    rawCase.sequenceOffset === undefined ? index : Number.parseInt(String(rawCase.sequenceOffset), 10);
+
+  if (!Number.isInteger(sequenceOffset) || sequenceOffset < 0) {
+    die(`sequenceOffset invalido no caso ${index + 1} do preset ${preset}.`);
+  }
+
+  return {
+    id: typeof rawCase.id === "string" && rawCase.id.trim() !== "" ? rawCase.id.trim() : `case_${index + 1}`,
+    label:
+      typeof rawCase.label === "string" && rawCase.label.trim() !== ""
+        ? rawCase.label.trim()
+        : `Caso ${index + 1}`,
+    sequenceOffset,
+    projectSuffix:
+      typeof rawCase.projectSuffix === "string" && rawCase.projectSuffix.trim() !== ""
+        ? rawCase.projectSuffix.trim()
+        : defaultProjectSuffix(index),
+    projectNameTemplate:
+      typeof rawCase.projectNameTemplate === "string" && rawCase.projectNameTemplate.trim() !== ""
+        ? rawCase.projectNameTemplate.trim()
+        : null,
+    niche,
+  };
+}
+
+function readCases(casePreset) {
+  const presetPath = resolve(casesDir, `${casePreset}.json`);
+  const parsed = JSON.parse(readFileSync(presetPath, "utf-8"));
+  const rawCases = Array.isArray(parsed) ? parsed : parsed?.cases;
+
+  if (!Array.isArray(rawCases) || rawCases.length === 0) {
+    die(`Preset ${casePreset} sem cases.`);
+  }
+
+  return rawCases.map((rawCase, index) => normalizeCase(rawCase, index, casePreset));
+}
+
 function buildAlias(sequence) {
   return `alcinoafonso380+convite${sequence}@gmail.com`;
 }
@@ -80,6 +122,13 @@ function buildPassword(sequence) {
 }
 
 function buildProjectName(sequence, testCase) {
+  if (testCase.projectNameTemplate) {
+    return testCase.projectNameTemplate
+      .replaceAll("{sequence}", String(sequence))
+      .replaceAll("{suffix}", testCase.projectSuffix)
+      .replaceAll("{id}", testCase.id);
+  }
+
   return `Convite teste runtime ${sequence} ${testCase.projectSuffix}`;
 }
 
@@ -277,6 +326,8 @@ async function main() {
 
   const appOrigin = new URL(appUrl).origin;
   const startSequence = readStartSequence();
+  const casePreset = readCasePreset();
+  const cases = readCases(casePreset);
   const outputPath = resolve(process.env.NICHE_RUNTIME_OUTPUT_PATH || defaultOutputPath);
   const startedAt = new Date().toISOString();
   const results = [];
@@ -285,6 +336,7 @@ async function main() {
   writeSummary(`- started_at: \`${startedAt}\``);
   writeSummary(`- app_url: \`${appUrl}\``);
   writeSummary(`- start_sequence: \`${startSequence}\``);
+  writeSummary(`- case_preset: \`${casePreset}\``);
 
   for (const testCase of cases) {
     const sequence = startSequence + testCase.sequenceOffset;
@@ -304,6 +356,7 @@ async function main() {
     kind: "niche_runtime_setup_results",
     appUrl,
     appOrigin,
+    casePreset,
     startSequence,
     startedAt,
     completedAt: new Date().toISOString(),

--- a/automations/validador-final/run-niche-setup.mjs
+++ b/automations/validador-final/run-niche-setup.mjs
@@ -60,9 +60,43 @@ function readCasePreset() {
   return preset;
 }
 
+function readManualNiches() {
+  const raw = process.env.NICHE_RUNTIME_NICHES;
+  if (typeof raw !== "string" || raw.trim() === "") return [];
+
+  const niches = raw
+    .split(/\r?\n|;/)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
+  if (niches.length === 0) return [];
+
+  const unique = new Set();
+  for (const niche of niches) {
+    const key = niche.toLowerCase();
+    if (unique.has(key)) {
+      die(`NICHE_RUNTIME_NICHES contem nicho duplicado: ${niche}`);
+    }
+    unique.add(key);
+  }
+
+  return niches;
+}
+
 function defaultProjectSuffix(index) {
   if (index >= 0 && index < 26) return String.fromCharCode(65 + index);
   return String(index + 1);
+}
+
+function buildManualCase(niche, index) {
+  return {
+    id: `manual_${index + 1}`,
+    label: `Caso ${index + 1} - ${niche}`,
+    sequenceOffset: index,
+    projectSuffix: defaultProjectSuffix(index),
+    projectNameTemplate: null,
+    niche,
+  };
 }
 
 function normalizeCase(rawCase, index, preset) {
@@ -326,8 +360,13 @@ async function main() {
 
   const appOrigin = new URL(appUrl).origin;
   const startSequence = readStartSequence();
-  const casePreset = readCasePreset();
-  const cases = readCases(casePreset);
+  const manualNiches = readManualNiches();
+  const casePreset = manualNiches.length > 0 ? null : readCasePreset();
+  const caseSource = manualNiches.length > 0 ? "manual_niches" : "preset";
+  const cases =
+    manualNiches.length > 0
+      ? manualNiches.map((niche, index) => buildManualCase(niche, index))
+      : readCases(casePreset);
   const outputPath = resolve(process.env.NICHE_RUNTIME_OUTPUT_PATH || defaultOutputPath);
   const startedAt = new Date().toISOString();
   const results = [];
@@ -336,7 +375,9 @@ async function main() {
   writeSummary(`- started_at: \`${startedAt}\``);
   writeSummary(`- app_url: \`${appUrl}\``);
   writeSummary(`- start_sequence: \`${startSequence}\``);
-  writeSummary(`- case_preset: \`${casePreset}\``);
+  writeSummary(`- case_source: \`${caseSource}\``);
+  writeSummary(`- case_preset: \`${casePreset ?? "null"}\``);
+  writeSummary(`- case_count: \`${cases.length}\``);
 
   for (const testCase of cases) {
     const sequence = startSequence + testCase.sequenceOffset;
@@ -356,6 +397,7 @@ async function main() {
     kind: "niche_runtime_setup_results",
     appUrl,
     appOrigin,
+    caseSource,
     casePreset,
     startSequence,
     startedAt,


### PR DESCRIPTION
## Objetivo

Flexibilizar a automacao `Automation Niche Runtime Tests` para permitir novos conjuntos de nichos sem alterar o script Playwright a cada teste.

## Mudancas

- adiciona input manual `case_preset` no workflow;
- move os casos atuais da etapa 20.6 para `automations/niche-runtime-tests/cases/niche-resolution-20-6.json`;
- faz `run-niche-setup.mjs` carregar casos de JSON e normalizar defaults de `id`, `label`, `sequenceOffset`, `projectSuffix` e `projectNameTemplate`;
- inclui `casePreset` na evidencia gerada;
- amarra `verification_mode=niche_resolution_20_6` ao preset `niche-resolution-20-6`, evitando usar verificacao especifica com casos genericos;
- atualiza a documentacao do piloto.

## Validacao local

- `npm ci`: sucesso;
- `npm run check`: sucesso, com warnings ja existentes;
- `automations/validador-final`: `npm ci`, `npm run check` e `node --check run-niche-setup.mjs` com sucesso;
- `automations/supabase-inspect`: `npm ci`, `npm run check` e `node --check verify-niche-runtime.mjs` com sucesso;
- JSON do preset default parseado com sucesso.

## Observacao

Nao roda automaticamente. Continua dependente de `workflow_dispatch`.