### PR TITLE
docs: adiciona Niche Runtime Tests sem reindexar seções

### DIFF
--- a/automations/niche-runtime-tests/README.md
+++ b/automations/niche-runtime-tests/README.md
@@ -2,6 +2,19 @@
 
 Piloto de automacao runtime para validar o fluxo real de `pending_setup` com persistencia de resolucao de nicho.
 
+## Papel da automacao
+
+O nucleo estavel desta automacao e funcional:
+
+- criar conta real;
+- confirmar email;
+- abrir sessao autenticada;
+- preencher `pending_setup`;
+- capturar `subdomain`, `email`, `projectName`, `niche`, `finalUrl` e timestamp;
+- publicar evidencia no Job Summary e no artifact.
+
+Esse nucleo ja funciona como teste de funcionamento do fluxo. Verificacoes rigidas de banco sao opcionais e devem ficar presas a presets versionados, porque a expectativa de persistencia muda conforme a etapa validada.
+
 ## Workflow
 
 GitHub Actions -> `Automation Niche Runtime Tests`
@@ -14,7 +27,7 @@ Inputs manuais:
 - `case_preset`: fallback versionado em `automations/niche-runtime-tests/cases`, sem a extensao `.json`. Default: `niche-resolution-20-6`.
 - `verification_mode`: nivel de verificacao apos preencher o setup.
   - `setup_only`: cria as contas, confirma email, preenche `pending_setup` e publica evidencia. Nao consulta o banco.
-  - `niche_resolution_20_6`: executa o preset read-only que valida a expectativa da etapa 20.6 no Supabase.
+  - `niche_resolution_20_6`: executa o preset read-only que valida a expectativa versionada da etapa 20.6 no Supabase.
 
 ## Nichos livres
 
@@ -30,7 +43,7 @@ Com `start_sequence = 103`, esse exemplo cria tres contas:
 - `alcinoafonso380+convite104@gmail.com` com nicho `Market Digital`;
 - `alcinoafonso380+convite105@gmail.com` com nicho `Digital marketing`.
 
-Use `verification_mode = setup_only` para nichos livres. Verificacoes rigidas de banco continuam presas a presets versionados.
+Use `verification_mode = setup_only` para nichos livres. Nesse modo, o workflow valida criacao de conta e preenchimento do setup, mas nao tenta decidir se o banco gravou uma resolucao correta para uma etapa especifica.
 
 ## Presets de casos
 
@@ -73,30 +86,17 @@ O preset default `niche-resolution-20-6` cria e confirma tres contas reais, usan
 
 Se `start_sequence` for alterado, os tres casos usam `start_sequence`, `start_sequence + 1` e `start_sequence + 2`. Os nomes dos projetos acompanham a sequencia usada.
 
-## Nucleo estavel
-
-O nucleo estavel da automacao e:
-
-- criar conta real;
-- confirmar email;
-- abrir sessao autenticada;
-- preencher `pending_setup`;
-- capturar `subdomain`, `email`, `projectName`, `niche`, `finalUrl` e timestamp;
-- publicar evidencia no Job Summary e no artifact.
-
-Esse nucleo ja funciona como teste de funcionamento do fluxo.
-
 ## Preset de validacao no banco
 
-A validacao no banco e opcional porque a expectativa muda por etapa. O modo `niche_resolution_20_6` exige o `case_preset` `niche-resolution-20-6`, consulta o Supabase com `SUPABASE_DB_URL_READONLY` e valida:
+A validacao no banco e opcional porque a expectativa muda por etapa. O modo `niche_resolution_20_6` exige o `case_preset` `niche-resolution-20-6`, consulta o Supabase com `SUPABASE_DB_URL_READONLY` e valida a evidencia versionada daquela etapa.
 
-- conta criada e `accounts.status = active`;
-- `account_profiles.niche` igual ao input;
-- `account_niche_resolutions.raw_input` igual ao input;
-- status esperado em `account_niche_resolutions.resolution_status`;
-- `selected_taxon_id` e `score` preenchidos quando o caso exige match forte;
-- `match_source` contendo `alias` no caso de alias;
-- nenhuma linha criada em `account_taxonomy`.
+Contrato de uso:
+
+- nao usar `niche_resolution_20_6` para nichos livres;
+- nao generalizar expectativas do preset 20.6 para etapas futuras;
+- quando a regra de produto mudar, criar novo preset/versionamento em vez de reaproveitar expectativa antiga.
+
+Observacao historica: apos a evolucao do vinculo deterministico oficial, match forte pode gravar `account_taxonomy`. Portanto, a ausencia de linha em `account_taxonomy` nao deve ser usada como expectativa generica da automacao. Ela so vale se estiver explicitamente prevista em um preset antigo ou em uma etapa que ainda exija esse comportamento.
 
 ## Secrets usados
 
@@ -112,4 +112,4 @@ O workflow escreve o resumo no Job Summary e publica o artifact `niche-runtime-r
 
 ## Cleanup
 
-Nao ha cleanup automatico neste piloto. As contas criadas ficam preservadas como evidencia funcional.
+Nao ha cleanup automatico neste piloto. As contas criadas ficam preservadas como evidencia funcional e podem ser excluidas manualmente depois da analise.

--- a/docs/automations.md
+++ b/docs/automations.md
@@ -22,6 +22,7 @@ docs/roadmap.md: evolução funcional.
 - `validador-final` migrado para `automations/validador-final/` e workflow legado removido.
 - `supabase-inspect` migrado para `automations/supabase-inspect/` com execução a partir da nova raiz canônica e sem fallback `npm install --no-save` no workflow.
 - `docs-apply-report` migrado para `automations/docs-apply-report/` com execução a partir da nova raiz canônica.
+- `niche-runtime-tests` criado como subprojeto canônico em `automations/niche-runtime-tests/`.
 - `pipelines/validador-final/`, `pipelines/supabase-inspect/` e `pipelines/docs-apply-report/` deixaram de ser paths oficiais.
 
 1. Objetivo e escopo
@@ -120,14 +121,22 @@ OPENAI_API_KEY
 Uso: pipelines com chamadas de modelo
 SUPABASE_DB_URL_READONLY
 Uso: inspeção read-only
+MAILBOX_EMAIL
+Uso: automações de runtime que precisam confirmar e-mails reais.
+MAILBOX_PASSWORD
+Uso: senha de app da mailbox para leitura programática por POP3.
 
 2.2.3 Integrações existentes
 OpenAI:
 supabase-inspect
 Supabase:
 supabase-inspect
+niche-runtime-tests quando o modo de verificação consulta banco
 Documentação:
 pipeline-docs-apply-report
+Mailbox:
+validador-final
+niche-runtime-tests
 
 2.2.4 Estrutura operacional
 Workflows em .github/workflows.
@@ -136,6 +145,7 @@ Workflows identificados:
 .github/workflows/pipeline-supabase-inspect.yml
 .github/workflows/pipeline-docs-apply-report.yml
 .github/workflows/automation-validador-final.yml
+.github/workflows/automation-niche-runtime-tests.yml
 .github/workflows/security.yml
 .github/workflows/upgrade-next-16-1-1.yml
 
@@ -146,7 +156,7 @@ Banco de dados, Auth e fonte de dados para inspeções automatizadas read-only.
 2.3.2 Credencial registrada
 SUPABASE_DB_URL_READONLY
 Armazenamento: GitHub Secrets
-Finalidade: inspeção read-only no pipeline supabase-inspect
+Finalidade: inspeção read-only no pipeline supabase-inspect e em verificações opcionais de runtime quando aplicável
 Escopo: role/usuário read-only
 
 2.3.3 Estrutura atual
@@ -157,6 +167,7 @@ Durante o MVP, a migration supabase/migrations/0010__ai_readonly_mvp_inspect_rel
 
 2.3.4 Observações
 O pipeline atual executa apenas SQL read-only.
+Verificações de runtime que consultam banco devem ser tratadas como presets versionados, não como expectativa genérica para qualquer teste.
 Discovery pode usar information_schema e pg_catalog.
 
 2.4 Vercel
@@ -391,6 +402,39 @@ Referências / dependências:
 `docs/lousa-automations3-6.md`
 `docs/lousa-automations3-6-1.md`
 
+3.7 Niche Runtime Tests
+
+Objetivo:
+Validar em runtime real o fluxo de criação de conta e preenchimento de `pending_setup` com nichos informados pelo usuário, usando contas reais, confirmação por e-mail e evidência operacional em Job Summary/artifact.
+
+Status:
+Implementada como piloto operacional flexível.
+
+Acesso:
+GitHub → Actions → workflow `automation-niche-runtime-tests`
+
+Como usar:
+Executar o workflow informando:
+- `app_url`: URL do app ou preview;
+- `start_sequence`: número inicial para `alcinoafonso380+conviteXX@gmail.com`;
+- `niches`: lista livre separada por `;`, quando o objetivo for explorar nichos escolhidos manualmente;
+- `case_preset`: fallback versionado quando o objetivo for repetir uma suíte formal;
+- `verification_mode`: `setup_only` para validação funcional flexível ou modo versionado quando a etapa tiver expectativa rígida de banco.
+
+Resposta esperada:
+Contas criadas e confirmadas, `pending_setup` preenchido, subdomínios capturados, evidência no Job Summary e artifact `niche-runtime-results`.
+
+Regra operacional:
+A automação não deve ser engessada por verificação de banco genérica. O teste base é criar conta e preencher o pipeline. Verificações no Supabase só devem entrar como presets versionados, porque a expectativa de tabelas como `account_niche_resolutions` e `account_taxonomy` muda conforme a etapa funcional.
+
+Referências / dependências:
+README local: `automations/niche-runtime-tests/README.md`
+Workflow: `.github/workflows/automation-niche-runtime-tests.yml`
+Runtime: `automations/niche-runtime-tests/`
+Casos versionados: `automations/niche-runtime-tests/cases/`
+Reuso de mailbox: `automations/validador-final/`
+Verificação opcional de banco: `automations/supabase-inspect/verify-niche-runtime.mjs`
+
 4. Aprendizados operacionais
 4.1 Princípios identificados
 Integração entre plataformas não garante utilidade real.
@@ -473,3 +517,15 @@ Weekly evals e complimentary daily tokens são benefícios distintos.
 4.10.7 Regra reutilizável pré-merge:
 - para feature branch sem alteração de pipeline, usar `workflow` da `main` + `app_url` da preview da feature
 - para feature branch com alteração de pipeline, usar `workflow` e `app_url` da própria feature branch
+
+4.11 Niche Runtime Tests (3.7)
+
+4.11.1 O núcleo estável da automação é criação de conta + confirmação + preenchimento de `pending_setup`. Isso já valida funcionamento real do fluxo.
+
+4.11.2 Nichos livres devem usar `verification_mode = setup_only`, porque a expectativa correta de banco depende da etapa funcional e não deve ser presumida.
+
+4.11.3 Presets versionados são o lugar correto para expectativa rígida de banco. Quando a regra muda, criar ou ajustar preset, em vez de engessar o workflow genérico.
+
+4.11.4 O uso de `start_sequence` e aliases `alcinoafonso380+conviteXX@gmail.com` permite criar múltiplas contas em uma mesma execução e reduz colisões previsíveis.
+
+4.11.5 Contas criadas por esse fluxo são evidência funcional temporária. Cleanup permanece manual até existir regra aprovada para remoção segura.


### PR DESCRIPTION
## Resumo

- Preserva `3.5 Resolver IA de Nicho no pending_setup` sem alteração de identidade.
- Preserva `3.6 Apply automático de migrations no Supabase`.
- Adiciona `3.7 Niche Runtime Tests` como novo item no catálogo de automações.
- Atualiza referências operacionais de GitHub Actions/secrets para incluir `automation-niche-runtime-tests`.
- Ajusta `automations/niche-runtime-tests/README.md` para deixar claro que `setup_only` é o núcleo funcional estável e que validações rígidas de banco são versionadas.

## Observação

A `base-tecnica.md` ainda deve ser tratada em PR separado se formos corrigir contrato prescritivo de runtime sobre `account_taxonomy`.

## Validação

- `npm ci`: não executado; alteração documental feita remotamente.
- `npm run check`: não executado; alteração documental feita remotamente.
