### PR TITLE
docs: atualiza contrato de taxonomia oficial (base-tecnica v2.0.34, schema v1.0.16)

### DIFF
--- a/docs/base-tecnica.md
+++ b/docs/base-tecnica.md
@@ -2,7 +2,7 @@
 
 0.1. Cabeçalho
 • Documento: Base Técnica LP Factory 10
-• Versão: v2.0.33
+• Versão: v2.0.34
 • Data: 11/05/2026
 
 0.2 Contrato do documento (consulta)
@@ -306,8 +306,14 @@
 • Regra: não embutir avaliação de confiança, thresholds ou reasons semânticos inline em UI, route ou server action; reutilizar helper + contrato.
 • `aiEscalationMode` é preparação contratual para evolução futura e não autoriza IA no runtime atual sem caso específico.
 • Resolução operacional: após avaliar o matching determinístico no pós-save do `pending_setup`, o runtime pode persistir a resolução atual da conta via adapter server-side canônico em `lib/onboarding/niche-resolution/adapters/accountNicheResolutionAdapter.ts`.
-• Regra: `account_niche_resolutions` registra a resolução operacional atual; `account_taxonomy` continua reservado para vínculo oficial futuro.
+• Regra: `account_niche_resolutions` registra a resolução operacional atual.
 • Regra: falha de matching ou persistência da resolução não pode bloquear o lead, `revalidatePath(route)` ou `redirect(route)`.
+• Vínculo oficial: após a resolução determinística, o runtime pode gravar vínculo oficial em `account_taxonomy` via adapter server-side canônico em `lib/onboarding/niche-resolution/adapters/accountTaxonomyAdapter.ts`.
+• Regra: gravar `account_taxonomy` somente quando a decisão determinística for de alta confiança, houver candidato oficial com `taxon_id` e não houver necessidade de revisão administrativa.
+• Regra: `account_niche_resolutions` permanece como registro operacional; `account_taxonomy` representa o vínculo oficial da conta com o taxon.
+• Regra: falha na gravação do vínculo oficial não pode bloquear o lead, setup, ativação da conta, `revalidatePath(route)` ou `redirect(route)`.
+• Regra MVP: se já houver vínculo primário ativo diferente, não substituir automaticamente; manter revisão humana para etapa futura.
+• Regra: IA, microdiálogo, criação automática de taxon/alias e alteração de UI ficam fora deste recorte.
 • Regra: logs do fluxo devem permanecer sem PII e não devem registrar `raw_input`, nicho bruto, query, aliases, candidatos completos ou dados de formulário.
 • Regra: timestamps da resolução operacional devem ser controlados pelo banco.
 
@@ -388,6 +394,7 @@
 • Regra (logs sem PII): não logar valores de formulário (ex.: name, whatsapp, site_url).
 • Onboarding pós-save (E10.4.6): revalidatePath(route) antes do redirect para evitar UI stale.
 • Matching de taxonomia: quando a RPC determinística for consumida em runtime, observability mínima deve registrar apenas metadados não sensíveis, como request_id, latency_ms, candidates_count, top_match_source e top_score; eventos canônicos: `setup_taxonomy_match_evaluated` e `setup_taxonomy_match_failed`; não logar nicho bruto, `p_query`, query, aliases digitados, dados de formulário ou valores identificáveis do usuário.
+• Vínculo oficial de taxonomia: logs devem registrar apenas sinais seguros de avaliação, gravação, skip ou falha do vínculo em `account_taxonomy`; não logar `niche`, `raw_input`, query, aliases, candidatos completos, `name`, `whatsapp` ou `site_url`.
 
 5.3.5 Signup
 • Entrada: /auth/sign-up (SignUpForm usa supabase.auth.signUp) (PATH: components/sign-up-form.tsx).
@@ -456,6 +463,8 @@ Fonte normativa da allowlist SULB para exceções de Auth. Qualquer novo arquivo
 • Tipos canônicos e adapters vNext: validar por 3.6 e 3.14.
 
 99. Changelog
+v2.0.34 — 11/05/2026 — Base técnica atualizada com contrato mínimo de runtime para gravação server-side do vínculo oficial em `account_taxonomy`, preservando `account_niche_resolutions` como registro operacional, regra de alta confiança, conflito de primário sem substituição automática, fluxo não bloqueante e logs sem PII.
+
 v2.0.33 — 11/05/2026 — Base técnica atualizada com contrato mínimo de runtime para persistência operacional de resolução em `account_niche_resolutions`, sem gravação de `account_taxonomy`, com fluxo não bloqueante e logs sem PII.
 
 v2.0.32 — 10/05/2026 — Base técnica atualizada com contrato runtime do matching determinístico de taxonomia no pós-save do `pending_setup`, regra não bloqueante e observability segura com eventos canônicos.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -2,7 +2,7 @@
 
 0.1 Cabeçalho
 • Data da última atualização: 11/05/2026
-• Documento: LP Factory 10 — Schema (DB Contract) v1.0.15
+• Documento: LP Factory 10 — Schema (DB Contract) v1.0.16
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -193,6 +193,7 @@
 • CHECK: account_taxonomy_source_type_chk (source_type IN ('manual', 'taxonomy_match'))
 • FK: account_id → accounts(id) ON UPDATE CASCADE ON DELETE CASCADE
 • FK: taxon_id → business_taxons(id) ON UPDATE CASCADE ON DELETE RESTRICT
+• Nota: não há constraint/índice garantindo apenas um `is_primary = true` por conta nesta etapa.
 
 1.12.2 Campos
 • account_id uuid not null
@@ -206,6 +207,8 @@
 1.12.3 Segurança
 • Trigger Hub: não
 • RLS: ativo (enable row level security)
+• service_role: SELECT, INSERT, UPDATE
+• anon/authenticated/public: sem acesso direto
 
 1.12.4 Policies
 • account_taxonomy_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
@@ -566,6 +569,11 @@
 • Rollback: não remove automaticamente a extensão, pois pode ser reutilizada por outros recursos
 
 99. Changelog
+v1.0.16 (11/05/2026) — E10.5.6: grants operacionais para account_taxonomy
+• Registrado `service_role` com SELECT, INSERT e UPDATE em `account_taxonomy`.
+• Registrado que `anon`, `authenticated` e `public` permanecem sem acesso direto.
+• Registrada ausência de constraint/índice para apenas um `is_primary = true` por conta nesta etapa.
+
 v1.0.15 (11/05/2026) — E10.5.6: account_niche_resolutions
 • Registrada a tabela `account_niche_resolutions` como persistência operacional da resolução atual da conta.
 • Registradas PK/FKs, constraints principais, RLS, policies admin-only e permissões operacionais de `service_role`.


### PR DESCRIPTION
### Motivation
- Registrar contrato mínimo do runtime para gravação server-side do vínculo oficial de taxonomia em `account_taxonomy` e clarificar o papel de `account_niche_resolutions` como registro operacional.
- Atualizar o contrato de DB e changelogs para refletir grants operacionais e limitações atuais sobre `is_primary` em `account_taxonomy`.

### Description
- Atualiza `docs/base-tecnica.md` para `v2.0.34` e adiciona regras para gravação server-side do vínculo oficial via adapter canônico em `lib/onboarding/niche-resolution/adapters/accountTaxonomyAdapter.ts`, incluindo requisitos de alta confiança, não bloqueio do fluxo e política MVP para não substituir primário ativo automaticamente.
- Adiciona diretriz de observabilidade em `docs/base-tecnica.md` para registrar apenas sinais seguros relacionados a gravação/skip/falha em `account_taxonomy` e proíbe log de PII/sensíveis (`niche`, `raw_input`, `query`, `aliases`, `name`, `whatsapp`, `site_url`, etc.).
- Atualiza `docs/schema.md` para `v1.0.16` e documenta que não existe, nesta etapa, constraint/índice garantindo apenas um `is_primary = true` por conta, além de declarar grants operacionais: `service_role: SELECT, INSERT, UPDATE` e `anon/authenticated/public: sem acesso direto` para `account_taxonomy`.
- Adiciona entradas de changelog em ambos os documentos: `v2.0.34` na Base Técnica e `v1.0.16` no Schema com resumo das mudanças.

### Testing
- Executed `npm ci` successfully (packages installed). 
- Executed `npm run check` successfully; the run completed with `tsc` success and `eslint` reporting warnings only (24 warnings, 0 errors). 
- No automated test failures were observed during `npm run check` (typecheck passed, lint returned warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a065319d1f8832993a69184905f6456)