### PR TITLE
docs: update AI niche resolution (roadmap, base-tecnica, schema)

### DIFF
--- a/docs/base-tecnica.md
+++ b/docs/base-tecnica.md
@@ -2,8 +2,8 @@
 
 0.1. Cabeçalho
 • Documento: Base Técnica LP Factory 10
-• Versão: v2.0.34
-• Data: 11/05/2026
+• Versão: v2.0.35
+• Data: 14/05/2026
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -191,6 +191,7 @@
 • Contrato técnico detalhado do pipeline: automations/supabase-inspect/README.md.
 
 3.5 Secrets & Variáveis
+• Server-only OpenAI niche resolver: `OPENAI_API_KEY`, `OPENAI_NICHE_RESOLVER_MODEL`.
 • Server-only: SUPABASE_SECRET_KEY, STRIPE_SECRET_KEY (futuro)
 • CI/Automations (GitHub Actions secrets): OPENAI_API_KEY, SUPABASE_DB_URL_READONLY
 • Públicas: NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
@@ -292,6 +293,13 @@
 • Gate adapters: pode retornar null, mas logs devem diferenciar deny vs error.
 
 3.14.1 Matching de taxonomia via adapter server-side
+• IA complementar: quando o matching determinístico não resolver com segurança, o runtime pode usar resolver server-side com OpenAI Responses API e Structured Outputs.
+• Resolver canônico: PATH: `lib/onboarding/niche-resolution/adapters/openAiResolver.ts`.
+• Regra: IA não roda em `high`, não cria taxon, não cria alias, não grava em `account_taxonomy` e não substitui vínculo oficial.
+• Regra: IA atualiza somente a resolução operacional em `account_niche_resolutions`.
+• Regra: falha da IA não pode bloquear lead, setup, ativação da conta, `revalidatePath(route)` ou `redirect(route)`.
+• Regra: `shouldCreateOfficialLink` no Structured Output deve permanecer sempre `false` no schema atual.
+• Regra: prompt, payload bruto, aliases, candidatos completos e dados de formulário não devem ser persistidos.
 • No pós-save do `pending_setup`, a integração determinística deve ocorrer server-side em `saveSetupAndContinueAction`, depois de salvar perfil, atualizar nome e promover a conta para `active`.
 • Regra: `matchBusinessTaxonsDeterministic(validated.values.niche, 10)` pode ser chamado no fluxo server-side após validação do onboarding, mas falha no matching não pode bloquear o lead, `revalidatePath(route)` ou `redirect(route)`.
 • Regra: a decisão observável do matching determinístico deve usar `evaluateDeterministicTaxonMatch(candidates)` e registrar somente metadados seguros.
@@ -388,6 +396,7 @@
 • Reset: cooldown UI de 60s (contador), iniciado após uma solicitação bem-sucedida.
 • Limitação adicional (server-side) é responsabilidade do Supabase Auth.
 5.3.4 Observabilidade
+• IA de resolução de nicho: logs devem registrar apenas sinais seguros como status, modo UX, quantidade de opções, necessidade de revisão/confirmação, persistência e código de erro seguro; não logar prompt, payload bruto, `niche`, `raw_input`, query, aliases, candidatos completos, `name`, `whatsapp` ou `site_url`.
 • server-timing/proxy-status não observados nos requests testados via DevTools
 • Diretriz: se precisar medir, instrumentar via logs/Apm e/ou headers próprios no server
 • Server Actions críticas devem emitir logs estruturados (JSON) com request_id e latency_ms (padrão mínimo).
@@ -463,6 +472,8 @@ Fonte normativa da allowlist SULB para exceções de Auth. Qualquer novo arquivo
 • Tipos canônicos e adapters vNext: validar por 3.6 e 3.14.
 
 99. Changelog
+v2.0.35 — 14/05/2026 — Base técnica atualizada com contrato mínimo de runtime para IA complementar server-side com Structured Outputs, variáveis server-only, preservação de `account_taxonomy`, persistência apenas em `account_niche_resolutions`, fluxo degradável e logs sem PII.
+
 v2.0.34 — 11/05/2026 — Base técnica atualizada com contrato mínimo de runtime para gravação server-side do vínculo oficial em `account_taxonomy`, preservando `account_niche_resolutions` como registro operacional, regra de alta confiança, conflito de primário sem substituição automática, fluxo não bloqueante e logs sem PII.
 
 v2.0.33 — 11/05/2026 — Base técnica atualizada com contrato mínimo de runtime para persistência operacional de resolução em `account_niche_resolutions`, sem gravação de `account_taxonomy`, com fluxo não bloqueante e logs sem PII.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data: 11/05/2026
-• Versão: v1.5.52
+• Data: 14/05/2026
+• Versão: v1.5.53
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -449,6 +449,28 @@
 • UX Partner Dashboard
 
 10.4 Primeiros passos (pending_setup — status-based)
+
+• Resolução complementar de nicho com IA estruturada no pós-save do `pending_setup` (14/05/2026): o fluxo passou a usar IA server-side apenas quando o matching determinístico não resolve com segurança.
+• Decisão: IA não roda em alta confiança determinística; pode atuar em medium, low e casos sem candidato útil.
+• Decisão: IA atualiza apenas a resolução operacional em `account_niche_resolutions`; não grava em `account_taxonomy`, não substitui vínculo oficial, não cria taxon e não cria alias.
+• Regra de fluxo: falha da IA não bloqueia lead, setup, redirect ou ativação da conta.
+• Fora do escopo: UI, microdiálogo visual, ChatKit, orquestrador multiagente, criação automática de taxon/alias, gravação em `account_taxonomy` via IA, substituição de vínculo oficial e escolha final de template comercial.
+• ARTEFATOS_REPO:
+• Criado: `lib/onboarding/niche-resolution/adapters/openAiResolver.ts`
+• Criado: `supabase/migrations/0013__e10_5_6_ai_structured_outputs.sql`
+• Criado: `supabase/rollbacks/20260514__e10_5_6_ai_structured_outputs.rollback.sql`
+• Ajustado: `app/a/[account]/actions.ts`
+• Ajustado: `lib/onboarding/niche-resolution/contracts.ts`
+• Ajustado: `lib/onboarding/niche-resolution/adapters/accountNicheResolutionAdapter.ts`
+• Checks/QA (reportado): Vercel Preview READY; Vercel build aprovado; Security Checks aprovados; Automation Niche Runtime Tests executado; Supabase Inspect executado; runtime aprovado em high, medium, low e unknown limpo.
+• Status de entrega: PR #258 mergeado; branch `codex/e10-5-6-ai-structured-outputs`; commit validado `623ef55`; 20.8 concluído.
+• Pendências futuras:
+• Criar fila/admin review para `ai_needs_admin_review = true`.
+• Decidir UI de confirmação para `confirm_single`.
+• Decidir UI para `choose_from_options`.
+• Decidir processo administrativo para sugerir novo taxon ou alias.
+• Avaliar logs/observability de erro OpenAI em produção.
+• Avaliar teste dedicado de env ausente e erro OpenAI.
 
 • Vínculo oficial de taxonomia no pós-save do `pending_setup` (11/05/2026): o fluxo passou a gravar vínculo oficial em `account_taxonomy` apenas quando a resolução determinística tem alta confiança.
 • Decisão: `account_niche_resolutions` permanece como registro operacional da resolução; `account_taxonomy` passa a representar o vínculo oficial da conta com o taxon.
@@ -1077,6 +1099,8 @@
 • Definir o primeiro recorte funcional do LP Builder no roadmap
 
 99. Changelog
+v1.5.53 — 14/05/2026 — Roadmap atualizado com o estado final da implementação 20.8: IA estruturada server-side como complemento ao matching determinístico, persistência apenas em `account_niche_resolutions`, preservação de `account_taxonomy`, artefatos, validações, PR mergeado e pendências futuras.
+
 v1.5.52 — 11/05/2026 — Roadmap atualizado com o estado final da implementação 20.7: vínculo oficial em `account_taxonomy` apenas para alta confiança, preservação de `account_niche_resolutions` como registro operacional, regra de conflito de primário, artefatos, QA runtime e pendências futuras.
 
 v1.5.51 — 11/05/2026 — Roadmap atualizado com o estado final da implementação 20.6: persistência da resolução operacional em `account_niche_resolutions`, decisão sobre `account_taxonomy`, artefatos, QA e pendências futuras.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data da última atualização: 11/05/2026
-• Documento: LP Factory 10 — Schema (DB Contract) v1.0.16
+• Data da última atualização: 14/05/2026
+• Documento: LP Factory 10 — Schema (DB Contract) v1.0.17
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -369,6 +369,10 @@
 1.18 account_niche_resolutions
 
 1.18.1 Chaves, constraints e relacionamentos
+• CHECK: account_niche_resolutions_ai_status_chk
+• CHECK: account_niche_resolutions_ai_result_json_chk
+• CHECK: account_niche_resolutions_ai_ux_mode_chk
+• FK: ai_suggested_taxon_id → business_taxons(id)
 • PK: account_id uuid
 • FK: account_id → accounts(id)
 • FK: selected_taxon_id → business_taxons(id)
@@ -380,6 +384,18 @@
 • CHECK: score entre 0 e 1 ou NULL
 
 1.18.2 Campos
+• ai_status text null
+• ai_error_code text null
+• ai_model text null
+• ai_schema_version text null
+• ai_result_json jsonb null
+• ai_ux_mode text null
+• ai_suggested_taxon_id uuid null
+• ai_suggested_new_taxon_label text null
+• ai_needs_user_confirmation boolean null
+• ai_needs_admin_review boolean null
+• ai_reason text null
+• ai_processed_at timestamptz null
 • account_id uuid not null
 • raw_input text not null
 • selected_taxon_id uuid null
@@ -402,6 +418,8 @@
 • Acesso direto removido de public, anon e authenticated
 • service_role: SELECT, INSERT e UPDATE
 
+1.18.4 Índices
+• account_niche_resolutions_ai_suggested_taxon_id_idx
 
 2. Views
 
@@ -569,6 +587,11 @@
 • Rollback: não remove automaticamente a extensão, pois pode ser reutilizada por outros recursos
 
 99. Changelog
+v1.0.17 (14/05/2026) — E10.5.6: IA Structured Outputs em account_niche_resolutions
+• Registradas colunas `ai_*` em `account_niche_resolutions` para persistência da saída estruturada da IA.
+• Registrados checks, FK e índice relacionados à resolução complementar com IA.
+• Registrado que a IA persiste apenas resolução operacional e não grava vínculo oficial em `account_taxonomy`.
+
 v1.0.16 (11/05/2026) — E10.5.6: grants operacionais para account_taxonomy
 • Registrado `service_role` com SELECT, INSERT e UPDATE em `account_taxonomy`.
 • Registrado que `anon`, `authenticated` e `public` permanecem sem acesso direto.


### PR DESCRIPTION
### Motivation

- Registrar o estado final da implementação 20.8: IA server-side com Structured Outputs como complemento ao matching determinístico no pós-save do `pending_setup`.
- Formalizar contratos mínimos de runtime, secrets server-only e regras de observabilidade para evitar persistência de dados sensíveis e preservar `account_taxonomy` como vínculo oficial.
- Atualizar o contrato de DB para permitir persistência operacional da saída estruturada da IA em `account_niche_resolutions`.

### Description

- Atualizado o cabeçalho de versão/data em `docs/roadmap.md` → `v1.5.53` (14/05/2026) e adicionado o bloco final da implementação 20.8 sob `10.4 Primeiros passos` com decisões, artefatos e pendências.
- Atualizado o cabeçalho de versão/data em `docs/base-tecnica.md` → `v2.0.35` (14/05/2026) e incluídas variáveis server-only (`OPENAI_API_KEY`, `OPENAI_NICHE_RESOLVER_MODEL`), regras de runtime para o resolver `openAiResolver.ts` e diretriz de logs sem PII para a IA de resolução de nicho.
- Atualizado o cabeçalho de versão/data em `docs/schema.md` → `v1.0.17` (14/05/2026) e adicionadas colunas `ai_*`, checks, FK (`ai_suggested_taxon_id → business_taxons(id)`) e índice relacionado em `account_niche_resolutions`, além de entrada no changelog do schema.
- Arquivos afetados: `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/schema.md`.

### Testing

- `npm ci`: executado com sucesso (packages instalados).
- `npm run check`: executado com sucesso; `eslint` retornou apenas warnings preexistentes (24 warnings, 0 errors) e `tsc` concluiu sem erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0654d0ef6083298a98a319bb747d13)