### PR TITLE
Simplify Codex App workflow instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,5 @@
 # AGENTS.md
 
-## Sandbox checks (rotina padrão)
-Rodar, nesta ordem:
-
-1. `npm ci`
-2. `npm run check`
-
-## Observação
-- No sandbox do Codex, não incluir `npm run build` na rotina de `check`.
-
 ## Referências de briefing e execução
 
 - Para estruturar pedidos incompletos em padrão outcome-first, usar `docs/template-prompts.md`.
@@ -16,65 +7,178 @@ Rodar, nesta ordem:
 - Para execução de plano-base no Codex App, usar `docs/prompt-codex-app-executor.md`.
 - Para tarefas com impacto visual/frontend, usar também `docs/template-briefing-codex-frontend.md`.
 
-## GitHub / fluxo remoto
+## Modelo operacional Codex App
 
-- Não usar Git remoto local dentro do sandbox do Codex:
-  - `git ls-remote`
-  - `git fetch`
-  - `git pull`
-  - `git push`
-  - `ssh -T git@github.com`
+A operação do Codex App deve seguir uma lógica outcome-first:
 
-- Para operações remotas, usar o conector GitHub do Codex:
-  - criar branch;
-  - criar/alterar/remover arquivos em branch de trabalho;
-  - criar commit/push via conector;
-  - abrir PR contra `main`;
-  - entregar link do PR.
+1. definir o resultado esperado;
+2. identificar fontes/contexto;
+3. declarar critérios de sucesso;
+4. respeitar limites e regras de parada;
+5. informar evidência/validação na entrega.
 
-- Nunca aplicar alterações diretamente na `main`.
+O Codex App tem dois modos de operação: **modo simples** e **modo robusto**.
 
-### Fluxo operacional Codex / GitHub Desktop
+### Modo simples
 
-- Para alterações feitas pelo Codex, o fluxo padrão é remoto:
-  - criar branch via conector GitHub;
-  - criar/alterar/remover arquivos na branch remota;
-  - abrir PR contra `main`;
-  - validar via GitHub Actions;
-  - mergear pelo GitHub Web.
+Usar para alterações pequenas, documentais ou isoladas.
 
-- O workspace local e o GitHub Desktop devem ser tratados como espelho limpo da `main`:
-  - não criar commits locais pelo Codex;
-  - não publicar branches locais criadas incidentalmente;
-  - não levar alterações locais antigas para `main`;
-  - após merge de PR remoto, manter o Desktop em `main`, com `0 changed files`, usando apenas Fetch/Pull.
+Exemplos:
 
-- O Codex só deve editar arquivos diretamente no workspace local se o usuário pedir explicitamente um fluxo local.
+- atualizar documentação;
+- ajustar prompts;
+- alterar arquivos `.md`;
+- pequenas correções sem impacto visual;
+- mudanças que não exigem preview local.
 
-- Se houver mudanças locais no Desktop que já foram resolvidas por PR remoto mergeado, tratá-las como resíduo operacional e orientar descarte, sem commit e sem publish.
+Regras:
 
-### Gate pré-edição no Codex App
+- Toda tarefa simples deve usar uma branch dedicada, com prefixo `codex/`, salvo instrução explícita em contrário.
+- Nunca aplicar tarefa simples em branch de tarefa robusta ou de outro caso.
+- Antes de editar, verificar branch ativa e `git status`.
+- Se estiver na `main`, em branch de outro caso ou com mudanças locais não relacionadas, parar e reportar bloqueio.
+- Editar somente os arquivos necessários para o resultado pedido.
+- Manter o estilo existente dos arquivos alterados.
 
-Antes de editar arquivos no workspace local, verificar a branch ativa.
+Validação:
 
-- Se estiver em `main`, parar imediatamente.
-- Não editar arquivos diretamente na working tree da `main`.
-- Usar o conector GitHub para criar uma branch de trabalho e aplicar as alterações.
-- Se o conector GitHub não estiver disponível, reportar bloqueio antes de editar.
+- Para alterações exclusivamente documentais ou de texto, `npm ci` e `npm run check` podem ser considerados não aplicáveis.
+- Se houver impacto em código, seguir a rotina padrão de validação.
 
-- Se o conector GitHub não estiver disponível ou falhar, parar e informar o bloqueio. Não tentar substituir por Git remoto local dentro do sandbox.
+### Modo robusto
 
-- Comandos Git locais continuam permitidos quando úteis:
-  - `git status`
-  - `git diff`
-  - inspeção de arquivos locais
+Usar para frontend, Admin Dashboard, E10.4/E10.5, refatorações, bugs difíceis ou mudanças com múltiplos arquivos.
 
-- Motivo: Git/SSH local pode falhar dentro do sandbox no Windows, enquanto o fluxo pelo conector GitHub foi validado e é o fluxo operacional desejado para branch, commit, push e PR.
+Regra-base:
+
+```txt
+1 frente robusta = 1 worktree
+1 etapa = 1 branch
+1 branch = 1 PR
+```
+
+O worktree isola a frente de trabalho. A branch/PR isola cada etapa aprovada.
+
+Regras:
+
+- Abrir o Codex App no worktree da frente robusta correspondente.
+- Cada etapa deve usar uma branch dedicada, com prefixo `codex/`.
+- Não misturar etapas diferentes na mesma branch.
+- Não manter um PR único por muitos dias quando houver etapas aprováveis separadamente.
+- Após merge de uma etapa, a próxima etapa deve começar em nova branch baseada na `main` atualizada.
+
+Validação:
+
+- Rodar a rotina padrão para mudanças com impacto em código.
+- Para impacto visual/frontend, rodar preview local e validar a tela antes de publicar PR.
+
+## Git / fluxo operacional
+
+### Regras gerais
+
+- Nunca editar diretamente na `main`.
+- Cada tarefa simples ou etapa robusta deve usar uma branch dedicada, com prefixo `codex/`.
+- Nunca reutilizar branch de outro chat/caso.
+- Não misturar mudanças de tarefas ou etapas diferentes na mesma branch.
+- O merge final deve acontecer somente pelo GitHub Web.
+- GitHub Web é a fonte de verdade para PRs, GitHub Actions, preview remoto e merge.
+- GitHub Desktop não faz parte obrigatória do fluxo operacional; se usado, é apoio visual ou fallback.
+
+### Gate obrigatório antes de editar
+
+Antes de qualquer edição local, verificar:
+
+1. pasta/worktree atual;
+2. branch ativa;
+3. `git status`;
+4. se a branch não é `main`;
+5. se a branch corresponde à tarefa/etapa atual;
+6. se não há mudanças locais não relacionadas.
+
+Se estiver na `main`, em branch de outro caso ou com mudanças locais não relacionadas, parar e reportar bloqueio antes de editar.
+
+### Edição local no Codex App
+
+O Codex pode editar arquivos localmente quando:
+
+- o usuário estiver usando o Codex App;
+- a tarefa estiver em uma branch dedicada;
+- o gate pré-edição tiver passado;
+- não houver mudanças locais não relacionadas.
+
+Para tarefas robustas, preferir abrir o Codex App diretamente no worktree da frente correspondente.
+
+### Comandos Git locais permitidos
+
+Permitidos para inspeção e trabalho local:
+
+```txt
+git status
+git diff
+git branch --show-current
+git switch
+git checkout
+git add
+git commit
+```
+
+Commits locais são permitidos apenas em branch dedicada da tarefa/etapa, nunca na `main`.
+
+### Comandos remotos locais proibidos no sandbox
+
+Não usar dentro do sandbox do Codex App:
+
+```txt
+git ls-remote
+git fetch
+git pull
+git push
+ssh -T git@github.com
+```
+
+Motivo: esses comandos foram instáveis no sandbox Windows/Git for Windows.
+
+### Operações remotas
+
+Para operações remotas, usar preferencialmente:
+
+- GitHub Connector do Codex, quando adequado;
+- GitHub Web;
+- GitHub Desktop ou PowerShell normal fora do sandbox, quando necessário para publicar branch local.
+
+Operações remotas incluem:
+
+- publicar branch;
+- abrir PR;
+- atualizar PR;
+- acompanhar checks;
+- mergear PR.
+
+## Preview local
+
+Para tarefas com impacto visual/frontend:
+
+1. Rodar `npm run dev`.
+2. Abrir a URL local indicada pelo terminal.
+3. Validar tela, comportamento e ausência de erros visíveis.
+4. Se `localhost:3000` recusar conexão, verificar se o servidor dev está rodando ou se iniciou em outra porta.
+
+Não assumir que `localhost:3000` está ativo sem iniciar o servidor.
+
+## Sandbox checks (rotina padrão)
+
+Para tarefas com impacto em código, rodar nesta ordem:
+
+1. `npm ci`
+2. `npm run check`
+
+No sandbox do Codex, não incluir `npm run build` na rotina de `check`.
 
 ## Entrega / validação
 
-- A resposta final deve informar o status da validação:
-  - `npm ci`: executado, não executado ou não aplicável, com motivo quando não passar ou não for executado;
-  - `npm run check`: executado, não executado ou não aplicável, com motivo quando não passar ou não for executado.
+A resposta final deve informar o status da validação:
 
-- Se a rotina padrão não for rodada, informar explicitamente na entrega final.
+- `npm ci`: executado, não executado ou não aplicável, com motivo quando não passar ou não for executado;
+- `npm run check`: executado, não executado ou não aplicável, com motivo quando não passar ou não for executado.
+
+Se a rotina padrão não for rodada, informar explicitamente na entrega final.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,53 +1,39 @@
 # AGENTS.md
 
-## Referências de briefing e execução
+## Referências
 
 - Para estruturar pedidos incompletos em padrão outcome-first, usar `docs/template-prompts.md`.
-- Para preparar briefings gerais para Codex, usar `docs/template-briefing-codex.md`.
-- Para execução de plano-base no Codex App, usar `docs/prompt-codex-app-executor.md`.
-- Para tarefas com impacto visual/frontend, usar também `docs/template-briefing-codex-frontend.md`.
+- Para briefings gerais, usar `docs/template-briefing-codex.md`.
+- Para execução no Codex App, usar `docs/prompt-codex-app-executor.md`.
+- Para impacto visual/frontend, usar também `docs/template-briefing-codex-frontend.md`.
 
 ## Modelo operacional Codex App
 
-A operação do Codex App deve seguir uma lógica outcome-first:
+O Codex App opera em dois modos: **simples** e **robusto**.
 
-1. definir o resultado esperado;
-2. identificar fontes/contexto;
-3. declarar critérios de sucesso;
-4. respeitar limites e regras de parada;
-5. informar evidência/validação na entrega.
+Antes de executar, identificar:
 
-O Codex App tem dois modos de operação: **modo simples** e **modo robusto**.
+1. resultado esperado;
+2. contexto/fonte;
+3. critérios de sucesso;
+4. limites e regras de parada;
+5. validação esperada.
 
 ### Modo simples
 
-Usar para alterações pequenas, documentais ou isoladas.
+Usar quando a tarefa for isolada e não exigir worktree próprio.
 
-Exemplos:
+Processo:
 
-- atualizar documentação;
-- ajustar prompts;
-- alterar arquivos `.md`;
-- pequenas correções sem impacto visual;
-- mudanças que não exigem preview local.
-
-Regras:
-
-- Toda tarefa simples deve usar uma branch dedicada, com prefixo `codex/`, salvo instrução explícita em contrário.
-- Nunca aplicar tarefa simples em branch de tarefa robusta ou de outro caso.
-- Antes de editar, verificar branch ativa e `git status`.
-- Se estiver na `main`, em branch de outro caso ou com mudanças locais não relacionadas, parar e reportar bloqueio.
-- Editar somente os arquivos necessários para o resultado pedido.
-- Manter o estilo existente dos arquivos alterados.
-
-Validação:
-
-- Para alterações exclusivamente documentais ou de texto, `npm ci` e `npm run check` podem ser considerados não aplicáveis.
-- Se houver impacto em código, seguir a rotina padrão de validação.
+1. Criar ou usar branch dedicada com prefixo `codex/`, salvo instrução explícita em contrário.
+2. Verificar branch ativa e `git status`.
+3. Parar se estiver na `main`, em branch de outro caso ou com mudanças locais não relacionadas.
+4. Editar somente o necessário.
+5. Publicar PR quando a alteração estiver pronta, salvo instrução explícita em contrário.
 
 ### Modo robusto
 
-Usar para frontend, Admin Dashboard, E10.4/E10.5, refatorações, bugs difíceis ou mudanças com múltiplos arquivos.
+Usar quando a tarefa exigir isolamento, execução em etapas, validação local recorrente ou preview.
 
 Regra-base:
 
@@ -57,60 +43,26 @@ Regra-base:
 1 branch = 1 PR
 ```
 
-O worktree isola a frente de trabalho. A branch/PR isola cada etapa aprovada.
+Processo:
 
-Regras:
+1. Abrir o Codex App no worktree da frente.
+2. Criar ou usar branch dedicada para a etapa.
+3. Verificar worktree, branch ativa e `git status`.
+4. Parar se estiver na `main`, em branch de outro caso ou com mudanças locais não relacionadas.
+5. Implementar somente a etapa atual.
+6. Validar localmente.
+7. Publicar PR da etapa quando estiver pronta.
+8. Após merge, iniciar a próxima etapa em nova branch baseada na `main` atualizada.
 
-- Abrir o Codex App no worktree da frente robusta correspondente.
-- Cada etapa deve usar uma branch dedicada, com prefixo `codex/`.
-- Não misturar etapas diferentes na mesma branch.
-- Não manter um PR único por muitos dias quando houver etapas aprováveis separadamente.
-- Após merge de uma etapa, a próxima etapa deve começar em nova branch baseada na `main` atualizada.
-
-Validação:
-
-- Rodar a rotina padrão para mudanças com impacto em código.
-- Para impacto visual/frontend, rodar preview local e validar a tela antes de publicar PR.
-
-## Git / fluxo operacional
-
-### Regras gerais
+## Git / limites operacionais
 
 - Nunca editar diretamente na `main`.
-- Cada tarefa simples ou etapa robusta deve usar uma branch dedicada, com prefixo `codex/`.
-- Nunca reutilizar branch de outro chat/caso.
-- Não misturar mudanças de tarefas ou etapas diferentes na mesma branch.
+- Nunca misturar tarefas ou etapas diferentes na mesma branch.
 - O merge final deve acontecer somente pelo GitHub Web.
-- GitHub Web é a fonte de verdade para PRs, GitHub Actions, preview remoto e merge.
-- GitHub Desktop não faz parte obrigatória do fluxo operacional; se usado, é apoio visual ou fallback.
+- GitHub Web é a fonte de verdade para PRs, Actions, preview remoto e merge.
+- GitHub Desktop é apoio/fallback, não etapa obrigatória.
 
-### Gate obrigatório antes de editar
-
-Antes de qualquer edição local, verificar:
-
-1. pasta/worktree atual;
-2. branch ativa;
-3. `git status`;
-4. se a branch não é `main`;
-5. se a branch corresponde à tarefa/etapa atual;
-6. se não há mudanças locais não relacionadas.
-
-Se estiver na `main`, em branch de outro caso ou com mudanças locais não relacionadas, parar e reportar bloqueio antes de editar.
-
-### Edição local no Codex App
-
-O Codex pode editar arquivos localmente quando:
-
-- o usuário estiver usando o Codex App;
-- a tarefa estiver em uma branch dedicada;
-- o gate pré-edição tiver passado;
-- não houver mudanças locais não relacionadas.
-
-Para tarefas robustas, preferir abrir o Codex App diretamente no worktree da frente correspondente.
-
-### Comandos Git locais permitidos
-
-Permitidos para inspeção e trabalho local:
+### Permitido localmente
 
 ```txt
 git status
@@ -122,11 +74,9 @@ git add
 git commit
 ```
 
-Commits locais são permitidos apenas em branch dedicada da tarefa/etapa, nunca na `main`.
+Commits locais só são permitidos em branch dedicada, nunca na `main`.
 
-### Comandos remotos locais proibidos no sandbox
-
-Não usar dentro do sandbox do Codex App:
+### Proibido no sandbox do Codex App
 
 ```txt
 git ls-remote
@@ -140,45 +90,39 @@ Motivo: esses comandos foram instáveis no sandbox Windows/Git for Windows.
 
 ### Operações remotas
 
-Para operações remotas, usar preferencialmente:
+Para operações remotas, usar:
 
 - GitHub Connector do Codex, quando adequado;
 - GitHub Web;
-- GitHub Desktop ou PowerShell normal fora do sandbox, quando necessário para publicar branch local.
+- GitHub Desktop ou PowerShell normal fora do sandbox, quando necessário.
 
-Operações remotas incluem:
-
-- publicar branch;
-- abrir PR;
-- atualizar PR;
-- acompanhar checks;
-- mergear PR.
+Operações remotas incluem publicar branch, abrir/atualizar PR, acompanhar checks e mergear.
 
 ## Preview local
 
-Para tarefas com impacto visual/frontend:
+Para impacto visual/frontend:
 
 1. Rodar `npm run dev`.
-2. Abrir a URL local indicada pelo terminal.
+2. Abrir a URL indicada pelo terminal.
 3. Validar tela, comportamento e ausência de erros visíveis.
 4. Se `localhost:3000` recusar conexão, verificar se o servidor dev está rodando ou se iniciou em outra porta.
 
-Não assumir que `localhost:3000` está ativo sem iniciar o servidor.
-
-## Sandbox checks (rotina padrão)
+## Sandbox checks
 
 Para tarefas com impacto em código, rodar nesta ordem:
 
 1. `npm ci`
 2. `npm run check`
 
-No sandbox do Codex, não incluir `npm run build` na rotina de `check`.
+No sandbox do Codex, não incluir `npm run build` na rotina de check.
 
-## Entrega / validação
+Para alterações exclusivamente documentais ou de texto, `npm ci` e `npm run check` podem ser considerados não aplicáveis.
 
-A resposta final deve informar o status da validação:
+## Entrega
 
-- `npm ci`: executado, não executado ou não aplicável, com motivo quando não passar ou não for executado;
-- `npm run check`: executado, não executado ou não aplicável, com motivo quando não passar ou não for executado.
+A resposta final deve informar:
 
-Se a rotina padrão não for rodada, informar explicitamente na entrega final.
+- arquivos alterados;
+- PR criado, quando aplicável;
+- `npm ci`: executado, não executado ou não aplicável;
+- `npm run check`: executado, não executado ou não aplicável.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,8 @@ Processo:
 7. Publicar PR da etapa quando estiver pronta.
 8. Após merge, iniciar a próxima etapa em nova branch baseada na `main` atualizada.
 
+No modo robusto, trabalhar localmente em worktree dedicado é intencional e permitido. O fluxo só é inválido se editar `main`, misturar tarefas/etapas ou depender de Git remoto local no sandbox.
+
 ## Git / limites operacionais
 
 - Nunca editar diretamente na `main`.
@@ -74,7 +76,7 @@ git add
 git commit
 ```
 
-Commits locais só são permitidos em branch dedicada, nunca na `main`.
+Commits locais só são permitidos em branch dedicada, nunca na `main`. No modo robusto, commit local pode ser usado como checkpoint; publicação remota e PR continuam seguindo as regras de operações remotas.
 
 ### Proibido no sandbox do Codex App
 


### PR DESCRIPTION
## Resumo

- Define os modos simples e robusto do Codex App como processos operacionais.
- Remove exemplos específicos de tarefas e mantém foco em branch, worktree, PR, limites e validação.
- Explicita que, no modo robusto, trabalhar localmente em worktree dedicado é intencional e permitido.
- Esclarece que commit local pode ser checkpoint, enquanto publicação remota e PR seguem as regras de operações remotas.

## Validação

- `npm ci`: não aplicável, alteração documental/processual.
- `npm run check`: não aplicável, alteração documental/processual.