### PR TITLE
Document post-merge local residue handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@ No modo robusto, trabalhar localmente em worktree dedicado é intencional e perm
 - O merge final deve acontecer somente pelo GitHub Web.
 - GitHub Web é a fonte de verdade para PRs, Actions, preview remoto e merge.
 - GitHub Desktop é apoio/fallback, não etapa obrigatória.
+- Se houver branch ou mudança local já resolvida por PR mergeado, tratar como resíduo operacional: não commitar, não publicar e orientar limpeza antes de nova tarefa.
 
 ### Permitido localmente
 


### PR DESCRIPTION
## Resumo

- Adiciona regra para tratar branch ou mudança local já resolvida por PR mergeado como resíduo operacional.
- Explicita que esse resíduo não deve ser commitado nem publicado.
- Orienta limpeza antes de iniciar nova tarefa.

## Validação

- `npm ci`: não aplicável, alteração documental/processual.
- `npm run check`: não aplicável, alteração documental/processual.