### PR TITLE
Clarify optional local commits in robust mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ git add
 git commit
 ```
 
-Commits locais só são permitidos em branch dedicada, nunca na `main`. No modo robusto, commit local pode ser usado como checkpoint; publicação remota e PR continuam seguindo as regras de operações remotas.
+Commits locais só são permitidos em branch dedicada, nunca na `main`. No modo robusto, commit local é checkpoint opcional: se falhar ou exigir execução fora do sandbox, reportar o bloqueio e seguir pelas regras de operações remotas.
 
 ### Proibido no sandbox do Codex App
 


### PR DESCRIPTION
## Resumo

- Esclarece que commit local no modo robusto é checkpoint opcional.
- Orienta reportar bloqueio quando o commit falhar ou exigir execução fora do sandbox.
- Mantém publicação remota e PR sob as regras de operações remotas.

## Validação

- `npm ci`: não aplicável, alteração documental/processual.
- `npm run check`: não aplicável, alteração documental/processual.