### PR TITLE
docs: registrar Data API GRANT explícito (supa-up item 58 + base-tecnica)

### DIFF
--- a/docs/base-tecnica.md
+++ b/docs/base-tecnica.md
@@ -246,6 +246,11 @@
 • Se for exposta ao app, tenant, admin ou fluxo operacional, nasce com RLS e policies na mesma etapa
 • Se for interna, schema e modelo de acesso devem ser definidos explicitamente
 • Toda tabela deve decidir se entra em auditoria, Trigger Hub ou fica fora
+• Data API / GRANT explícito: toda tabela nova no schema `public` que precise ser acessada via Supabase Data API/PostgREST/GraphQL deve declarar explicitamente, na mesma migration, os `GRANTs` necessários para as roles aplicáveis.
+• `GRANT` não substitui RLS/policies.
+• RLS/policies não substituem `GRANT`.
+• Tabelas internas podem nascer sem `GRANT` para `anon`/`authenticated`, desde que o modelo de acesso esteja explícito.
+• Tabelas expostas ao app, admin, adapters ou fluxo operacional via Supabase API devem ter decisão explícita de grants junto com RLS e policies.
 
 3.9 Rate Limit administrativo (estado atual)
 • Não há rate limit ativo do fluxo legado de tokens no runtime atual.

--- a/docs/supa-up.md
+++ b/docs/supa-up.md
@@ -1896,3 +1896,45 @@ Melhorias do Schema Visualiser para inspeção de modelagem (relações clicáve
 - Observação: recurso de apoio operacional de modelagem e inspeção visual; complementa `docs/schema.md`, sem substituí-lo.
 
 ---
+
+## 58 — Data API: exposição explícita por GRANT para novas tabelas *(🟦 Estável)*
+
+2026-05-19
+
+### Status no Projeto
+
+- Status: Não implementado
+- Evidência: update oficial Supabase May 2026; regra ainda não incorporada à Base Técnica nem validada em migrations do projeto.
+
+### Descrição
+
+A Supabase passou a mudar o comportamento de exposição automática de novas tabelas do schema `public` na Data API/PostgREST/GraphQL. Novas tabelas podem exigir `GRANT` explícito para ficarem acessíveis pela API, em vez de serem expostas automaticamente apenas por estarem no schema `public`.
+
+### Valor para o Projeto
+
+- Reduz risco de exposição acidental de tabelas novas.
+- Obriga migrations futuras a declarar explicitamente quais roles podem acessar cada tabela via Data API.
+- Evita drift entre tabela criada, RLS/policies configuradas e acesso real via `supabase-js`/PostgREST.
+- Impacta diretamente novas tabelas em E10.5, E12, E19, billing, analytics, CRM e futuras automações.
+
+### Valor para o Usuário
+
+- Mais segurança indireta sobre dados e superfícies expostas.
+- Menor risco de falhas silenciosas quando uma tabela existe no banco, mas não está acessível pela API por falta de grant explícito.
+
+### Ações Recomendadas
+
+1. Atualizar a Base Técnica para exigir decisão explícita de `GRANT` em migrations que criem tabelas no schema `public`.
+2. Em toda tabela nova, separar claramente:
+   - `GRANT`: define se a role pode acessar a tabela pela Data API.
+   - RLS/policies: definem quais linhas podem ser acessadas.
+3. Não conceder grants automaticamente para tabelas internas.
+4. Quando a tabela precisar ser acessada por app, admin, adapters ou fluxo operacional via Supabase API, declarar os grants necessários na mesma migration da criação da tabela.
+
+### Registro (Tipo C — Infra/Schema/Contrato)
+
+- Status: PENDENTE
+- Verificado em: —
+- Ambiente: Supabase Data API / PostgREST / GraphQL / schema public
+- Evidência: —
+- Observação: mudança nasce na plataforma, mas a absorção no projeto é regra de migration, grants e contrato técnico.


### PR DESCRIPTION
### Motivation

- A Supabase mudou o comportamento de exposição da Data API para novas tabelas do schema `public`, podendo exigir `GRANT` explícito para acesso, e o projeto precisa registrar e adaptar essa regra para evitar exposições silenciosas ou drift entre migrations e acesso via API.  
- Atualizar a documentação garante que migrations futuras declarem formalmente `GRANT` quando necessário e que reviewers/operações sigam o contrato técnico entre `GRANT` e RLS/policies.

### Description

- Adiciona o item `58 — Data API: exposição explícita por GRANT para novas tabelas` ao final de `docs/supa-up.md` com o conteúdo fornecido.  
- Atualiza a seção `3.8.1.5 Segurança e governança` em `docs/base-tecnica.md` adicionando regras explícitas sobre `GRANT` vs RLS/policies para novas tabelas no schema `public`.  
- Mantidos cabeçalhos, versão e itens antigos dos documentos, e apenas os arquivos `docs/supa-up.md` e `docs/base-tecnica.md` foram modificados.  
- Commit local realizado e PR criado com o título `docs: registrar update Data API com GRANT explícito`.

### Testing

- Executed `npm ci` which completed successfully.  
- Executed `npm run check` which ran `eslint .` and `tsc -p tsconfig.json --noEmit`, succeeding with `24` lint warnings and `0` errors, and with typecheck passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c882b25bc8329b9ee8642d28e16e3)