### PR TITLE
docs: ajustar item 58 de GRANT no supa-up

### DIFF
--- a/docs/supa-up.md
+++ b/docs/supa-up.md
@@ -1903,8 +1903,8 @@ Melhorias do Schema Visualiser para inspeção de modelagem (relações clicáve
 
 ### Status no Projeto
 
-- Status: Não implementado
-- Evidência: update oficial Supabase May 2026; regra ainda não incorporada à Base Técnica nem validada em migrations do projeto.
+- Status: Em implementação por casos de uso
+- Evidência: docs/base-tecnica.md (regra incorporada em 3.8.1.5; aplicação prática dependerá das próximas migrations com tabelas em `public`)
 
 ### Descrição
 
@@ -1924,7 +1924,7 @@ A Supabase passou a mudar o comportamento de exposição automática de novas ta
 
 ### Ações Recomendadas
 
-1. Atualizar a Base Técnica para exigir decisão explícita de `GRANT` em migrations que criem tabelas no schema `public`.
+1. Aplicar a regra da Base Técnica em toda nova migration que criar tabela no schema `public`.
 2. Em toda tabela nova, separar claramente:
    - `GRANT`: define se a role pode acessar a tabela pela Data API.
    - RLS/policies: definem quais linhas podem ser acessadas.

--- a/docs/supa-up.md
+++ b/docs/supa-up.md
@@ -1903,8 +1903,9 @@ Melhorias do Schema Visualiser para inspeção de modelagem (relações clicáve
 
 ### Status no Projeto
 
-- Status: Em implementação por casos de uso
-- Evidência: docs/base-tecnica.md (regra incorporada em 3.8.1.5; aplicação prática dependerá das próximas migrations com tabelas em `public`)
+- Status: Implementado globalmente no projeto
+- Evidência: docs/base-tecnica.md (regra incorporada em 3.8.1.5 para novas tabelas no schema public)
+- Observação: aplicação prática será validada nas próximas migrations; rollout/configuração Supabase pode depender da plataforma.
 
 ### Descrição
 


### PR DESCRIPTION
### Motivation

- Atualizar o status e a recomendação do item 58 para refletir que a regra foi incorporada à Base Técnica e orientar aplicação da regra em novas migrations.

### Description

- Substituído o bloco `### Status no Projeto` e o item 1 de `### Ações Recomendadas` do item "58 — Data API: exposição explícita por GRANT para novas tabelas" em `docs/supa-up.md`, sem alterar outros itens nem `docs/base-tecnica.md`.

### Testing

- Executados `npm ci` e `npm run check` (que roda `lint` e `typecheck`); ambos concluíram com sucesso, `lint` exibiu apenas warnings preexistentes; arquivo alterado: `docs/supa-up.md`; item ajustado: item 58 (bloco `Status no Projeto` e ação recomendada 1).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c8c4691008329bbb2218aceeabd65)