### PR TITLE
docs: atualizar prompt-abc com contrato visual e regras anti-inflação

### DIFF
--- a/docs/prompt-abc.md
+++ b/docs/prompt-abc.md
@@ -6,7 +6,7 @@ ENTRADA
 
 * REPO (GitHub): LP-Factory-10
 * REF (GitHub): [main | branch | commit] (se não informado, main)
-* DOC_ALVO: [docs/base-tecnica.md | docs/schema.md | docs/roadmap.md]
+* DOC_ALVO: [docs/base-tecnica.md | docs/schema.md | docs/roadmap.md | docs/design-system.md]
 
 OBJETIVO
 Gerar o **ABC humano** para o DOC_ALVO.
@@ -16,12 +16,15 @@ VISÃO GERAL (RESIDÊNCIA DO CONTEÚDO)
 * `docs/schema.md` = contrato de banco (objetos e permissões de DB).
 * `docs/base-tecnica.md` = contrato técnico de runtime (regras de implementação segura).
 * `docs/roadmap.md` = estado final dos casos E* (status/escopo/dependências/artefatos).
+* `docs/design-system.md` = contrato visual atual do produto (padrões UI, componentes, superfícies visuais e regras de uso).
 
 REGRA GLOBAL (ANTI-INFLAÇÃO)
 
 * 1 assunto = 1 residência.
 * Não duplicar guardrails/listas já cobertos por contrato dedicado do repo; nos docs manter só: objetivo em 1 linha + paths + referência.
 * Tudo fora da residência do DOC_ALVO está fora de escopo.
+* Docs descrevem o estado atual do projeto; histórico de evolução fica apenas no changelog quando o documento tiver changelog.
+* Ao atualizar uma seção, substituir o estado antigo pelo estado atual consolidado, sem manter fases intermediárias já superadas.
 
 CRITÉRIO BASE TÉCNICA (RELEVÂNCIA PARA IA)
 
@@ -55,6 +58,17 @@ ALLOWLIST — `docs/roadmap.md` (CONTRATO_DE_CASOS)
 * Convenção: “E” só no título principal do caso; subitens sem repetir “E”.
 * PERMITIDO (DELTA): status com data, escopo final em bullets curtos, dependências entre casos E*, artefatos de repo, decisões explícitas do caso, pendências marcadas explicitamente no RELATÓRIO.
 * Fora do escopo: qualquer item fora dessa lista.
+* Em `docs/roadmap.md`, quando houver artefatos de repo, separar obrigatoriamente:
+  * Criados
+  * Ajustados
+  * Removidos
+* Se uma categoria não tiver itens, omitir a categoria.
+
+ALLOWLIST — `docs/design-system.md` (CONTRATO_VISUAL)
+
+* PERMITIDO (DELTA): padrões visuais atuais, componentes UI ativos, regras de uso, comportamento responsivo, superfícies visuais consolidadas.
+* Quando citar superfícies, descrever comportamento/padrão visual; evitar inventário de arquivos se isso já estiver no roadmap.
+* Fora do escopo: status de caso, lista detalhada de artefatos, contrato DB, regras runtime, histórico de implementação.
 
 REGRAS DE EXTRAÇÃO (RELATÓRIO → ESTADO FINAL)
 
@@ -131,7 +145,7 @@ CH1) (entrada nova)
 PAUSA OBRIGATÓRIA (1 DOC POR EXECUÇÃO)
 
 19. Executar o ciclo completo apenas para o DOC_ALVO atual.
-20. Depois de emitir a saída, parar e aguardar próximo `DOC_ALVO`.
-21. Não gerar ABC de outro documento na mesma execução.
+20. Depois de emitir a saída, parar e aguardar próximo `DOC_ALVO`, salvo quando o usuário pedir explicitamente ABCs de múltiplos documentos.
+21. Quando múltiplos DOC_ALVO forem solicitados na mesma execução, emitir um bloco ABC completo por documento, mantendo cada bloco independente e sem misturar operações.
 
 ---


### PR DESCRIPTION
### Motivation

- Incluir `docs/design-system.md` como `DOC_ALVO` e formalizar seu contrato visual para que o prompt ABC suporte deltas relativos a padrões e componentes visuais.
- Reduzir inflação de histórico em documentos exigindo que atualizações reflitam o estado atual consolidado e que o histórico fique no changelog quando existir.
- Tornar mais explícita a publicação de artefatos no `docs/roadmap.md` separando-os em categorias `Criados`, `Ajustados` e `Removidos`.

### Description

- Atualizei `docs/prompt-abc.md` para adicionar `docs/design-system.md` à lista de `DOC_ALVO` e inserir sua descrição na seção de visão geral.
- Adicionei duas regras globais anti-inflação que exigem substituição do estado antigo pelo estado consolidado e que o histórico fique apenas no changelog quando aplicável.
- Ampliei a allowlist de `docs/roadmap.md` para requerer a separação obrigatória de artefatos em `Criados`, `Ajustados` e `Removidos` e adicionei a seção `ALLOWLIST — docs/design-system.md (CONTRATO_VISUAL)` com escopo permitido e fora de escopo.
- Ajustei a seção `PAUSA OBRIGATÓRIA` para permitir a emissão de múltiplos blocos ABC independentes quando isso for solicitado explicitamente pelo usuário.

### Testing

- A edição do arquivo foi feita programaticamente e a diferença foi verificada com `git diff` para o único arquivo modificado `docs/prompt-abc.md`, e a alteração corresponde ao escopo esperado.
- Alterações foram salvas em branch dedicada `codex/abc-prompt-2026-05-19` e um PR foi criado com o título `docs: atualizar prompt-abc com contrato visual e regras anti-inflação`, com sucesso na criação do PR.
- `npm ci` e `npm run check` não foram executados por se tratar de alteração exclusivamente documental e, portanto, foram considerados não aplicáveis.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cb0710a9483298d5abc3fcecb0839)