### PR TITLE
docs: atualizar evidência e observação do item 58 em supa-up

### DIFF
--- a/docs/supa-up.md
+++ b/docs/supa-up.md
@@ -1906,8 +1906,8 @@ Melhorias do Schema Visualiser para inspeção de modelagem (relações clicáve
 ### Status no Projeto
 
 - Status: Implementado globalmente no projeto
-- Evidência: docs/base-tecnica.md (regra incorporada em 3.8.1.5 para novas tabelas no schema public)
-- Observação: aplicação prática será validada nas próximas migrations; rollout/configuração Supabase pode depender da plataforma.
+- Evidência: docs/base-tecnica.md (regra incorporada em 3.8.1.5 para novas tabelas no schema public); e-mail da Supabase indica 1 projeto afetável por uso de Data API, sem indicação de erro atual.
+- Observação: tabelas existentes mantêm grants atuais; o risco concentra-se em novas tabelas em `public` sem `GRANT` explícito; erro esperado na ausência de grant: `42501`.
 
 ### Descrição
 


### PR DESCRIPTION
### Motivation
- Esclarecer a evidência e a observação do item #58 sobre a mudança de exposição da Data API para registrar o e-mail da Supabase (1 projeto afetável) e explicitar o risco para novas tabelas mantendo o status como `Implementado globalmente no projeto`.

### Description
- Atualiza apenas `docs/supa-up.md` no item **#58** para acrescentar na `Evidência` que o e-mail da Supabase indica `1 projeto afetável por uso de Data API` sem indicar erro atual, e na `Observação` que tabelas existentes mantêm grants, o risco se concentra em novas tabelas em `public` sem `GRANT` explícito, e o erro esperado sem grant é `42501`, sem alterar `docs/base-tecnica.md`, `docs/schema.md` ou `docs/roadmap.md`.

### Testing
- Nenhum teste automatizado foi executado por se tratar de alteração documental; validações locais e de fluxo incluíram verificação de arquivo (`sed`/`nl`), `git add`/`git commit` bem-sucedidos e criação de PR com título `docs: atualizar evidência e observação do item 58 em supa-up`, enquanto `npm ci` e `npm run check` não foram executados por não serem aplicáveis à mudança documental.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dc329372083298036ae3c4fb78e35)