### PR TITLE
docs: add operational branch and pre-PR gates to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,8 @@ No modo robusto, trabalhar localmente em worktree dedicado é intencional e perm
 - GitHub Web é a fonte de verdade para PRs, Actions, preview remoto e merge.
 - GitHub Desktop é apoio/fallback, não etapa obrigatória.
 - Se houver branch ou mudança local já resolvida por PR mergeado, tratar como resíduo operacional: não commitar, não publicar e orientar limpeza antes de nova tarefa.
+- Gate operacional (GitHub Desktop) antes de novo escopo: voltar para `main`, executar Fetch/Pull, confirmar `0 changed files` e criar nova branch pelo Desktop a partir da `main`.
+- Gate pré-PR: antes de publicar/abrir PR, validar que `main..HEAD` contém apenas commits do escopo atual e que `main...HEAD` contém apenas arquivos do escopo atual.
 
 ### Permitido localmente
 


### PR DESCRIPTION
### Motivation
- Incluir gates operacionais no fluxo Git para assegurar que novas branches são criadas a partir de uma `main` atualizada e que o escopo do PR é previamente validado.

### Description
- Adiciona duas linhas em `AGENTS.md` no bloco "Git / limites operacionais" que definem o gate operacional via GitHub Desktop (voltar para `main`, executar Fetch/Pull, confirmar `0 changed files` e criar a nova branch a partir da `main`) e o gate pré-PR que exige validação de `main..HEAD` (commits do escopo) e `main...HEAD` (arquivos do escopo).

### Testing
- Executados cheques locais e de inspeção de arquivo (`git branch --show-current`, `git status --short`, `git status --porcelain=v1 -b`, e `nl -ba AGENTS.md | sed -n '45,95p'`) que retornaram sucesso, a alteração foi aplicada em `AGENTS.md` e um PR foi criado via ferramenta, e `npm ci` e `npm run check` não foram executados por se tratar de mudança exclusivamente documental.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f31b24ef88329bace1017b666535e)