### PR TITLE
Rename E10.5.4 taxon lookup snippet to E10.5.5

### DIFF
--- a/docs/prompt-nicho-identificacao.md
+++ b/docs/prompt-nicho-identificacao.md
@@ -28,7 +28,7 @@ Aceite apenas `research_blocks` da lista acima.
 
 Use o snippet:
 
-`supabase/snippets/e10_5_4_nicho_identificacao_taxon_lookup.sql`
+`supabase/snippets/e10_5_5_nicho_identificacao_taxon_lookup.sql`
 
 Peça ao humano para executar o SQL no Supabase com o nome informado e colar o resultado no chat.
 

--- a/supabase/snippets/e10_5_5_nicho_identificacao_taxon_lookup.sql
+++ b/supabase/snippets/e10_5_5_nicho_identificacao_taxon_lookup.sql
@@ -1,4 +1,4 @@
--- e10_5_4_nicho_identificacao_taxon_lookup.sql
+-- e10_5_5_nicho_identificacao_taxon_lookup.sql
 -- Objetivo: localizar taxon cadastrado por nome, slug ou alias.
 -- Uso: substituir o valor de input.q pelo nome informado pelo humano.
 -- Tipo: read-only.


### PR DESCRIPTION
### Motivation
- Corrigir o nome operacional do snippet de identificação de nicho/taxon para refletir que pertence ao fluxo E10.5.5 em vez de E10.5.4.

### Description
- Renomeei `supabase/snippets/e10_5_4_nicho_identificacao_taxon_lookup.sql` para `supabase/snippets/e10_5_5_nicho_identificacao_taxon_lookup.sql`, atualizei o comentário interno no topo do SQL e alterei a referência em `docs/prompt-nicho-identificacao.md` para apontar ao novo caminho.

### Testing
- Executei `npm ci` e `npm run check`, ambos concluíram com sucesso (o `npm run check` exibiu avisos de lint preexistentes, sem erros), e criei o PR titled "Rename nicho identificação snippet to E10.5.5" com as alterações commitadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10c85054f48329a9bb02682c154c65)