### PR TITLE
Ajusta relatório do prompt de identificação para pesquisa incremental por bloco

### DIFF
--- a/docs/prompt-nicho-identificacao.md
+++ b/docs/prompt-nicho-identificacao.md
@@ -79,15 +79,13 @@ Não refaça a identificação do taxon.
 
 Pesquise os `research_blocks` na ordem definida em `research_blocks_order`.
 
-Pesquise apenas um `research_block` por vez.
+Pesquise apenas o primeiro `research_block` pendente da ordem definida.
 
-Após entregar cada bloco, pare e aguarde comando humano para continuar.
+Não pesquise mais de um `research_block` na mesma execução.
 
-Após todos os blocos serem pesquisados, aguarde comando humano para consolidar.
+Após entregar o bloco pesquisado, pare e aguarde comando humano para continuar.
 
-Após a consolidação, aguarde comando humano para gerar SQL de carregamento.
-
-Após o carregamento, gere SQL de verificação.
+Quando o humano mandar continuar, execute apenas o próximo `research_block` pendente da ordem definida.
 ```
 
 ## Parada


### PR DESCRIPTION
### Motivation

- Limitar o relatório final em `docs/prompt-nicho-identificacao.md` para orientar apenas a próxima etapa operacional: executar pesquisa profunda por bloco pendente e evitar instruções que antecipem consolidação, carregamento ou verificação.

### Description

- Atualiza a seção `## 2. Instrução para a IA de pesquisa` em `docs/prompt-nicho-identificacao.md` para manter o uso de `docs/prompt-nicho-pesquisa.md` e a ordem de `research_blocks`, instruir a pesquisar somente o primeiro `research_block` pendente por execução, não pesquisar mais de um bloco na mesma execução, parar após entregar o bloco e aguardar comando humano, e ao continuar executar apenas o próximo bloco pendente; remove as linhas que antecipavam consolidação, geração de SQL de carregamento e verificação; arquivo alterado: `docs/prompt-nicho-identificacao.md`; PR criado com título "Ajusta relatório do prompt de identificação para executar pesquisa por bloco pendente".

### Testing

- Executed `npm ci` successfully and ran `npm run check` successfully (lint + typecheck), which completed with preexisting lint warnings but no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10dbf0943083299e933387494b5c79)