### PR TITLE
Clarify sequential execution of research_blocks in prompt-nicho-identificacao.md

### DIFF
--- a/docs/prompt-nicho-identificacao.md
+++ b/docs/prompt-nicho-identificacao.md
@@ -79,15 +79,13 @@ Não refaça a identificação do taxon.
 
 Pesquise os `research_blocks` na ordem definida em `research_blocks_order`.
 
-Pesquise apenas um `research_block` por vez.
+Pesquise apenas o primeiro `research_block` ainda não executado da ordem definida.
 
-Após entregar cada bloco, pare e aguarde comando humano para continuar.
+Não pesquise mais de um `research_block` na mesma execução.
 
-Após todos os blocos serem pesquisados, aguarde comando humano para consolidar.
+Após entregar o bloco pesquisado, pare e aguarde comando humano para continuar.
 
-Após a consolidação, aguarde comando humano para gerar SQL de carregamento.
-
-Após o carregamento, gere SQL de verificação.
+Quando o humano mandar continuar, execute apenas o próximo `research_block` ainda não executado da ordem definida.
 ```
 
 ## Parada


### PR DESCRIPTION
### Motivation
- Make the prompt behavior explicit so the assistant processes only the next unexecuted `research_block` per human continuation and does not proceed to automatic consolidation or SQL steps.

### Description
- Edit `docs/prompt-nicho-identificacao.md` to replace the ambiguous "one block at a time" wording with instructions to research only the first unexecuted `research_block`, to not research more than one block in the same execution, and to wait for human confirmation before proceeding to the next block.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10dbf0943083299e933387494b5c79)