### PR TITLE
docs: inserir seção 10.5.5 Fluxo operacional de pesquisa por taxon no roadmap

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -595,6 +595,52 @@
 • Ajustados:
 • `lib/onboarding/niche-resolution/contracts.ts`
 
+10.5.5 Fluxo operacional de pesquisa por taxon
+
+10.5.5.1 Objetivo
+
+• estruturar o fluxo operacional de pesquisa por taxon em etapas separadas de identificação, pesquisa profunda, consolidação, carregamento e verificação
+• garantir compatibilidade com `taxon_market_research` e `taxon_market_research_items`
+
+10.5.5.2 Artefatos na ordem de uso
+
+• A. Identificação do taxon
+• `docs/prompt-nicho-identificacao.md`
+  • identifica o taxon correto antes da pesquisa
+  • chama `supabase/snippets/e10_5_5_nicho_identificacao_taxon_lookup.sql`
+  • gera o relatório-instrução que será usado na pesquisa profunda
+• `supabase/snippets/e10_5_5_nicho_identificacao_taxon_lookup.sql`
+  • localiza taxons cadastrados por nome, slug ou alias
+  • deve ser usado na etapa de identificação do taxon
+
+• B. Pesquisa profunda
+• `docs/prompt-nicho-pesquisa.md`
+  • executa a pesquisa profunda por taxon
+  • pesquisa um `research_block` por vez
+  • entrega os blocos no formato esperado para consolidação posterior
+
+• C. Consolidação
+• `docs/prompt-nicho-consolidacao.md`
+  • consolida os blocos pesquisados e aprovados
+  • prepara a saída para futura carga nas tabelas de pesquisa
+
+• D. Carregamento
+• `docs/prompt-nicho-carregamento.md` — não implementado
+  • etapa prevista para orientar a geração do SQL de carregamento
+  • deve transformar a pesquisa consolidada em carga compatível com `taxon_market_research` e `taxon_market_research_items`
+• `supabase/snippets/e10_5_5_nicho_carregamento.sql` — não implementado
+  • snippet previsto para carregar a pesquisa consolidada
+  • deve inserir ou atualizar o registro-pai em `taxon_market_research`
+  • deve inserir os itens em `taxon_market_research_items`
+
+• E. Verificação
+• `docs/prompt-nicho-verificacao.md` — não implementado
+  • etapa prevista para orientar a verificação após o carregamento
+  • deve confirmar se o registro-pai e os itens foram gravados corretamente
+• `supabase/snippets/e10_5_5_nicho_verificacao.sql` — não implementado
+  • snippet previsto para verificar o carregamento da pesquisa
+  • deve listar o registro-pai e os itens carregados para conferência humana
+
 10.5.6 Classificação da conta e resolução do nicho
 • Status: Parcialmente concluído (14/05/2026)
 • Escopo atual: pipeline server-side no pós-save do `pending_setup`, com matching determinístico, decisão de confiança, persistência operacional, vínculo oficial sob alta confiança e escalonamento IA estruturado.


### PR DESCRIPTION
### Motivation

- Inserir a seção `10.5.5 Fluxo operacional de pesquisa por taxon` em `docs/roadmap.md` conforme o briefing consolidado na lousa, para registrar o fluxo operacional e os artefatos previstos relacionados a pesquisa por taxon.

### Description

- Adicionada a seção `10.5.5` com os subitens `10.5.5.1 Objetivo` e `10.5.5.2 Artefatos na ordem de uso` exatamente com o conteúdo fornecido pelo briefing. 
- A nova seção foi posicionada dentro do bloco `10.5` imediatamente após `10.5.4 Helper puro de confiança determinística para taxon match` e antes de `10.5.6 Classificação da conta e resolução do nicho` sem renumerar ou reordenar seções existentes. 
- Apenas o arquivo `docs/roadmap.md` foi modificado; nenhum prompt, snippet, schema ou migration foi alterado. 

### Testing

- `npm ci` foi executado com sucesso e as dependências foram instaladas. 
- `npm run check` foi executado com sucesso; a verificação retornou `eslint` com warnings preexistentes (24 warnings) e `tsc` sem erros (sem emitted files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11b5bc2d208329b157d966e1fc1ef5)