### PR TITLE
docs: adicionar research_block `seo` em prompt de pesquisa por nicho

### DIFF
--- a/docs/prompt-nicho-pesquisa.md
+++ b/docs/prompt-nicho-pesquisa.md
@@ -205,12 +205,6 @@ Critérios de sucesso:
 - priorizar buscas comerciais e dúvidas úteis para conversão;
 - marcar inferência em `evidência` quando não houver fonte direta.
 
-Fontes específicas para `seo`:
-
-- SERP brasileira do nicho;
-- páginas reais de concorrentes;
-- perguntas frequentes observadas em páginas comerciais;
-- padrões já observados em `lp_overview` e `lp_sections`, quando disponíveis.
 
 Limites:
 

--- a/docs/prompt-nicho-pesquisa.md
+++ b/docs/prompt-nicho-pesquisa.md
@@ -177,3 +177,43 @@ Limites:
 - Não escrever copy final.
 - Não transformar este bloco em briefing de design completo.
 - Não montar Light, Pro ou Ultra dentro da pesquisa.
+
+## 9. seo
+
+Entregue uma tabela com os principais insumos de SEO para landing pages do taxon confirmado, considerando o `audience_scope` recebido.
+
+O objetivo deste bloco é identificar intenções de busca, termos comerciais e perguntas úteis para orientar futuras LPs do nicho.
+
+Use exatamente estas colunas, nesta ordem:
+
+`item_key | item_text | priority | sort_order | notes | evidência`
+
+Use `item_key` simples, como:
+
+- `search_intent`
+- `commercial_keywords`
+- `support_keywords`
+- `local_terms`
+- `faq_questions`
+- `seo_requirements`
+
+Critérios de sucesso:
+
+- entregar insumos práticos para uma landing page;
+- manter volume enxuto;
+- agrupar termos relacionados no `item_text`;
+- priorizar buscas comerciais e dúvidas úteis para conversão;
+- marcar inferência em `evidência` quando não houver fonte direta.
+
+Fontes específicas para `seo`:
+
+- SERP brasileira do nicho;
+- páginas reais de concorrentes;
+- perguntas frequentes observadas em páginas comerciais;
+- padrões já observados em `lp_overview` e `lp_sections`, quando disponíveis.
+
+Limites:
+
+- não escrever copy final;
+- não inventar volume de busca, CPC ou dificuldade;
+- não transformar este bloco em calendário editorial.


### PR DESCRIPTION
### Motivation
- Padronizar a captura de insumos SEO para landing pages no fluxo de pesquisa por nicho, permitindo que o bloco `seo` oriente futuras LPs sem alterar os blocos existentes.

### Description
- Adiciona o bloco `## 9. seo` em `docs/prompt-nicho-pesquisa.md` imediatamente após `lp_sections`, definindo colunas obrigatórias `item_key | item_text | priority | sort_order | notes | evidência`, exemplos de `item_key`, critérios de sucesso, fontes específicas e limites do bloco.
- Mudança exclusivamente documental e compatível com o padrão de `docs/template-prompts.md`, mantendo `strategic_core`, `lp_overview` e `lp_sections` inalterados.

### Testing
- Verifiquei posicionamento e conteúdo usando `git branch --show-current`, `git status --short`, `git diff -- docs/prompt-nicho-pesquisa.md` e `nl -ba docs/prompt-nicho-pesquisa.md | sed -n '170,250p'`, e as saídas confirmaram a inclusão correta do bloco; todas as verificações locais sucederam.
- `npm ci` e `npm run check` não foram executados por se tratar de alteração exclusivamente documental e por estarem marcados como não aplicáveis segundo as regras do sandbox.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12483a153883299ace648add8acf17)