### PR TITLE
feat: implementar etapa D de carregamento E10.5.5

### DIFF
--- a/docs/prompt-nicho-carregamento.md
+++ b/docs/prompt-nicho-carregamento.md
@@ -1,0 +1,59 @@
+# Prompt — Carregamento de pesquisa por nicho/taxon
+
+## 1. Papel / função
+
+Atuar como gerador técnico de SQL de carga operacional a partir da pesquisa consolidada aprovada.
+
+## 2. Objetivo
+
+Transformar a pesquisa consolidada em SQL completo, idempotente e pronto para execução no Supabase SQL Editor.
+
+O SQL deve carregar os registros em:
+
+- `taxon_market_research`
+- `taxon_market_research_items`
+
+## 3. Entrada obrigatória
+
+Receba a pesquisa consolidada gerada por `docs/prompt-nicho-consolidacao.md`.
+
+Use como fonte de verdade:
+
+- `taxon_id`
+- `taxon_name`
+- `taxon_level`
+- `research_block`
+- `audience_scope`
+- `version`
+- `status`
+- tabela de itens consolidados
+
+## 4. Critérios de sucesso
+
+O SQL gerado deve:
+
+- criar ou atualizar o registro-pai em `taxon_market_research`
+- usar como chave lógica `taxon_id + research_block + audience_scope + version`
+- carregar os itens em `taxon_market_research_items`
+- substituir os itens existentes daquele `research_id` antes de reinserir os itens consolidados
+- preservar `item_key`, `item_text`, `priority`, `sort_order` e `notes`
+- manter `status = draft`, salvo se outro status vier explicitamente na consolidação
+- ser seguro para reexecução com os mesmos dados
+
+## 5. Limites
+
+- Não faça nova pesquisa.
+- Não altere o conteúdo consolidado.
+- Não gere migration.
+- Não altere schema, RLS, policies, triggers, views ou funções.
+- Não ative versão automaticamente.
+- Não invente `taxon_id`, `research_block`, `audience_scope`, `version` ou itens ausentes.
+- Se faltar a pesquisa consolidada completa, pare e peça o conteúdo faltante.
+
+## 6. Entrega esperada
+
+Entregue apenas o SQL completo para execução no Supabase SQL Editor.
+
+Use como base o snippet:
+
+`supabase/snippets/e10_5_5_nicho_carregamento.sql`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -634,10 +634,10 @@
   • deve inserir os itens em `taxon_market_research_items`
 
 • E. Verificação
-• `docs/prompt-nicho-verificacao.md`
+• `docs/prompt-nicho-verificacao.md` — não implementado
   • etapa prevista para orientar a verificação após o carregamento
   • deve confirmar se o registro-pai e os itens foram gravados corretamente
-• `supabase/snippets/e10_5_5_nicho_verificacao.sql`
+• `supabase/snippets/e10_5_5_nicho_verificacao.sql` — não implementado
   • snippet previsto para verificar o carregamento da pesquisa
   • deve listar o registro-pai e os itens carregados para conferência humana
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -625,19 +625,19 @@
   • prepara a saída para futura carga nas tabelas de pesquisa
 
 • D. Carregamento
-• `docs/prompt-nicho-carregamento.md` — não implementado
+• `docs/prompt-nicho-carregamento.md`
   • etapa prevista para orientar a geração do SQL de carregamento
   • deve transformar a pesquisa consolidada em carga compatível com `taxon_market_research` e `taxon_market_research_items`
-• `supabase/snippets/e10_5_5_nicho_carregamento.sql` — não implementado
+• `supabase/snippets/e10_5_5_nicho_carregamento.sql`
   • snippet previsto para carregar a pesquisa consolidada
   • deve inserir ou atualizar o registro-pai em `taxon_market_research`
   • deve inserir os itens em `taxon_market_research_items`
 
 • E. Verificação
-• `docs/prompt-nicho-verificacao.md` — não implementado
+• `docs/prompt-nicho-verificacao.md`
   • etapa prevista para orientar a verificação após o carregamento
   • deve confirmar se o registro-pai e os itens foram gravados corretamente
-• `supabase/snippets/e10_5_5_nicho_verificacao.sql` — não implementado
+• `supabase/snippets/e10_5_5_nicho_verificacao.sql`
   • snippet previsto para verificar o carregamento da pesquisa
   • deve listar o registro-pai e os itens carregados para conferência humana
 

--- a/supabase/snippets/e10_5_5_nicho_carregamento.sql
+++ b/supabase/snippets/e10_5_5_nicho_carregamento.sql
@@ -1,0 +1,168 @@
+-- e10_5_5_nicho_carregamento.sql
+-- Objetivo: carregar pesquisa consolidada por taxon em taxon_market_research e taxon_market_research_items.
+-- Uso: substituir os exemplos das tabelas temporárias pelos dados aprovados na pesquisa consolidada.
+-- Tipo: operacional / execução manual no Supabase SQL Editor.
+-- Observação: por padrão, usar status = 'draft'. Não ativar versão automaticamente.
+
+begin;
+
+drop table if exists pg_temp._e10_5_5_research_input;
+
+create temp table _e10_5_5_research_input (
+  taxon_id uuid not null,
+  research_block text not null,
+  audience_scope text not null,
+  version integer not null default 1,
+  status text not null default 'draft',
+  constraint _e10_5_5_research_input_audience_scope_chk
+    check (audience_scope in ('end_customer', 'business_buyer')),
+  constraint _e10_5_5_research_input_status_chk
+    check (status in ('draft', 'active', 'archived'))
+) on commit drop;
+
+-- Substituir pelos registros-pai da pesquisa consolidada.
+insert into _e10_5_5_research_input (
+  taxon_id,
+  research_block,
+  audience_scope,
+  version,
+  status
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    'strategic_core',
+    'business_buyer',
+    1,
+    'draft'
+  );
+
+drop table if exists pg_temp._e10_5_5_items_input;
+
+create temp table _e10_5_5_items_input (
+  research_block text not null,
+  item_key text not null,
+  item_text text not null,
+  priority integer not null default 0,
+  sort_order integer not null default 999,
+  notes text null
+) on commit drop;
+
+-- Substituir pelos itens consolidados aprovados.
+-- Usar dollar-quoted strings ($txt$...$txt$) para evitar problemas com aspas.
+insert into _e10_5_5_items_input (
+  research_block,
+  item_key,
+  item_text,
+  priority,
+  sort_order,
+  notes
+)
+values
+  (
+    'strategic_core',
+    'pain',
+    $txt$Exemplo de item consolidado.$txt$,
+    3,
+    1,
+    $txt$Exemplo de observação consolidada.$txt$
+  );
+
+do $$
+begin
+  if exists (
+    select 1
+    from _e10_5_5_items_input items_input
+    left join _e10_5_5_research_input research_input
+      on research_input.research_block = items_input.research_block
+    where research_input.research_block is null
+  ) then
+    raise exception 'Há itens com research_block sem registro-pai em _e10_5_5_research_input.';
+  end if;
+end $$;
+
+insert into public.taxon_market_research (
+  taxon_id,
+  research_block,
+  audience_scope,
+  version,
+  status
+)
+select
+  taxon_id,
+  research_block,
+  audience_scope,
+  version,
+  status
+from _e10_5_5_research_input
+on conflict (taxon_id, research_block, audience_scope, version)
+do update set
+  status = excluded.status,
+  updated_at = now();
+
+delete from public.taxon_market_research_items research_items
+using public.taxon_market_research research,
+      _e10_5_5_research_input research_input
+where research_items.research_id = research.id
+  and research.taxon_id = research_input.taxon_id
+  and research.research_block = research_input.research_block
+  and research.audience_scope = research_input.audience_scope
+  and research.version = research_input.version;
+
+insert into public.taxon_market_research_items (
+  research_id,
+  item_key,
+  item_text,
+  priority,
+  sort_order,
+  is_active,
+  notes
+)
+select
+  research.id,
+  items_input.item_key,
+  items_input.item_text,
+  items_input.priority,
+  items_input.sort_order,
+  true,
+  nullif(items_input.notes, '')
+from _e10_5_5_items_input items_input
+join _e10_5_5_research_input research_input
+  on research_input.research_block = items_input.research_block
+join public.taxon_market_research research
+  on research.taxon_id = research_input.taxon_id
+ and research.research_block = research_input.research_block
+ and research.audience_scope = research_input.audience_scope
+ and research.version = research_input.version
+order by
+  research_input.research_block,
+  items_input.sort_order,
+  items_input.item_key;
+
+select
+  research.id as research_id,
+  research.taxon_id,
+  research.research_block,
+  research.audience_scope,
+  research.version,
+  research.status,
+  count(research_items.id) as loaded_items
+from public.taxon_market_research research
+join _e10_5_5_research_input research_input
+  on research.taxon_id = research_input.taxon_id
+ and research.research_block = research_input.research_block
+ and research.audience_scope = research_input.audience_scope
+ and research.version = research_input.version
+left join public.taxon_market_research_items research_items
+  on research_items.research_id = research.id
+group by
+  research.id,
+  research.taxon_id,
+  research.research_block,
+  research.audience_scope,
+  research.version,
+  research.status
+order by
+  research.research_block;
+
+commit;


### PR DESCRIPTION
### Motivation

- Implementar a etapa D do fluxo de pesquisa por taxon para gerar o prompt de carregamento e o snippet SQL operacional; isso permite transformar a pesquisa consolidada aprovada em carga consistente para as tabelas de destino.
- Garantir que o processo de carga seja idempotente e compatível com a unicidade por `(taxon_id, research_block, audience_scope, version)` e com a relação `research_id` em `taxon_market_research_items`.
- Registrar a conclusão da etapa D no roadmap sem alterar a etapa E de verificação ou o schema/migrations existentes.

### Description

- Cria `docs/prompt-nicho-carregamento.md` com o prompt completo que descreve papel, objetivo, entrada obrigatória, critérios de sucesso, limites e entrega esperada para a etapa D.
- Cria `supabase/snippets/e10_5_5_nicho_carregamento.sql` contendo SQL idempotente de carga que valida consistência entre itens e registro-pai, upsert do registro-pai em `taxon_market_research`, limpeza dos itens anteriores e reinserção ordenada dos itens consolidados em `taxon_market_research_items`.
- Ajusta `docs/roadmap.md` em `10.5.5.2 Artefatos na ordem de uso` removendo `— não implementado` apenas dos dois artefatos da etapa D (`docs/prompt-nicho-carregamento.md` e `supabase/snippets/e10_5_5_nicho_carregamento.sql`) e preservando o status não implementado da etapa E.
- Não foram feitas alterações em migrations, schema, RLS, policies, triggers, views ou funções.

### Testing

- Executed `npm ci` which completed successfully and installed dependencies.
- Executed `npm run check` which completed successfully with no errors but reported existing lint warnings (24 warnings) that are preexisting and not blocking.
- No automated DB migrations or runtime tests were run as part of this change; validation limited to the repository checks above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13088cb3a4832986004a4563cc2849)