### PR TITLE
Implementa etapa E de verificação do E10.5.5

### DIFF
--- a/docs/prompt-nicho-verificacao.md
+++ b/docs/prompt-nicho-verificacao.md
@@ -1,0 +1,53 @@
+# Prompt — Verificação de carregamento de pesquisa por nicho/taxon
+
+## 1. Papel / função
+
+Atuar como verificador técnico-operacional do carregamento da pesquisa por taxon.
+
+## 2. Objetivo
+
+Gerar SQL de verificação para confirmar se os registros da pesquisa consolidada foram carregados corretamente em:
+
+- `taxon_market_research`
+- `taxon_market_research_items`
+
+## 3. Entrada obrigatória
+
+Receba os dados usados no carregamento ou a pesquisa consolidada aprovada.
+
+Use como fonte de verdade:
+
+- `taxon_id`
+- `research_block`
+- `audience_scope`
+- `version`
+- `status` esperado, quando informado
+- quantidade esperada de itens por `research_block`, quando disponível
+
+## 4. Critérios de sucesso
+
+O SQL de verificação deve permitir conferir:
+
+- se o registro-pai existe em `taxon_market_research`
+- se `taxon_id`, `research_block`, `audience_scope`, `version` e `status` estão corretos
+- quantos itens foram carregados por `research_block`
+- quantos itens estão ativos
+- se existem itens sem `item_key`, `item_text`, `priority` ou `sort_order`
+- a lista dos itens carregados, ordenada por `research_block`, `sort_order` e `item_key`
+
+## 5. Limites
+
+- Não faça nova pesquisa.
+- Não gere SQL de carregamento.
+- Não altere dados.
+- Não gere migration.
+- Não altere schema, RLS, policies, triggers, views ou funções.
+- Se faltar `taxon_id`, `research_block`, `audience_scope` ou `version`, pare e peça o dado faltante.
+
+## 6. Entrega esperada
+
+Entregue apenas o SQL completo para execução no Supabase SQL Editor.
+
+Use como base o snippet:
+
+`supabase/snippets/e10_5_5_nicho_verificacao.sql`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -634,10 +634,10 @@
   • deve inserir os itens em `taxon_market_research_items`
 
 • E. Verificação
-• `docs/prompt-nicho-verificacao.md` — não implementado
+• `docs/prompt-nicho-verificacao.md`
   • etapa prevista para orientar a verificação após o carregamento
   • deve confirmar se o registro-pai e os itens foram gravados corretamente
-• `supabase/snippets/e10_5_5_nicho_verificacao.sql` — não implementado
+• `supabase/snippets/e10_5_5_nicho_verificacao.sql`
   • snippet previsto para verificar o carregamento da pesquisa
   • deve listar o registro-pai e os itens carregados para conferência humana
 

--- a/supabase/snippets/e10_5_5_nicho_verificacao.sql
+++ b/supabase/snippets/e10_5_5_nicho_verificacao.sql
@@ -136,3 +136,60 @@ order by
   research_block,
   check_type desc,
   check_status;
+
+with input as (
+  select
+    '00000000-0000-0000-0000-000000000000'::uuid as taxon_id,
+    'business_buyer'::text as audience_scope,
+    1::integer as version,
+    *
+  from (
+    values
+      ('strategic_core'::text),
+      ('lp_overview'::text),
+      ('lp_sections'::text),
+      ('seo'::text)
+  ) as blocks(research_block)
+),
+
+parents as (
+  select
+    input.research_block,
+    research.id as research_id
+  from input
+  left join public.taxon_market_research research
+    on research.taxon_id = input.taxon_id
+   and research.research_block = input.research_block
+   and research.audience_scope = input.audience_scope
+   and research.version = input.version
+),
+
+items as (
+  select
+    parents.research_block,
+    research_items.id as item_id,
+    research_items.item_key,
+    research_items.item_text,
+    research_items.priority,
+    research_items.sort_order,
+    research_items.is_active,
+    research_items.notes
+  from parents
+  left join public.taxon_market_research_items research_items
+    on research_items.research_id = parents.research_id
+)
+
+select
+  items.research_block,
+  items.item_key,
+  items.item_text,
+  items.priority,
+  items.sort_order,
+  items.is_active,
+  items.notes
+from items
+where items.item_id is not null
+order by
+  items.research_block,
+  items.sort_order,
+  items.item_key;

--- a/supabase/snippets/e10_5_5_nicho_verificacao.sql
+++ b/supabase/snippets/e10_5_5_nicho_verificacao.sql
@@ -1,0 +1,138 @@
+-- e10_5_5_nicho_verificacao.sql
+-- Objetivo: verificar carregamento de pesquisa por taxon em taxon_market_research e taxon_market_research_items.
+-- Uso: substituir os exemplos em input pelos blocos carregados.
+-- Tipo: read-only / execução manual no Supabase SQL Editor.
+
+with input as (
+  select
+    '00000000-0000-0000-0000-000000000000'::uuid as taxon_id,
+    'business_buyer'::text as audience_scope,
+    1::integer as version,
+    'draft'::text as expected_status,
+    *
+  from (
+    values
+      ('strategic_core'::text, null::integer),
+      ('lp_overview'::text, null::integer),
+      ('lp_sections'::text, null::integer),
+      ('seo'::text, null::integer)
+  ) as blocks(research_block, expected_items)
+),
+
+parents as (
+  select
+    input.research_block,
+    input.expected_items,
+    research.id as research_id,
+    research.taxon_id,
+    research.audience_scope,
+    research.version,
+    research.status,
+    research.created_at,
+    research.updated_at
+  from input
+  left join public.taxon_market_research research
+    on research.taxon_id = input.taxon_id
+   and research.research_block = input.research_block
+   and research.audience_scope = input.audience_scope
+   and research.version = input.version
+),
+
+items as (
+  select
+    parents.research_block,
+    parents.research_id,
+    research_items.id as item_id,
+    research_items.item_key,
+    research_items.item_text,
+    research_items.priority,
+    research_items.sort_order,
+    research_items.is_active,
+    research_items.notes,
+    research_items.created_at,
+    research_items.updated_at
+  from parents
+  left join public.taxon_market_research_items research_items
+    on research_items.research_id = parents.research_id
+)
+
+select
+  'parent_summary' as check_type,
+  parents.research_block,
+  case
+    when parents.research_id is null then 'missing_parent'
+    when parents.status <> input.expected_status then 'status_mismatch'
+    when input.expected_items is not null
+      and count(items.item_id) <> input.expected_items then 'item_count_mismatch'
+    else 'ok'
+  end as check_status,
+  parents.research_id,
+  parents.taxon_id,
+  parents.audience_scope,
+  parents.version,
+  parents.status,
+  input.expected_status,
+  input.expected_items,
+  count(items.item_id) as loaded_items,
+  count(items.item_id) filter (where items.is_active = true) as active_items,
+  count(items.item_id) filter (
+    where items.item_key is null
+       or btrim(items.item_key) = ''
+       or items.item_text is null
+       or btrim(items.item_text) = ''
+       or items.priority is null
+       or items.sort_order is null
+  ) as invalid_items,
+  parents.created_at,
+  parents.updated_at
+from parents
+join input
+  on input.research_block = parents.research_block
+left join items
+  on items.research_id = parents.research_id
+group by
+  parents.research_block,
+  parents.research_id,
+  parents.taxon_id,
+  parents.audience_scope,
+  parents.version,
+  parents.status,
+  parents.created_at,
+  parents.updated_at,
+  input.expected_status,
+  input.expected_items
+
+union all
+
+select
+  'item_detail' as check_type,
+  items.research_block,
+  case
+    when items.item_id is null then 'no_items'
+    when items.item_key is null
+      or btrim(items.item_key) = ''
+      or items.item_text is null
+      or btrim(items.item_text) = ''
+      or items.priority is null
+      or items.sort_order is null then 'invalid_item'
+    when items.is_active is false then 'inactive_item'
+    else 'ok'
+  end as check_status,
+  items.research_id,
+  null::uuid as taxon_id,
+  null::text as audience_scope,
+  null::integer as version,
+  null::text as status,
+  null::text as expected_status,
+  null::integer as expected_items,
+  null::bigint as loaded_items,
+  null::bigint as active_items,
+  null::bigint as invalid_items,
+  items.created_at,
+  items.updated_at
+from items
+
+order by
+  research_block,
+  check_type desc,
+  check_status;


### PR DESCRIPTION
### Motivation

- Implementar a etapa E do fluxo de pesquisa por taxon para validar se o carregamento da etapa D gravou corretamente os registros em `taxon_market_research` e `taxon_market_research_items`. 
- Fornecer um prompt formalizado para geração de SQL de verificação e um snippet pronto para execução no editor SQL do Supabase. 

### Description

- Cria `docs/prompt-nicho-verificacao.md` contendo papel, objetivo, entrada obrigatória, critérios de sucesso, limites e entrega esperada para a etapa E. 
- Cria `supabase/snippets/e10_5_5_nicho_verificacao.sql`, um snippet read-only que verifica existência do registro-pai, status, contagem de itens, itens ativos, itens inválidos e fornece detalhe dos itens ordenados por `research_block`, `sort_order` e `item_key`. 
- Atualiza `docs/roadmap.md` removendo o marcador `— não implementado` das duas entradas da etapa E para refletir que a etapa foi implementada. 
- Não foram criadas migrations nem alterados schema, RLS, policies, triggers, views ou functions. 

### Testing

- Executed `npm ci`, which completed successfully. 
- Executed `npm run check`, which completed successfully with ESLint/TypeScript validation and reported 24 ESLint warnings and 0 errors. 
- Não foram executados testes automáticos de banco de dados nem criadas alterações de migração (não aplicável).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a131cd33ab8832991da3b611a0f6769)