### PR TITLE
docs: alinhar Platform Config e Automations (v0.1.1 / v1.8)

### DIFF
--- a/docs/automations.md
+++ b/docs/automations.md
@@ -1,7 +1,7 @@
 0.1 Cabeçalho
-Data: 18/03/2026
-Versão: v1.7
-Status: Estrutura ajustada para automações, agentes e MCP
+Data: 26/05/2026
+Versão: v1.8
+Status: Alinhado ao Platform Config
 
 0.2 Função do documento
 Registrar a camada de automações operacionais do LP Factory 10 como referência operacional para plataformas usadas nessa camada, integrações, automações operacionais, componentes consumidores e aprendizados operacionais, sem expor segredos.
@@ -11,6 +11,7 @@ docs/services.md: services implantáveis, MCPs, endpoints e infraestrutura reuti
 docs/base-tecnica.md: regras estruturais gerais, guardrails, checks e workflows técnicos de manutenção.
 docs/schema.md: banco, tabelas, views, policies e functions.
 docs/roadmap.md: evolução funcional.
+docs/platform-config.md: configurações operacionais de plataformas, secrets por nome, workflows, ambientes, endpoints e regras de plataforma usados por automações.
 
 0.4 Atualização estrutural — 26/03/2026
 - `automations/` passa a ser a raiz canônica para novas automações.
@@ -26,7 +27,9 @@ docs/roadmap.md: evolução funcional.
 - `pipelines/validador-final/`, `pipelines/supabase-inspect/` e `pipelines/docs-apply-report/` deixaram de ser paths oficiais.
 
 1. Objetivo e escopo
-Registrar a camada de automações operacionais do LP Factory 10: plataformas usadas, credenciais registradas sem valores secretos, catálogo de automações, componentes consumidores e aprendizados operacionais.
+Registrar a camada de automações operacionais do LP Factory 10: catálogo de automações, status, como usar, componentes consumidores, dependências e aprendizados operacionais.
+
+Configurações de plataformas, secrets por nome, ambientes, endpoints e lista consolidada de workflows devem ficar em `docs/platform-config.md`.
 
 Este documento não substitui:
 - `docs/services.md`, para services, MCPs, endpoints e infraestrutura reutilizável;
@@ -38,41 +41,29 @@ Regra de segurança:
 Nunca registrar segredos brutos. Registrar apenas nome da credencial, plataforma, ambiente, localização, finalidade e escopo.
 
 2. Plataformas e configuração global
+Configurações operacionais de plataformas, secrets por nome, ambientes, endpoints e lista consolidada de workflows ficam em `docs/platform-config.md`.
+
+Esta seção mantém apenas o contexto de uso das plataformas pela camada de automações.
+
 2.1 OpenAI
 - Papel na automação: execução de modelos, Agent Builder/SDK e integração com pipelines/agentes.
 - Ambientes operacionais: `LPF10-DEV` e `LPF10-PROD`.
-- Credencial registrada: `OPENAI_API_KEY` (armazenada em GitHub Secrets).
 - Regra operacional: desenvolvimento prioriza DEV; análise de consumo deve ser feita por projeto.
-- Governança de consumo: API keys e service accounts ficam vinculados ao projeto onde foram criados.
-- Benefícios e custo: DEV possui `complimentary daily tokens` (diário, não acumulado) e `complimentary weekly evals`.
-- Qualidade/custo: escolher modelo conforme necessidade real; cobertura de `tool use` deve ser validada com cautela conforme política vigente.
 
 2.2 GitHub
 - Papel: repositório principal, GitHub Actions, pipelines, PRs e secrets.
-- Credenciais registradas: `OPENAI_API_KEY`, `SUPABASE_DB_URL_READONLY`, `MAILBOX_EMAIL`, `MAILBOX_PASSWORD`.
-- Estrutura operacional: raiz canônica de automações em `automations/`; orquestração em `.github/workflows/`.
-- Workflows ativos identificados:
-  - `.github/workflows/pipeline-supabase-inspect.yml`
-  - `.github/workflows/pipeline-docs-apply-report.yml`
-  - `.github/workflows/automation-validador-final.yml`
-  - `.github/workflows/automation-niche-runtime-tests.yml`
-  - `.github/workflows/security.yml`
-  - `.github/workflows/upgrade-next-16-1-1.yml`
+- Contexto de uso: orquestração dos workflows e execução das automações em `automations/`.
 
 2.3 Supabase
 - Papel: banco, Auth e fonte para inspeções/verificações read-only.
-- Credencial registrada: `SUPABASE_DB_URL_READONLY` (GitHub Secrets), com escopo read-only para inspeções e verificações quando aplicável.
-- Estrutura de acesso: role `ai_readonly` para consultas e inspeções.
-- Exceção MVP: houve relaxamento temporário para acelerar o Supabase Inspect, sem service_role e sem escrita direta; revisar permissões antes de ampliar o acesso operacional.
-- Observação operacional: verificações de runtime que consultam banco devem ser tratadas como presets versionados quando aplicável.
+- Contexto de uso: automações podem consumir acesso read-only quando aplicável, sem mutações.
 
 2.4 Vercel
-- Papel: hospedagem do Core SaaS e de services dedicados.
-- Projetos: `lp-factory-10` e `lpf-10-services`.
-- Detalhes operacionais de services e variáveis devem ser consultados em `docs/services.md`.
+- Papel: hospedagem do Core SaaS e de services dedicados consumidos por automações.
+- Contexto de uso: previews e produção podem ser usados como alvo de execução dos workflows.
 
 2.5 Resend
-- Papel no ecossistema: plataforma relacionada ao projeto.
+- Papel no ecossistema: plataforma relacionada ao projeto para fluxos de e-mail transacional.
 - Estado atual: não há automação operacional formalizada de Resend neste documento.
 
 3. Catálogo de automações operacionais

--- a/docs/platform-config.md
+++ b/docs/platform-config.md
@@ -2,8 +2,8 @@
 
 0.1 Cabeçalho
 • Documento: LP Factory 10 — Platform Config
-• Versão: v0.1.0
-• Data: 15/05/2026
+• Versão: v0.1.1
+• Data: 26/05/2026
 
 0.2 Contrato do documento
 • O QUE É: fonte única de configurações operacionais de plataformas externas do LP Factory 10.
@@ -32,12 +32,19 @@
 • Secrets conhecidos:
 • `OPENAI_API_KEY`: usado por automações/CI que chamam OpenAI.
 • `SUPABASE_DB_URL_READONLY`: conexão read-only para inspeções/automação de banco.
+• `MAILBOX_EMAIL`: e-mail usado por automações de autenticação/mailbox.
+• `MAILBOX_PASSWORD`: senha/app password da mailbox usada por automações de autenticação/mailbox.
+• Regra: valores reais de secrets não devem ser versionados.
+• Regra: secrets de mailbox devem existir apenas nos escopos necessários dos workflows que os consomem.
 • Regra: `SUPABASE_DB_URL_READONLY` deve autenticar com role/usuário read-only e usar preferencialmente session pooler.
 • Regra: workflows que acessam banco para inspeção devem ser read-only, salvo caso explicitamente aprovado.
 
 2.3 Workflows conhecidos
 • `.github/workflows/security.yml`: checks de segurança.
 • `.github/workflows/pipeline-supabase-inspect.yml`: pipeline de inspeção Supabase.
+• `.github/workflows/pipeline-docs-apply-report.yml`: aplicação automatizada de reports em documentos Markdown.
+• `.github/workflows/automation-validador-final.yml`: validação ponta a ponta de fluxos reais de autenticação.
+• `.github/workflows/automation-niche-runtime-tests.yml`: testes runtime de criação de conta e preenchimento de `pending_setup`.
 • `.github/workflows/upgrade-next-16-1-1.yml`: manutenção de Next.js + lockfile.
 
 3. Vercel
@@ -146,6 +153,14 @@
 • Regra: manter SPF/DKIM compatíveis com Resend.
 • Validação atual conhecida: signup e forgot password testados, entrega confirmada, links funcionais e sem erro de envio.
 
+
+4.6 Acesso operacional read-only para automações
+• Role operacional read-only: `ai_readonly`.
+• Secret relacionado: `SUPABASE_DB_URL_READONLY`.
+• Uso: inspeções e verificações read-only em automações.
+• Regra: não usar esse acesso para mutações.
+• Regra: revisar permissões antes de ampliar o escopo operacional.
+
 5. Resend
 
 5.1 Uso
@@ -187,6 +202,14 @@
 • Plataforma: Vercel.
 • Finalidade: selecionar modelo do resolvedor IA de nicho.
 • Valor atual de referência: `gpt-5.4-mini`
+
+
+6.4 Agent Builder — Supabase Inspect
+• Ativo operacional: Supabase Inspect Agente.
+• Workflow ID: `wf_69b57fed963c8190b9da8e40797aa5820147027ff7bd60d7`.
+• Uso: validação operacional do Supabase Inspect via Agent Builder.
+• Regra: não tratar como camada final robusta de orquestração.
+• Dependência: MCP Supabase Inspect em `https://lpf-10-services.vercel.app/api/mcp`.
 
 7. Domínios e DNS
 
@@ -250,7 +273,19 @@
 9.4 Design System
 • `docs/design-system.md` permanece como fonte única para padrões visuais, componentes UI e regras de uso visual.
 
+
+9.5 Automations
+• `docs/automations.md` permanece como fonte para catálogo, uso, status, dependências e aprendizados das automações.
+• Configurações de plataformas, secrets por nome, workflows, ambientes e endpoints usados por automações devem ser registrados neste documento.
+
 99. Changelog
+v0.1.1 (26/05/2026) — Alinhamento com Automations
+• Registrados secrets de mailbox usados por automações.
+• Complementada a lista de workflows operacionais conhecidos.
+• Registrado acesso operacional read-only `ai_readonly`/`SUPABASE_DB_URL_READONLY`.
+• Registrado ativo Agent Builder — Supabase Inspect.
+• Definida relação entre Platform Config e Automations.
+
 v0.1.0 (15/05/2026) — Criação do Platform Config
 • Criado documento inicial para centralizar configurações operacionais de plataformas.
 • Registradas plataformas em uso: GitHub, Vercel, Supabase, Resend, OpenAI Platform, Registro.com e Zoho Mail.

--- a/docs/platform-config.md
+++ b/docs/platform-config.md
@@ -34,6 +34,9 @@
 • `SUPABASE_DB_URL_READONLY`: conexão read-only para inspeções/automação de banco.
 • `MAILBOX_EMAIL`: e-mail usado por automações de autenticação/mailbox.
 • `MAILBOX_PASSWORD`: senha/app password da mailbox usada por automações de autenticação/mailbox.
+• `SUPABASE_ACCESS_TOKEN`: token usado pelo workflow de apply de migrations Supabase.
+• `SUPABASE_DB_PASSWORD`: senha do banco usada pelo workflow de apply de migrations Supabase.
+• `SUPABASE_APPLY_MIGRATIONS_ENABLED`: variável/gate operacional para habilitar ou bloquear o apply automático de migrations.
 • Regra: valores reais de secrets não devem ser versionados.
 • Regra: secrets de mailbox devem existir apenas nos escopos necessários dos workflows que os consomem.
 • Regra: `SUPABASE_DB_URL_READONLY` deve autenticar com role/usuário read-only e usar preferencialmente session pooler.
@@ -45,6 +48,7 @@
 • `.github/workflows/pipeline-docs-apply-report.yml`: aplicação automatizada de reports em documentos Markdown.
 • `.github/workflows/automation-validador-final.yml`: validação ponta a ponta de fluxos reais de autenticação.
 • `.github/workflows/automation-niche-runtime-tests.yml`: testes runtime de criação de conta e preenchimento de `pending_setup`.
+• `.github/workflows/pipeline-supabase-apply-migrations.yml`: apply controlado de migrations Supabase em `main` quando há mudanças em `supabase/migrations/**`, com `workflow_dispatch` e gate por `SUPABASE_APPLY_MIGRATIONS_ENABLED`.
 • `.github/workflows/upgrade-next-16-1-1.yml`: manutenção de Next.js + lockfile.
 
 3. Vercel


### PR DESCRIPTION
### Motivation
- Unificar a residência das configurações operacionais e reduzir duplicação entre `docs/platform-config.md` e `docs/automations.md` para ter um único lugar de verdade para secrets, workflows, ambientes e endpoints. 
- Registrar itens faltantes usados pelas automações (secrets de mailbox, workflows operacionais, acesso read-only ao Supabase e integração Agent Builder) sem adicionar valores reais de secrets.

### Description
- Atualiza `docs/platform-config.md` para `v0.1.1` (26/05/2026) e adiciona `MAILBOX_EMAIL` e `MAILBOX_PASSWORD` à lista de secrets conhecidos, regras de uso e escopo, lista complementada de workflows, subseção de acesso read-only `ai_readonly`/`SUPABASE_DB_URL_READONLY`, subseção `6.4` para Agent Builder — Supabase Inspect e entrada de changelog v0.1.1. 
- Atualiza `docs/automations.md` para `v1.8` (26/05/2026), adiciona referência explícita para `docs/platform-config.md`, ajusta o objetivo/escopo para evitar duplicação e reduz a seção de plataformas para manter apenas contexto de uso pelas automações. 
- Mantidos conteúdos do catálogo de automações (seção 3) e todas as regras de segurança (nenhum valor real de secret foi versionado). 
- Arquivos modificados: `docs/platform-config.md`, `docs/automations.md`.

### Testing
- Executed `npm ci` which completed successfully. 
- Executed `npm run check` which ran `eslint` and `tsc`; the run completed with no errors, producing lint warnings only (no failing checks). 
- Verificações adicionais: updated files staged and committed; no files outside the allowed scope were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a172c74fd50832989f2fd36f9812613)