### PR TITLE
docs: esclarecer limitação de Git remoto no sandbox do Codex App

### DIFF
--- a/docs/gestor-codex.md
+++ b/docs/gestor-codex.md
@@ -129,8 +129,23 @@ Este documento deve evitar duplicar essas fontes.
 
 ### 6.1 Git remoto no sandbox do Codex App
 
-- Não usar `git fetch`, `git pull`, `git push`, `git ls-remote` ou SSH remoto dentro do sandbox.
-- Contorno atual: GitHub Connector, GitHub Web, GitHub Desktop ou PowerShell normal fora do sandbox, conforme o caso.
+A limitação atual não é acesso geral ao computador. O Codex App consegue editar e validar arquivos no workspace local.
+
+O problema está nas operações Git remotas locais dentro do sandbox, como:
+
+- `git fetch`
+- `git pull`
+- `git push`
+- `git ls-remote`
+- `ssh -T git@github.com`
+
+Mesmo com rede habilitada, essas operações podem exigir escrita em áreas internas do Git, como `.git`, `FETCH_HEAD`, refs remotas e arquivos de lock. Por isso, o Codex App ainda não fecha sozinho o ciclo remoto completo de atualizar base, publicar branch e abrir fluxo de PR sem apoio externo.
+
+Decisão vigente:
+
+- não usar Git remoto local dentro do sandbox;
+- usar GitHub Connector, GitHub Web, GitHub Desktop ou PowerShell normal fora do sandbox, conforme o caso;
+- investigar se existe configuração oficial segura para permitir Git remoto local completo sem usar modo inseguro/full access.
 
 ### 6.2 Mistura de alterações locais
 


### PR DESCRIPTION
### Motivation

- Esclarecer em `docs/gestor-codex.md` que a limitação do Codex App no Windows não é acesso geral ao workspace, mas especificamente nas operações Git remotas locais dentro do sandbox.
- Evitar interpretações erradas de segurança e explicitar que o problema pode envolver escrita no estado interno do Git (por exemplo `.git`, `FETCH_HEAD`, refs remotas e arquivos de lock).
- Manter a decisão operacional atual e registrar a pendência de investigação de uma alternativa segura sem `full access`.

### Description

- Atualizada a seção `6.1 Git remoto no sandbox do Codex App` para substituir a proibição sucinta por um texto explicativo que lista os comandos afetados: `git fetch`, `git pull`, `git push`, `git ls-remote` e `ssh -T git@github.com`.
- Adicionada a justificativa operacional apontando que essas operações podem exigir escrita em áreas internas do Git e por isso o ciclo remoto não é fechado automaticamente pelo Codex App dentro do sandbox.
- Registrada a decisão vigente de não usar Git remoto local no sandbox e de preferir `GitHub Connector`, `GitHub Web`, `GitHub Desktop` ou PowerShell fora do sandbox, além da pendência de investigação.
- Escopo limitado a `docs/gestor-codex.md` e branch de trabalho `codex/ajuste-gestor-sandbox-git`, com PR aberto para revisão.

### Testing

- Alteração é documental; não foram executados testes de código automatizados e a mudança não afeta a base de código.
- `npm ci`: não aplicável para este escopo documental.
- `npm run check`: não aplicável para este escopo documental.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a182e4ee3d88329876f244ffd87e445)