### PR TITLE
docs: clarify platform-config as operational snapshot (v0.1.2)

### DIFF
--- a/docs/platform-config.md
+++ b/docs/platform-config.md
@@ -2,14 +2,16 @@
 
 0.1 Cabeçalho
 • Documento: LP Factory 10 — Platform Config
-• Versão: v0.1.1
-• Data: 26/05/2026
+• Versão: v0.1.2
+• Data: 27/05/2026
 
 0.2 Contrato do documento
-• O QUE É: fonte única de configurações operacionais de plataformas externas do LP Factory 10.
+• O QUE É: snapshot operacional e fonte única das configurações de plataformas externas do LP Factory 10, refletindo o estado conhecido/cadastrado nas plataformas conforme indicado.
 • USAR PARA: variáveis, secrets por nome, endpoints, URLs, redirects, SMTP, DNS, projetos externos, ambientes e regras de redeploy.
 • NÃO USAR PARA: regras de runtime/código, contrato de DB, status de casos E* ou padrões visuais.
 • REGRA: nunca registrar valores reais de secrets; registrar apenas nome, finalidade, plataforma e escopo.
+• LEITURA OPERACIONAL: secrets, variáveis, workflows, endpoints e conectores listados aqui devem ser tratados como disponíveis no ambiente/plataforma indicada, salvo marcação explícita de futuro, pendente, bloqueado ou não validado.
+• LIMITE: este documento não versiona valores reais de secrets e não garante que o chat tenha acesso direto a eles; quando o uso exigir segredo, a execução deve ocorrer na plataforma autorizada, por exemplo GitHub Actions, Vercel ou Supabase.
 
 1. Visão geral de plataformas
 • GitHub: repositório, PRs, Actions e secrets de automações.
@@ -283,6 +285,11 @@
 • Configurações de plataformas, secrets por nome, workflows, ambientes e endpoints usados por automações devem ser registrados neste documento.
 
 99. Changelog
+v0.1.2 (27/05/2026) — Clarificação de snapshot operacional
+• Clarificado que o Platform Config reflete o estado conhecido/cadastrado nas plataformas.
+• Definida a leitura operacional para secrets, variáveis, workflows, endpoints e conectores listados.
+• Reforçado que valores reais de secrets não são versionados e devem ser consumidos apenas por plataformas autorizadas.
+
 v0.1.1 (26/05/2026) — Alinhamento com Automations
 • Registrados secrets de mailbox usados por automações.
 • Complementada a lista de workflows operacionais conhecidos.


### PR DESCRIPTION
### Motivation
- Make explicit that `docs/platform-config.md` is an operational snapshot and not a store of real secret values. 
- Reduce ambiguity about how listed secrets, variables and connectors should be treated and where secret consumption must occur. 

### Description
- Update header version and date to `Versão: v0.1.2` and `Data: 27/05/2026` in `docs/platform-config.md`. 
- Replace the `O QUE É` bullet with text clarifying the document is a snapshot reflecting the state known/cadastrado nas plataformas. 
- Add `LEITURA OPERACIONAL` and `LIMITE` bullets under `0.2 Contrato do documento` to define operational reading for listed secrets/variables/workflows/endpoints/connectors and to state that real secret values are not versioned and must be consumed on authorized platforms. 
- Add changelog entry `v0.1.2 (27/05/2026)` with the requested summary lines. 

### Testing
- Ran `npm ci`, which completed successfully. 
- Ran `npm run check`, which completed successfully with pre-existing lint warnings only and no errors. 
- Files changed: `docs/platform-config.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18b25d9cb483298bdd3ff8a70ebca2)