### PR TITLE
docs: ajusta fluxo E10.5.5 para itens estruturados por research_block

### DIFF
--- a/docs/prompt-nicho-itens-estruturados.md
+++ b/docs/prompt-nicho-itens-estruturados.md
@@ -204,14 +204,29 @@ Formato:
 - audience_scope:
 - research_blocks_order:
 
-## Registro-pai
+Gerar um Registro-pai para cada `research_block` estruturado.
+
+Formato esperado:
+
+## Registro-pai — [research_block]
 
 - taxon_id:
 - taxon_name:
 - taxon_level:
+- research_block:
 - audience_scope:
 - version: 1
 - status: draft
+
+Regras:
+
+- `research_block` é obrigatório.
+- Criar um Registro-pai separado para cada bloco estruturado.
+- Os itens de cada seção devem pertencer ao respectivo `research_block`.
+- Não gerar SQL.
+- Não fazer nova pesquisa.
+- Consolidar duplicidades e priorizar os itens mais fortes.
+- Evitar transcrever listas extensas da pesquisa bruta sem síntese.
 
 ## [research_block]
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -634,10 +634,10 @@
   • entrega material para estruturação posterior dos itens da pesquisa
 
 • C. Estruturação dos itens da pesquisa
-• `docs/prompt-nicho-consolidacao.md`
+• `docs/prompt-nicho-itens-estruturados.md`
   • transforma a pesquisa bruta aprovada em itens estruturados por `research_block`
   • prepara a saída compatível com `taxon_market_research_items`
-  • pendente de revisão para refletir o novo modelo de pesquisa bruta
+  • gera um Registro-pai por `research_block` para orientar a carga em `taxon_market_research`
 
 • D. Carregamento
 • `docs/prompt-nicho-carregamento.md`
@@ -674,7 +674,6 @@
 
 10.5.5.4 Pendências atuais
 • Testar o fluxo real usando os prompts da `main`, após merge da feature branch.
-• Revisar `docs/prompt-nicho-consolidacao.md` para transformar pesquisa bruta em itens estruturados da pesquisa.
 • Decidir onde a pesquisa bruta será arquivada: repo, banco ou ambos.
 • Se a decisão for arquivamento no banco, avaliar ajuste de schema em `taxon_market_research`.
 • Revisar carregamento e verificação após a definição de arquivamento da pesquisa bruta.
@@ -685,7 +684,6 @@
 
 • A revisar:
   • `docs/prompt-nicho-identificacao.md`
-  • `docs/prompt-nicho-consolidacao.md`
   • `docs/prompt-nicho-carregamento.md`
   • `docs/prompt-nicho-verificacao.md`
   • `supabase/snippets/e10_5_5_nicho_carregamento.sql`


### PR DESCRIPTION
### Motivation
- Corrigir o fluxo E10.5.5 para que a etapa de estruturação gere um `Registro-pai` por `research_block` e impedir referências ao prompt antigo de consolidação que já não se aplica.
- Incluir `research_block` no bloco `Registro-pai` para garantir compatibilidade com `taxon_market_research` e orientar o carregamento de itens.
- Atualizar o roadmap para apontar explicitamente para o novo prompt de itens estruturados sem alterar versão, data ou changelog.

### Description
- Atualiza `docs/prompt-nicho-itens-estruturados.md` para instruir a geração de um `Registro-pai` por `research_block`, inserir o campo `research_block` no bloco e adicionar regras de separação e síntese por bloco.
- Substitui em `docs/roadmap.md` a referência à etapa C de `docs/prompt-nicho-consolidacao.md` por `docs/prompt-nicho-itens-estruturados.md` e documenta que a etapa agora gera um `Registro-pai` por `research_block`.
- Remove referências pendentes ao `docs/prompt-nicho-consolidacao.md` nas seções 10.5.5.4 e 10.5.5.5, mantendo demais artefatos e sem tocar versão/data/changelog/schema/snippets/prompts de outras etapas.
- Files changed: `docs/prompt-nicho-itens-estruturados.md`, `docs/roadmap.md`; `docs/prompt-nicho-consolidacao.md` was not present in the branch and therefore not removed.

### Testing
- Executed content checks with `rg` to confirm presence of `research_block` and replacement of `prompt-nicho-consolidacao` references and the check passed.
- Validated Markdown fences with a Python check (`python3` script) and the check reported balanced code fences for the modified files.
- Ran `npm ci` which completed successfully and `npm run check` which ran `eslint` and `tsc` successfully, producing only warnings (24 lint warnings) and no errors.
- Performed `git` operations locally and committed the changes as `83b6a4c` and prepared the PR titled above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c4771495883299f14d96f2446080a)