### PR TITLE
docs: align services references

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -1,15 +1,16 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data: 15/04/2026
-• Versão: v1.1
-• Status: Atualizado com boundary operacional de deploy do service MCP
+• Data: 27/05/2026
+• Versão: v1.2
+• Status: Alinhado ao Platform Config e Automations
 
 0.2 Função do documento
 Registrar a camada `services` do LP Factory 10 como referência oficial e amigável para humano para services implantáveis, MCPs, endpoints e infraestrutura reutilizável com identidade própria, sem expor segredos.
 
 0.3 Relação com outros documentos
-• docs/automacoes.md: automações operacionais, componentes consumidores, uso humano essencial e referências para services base quando houver dependência
+• docs/automations.md: automações operacionais, componentes consumidores, uso humano essencial e referências para services base quando houver dependência
+• docs/platform-config.md: snapshot operacional das configurações de plataformas, endpoints, projetos externos, secrets por nome, variáveis e regras de redeploy usadas por services.
 • docs/base-tecnica.md: guardrails, regras estruturais, checks de CI, segurança, workflows técnicos e topologia canônica do repositório
 • docs/roadmap.md: evolução planejada, próximos casos, fases futuras e itens ainda não materializados como caso operacional
 
@@ -43,7 +44,7 @@ Registrar a camada `services` do LP Factory 10 como referência oficial e amigá
 • implementação canônica: `services/mcp-supabase-inspect/api/mcp.js`
 • README técnico local: `services/mcp-supabase-inspect/README.md`
 • docs/base-tecnica.md
-• consumidor atual: `docs/automacoes.md` — `3.3 Supabase Inspect Agente`
+• consumidor atual: `docs/automations.md` — `3.3 Supabase Inspect Agente`
 
 1.2 Pendência operacional vinculada
 
@@ -55,10 +56,11 @@ Registrar a camada `services` do LP Factory 10 como referência oficial e amigá
 • Observação: a pendência não invalida a MCP como service base reutilizável; bloqueia apenas a completude funcional da tool
 
 2. Regras de fronteira desta camada
-• `docs/services.md` registra services implantáveis, MCPs, endpoints, infraestrutura reutilizável com identidade própria e suas referências técnicas locais
-• `docs/automacoes.md` permanece responsável por automações operacionais e componentes consumidores
-• `docs/base-tecnica.md` permanece responsável por guardrails, checks, segurança e regras estruturais
-• `docs/roadmap.md` permanece responsável por evolução futura
+• `docs/services.md` registra services implantáveis, MCPs, endpoints, infraestrutura reutilizável com identidade própria e suas referências técnicas locais.
+• `docs/automations.md` permanece responsável por automações operacionais e componentes consumidores.
+• `docs/platform-config.md` permanece responsável pelo snapshot operacional de plataformas, endpoints, projetos externos, secrets por nome, variáveis e regras de redeploy.
+• `docs/base-tecnica.md` permanece responsável por guardrails, checks, segurança e regras estruturais.
+• `docs/roadmap.md` permanece responsável por evolução futura.
 
 3. Observação de manutenção
 • `docs/services.md` passa a ser a referência oficial e amigável para humano da camada `services`
@@ -67,6 +69,10 @@ Registrar a camada `services` do LP Factory 10 como referência oficial e amigá
 • quando um service compartilhado com o Core tiver deploy independente no mesmo repositório, registrar explicitamente a boundary operacional (projeto Vercel, Root Directory e regras de build) para evitar drift documental e builds desnecessários
 
 99. Changelog
+v1.2 (27/05/2026)
+• corrigidas referências antigas de `docs/automacoes.md` para `docs/automations.md`
+• adicionada relação documental com `docs/platform-config.md`
+• reforçada a fronteira entre services, automações, configurações operacionais e regras técnicas
 v1.1 (15/04/2026)
 • registrada a boundary operacional de deploy do `LPF Supabase Inspect MCP` no projeto Vercel `lpf-10-services`
 • adicionadas as regras operacionais `Root Directory`, `Include files outside the root directory in the Build Step = OFF` e `Ignored Build Step` customizado


### PR DESCRIPTION
### Motivation
- Update `docs/services.md` to remove legacy references and align its scope with the repository's operational configuration source. 
- Reflect the new document version and date to record the consolidation of references between services, automations and platform config. 

### Description
- Updated header to `Data: 27/05/2026`, `Versão: v1.2` and `Status: Alinhado ao Platform Config e Automations` in `docs/services.md`. 
- Replaced occurrences of `docs/automacoes.md` with `docs/automations.md` including the consumer reference. 
- Added `docs/platform-config.md` to the `0.3 Relação com outros documentos` section and clarified the frontier in `2. Regras de fronteira desta camada`. 
- Added `v1.2 (27/05/2026)` changelog entry describing the reference corrections and boundary clarifications; no other files were modified. 

### Testing
- Ran `npm ci`, which completed successfully and installed dependencies. 
- Ran `npm run check`, which completed successfully; `eslint` reported 24 warnings and no errors, and `tsc` typecheck passed. 
- Files changed: `docs/services.md` (only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c4b5c669c8329a83cb62663428a6c)