### PR TITLE
docs: ajusta prompt de verificação E10.5.5

### DIFF
--- a/docs/prompt-nicho-verificacao.md
+++ b/docs/prompt-nicho-verificacao.md
@@ -4,11 +4,11 @@
 
 Atue como verificador técnico-operacional do carregamento da pesquisa por nicho/taxon no fluxo E10.5.5.
 
-Sua função é gerar um SQL de verificação read-only, pronto para execução manual no Supabase SQL Editor, e depois aguardar o resultado retornado pelo usuário para avaliar se o carregamento deu certo.
+Sua função é gerar um SQL de resumo read-only, pronto para execução manual no Supabase SQL Editor, e depois aguardar o resultado retornado pelo usuário para avaliar se o carregamento deu certo.
 
 ## 2. Objetivo
 
-Gerar um SQL completo para confirmar, depois do carregamento, se os registros da pesquisa consolidada foram gravados corretamente nas tabelas definitivas:
+Gerar um SQL completo de resumo para confirmar, depois do carregamento, se os registros da pesquisa consolidada foram gravados corretamente nas tabelas definitivas:
 
 - `taxon_market_research`
 - `taxon_market_research_items`
@@ -23,7 +23,7 @@ Use como base o snippet:
 
 O snippet contém placeholders e exemplos de preenchimento. Não copie esses placeholders crus para a resposta final.
 
-Ao gerar o SQL, substitua o bloco `input` do snippet pelos dados reais do carregamento informado pelo usuário.
+Ao gerar o SQL, substitua o bloco `input` do snippet pelos dados reais do carregamento informado pelo usuário. O SQL final deve retornar apenas o resumo por `research_block`, em um único resultado final.
 
 ## 4. Entrada obrigatória
 
@@ -49,7 +49,7 @@ O SQL de verificação deve permitir conferir:
 - quantos itens foram carregados por `research_block`
 - quantos itens estão ativos
 - se existem itens sem `item_key`, `item_text`, `priority` ou `sort_order`
-- a lista dos itens carregados, ordenada por `research_block`, `sort_order` e `item_key`
+- uma linha de resumo por `research_block`, sem listagem completa dos itens carregados
 
 ## 6. Limites
 
@@ -60,13 +60,15 @@ O SQL de verificação deve permitir conferir:
 - Não altere schema, RLS, policies, triggers, views ou funções.
 - Não copie cru o bloco `input` de exemplo do snippet.
 - Não mantenha no SQL final placeholders como `00000000-0000-0000-0000-000000000000`, `business_buyer`, blocos de exemplo ou valores fictícios.
+- Não liste todos os itens carregados.
+- Gere apenas um resultado final de resumo, com uma linha por `research_block`.
 - A verificação deve ser apenas read-only, usando `select`/CTEs de consulta, sem `insert`, `update`, `delete`, `merge`, `truncate`, `drop`, `alter` ou comandos equivalentes de escrita.
 
 ## 7. Entrega esperada
 
 Entregue apenas:
 
-1. o SQL completo, pronto para copiar e colar no Supabase SQL Editor;
+1. o SQL completo de resumo, pronto para copiar e colar no Supabase SQL Editor;
 2. depois do SQL, no máximo a frase:
 
    “Execute o SQL no Supabase SQL Editor e traga o resultado para avaliação.”
@@ -77,4 +79,4 @@ Não inclua explicações, análise, comentários adicionais ou instruções for
 
 Depois que o usuário executar o SQL no Supabase SQL Editor e trouxer o resultado, avalie a saída para concluir se o carregamento deu certo.
 
-Considere o carregamento aprovado quando os registros-pai esperados existirem, os metadados estiverem corretos, as contagens esperadas baterem quando informadas e não houver itens inválidos ou ausentes.
+Considere o carregamento aprovado somente quando todos os `research_blocks` retornarem `check_status = ok` e `invalid_items = 0`.

--- a/docs/prompt-nicho-verificacao.md
+++ b/docs/prompt-nicho-verificacao.md
@@ -2,29 +2,45 @@
 
 ## 1. Papel / função
 
-Atuar como verificador técnico-operacional do carregamento da pesquisa por taxon.
+Atue como verificador técnico-operacional do carregamento da pesquisa por nicho/taxon no fluxo E10.5.5.
+
+Sua função é gerar um SQL de verificação read-only, pronto para execução manual no Supabase SQL Editor, e depois aguardar o resultado retornado pelo usuário para avaliar se o carregamento deu certo.
 
 ## 2. Objetivo
 
-Gerar SQL de verificação para confirmar se os registros da pesquisa consolidada foram carregados corretamente em:
+Gerar um SQL completo para confirmar, depois do carregamento, se os registros da pesquisa consolidada foram gravados corretamente nas tabelas definitivas:
 
 - `taxon_market_research`
 - `taxon_market_research_items`
 
-## 3. Entrada obrigatória
+A verificação deve ser universal para qualquer taxon e para qualquer conjunto de blocos de pesquisa carregados.
+
+## 3. Fonte obrigatória do SQL
+
+Use como base o snippet:
+
+`supabase/snippets/e10_5_5_nicho_verificacao.sql`
+
+O snippet contém placeholders e exemplos de preenchimento. Não copie esses placeholders crus para a resposta final.
+
+Ao gerar o SQL, substitua o bloco `input` do snippet pelos dados reais do carregamento informado pelo usuário.
+
+## 4. Entrada obrigatória
 
 Receba os dados usados no carregamento ou a pesquisa consolidada aprovada.
 
-Use como fonte de verdade:
+Use como fonte de verdade para montar o bloco `input`:
 
 - `taxon_id`
-- `research_block`
 - `audience_scope`
 - `version`
-- `status` esperado, quando informado
-- quantidade esperada de itens por `research_block`, quando disponível
+- `research_blocks` carregados
+- `expected_items` por `research_block`, quando disponível
+- `expected_status`, quando disponível
 
-## 4. Critérios de sucesso
+Se faltar `taxon_id`, `research_block`/`research_blocks`, `audience_scope` ou `version`, pare e peça exatamente o dado faltante. Não gere SQL enquanto algum desses dados obrigatórios estiver ausente.
+
+## 5. Critérios de sucesso
 
 O SQL de verificação deve permitir conferir:
 
@@ -35,19 +51,30 @@ O SQL de verificação deve permitir conferir:
 - se existem itens sem `item_key`, `item_text`, `priority` ou `sort_order`
 - a lista dos itens carregados, ordenada por `research_block`, `sort_order` e `item_key`
 
-## 5. Limites
+## 6. Limites
 
 - Não faça nova pesquisa.
 - Não gere SQL de carregamento.
 - Não altere dados.
 - Não gere migration.
 - Não altere schema, RLS, policies, triggers, views ou funções.
-- Se faltar `taxon_id`, `research_block`, `audience_scope` ou `version`, pare e peça o dado faltante.
+- Não copie cru o bloco `input` de exemplo do snippet.
+- Não mantenha no SQL final placeholders como `00000000-0000-0000-0000-000000000000`, `business_buyer`, blocos de exemplo ou valores fictícios.
+- A verificação deve ser apenas read-only, usando `select`/CTEs de consulta, sem `insert`, `update`, `delete`, `merge`, `truncate`, `drop`, `alter` ou comandos equivalentes de escrita.
 
-## 6. Entrega esperada
+## 7. Entrega esperada
 
-Entregue apenas o SQL completo para execução no Supabase SQL Editor.
+Entregue apenas:
 
-Use como base o snippet:
+1. o SQL completo, pronto para copiar e colar no Supabase SQL Editor;
+2. depois do SQL, no máximo a frase:
 
-`supabase/snippets/e10_5_5_nicho_verificacao.sql`
+   “Execute o SQL no Supabase SQL Editor e traga o resultado para avaliação.”
+
+Não inclua explicações, análise, comentários adicionais ou instruções fora do SQL e da frase permitida.
+
+## 8. Avaliação posterior
+
+Depois que o usuário executar o SQL no Supabase SQL Editor e trouxer o resultado, avalie a saída para concluir se o carregamento deu certo.
+
+Considere o carregamento aprovado quando os registros-pai esperados existirem, os metadados estiverem corretos, as contagens esperadas baterem quando informadas e não houver itens inválidos ou ausentes.

--- a/supabase/snippets/e10_5_5_nicho_verificacao.sql
+++ b/supabase/snippets/e10_5_5_nicho_verificacao.sql
@@ -1,6 +1,7 @@
 -- e10_5_5_nicho_verificacao.sql
--- Objetivo: verificar carregamento de pesquisa por taxon em taxon_market_research e taxon_market_research_items.
--- Uso: substituir os exemplos em input pelos blocos carregados.
+-- Objetivo: verificar o carregamento de pesquisa por taxon em taxon_market_research e taxon_market_research_items.
+-- Uso: substituir todo o bloco input de exemplo abaixo pelos dados reais do carregamento antes de executar.
+-- Saída: um único resultado final de resumo, com uma linha por research_block.
 -- Tipo: read-only / execução manual no Supabase SQL Editor.
 
 with input as (
@@ -23,6 +24,10 @@ parents as (
   select
     input.research_block,
     input.expected_items,
+    input.taxon_id as expected_taxon_id,
+    input.audience_scope as expected_audience_scope,
+    input.version as expected_version,
+    input.expected_status,
     research.id as research_id,
     research.taxon_id,
     research.audience_scope,
@@ -47,149 +52,67 @@ items as (
     research_items.item_text,
     research_items.priority,
     research_items.sort_order,
-    research_items.is_active,
-    research_items.notes,
-    research_items.created_at,
-    research_items.updated_at
+    research_items.is_active
   from parents
   left join public.taxon_market_research_items research_items
     on research_items.research_id = parents.research_id
 )
 
 select
-  'parent_summary' as check_type,
   parents.research_block,
   case
     when parents.research_id is null then 'missing_parent'
-    when parents.status <> input.expected_status then 'status_mismatch'
-    when input.expected_items is not null
-      and count(items.item_id) <> input.expected_items then 'item_count_mismatch'
+    when parents.expected_status is not null
+      and parents.status is distinct from parents.expected_status then 'status_mismatch'
+    when parents.expected_items is not null
+      and count(items.item_id) <> parents.expected_items then 'item_count_mismatch'
+    when count(items.item_id) filter (
+      where items.item_id is not null
+        and (items.item_key is null
+          or btrim(items.item_key) = ''
+          or items.item_text is null
+          or btrim(items.item_text) = ''
+          or items.priority is null
+          or items.sort_order is null)
+    ) > 0 then 'invalid_items'
     else 'ok'
   end as check_status,
   parents.research_id,
-  parents.taxon_id,
-  parents.audience_scope,
-  parents.version,
+  coalesce(parents.taxon_id, parents.expected_taxon_id) as taxon_id,
+  coalesce(parents.audience_scope, parents.expected_audience_scope) as audience_scope,
+  coalesce(parents.version, parents.expected_version) as version,
   parents.status,
-  input.expected_status,
-  input.expected_items,
+  parents.expected_status,
+  parents.expected_items,
   count(items.item_id) as loaded_items,
   count(items.item_id) filter (where items.is_active = true) as active_items,
   count(items.item_id) filter (
-    where items.item_key is null
-       or btrim(items.item_key) = ''
-       or items.item_text is null
-       or btrim(items.item_text) = ''
-       or items.priority is null
-       or items.sort_order is null
+    where items.item_id is not null
+      and (items.item_key is null
+        or btrim(items.item_key) = ''
+        or items.item_text is null
+        or btrim(items.item_text) = ''
+        or items.priority is null
+        or items.sort_order is null)
   ) as invalid_items,
   parents.created_at,
   parents.updated_at
 from parents
-join input
-  on input.research_block = parents.research_block
 left join items
   on items.research_id = parents.research_id
 group by
   parents.research_block,
+  parents.expected_items,
+  parents.expected_taxon_id,
+  parents.expected_audience_scope,
+  parents.expected_version,
+  parents.expected_status,
   parents.research_id,
   parents.taxon_id,
   parents.audience_scope,
   parents.version,
   parents.status,
   parents.created_at,
-  parents.updated_at,
-  input.expected_status,
-  input.expected_items
-
-union all
-
-select
-  'item_detail' as check_type,
-  items.research_block,
-  case
-    when items.item_id is null then 'no_items'
-    when items.item_key is null
-      or btrim(items.item_key) = ''
-      or items.item_text is null
-      or btrim(items.item_text) = ''
-      or items.priority is null
-      or items.sort_order is null then 'invalid_item'
-    when items.is_active is false then 'inactive_item'
-    else 'ok'
-  end as check_status,
-  items.research_id,
-  null::uuid as taxon_id,
-  null::text as audience_scope,
-  null::integer as version,
-  null::text as status,
-  null::text as expected_status,
-  null::integer as expected_items,
-  null::bigint as loaded_items,
-  null::bigint as active_items,
-  null::bigint as invalid_items,
-  items.created_at,
-  items.updated_at
-from items
-
+  parents.updated_at
 order by
-  research_block,
-  check_type desc,
-  check_status;
-
-with input as (
-  select
-    '00000000-0000-0000-0000-000000000000'::uuid as taxon_id,
-    'business_buyer'::text as audience_scope,
-    1::integer as version,
-    *
-  from (
-    values
-      ('strategic_core'::text),
-      ('lp_overview'::text),
-      ('lp_sections'::text),
-      ('seo'::text)
-  ) as blocks(research_block)
-),
-
-parents as (
-  select
-    input.research_block,
-    research.id as research_id
-  from input
-  left join public.taxon_market_research research
-    on research.taxon_id = input.taxon_id
-   and research.research_block = input.research_block
-   and research.audience_scope = input.audience_scope
-   and research.version = input.version
-),
-
-items as (
-  select
-    parents.research_block,
-    research_items.id as item_id,
-    research_items.item_key,
-    research_items.item_text,
-    research_items.priority,
-    research_items.sort_order,
-    research_items.is_active,
-    research_items.notes
-  from parents
-  left join public.taxon_market_research_items research_items
-    on research_items.research_id = parents.research_id
-)
-
-select
-  items.research_block,
-  items.item_key,
-  items.item_text,
-  items.priority,
-  items.sort_order,
-  items.is_active,
-  items.notes
-from items
-where items.item_id is not null
-order by
-  items.research_block,
-  items.sort_order,
-  items.item_key;
+  parents.research_block;


### PR DESCRIPTION
### Motivation

- Tornar o prompt de verificação mais amigável e universal para o fluxo E10.5.5, garantindo que a IA gere um SQL de verificação pronto para execução no Supabase SQL Editor e depois aguarde o resultado para avaliação.
- Assegurar que a verificação use o snippet oficial como base, sem copiar placeholders de exemplo, e que seja claramente read-only sobre as tabelas definitivas.

### Description

- Atualiza `docs/prompt-nicho-verificacao.md` para explicitar o uso do snippet `supabase/snippets/e10_5_5_nicho_verificacao.sql` como base e proibir copiar seus placeholders crus. 
- Define os campos obrigatórios que devem compor o bloco `input`: `taxon_id`, `audience_scope`, `version`, `research_blocks`, `expected_items` por `research_block` e `expected_status`, e instrui a IA a parar e pedir exatamente o dado faltante quando algum desses estiver ausente. 
- Reforça limites operacionais de leitura apenas (`select`/CTEs) e proíbe qualquer comando de escrita ou alteração de schema, RLS, policies, triggers, views ou funções. 
- Ajusta a entrega esperada para exigir somente o SQL completo pronto para colar no Supabase SQL Editor e, após o SQL, apenas a frase: “Execute o SQL no Supabase SQL Editor e traga o resultado para avaliação.”

### Testing

- Executado `git diff --check` sem problemas detectados. 
- Executado `npm ci` com sucesso. 
- Executado `npm run check` com exit 0; o lint retornou 24 avisos existentes em arquivos não alterados por esta PR e o `tsc` passou sem erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2089d597088329a92650d7e200999e)