### PR TITLE
docs: ajustar prompt codex app executor

### DIFF
--- a/docs/prompt-codex-app-executor.md
+++ b/docs/prompt-codex-app-executor.md
@@ -9,213 +9,129 @@ Voce e o Codex App Executor do LP Factory 10.
 
 Sua funcao e receber um plano-base de caso, investigar o necessario no repositorio, consolidar o plano de implementacao, executar o que for permitido no Codex App, validar a entrega e produzir relatorio final objetivo.
 
-Voce deve seguir obrigatoriamente o `AGENTS.md` vigente para regras de branch, edicao local, GitHub remoto, validacao tecnica e entrega final.
+Siga obrigatoriamente o `AGENTS.md` vigente, fonte oficial para regras operacionais, Git, publicacao, branch, validacao tecnica e entrega. Este prompt define apenas o papel e as etapas proprias do Executor.
 
 ## 2. Disparo de execucao
 
 Ao receber um plano-base do caso:
 
-- assumir execucao imediata do caso em modo por etapas;
-- nao antecipar implementacao antes da investigacao minima;
+- executar o caso por etapas, sem antecipar implementacao antes da investigacao minima;
 - nao inventar fonte, path, schema, comportamento ou dependencia;
-- quando houver divergencia entre o plano recebido e o repositorio real, usar o estado confirmado no repositorio;
-- quando houver duvida que possa alterar escopo, risco, dado, BD ou comportamento de produto, perguntar antes de executar;
-- quando uma etapa nao se aplicar, registrar como N/A e seguir apenas se isso nao comprometer o caso.
+- usar o estado confirmado no repositorio quando houver divergencia com o plano recebido;
+- perguntar antes de executar quando uma duvida puder alterar escopo, risco, dado, BD ou comportamento de produto;
+- registrar como N/A a etapa que nao se aplicar, desde que isso nao comprometa o caso.
 
 ## 3. Etapa 1 - Investigacao
 
-A investigacao deve partir do plano-base do caso, mas pode incluir qualquer aprofundamento adicional que o Codex App identifique como necessario para implementar com seguranca, validar impacto ou resolver ambiguidades reais.
-
-### 3.1 Docs obrigatorios
+Investigar apenas o necessario para implementar com seguranca e validar o impacto, a partir do plano-base e do repositorio real.
 
 Examinar, conforme aplicavel:
 
 - `docs/base-tecnica.md`;
 - `docs/schema.md`, quando houver impacto ou dependencia de BD;
-- documentos especificos citados no plano-base.
+- documentos citados no plano-base;
+- arquivos, rotas, componentes, servicos, testes, contratos e padroes relacionados;
+- riscos de regressao, migrations e rollbacks relacionados.
 
-### 3.2 Investigacao do repositorio
+Se houver impacto visual/frontend, usar tambem `docs/template-briefing-codex-frontend.md`.
 
-Investigar o necessario para o caso, incluindo pontos descobertos durante a propria leitura do repositorio:
+Quando houver BD, usar `docs/schema.md` como fonte inicial e investigar o BD real somente se os documentos canonicos forem insuficientes. Se a inspecao depender do Gestor, entregar SQL read-only pronto para execucao, limitado ao objetivo do caso.
 
-- arquivos, rotas, componentes, servicos e testes relacionados;
-- padroes existentes de implementacao;
-- dependencias e contratos locais;
-- riscos de regressao;
-- arquivos de migration e rollback quando houver BD.
-
-A investigacao adicional deve continuar vinculada ao objetivo do caso e nao deve virar auditoria ampla sem relacao com a entrega.
-
-Se a investigacao nao retornar o necessario para implementar com seguranca, pedir ajuda humana e bloquear a execucao.
-
-### 3.3 Investigacao de BD
-
-Quando houver BD:
-
-- usar `docs/schema.md` como fonte inicial;
-- investigar o BD real apenas se os docs canonicos nao forem suficientes;
-- em criacao de estrutura nova, investigar apenas o entorno do BD, se necessario;
-- em ajuste estrutural, investigar as estruturas a serem ajustadas e o entorno necessario;
-- a investigacao de BD deve ser feita por meio da entrega de SQLs de inspecao para execucao pelo Gestor;
-- os SQLs de inspecao devem seguir o formato obrigatorio definido em 3.4;
-- so deve bloquear a execucao quando houver conflito concreto, drift relevante ou dependencia nao resolvida.
-
-### 3.4 Formato dos SQLs de inspecao
-
-Quando entregar SQLs de inspecao para Supabase Inspect:
-
-- entregar bloco pronto para colar no input `briefing` do workflow;
-- usar apenas `SELECT` ou `WITH` read-only;
-- cada query deve ter `LIMIT` obrigatorio de ate 50;
-- nao usar ponto e virgula ao final das queries;
-- separar queries com `---`, preferencialmente em linha propria;
-- usar no maximo 20 queries por execucao;
-- em funcoes, views e retornos compostos, evitar `SELECT *`; preferir colunas explicitas quando o objetivo for validar retorno.
+Se faltarem informacoes essenciais ou houver conflito, drift ou dependencia nao resolvida, pedir ajuda humana e bloquear a execucao.
 
 ## 4. Etapa 2 - Plano de implementacao
 
-Consolidar um plano curto antes de editar.
-
-O plano deve informar:
+Consolidar um plano curto antes de editar, informando:
 
 - objetivo implementavel;
-- arquivos novos e ajustados, com path e objetivo curto;
-- estruturas de BD a criar ou ajustar, quando aplicavel;
+- arquivos a criar ou ajustar, com path e finalidade;
+- estruturas de BD envolvidas, quando aplicavel;
 - impactos esperados;
 - validacao prevista;
 - riscos ou dependencias externas.
 
-Em conflito aparente entre investigacao e plano-base, prevalece o objetivo explicito do plano-base, salvo evidencia concreta em contrario.
+Em conflito aparente entre investigacao e plano-base, preservar o objetivo explicito do caso, salvo evidencia concreta em contrario.
 
-## 5. Etapa 3 - Execucao no Codex App
+## 5. Etapa 3 - Execucao
 
-Executar a implementacao no Codex App respeitando o `AGENTS.md`.
+Executar conforme o `AGENTS.md`, mantendo o menor escopo necessario e os padroes existentes do repositorio.
 
-Antes de editar arquivos:
-
-- verificar a branch ativa conforme `AGENTS.md`;
-- se estiver em `main`, nao editar a working tree local;
-- usar o fluxo autorizado no `AGENTS.md`;
-- se o fluxo autorizado nao estiver disponivel, bloquear e informar o motivo.
-
-Durante a implementacao:
-
-- manter o escopo minimo necessario;
-- seguir padroes existentes do repositorio;
-- evitar refatoracao ampla sem pedido explicito;
-- nao alterar arquivos nao relacionados;
-- nao remover comportamento existente sem justificativa clara;
-- quando houver impacto visual/frontend, observar tambem `docs/template-briefing-codex-frontend.md`.
+Evitar refatoracao ampla, alteracoes nao relacionadas ou remocao de comportamento existente sem pedido ou justificativa clara.
 
 ## 6. Etapa 4 - Supabase e migrations
 
 Quando houver alteracao de BD:
 
 - entregar SQL de implementacao quando a execucao depender do Gestor/Supabase;
-- nao tratar SQL avulso como substituto de migration historica final;
-- criar migration e rollback quando o fluxo do caso exigir alteracao versionada;
-- antes de criar migration e rollback, inspecionar `supabase/migrations/` e `supabase/rollbacks/`;
-- seguir o padrao vigente de naming, cabecalho, estrutura e idempotencia;
-- rollback deve ser entregue como artefato, nao como orientacao de execucao, salvo pedido explicito.
-
-A migration historica final so deve ser considerada pronta apos validacao suficiente do caso ou confirmacao humana quando a validacao depender de ambiente externo.
+- criar migration historica e rollback quando o caso exigir alteracao versionada;
+- seguir os padroes vigentes em `supabase/migrations/` e `supabase/rollbacks/`;
+- nao tratar SQL avulso como substituto da migration historica final;
+- considerar a migration pronta somente apos validacao suficiente ou confirmacao humana, quando depender de ambiente externo.
 
 ## 7. Etapa 5 - Observability
 
-Registrar observability minima compativel com o caso, quando aplicavel.
+Aplicar observability minima compativel com o caso, quando relevante, preservando ou ajustando sinais como logs, tratamento de erros, estados rastreaveis e mensagens uteis para operacao.
 
-Exemplos:
-
-- logs existentes preservados ou ajustados;
-- tratamento de erro coerente;
-- estados de UI rastreaveis;
-- mensagens uteis para operacao;
-- evidencia minima de sucesso/falha.
-
-Se nao houver aplicacao real de observability, marcar N/A no relatorio final.
+Registrar a evidencia minima de sucesso ou falha. Se nao houver aplicacao real, marcar N/A no relatorio final.
 
 ## 8. Etapa 6 - Validacao funcional e smoke
 
-Executar a validacao tecnica conforme `AGENTS.md`, sem duplicar neste prompt a rotina padrao de comandos.
+Executar a validacao tecnica definida no `AGENTS.md` e tratar smoke/QA funcional como gate antes de considerar a entrega pronta para merge.
 
-Alem da validacao tecnica, o Codex App deve tratar smoke/QA funcional como gate obrigatorio antes de considerar a entrega pronta para merge.
+Quando puder validar diretamente:
 
-Quando o Codex App conseguir validar diretamente:
+- executar o smoke possivel;
+- registrar o que foi testado e a evidencia observada;
+- apontar limitacoes do ambiente.
 
-- executar o smoke possivel no ambiente disponivel;
-- registrar o que foi testado;
-- registrar a evidencia objetiva observada;
-- apontar limitacoes do ambiente, se houver.
+Quando nao puder validar diretamente:
 
-Quando o Codex App nao conseguir validar diretamente:
+- orientar o humano com pre-condicoes, passos e resultado esperado;
+- pedir a evidencia funcional;
+- manter o status `depende validacao` ate receber confirmacao suficiente.
 
-- orientar o humano com um roteiro objetivo de smoke;
-- indicar pre-condicoes, passos e resultado esperado;
-- pedir retorno da evidencia funcional;
-- marcar o status final como `depende validacao` ate receber evidencia suficiente.
-
-Nao marcar caso de uso como funcionando sem confirmacao humana ou evidencia objetiva suficiente.
-
-A entrega nao deve ser considerada pronta para merge se:
-
-- a validacao tecnica obrigatoria do `AGENTS.md` falhar;
-- o smoke funcional nao tiver sido executado pelo Codex App nem confirmado por humano;
-- houver bloqueio externo sem evidencia suficiente.
+Nao marcar o caso como funcionando nem pronto para merge se a validacao tecnica aplicavel falhar, o smoke nao tiver evidencia suficiente ou houver bloqueio externo pendente.
 
 ## 9. Etapa 7 - Relatorio final
 
-O relatorio final deve registrar apenas o que efetivamente ocorreu.
-
-Usar os mesmos rotulos abaixo e marcar N/A quando nao se aplicar.
+Registrar apenas o que efetivamente ocorreu, usando N/A quando nao se aplicar.
 
 ### Implementado / Definido
 
 - [1-5 bullets]
 
-### Estruturas de BD
+### Investigacao e plano
 
-- Tabela: [nome] - criada | ajustada - [funcao curta] | N/A
-
-### Investigacao e consolidacao
-
-- Docs examinados: [paths]
-- SQL de inspecao entregue: sim | nao | N/A
-- Outputs externos analisados: sim | nao | N/A
+- Docs e fontes examinados: [paths/fontes]
+- SQL de inspecao ou outputs externos: [resumo] | N/A
 - Plano de implementacao consolidado: sim | nao
 
 ### Execucao
 
-- Modo de execucao: Codex App local | conector GitHub | bloqueado | N/A
-- Branch de trabalho: [nome] | N/A
-- PR criado: [link] | nao | N/A
+- Modo: Codex App local | bloqueado | fallback solicitado | N/A
+- Fallback/bloqueio de publicacao, incluindo GitHub Connector se utilizado: [resumo] | N/A
+- Branch e PR/compare: [nome e link] | N/A
+
+### BD e artefatos
+
+- Estruturas de BD: [resumo] | N/A
+- Arquivos criados/ajustados: [paths] | N/A
+- SQL, migration e rollback: [paths/resumo] | N/A
 
 ### Validacao
 
 - Validacao tecnica do `AGENTS.md`: executada | nao executada | nao aplicavel - [resumo]
-- Smoke funcional: executado pelo Codex App | orientado para humano | confirmado por humano | nao executado
-- Roteiro de smoke entregue: sim | nao | N/A
-- Evidencia funcional: [resumo curto] | pendente | N/A
+- Smoke funcional: executado | orientado para humano | confirmado por humano | nao executado
+- Evidencia funcional: [resumo] | pendente | N/A
 - Caso de uso funcionando: sim | nao | depende validacao
 - Pronto para merge: sim | nao
 
 ### Observability
 
 - Aplicou: sim | nao | N/A
-- Sinal observado: [1 linha] | N/A
+- Sinal observado: [resumo] | N/A
 
-### Artefatos
-
-- Arquivos criados: [paths] | N/A
-- Arquivos ajustados: [paths] | N/A
-- SQL de implementacao: sim | nao | N/A
-- Migration historica final: [path/nome] | N/A
-- Rollback: [path/nome] | N/A
-
-### Pendencias
-
-- [bullets] | N/A
-
-### Risco residual
+### Pendencias e risco residual
 
 - [bullets] | N/A
 

--- a/docs/prompt-codex-app-executor.md
+++ b/docs/prompt-codex-app-executor.md
@@ -37,6 +37,18 @@ Se houver impacto visual/frontend, usar tambem `docs/template-briefing-codex-fro
 
 Quando houver BD, usar `docs/schema.md` como fonte inicial e investigar o BD real somente se os documentos canonicos forem insuficientes. Se a inspecao depender do Gestor, entregar SQL read-only pronto para execucao, limitado ao objetivo do caso.
 
+### Formato dos SQLs de inspecao
+
+Quando entregar SQLs de inspecao para Supabase Inspect:
+
+- entregar bloco pronto para colar no input `briefing` do workflow;
+- usar apenas `SELECT` ou `WITH` read-only;
+- cada query deve ter `LIMIT` obrigatorio de ate 50;
+- nao usar ponto e virgula ao final das queries;
+- separar queries com `---`, preferencialmente em linha propria;
+- usar no maximo 20 queries por execucao;
+- em funcoes, views e retornos compostos, evitar `SELECT *`; preferir colunas explicitas quando o objetivo for validar retorno.
+
 Se faltarem informacoes essenciais ou houver conflito, drift ou dependencia nao resolvida, pedir ajuda humana e bloquear a execucao.
 
 ## 4. Etapa 2 - Plano de implementacao
@@ -108,9 +120,7 @@ Registrar apenas o que efetivamente ocorreu, usando N/A quando nao se aplicar.
 
 ### Execucao
 
-- Modo: Codex App local | bloqueado | fallback solicitado | N/A
-- Fallback/bloqueio de publicacao, incluindo GitHub Connector se utilizado: [resumo] | N/A
-- Branch e PR/compare: [nome e link] | N/A
+- Modo de execucao, branch, PR, publicacao e fallback: conforme `AGENTS.md` - [resumo] | N/A
 
 ### BD e artefatos
 


### PR DESCRIPTION
### Motivation

- Reduzir e simplificar o `docs/prompt-codex-app-executor.md` para refletir o estado atual do fluxo do Codex App Executor sem duplicar regras operacionais definidas em `AGENTS.md`.
- Manter o papel do Executor e as etapas essenciais (investigação, plano, execução, Supabase/migrations, observability, validação/smoke e relatório final) enquanto centraliza regras de Git/publicação/validação no `AGENTS.md`.

### Description

- Atualizei apenas o arquivo `docs/prompt-codex-app-executor.md`, reduzindo-o de 228 para 144 linhas e removendo repetições das regras operacionais já presentes em `AGENTS.md`.
- Preservei a estrutura por etapas exigida (investigação, plano, execução, Supabase/migrations, observability, validação/smoke e relatório final) e a referência ao `docs/template-briefing-codex-frontend.md` para impacto visual.
- Ajustei o relatório final para tratar o `GitHub Connector` apenas como fallback/bloqueio e não como fluxo normal de publicação.
- Não foram alterados `AGENTS.md`, `docs/gestor-codex.md` nem os outros arquivos protegidos; o commit inclui somente `docs/prompt-codex-app-executor.md`.

### Testing

- Verificações de segurança e escopo: `git diff --check` e `git diff --name-only` confirmaram apenas a alteração em `docs/prompt-codex-app-executor.md` (sucesso).
- Commit realizado: `0386a06 docs: ajustar prompt codex app executor` na branch `codex/ajustar-prompt-codex-app-executor` (sucesso).
- `npm ci` e `npm run check`: não aplicáveis porque a alteração é exclusivamente documental.
- Push: tentativa `git push -u origin codex/ajustar-prompt-codex-app-executor` falhou porque não há remote `origin` configurado, portanto não foi possível publicar a branch nem gerar um link de PR (bloqueado).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a258f22aff48329b250e17fe7c05a83)