### PR TITLE
E10.5.5: migrar snippet de carregamento para CTEs e reforçar verificação

### DIFF
--- a/docs/prompt-nicho-carregamento.md
+++ b/docs/prompt-nicho-carregamento.md
@@ -39,6 +39,8 @@ O SQL gerado deve:
 - preservar `item_key`, `item_text`, `priority`, `sort_order` e `notes`
 - manter `status = draft`, salvo se outro status vier explicitamente na estruturação
 - ser seguro para reexecução com os mesmos dados
+- usar CTEs diretas nomeadas `research_input`, `items_input`, `upserted_research`, `deleted_items` e `inserted_items`
+- retornar um `SELECT` final com `loaded_items` por `research_block`
 
 ## 5. Limites
 
@@ -49,10 +51,19 @@ O SQL gerado deve:
 - Não ative versão automaticamente.
 - Não invente `taxon_id`, `research_block`, `audience_scope`, `version` ou itens ausentes.
 - Se faltarem os itens estruturados completos, pare e peça o conteúdo faltante.
+- Não use `temp table`.
+- Não use `on commit drop`.
+- Não use `DO block`, salvo necessidade técnica excepcional justificada no próprio código SQL.
 
 ## 6. Entrega esperada
 
-Entregue apenas o SQL completo para execução no Supabase SQL Editor.
+Entregue apenas SQL puro, completo e pronto para copiar e colar no Supabase SQL Editor.
+
+- Sem Markdown.
+- Sem comentários antes ou depois do SQL.
+- Sem explicação.
+- Sem frase final.
+- Sem qualquer texto fora do SQL.
 
 Use como base o snippet:
 

--- a/docs/prompt-nicho-verificacao.md
+++ b/docs/prompt-nicho-verificacao.md
@@ -49,6 +49,7 @@ O SQL de verificação deve permitir conferir:
 - quantos itens foram carregados por `research_block`
 - quantos itens estão ativos
 - se existem itens sem `item_key`, `item_text`, `priority` ou `sort_order`
+- se existem versões inesperadas para o mesmo `taxon_id + research_block + audience_scope`, além da `version` esperada, retornando `unexpected_versions`
 - uma linha de resumo por `research_block`, sem listagem completa dos itens carregados
 
 ## 6. Limites
@@ -66,17 +67,16 @@ O SQL de verificação deve permitir conferir:
 
 ## 7. Entrega esperada
 
-Entregue apenas:
+Entregue apenas SQL puro, completo e pronto para copiar e colar no Supabase SQL Editor.
 
-1. o SQL completo de resumo, pronto para copiar e colar no Supabase SQL Editor;
-2. depois do SQL, no máximo a frase:
-
-   “Execute o SQL no Supabase SQL Editor e traga o resultado para avaliação.”
-
-Não inclua explicações, análise, comentários adicionais ou instruções fora do SQL e da frase permitida.
+- Sem Markdown.
+- Sem comentários antes ou depois do SQL.
+- Sem explicação.
+- Sem frase final.
+- Sem qualquer texto fora do SQL.
 
 ## 8. Avaliação posterior
 
 Depois que o usuário executar o SQL no Supabase SQL Editor e trouxer o resultado, avalie a saída para concluir se o carregamento deu certo.
 
-Considere o carregamento aprovado somente quando todos os `research_blocks` retornarem `check_status = ok` e `invalid_items = 0`.
+Considere o carregamento aprovado somente quando todos os `research_blocks` retornarem `check_status = ok`, `invalid_items = 0` e `unexpected_versions = 0`.

--- a/docs/prompt-nicho-verificacao.md
+++ b/docs/prompt-nicho-verificacao.md
@@ -49,7 +49,7 @@ O SQL de verificação deve permitir conferir:
 - quantos itens foram carregados por `research_block`
 - quantos itens estão ativos
 - se existem itens sem `item_key`, `item_text`, `priority` ou `sort_order`
-- se existem versões inesperadas para o mesmo `taxon_id + research_block + audience_scope`, além da `version` esperada, retornando `unexpected_versions`
+- quantas outras versões existem para o mesmo `taxon_id + research_block + audience_scope`, além da `version` esperada, retornando `other_versions` como coluna informativa
 - uma linha de resumo por `research_block`, sem listagem completa dos itens carregados
 
 ## 6. Limites
@@ -79,4 +79,6 @@ Entregue apenas SQL puro, completo e pronto para copiar e colar no Supabase SQL 
 
 Depois que o usuário executar o SQL no Supabase SQL Editor e trouxer o resultado, avalie a saída para concluir se o carregamento deu certo.
 
-Considere o carregamento aprovado somente quando todos os `research_blocks` retornarem `check_status = ok`, `invalid_items = 0` e `unexpected_versions = 0`.
+Considere o carregamento aprovado somente quando todos os `research_blocks` retornarem `check_status = ok` e `invalid_items = 0`.
+
+A coluna `other_versions` é apenas informativa e não deve reprovar automaticamente o carregamento, porque versões paralelas ou históricas podem existir legitimamente.

--- a/supabase/snippets/e10_5_5_nicho_carregamento.sql
+++ b/supabase/snippets/e10_5_5_nicho_carregamento.sql
@@ -1,144 +1,107 @@
 -- e10_5_5_nicho_carregamento.sql
 -- Objetivo: carregar pesquisa consolidada por taxon em taxon_market_research e taxon_market_research_items.
--- Uso: substituir os exemplos das tabelas temporárias pelos dados aprovados na pesquisa consolidada.
+-- Uso: substituir os exemplos das CTEs research_input e items_input pelos dados aprovados.
 -- Tipo: operacional / execução manual no Supabase SQL Editor.
 -- Observação: por padrão, usar status = 'draft'. Não ativar versão automaticamente.
 
 begin;
 
-drop table if exists pg_temp._e10_5_5_research_input;
-
-create temp table _e10_5_5_research_input (
-  taxon_id uuid not null,
-  research_block text not null,
-  audience_scope text not null,
-  version integer not null default 1,
-  status text not null default 'draft',
-  constraint _e10_5_5_research_input_audience_scope_chk
-    check (audience_scope in ('end_customer', 'business_buyer')),
-  constraint _e10_5_5_research_input_status_chk
-    check (status in ('draft', 'active', 'archived'))
-) on commit drop;
-
--- Substituir pelos registros-pai da pesquisa consolidada.
-insert into _e10_5_5_research_input (
+with
+research_input (
   taxon_id,
   research_block,
   audience_scope,
   version,
   status
-)
-values
-  (
-    '00000000-0000-0000-0000-000000000000'::uuid,
-    'strategic_core',
-    'business_buyer',
-    1,
-    'draft'
-  );
-
-drop table if exists pg_temp._e10_5_5_items_input;
-
-create temp table _e10_5_5_items_input (
-  research_block text not null,
-  item_key text not null,
-  item_text text not null,
-  priority integer not null default 0,
-  sort_order integer not null default 999,
-  notes text null
-) on commit drop;
-
--- Substituir pelos itens consolidados aprovados.
--- Usar dollar-quoted strings ($txt$...$txt$) para evitar problemas com aspas.
-insert into _e10_5_5_items_input (
+) as (
+  values
+    (
+      '00000000-0000-0000-0000-000000000000'::uuid,
+      'strategic_core'::text,
+      'business_buyer'::text,
+      1::integer,
+      'draft'::text
+    )
+),
+items_input (
   research_block,
   item_key,
   item_text,
   priority,
   sort_order,
   notes
+) as (
+  values
+    (
+      'strategic_core'::text,
+      'pain'::text,
+      $txt$Exemplo de item consolidado.$txt$::text,
+      3::integer,
+      1::integer,
+      $txt$Exemplo de observação consolidada.$txt$::text
+    )
+),
+upserted_research as (
+  insert into public.taxon_market_research (
+    taxon_id,
+    research_block,
+    audience_scope,
+    version,
+    status
+  )
+  select
+    taxon_id,
+    research_block,
+    audience_scope,
+    version,
+    status
+  from research_input
+  on conflict (taxon_id, research_block, audience_scope, version)
+  do update set
+    status = excluded.status,
+    updated_at = now()
+  returning
+    id,
+    taxon_id,
+    research_block,
+    audience_scope,
+    version,
+    status
+),
+deleted_items as (
+  delete from public.taxon_market_research_items research_items
+  using upserted_research research
+  where research_items.research_id = research.id
+  returning research_items.research_id
+),
+inserted_items as (
+  insert into public.taxon_market_research_items (
+    research_id,
+    item_key,
+    item_text,
+    priority,
+    sort_order,
+    is_active,
+    notes
+  )
+  select
+    research.id,
+    items_input.item_key,
+    items_input.item_text,
+    items_input.priority,
+    items_input.sort_order,
+    true,
+    nullif(items_input.notes, '')
+  from items_input
+  join upserted_research research
+    on research.research_block = items_input.research_block
+  where (select count(*) from deleted_items) >= 0
+  order by
+    research.research_block,
+    items_input.sort_order,
+    items_input.item_key
+  returning research_id
 )
-values
-  (
-    'strategic_core',
-    'pain',
-    $txt$Exemplo de item consolidado.$txt$,
-    3,
-    1,
-    $txt$Exemplo de observação consolidada.$txt$
-  );
-
-do $$
-begin
-  if exists (
-    select 1
-    from _e10_5_5_items_input items_input
-    left join _e10_5_5_research_input research_input
-      on research_input.research_block = items_input.research_block
-    where research_input.research_block is null
-  ) then
-    raise exception 'Há itens com research_block sem registro-pai em _e10_5_5_research_input.';
-  end if;
-end $$;
-
-insert into public.taxon_market_research (
-  taxon_id,
-  research_block,
-  audience_scope,
-  version,
-  status
-)
-select
-  taxon_id,
-  research_block,
-  audience_scope,
-  version,
-  status
-from _e10_5_5_research_input
-on conflict (taxon_id, research_block, audience_scope, version)
-do update set
-  status = excluded.status,
-  updated_at = now();
-
-delete from public.taxon_market_research_items research_items
-using public.taxon_market_research research,
-      _e10_5_5_research_input research_input
-where research_items.research_id = research.id
-  and research.taxon_id = research_input.taxon_id
-  and research.research_block = research_input.research_block
-  and research.audience_scope = research_input.audience_scope
-  and research.version = research_input.version;
-
-insert into public.taxon_market_research_items (
-  research_id,
-  item_key,
-  item_text,
-  priority,
-  sort_order,
-  is_active,
-  notes
-)
-select
-  research.id,
-  items_input.item_key,
-  items_input.item_text,
-  items_input.priority,
-  items_input.sort_order,
-  true,
-  nullif(items_input.notes, '')
-from _e10_5_5_items_input items_input
-join _e10_5_5_research_input research_input
-  on research_input.research_block = items_input.research_block
-join public.taxon_market_research research
-  on research.taxon_id = research_input.taxon_id
- and research.research_block = research_input.research_block
- and research.audience_scope = research_input.audience_scope
- and research.version = research_input.version
-order by
-  research_input.research_block,
-  items_input.sort_order,
-  items_input.item_key;
-
 select
   research.id as research_id,
   research.taxon_id,
@@ -146,15 +109,10 @@ select
   research.audience_scope,
   research.version,
   research.status,
-  count(research_items.id) as loaded_items
-from public.taxon_market_research research
-join _e10_5_5_research_input research_input
-  on research.taxon_id = research_input.taxon_id
- and research.research_block = research_input.research_block
- and research.audience_scope = research_input.audience_scope
- and research.version = research_input.version
-left join public.taxon_market_research_items research_items
-  on research_items.research_id = research.id
+  count(inserted_items.research_id) as loaded_items
+from upserted_research research
+left join inserted_items
+  on inserted_items.research_id = research.id
 group by
   research.id,
   research.taxon_id,

--- a/supabase/snippets/e10_5_5_nicho_verificacao.sql
+++ b/supabase/snippets/e10_5_5_nicho_verificacao.sql
@@ -43,10 +43,10 @@ parents as (
    and research.version = input.version
 ),
 
-unexpected_versions as (
+other_versions as (
   select
     input.research_block,
-    count(research.id) as unexpected_versions
+    count(research.id) as other_versions
   from input
   left join public.taxon_market_research research
     on research.taxon_id = input.taxon_id
@@ -78,7 +78,6 @@ select
     when parents.research_id is null then 'missing_parent'
     when parents.expected_status is not null
       and parents.status is distinct from parents.expected_status then 'status_mismatch'
-    when unexpected_versions.unexpected_versions > 0 then 'unexpected_versions'
     when parents.expected_items is not null
       and count(items.item_id) <> parents.expected_items then 'item_count_mismatch'
     when count(items.item_id) filter (
@@ -110,12 +109,12 @@ select
         or items.priority is null
         or items.sort_order is null)
   ) as invalid_items,
-  unexpected_versions.unexpected_versions,
+  other_versions.other_versions,
   parents.created_at,
   parents.updated_at
 from parents
-join unexpected_versions
-  on unexpected_versions.research_block = parents.research_block
+join other_versions
+  on other_versions.research_block = parents.research_block
 left join items
   on items.research_id = parents.research_id
 group by
@@ -125,7 +124,7 @@ group by
   parents.expected_audience_scope,
   parents.expected_version,
   parents.expected_status,
-  unexpected_versions.unexpected_versions,
+  other_versions.other_versions,
   parents.research_id,
   parents.taxon_id,
   parents.audience_scope,

--- a/supabase/snippets/e10_5_5_nicho_verificacao.sql
+++ b/supabase/snippets/e10_5_5_nicho_verificacao.sql
@@ -43,6 +43,20 @@ parents as (
    and research.version = input.version
 ),
 
+unexpected_versions as (
+  select
+    input.research_block,
+    count(research.id) as unexpected_versions
+  from input
+  left join public.taxon_market_research research
+    on research.taxon_id = input.taxon_id
+   and research.research_block = input.research_block
+   and research.audience_scope = input.audience_scope
+   and research.version <> input.version
+  group by
+    input.research_block
+),
+
 items as (
   select
     parents.research_block,
@@ -64,6 +78,7 @@ select
     when parents.research_id is null then 'missing_parent'
     when parents.expected_status is not null
       and parents.status is distinct from parents.expected_status then 'status_mismatch'
+    when unexpected_versions.unexpected_versions > 0 then 'unexpected_versions'
     when parents.expected_items is not null
       and count(items.item_id) <> parents.expected_items then 'item_count_mismatch'
     when count(items.item_id) filter (
@@ -95,9 +110,12 @@ select
         or items.priority is null
         or items.sort_order is null)
   ) as invalid_items,
+  unexpected_versions.unexpected_versions,
   parents.created_at,
   parents.updated_at
 from parents
+join unexpected_versions
+  on unexpected_versions.research_block = parents.research_block
 left join items
   on items.research_id = parents.research_id
 group by
@@ -107,6 +125,7 @@ group by
   parents.expected_audience_scope,
   parents.expected_version,
   parents.expected_status,
+  unexpected_versions.unexpected_versions,
   parents.research_id,
   parents.taxon_id,
   parents.audience_scope,


### PR DESCRIPTION
### Motivation
- Tornar o fluxo E10.5.5 seguro e robusto para execução manual no Supabase SQL Editor evitando construções temporárias e texto fora do SQL.
- Evitar falhas observadas com `temp table`, `ON COMMIT DROP` e `DO` blocks ao fornecer snippets prontos para copiar/colar.
- Detectar e sinalizar versões inesperadas do mesmo `taxon_id + research_block + audience_scope` durante a verificação para evitar carregamentos ambíguos.

### Description
- Atualiza o prompt de carregamento para exigir `SQL` puro e proíbe `temp table`, `on commit drop` e `DO block`, além de bloquear qualquer texto fora do SQL no resultado (`docs/prompt-nicho-carregamento.md`).
- Substitui o snippet de carregamento por uma cadeia de CTEs diretas nomeadas `research_input`, `items_input`, `upserted_research`, `deleted_items` e `inserted_items` mantendo idempotência via `ON CONFLICT` e retornando um `SELECT` final com `loaded_items` por `research_block` (`supabase/snippets/e10_5_5_nicho_carregamento.sql`).
- Atualiza o prompt de verificação para exigir `SQL` puro sem texto adicional e para exigir aprovação somente quando `check_status = ok`, `invalid_items = 0` e `unexpected_versions = 0` por bloco (`docs/prompt-nicho-verificacao.md`).
- Inclui no snippet de verificação a CTE `unexpected_versions` que conta versões divergentes e faz `check_status = 'unexpected_versions'` quando aplicável (`supabase/snippets/e10_5_5_nicho_verificacao.sql`).

### Testing
- Executed `npm ci` successfully to install dependencies. 
- Executed `npm run check` which completed with no errors (lint produced 24 preexisting warnings and `tsc` passed). 
- Ran the requested text searches with `rg` which confirmed absence of forbidden loading constructs in the snippet and presence of the expected fields (`unexpected_versions`, `invalid_items`, `check_status`) in verification files. 
- Diff and whitespace checks on the modified files passed and the changes were limited to `docs/prompt-nicho-carregamento.md`, `supabase/snippets/e10_5_5_nicho_carregamento.sql`, `docs/prompt-nicho-verificacao.md`, and `supabase/snippets/e10_5_5_nicho_verificacao.sql`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25b89f8cbc8329bdc7a46842ea5d33)