### PR TITLE
docs: esclarecer sequência de sort_order no bloco seo

### DIFF
--- a/docs/prompt-nicho-itens-estruturados.md
+++ b/docs/prompt-nicho-itens-estruturados.md
@@ -180,7 +180,7 @@ Regras específicas:
 - manter dúvidas e objeções pesquisadas úteis para conversão;
 - não incluir volume, CPC ou dificuldade;
 - não converter este bloco em calendário editorial;
-- em `seo`, o `sort_order` deve seguir a ordem prática/relevância dos itens no bloco.
+- em `seo`, o `sort_order` deve seguir a ordem prática/relevância dos itens no bloco, em sequência única crescente, sem reiniciar por `item_key`.
 
 ## 7. Entrega esperada
 


### PR DESCRIPTION
### Motivation
- Tornar explícito que, no bloco `seo`, o `sort_order` deve formar uma sequência única crescente de acordo com a ordem prática/relevância dos itens do bloco, sem reiniciar por `item_key`, enquanto a regra de `strategic_core` (reiniciar por `item_key`) permanece inalterada.

### Description
- Atualizei apenas `docs/prompt-nicho-itens-estruturados.md` substituindo a frase de `seo` para: "em `seo`, o `sort_order` deve seguir a ordem prática/relevância dos itens no bloco, em sequência única crescente, sem reiniciar por `item_key`." (branch usada: `codex/seo-sort-order-sequencia-unica`).

### Testing
- Executei `npm ci` e `npm run check`, ambos concluídos com sucesso; o lint reportou 24 warnings preexistentes e o typecheck não retornou erros; apenas `docs/prompt-nicho-itens-estruturados.md` foi alterado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25ce2ff9bc8329bfeafdf32d995186)