### PR TITLE
docs: preferir Supabase Plugin em teste para investigação read-only no Codex App

### DIFF
--- a/docs/prompt-codex-app-executor.md
+++ b/docs/prompt-codex-app-executor.md
@@ -35,7 +35,12 @@ Examinar, conforme aplicavel:
 
 Se houver impacto visual/frontend, usar tambem `docs/template-briefing-codex-frontend.md`.
 
-Quando houver BD, usar `docs/schema.md` como fonte inicial e investigar o BD real somente se os documentos canonicos forem insuficientes. Se a inspecao depender do Gestor, entregar SQL read-only pronto para execucao, limitado ao objetivo do caso.
+Quando houver BD, usar `docs/schema.md` como fonte inicial e investigar o BD real somente se os documentos canonicos forem insuficientes.
+
+- quando o Codex App tiver o Supabase Plugin disponivel, usa-lo como caminho preferencial em teste para investigacao read-only de BD;
+- limitar a investigacao aos metadados necessarios ao caso: schema, tabelas, colunas, PKs, FKs, RLS/policies, views, functions, indices, extensoes e migrations;
+- nao usar o plugin para SQL de escrita, DDL/DML, migrations, deploy de Edge Functions, operacoes de branches Supabase, pause/restore, acesso a secrets ou objetos sensiveis;
+- se o plugin nao estiver disponivel, for insuficiente ou houver necessidade de artefato auditavel, manter o fluxo de SQLs read-only para Supabase Inspect, pronto para execucao e limitado ao objetivo do caso.
 
 ### Formato dos SQLs de inspecao
 


### PR DESCRIPTION
### Motivation

- Permitir que o Codex App use o Supabase Plugin como caminho preferencial em teste para investigação read-only de banco sem substituir o fluxo atual de inspeção por SQLs para Supabase Inspect. 
- Restringir o uso do plugin a consultas de investigação e proteger operações sensíveis e processos auditáveis.

### Description

- Ajustada a `Etapa 1 — Investigacao` em `docs/prompt-codex-app-executor.md` para indicar que, quando disponível, o Supabase Plugin deve ser usado como caminho preferencial em teste para investigação read-only de BD. 
- Especificada a limitação da investigação aos metadados necessários: schema, tabelas, colunas, PKs, FKs, RLS/policies, views, functions, índices, extensões e migrations. 
- Explicitado que o plugin não deve ser usado para escrita, DDL/DML, migrations, deploy de Edge Functions, operações de branches Supabase, pause/restore, acesso a secrets ou objetos sensíveis, e que o fluxo por SQLs read-only para Supabase Inspect permanece como fallback.

### Testing

- Executado `git diff --check` e verificado que não há problemas no diff (sucesso). 
- Verificação programática confirmando que a seção `### Formato dos SQLs de inspecao` permaneceu idêntica antes e depois da alteração (sucesso). 
- `npm ci` e `npm run check` considerados não aplicáveis por se tratar de mudança exclusivamente documental (não executados).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26b1c9843c83299e676260677655a8)