### PR TITLE
docs: mark Agent Builder legacy and prioritize Agents SDK for Supabase Inspect

### DIFF
--- a/docs/automations.md
+++ b/docs/automations.md
@@ -46,9 +46,9 @@ Configurações operacionais de plataformas, secrets por nome, ambientes, endpoi
 Esta seção mantém apenas o contexto de uso das plataformas pela camada de automações.
 
 2.1 OpenAI
-- Papel na automação: execução de modelos, Agent Builder/SDK e integração com pipelines/agentes.
-- Ambientes operacionais: `LPF10-DEV` e `LPF10-PROD`.
-- Regra operacional: desenvolvimento prioriza DEV; análise de consumo deve ser feita por projeto.
+- Papel na automação: execução de modelos e integração com pipelines/agentes.
+- Caminhos futuros: Agents SDK para fluxos programáticos; Workspace Agents em ChatGPT para agentes definidos por prompting/linguagem natural.
+- Ambientes operacionais: `LPF10-DEV` e `LPF10-PROD`; desenvolvimento prioriza DEV e a análise de consumo deve ser feita por projeto.
 
 2.2 GitHub
 - Papel: repositório principal, GitHub Actions, pipelines, PRs e secrets.
@@ -125,35 +125,25 @@ Runtime: `automations/docs-apply-report/`
 
 3.3 Supabase Inspect Agente
 Objetivo:
-Validar o uso operacional do Supabase Inspect no Agent Builder por meio da MCP base documentada em `docs/services.md`, sem acesso direto ao banco.
+Registrar a validação funcional histórica do Supabase Inspect no Agent Builder por meio da MCP base documentada em `docs/services.md`, sem acesso direto ao banco.
 
 Status:
-Concluído como validação funcional em Agent Builder
+Concluído como validação funcional histórica
 
-Acesso:
-Agent Builder (OpenAI)
-
-Onde acessar:
-URL do Builder: https://platform.openai.com/agent-builder/edit?workflow=wf_69b57fed963c8190b9da8e40797aa5820147027ff7bd60d7&version=3
-
-Como usar:
-Executar perguntas técnicas ou SQL dentro do escopo read-only validado
-
-Resposta esperada:
-Resposta assistida para validação funcional (não usar como camada final de orquestração robusta)
+Nota de legado:
+O Agent Builder deixará de receber novos recursos e será descontinuado na plataforma OpenAI até 30/11/2026; esta integração não deve ser expandida.
 
 Referências / dependências:
 docs/services.md — `1.1 LPF Supabase Inspect MCP`
 services/mcp-supabase-inspect/README.md
 Workflow ID: `wf_69b57fed963c8190b9da8e40797aa5820147027ff7bd60d7`
-Endpoint MCP: `https://lpf-10-services.vercel.app/api/mcp`
 
 3.3.1 Update — Agents SDK
 Status:
-Planejado
+Prioritário / pendente de migração
 
 Objetivo:
-Migrar a validação do Builder para execução programática mais controlada
+Migrar ou substituir o uso validado no Agent Builder por um fluxo programático mantido no Agents SDK.
 
 3.3.2 Update — ChatGPT + MCP
 Status:


### PR DESCRIPTION
### Motivation
- Record the OpenAI Agent Builder deprecation and remove its treatment as an active future path while keeping operational automations concise.
- Ensure the document points teams to maintained options (Agents SDK or Workspace Agents) for future agent work without expanding legacy Builder integrations.

### Description
- Update `2.1 OpenAI` to remove Agent Builder as an active option and add guidance: use `Agents SDK` for programmatic flows and `Workspace Agents` (ChatGPT) for prompting/natural-language agents.
- Change `3.3 Supabase Inspect Agente` to mark the Agent Builder usage as a concluded historical validation and add a legacy note that Agent Builder will be discontinued on OpenAI by `30/11/2026` and must not be expanded.
- Change `3.3.1 Update — Agents SDK` status to `Prioritário / pendente de migração` and clarify the objective to migrate or replace the validated Builder flow with the Agents SDK; remove redundant Builder-specific instructions and reduce overlap.
- Restrict edits to a single file (`docs/automations.md`) with a small, localized reduction in lines (approximately 409 -> 399 lines; net -10 lines).

### Testing
- Ran `git diff --check` to validate whitespace and patch sanity, which passed.
- Verified changed files with `git diff --name-only`, confirming only `docs/automations.md` was modified.
- Inspected `git diff --stat`, which reports 1 file changed with 9 insertions and 19 deletions as expected.
- Confirmed working tree state with `git status --short --branch` and verified the file line count with `wc -l docs/automations.md` (399 lines after the edit).
- `npm ci` and `npm run check` were not executed because the change is exclusively documentation and these checks were considered not applicable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26ce05d1f48329bdeddf2f3501e458)