### PR TITLE
docs: simplify README product objective

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,45 +11,37 @@
 • Ultranicho: não usar agora.
 
 1.2. Descrição
-• LP Factory 10 é uma plataforma SaaS de comunicação comercial por nicho, com landing pages como um dos canais principais de aquisição e conversão.
-• O produto combina páginas, dashboards, dados estruturados, automações e recursos operacionais para apoiar a criação, execução e melhoria contínua da comunicação com leads e clientes.
-• O foco atual é validar a oferta, o processo e a repetibilidade antes de escalar.
-• A aplicação de IA diretamente no produto para o cliente está em estudo, especialmente para apoiar geração, personalização e melhoria de mensagens, páginas e canais de comunicação.
+• LP Factory 10 é uma plataforma SaaS de comunicação comercial para aquisição, venda e nutrição de leads.
+• O produto entrega canais de comunicação como landing pages, Instagram, WhatsApp e e-mail.
+• O dashboard deve priorizar automações internas com IA para reduzir operação, validar processos e identificar quais automações podem virar funcionalidades de produto para venda ou retenção.
 
-2. Estratégia (atual e evolutiva)
-2.1. Go-to-market inicial
-• Início por conta consultiva (caso a caso) para vender, testar e validar saindo do zero.
-
-2.2. Direção do produto
-• Evoluir para SaaS self-serve quando houver sinais claros de repetibilidade e demanda.
-
-3. Proposta de valor
+2. Proposta de valor
 • Oferecer landing pages por nicho com acompanhamento contínuo de performance.
 • Reduzir esforço, tempo e dependência para criar, medir, ajustar e otimizar LPs.
 • Transformar dados de uso e conversão em leitura prática para orientar melhorias.
 • Ajudar o cliente a evoluir a landing page com mais clareza, autonomia e direção.
 
-4. Produto (alto nível)
-4.1. Prático
+3. Produto (alto nível)
+3.1. Prático
 • Templates por nicho e criação fácil.
 
-4.2. Inteligente
+3.2. Inteligente
 • Recursos orientados por dados (tracking/coleta e recomendações).
 
-4.3. Dashboard
+3.3. Dashboard
 • Suporte para ajustes e testes guiados por dados.
 
-5. Modelo de oferta
+4. Modelo de oferta
 • Planos em camadas (Starter → Lite → Pro → Ultra), com capacidades escalando ao longo do tempo.
 
-6. Pendências estratégicas (em aberto)
-6.1. Definições do MVP
+5. Pendências estratégicas (em aberto)
+5.1. Definições do MVP
 • Starter mínimo • Tracking mínimo • Atendimento no MVP • Primeira recomendação concreta da IA
 
-6.2. Padrões de entrega
+5.2. Padrões de entrega
 • Definir regra de “o que é uma LP entregue”, com checklist.
 
-7. Referências oficiais
+6. Referências oficiais
 • docs/base-tecnica.md — regras técnicas de runtime, implementação segura, arquitetura, adapters, imports, SSR, observability e anti-regressão.
 • docs/platform-config.md — configurações operacionais de plataformas, variáveis, secrets por nome, endpoints, URLs, redirects, SMTP, DNS e regras de redeploy.
 • docs/schema.md — contrato de banco: tabelas, colunas, constraints, views, RPCs/functions, triggers, RLS, policies e grants.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 0. Introdução
 0.1. Cabeçalho
 • Documento: README — LP Factory 10 (MVP)
-• Data: 24/03/2026
-• Escopo: visão geral do produto + estratégia empresarial (alto nível) + referências oficiais do projeto
+• Versão: 0.2 — 10/06/2026
+• Data: 10/06/2026
+• Escopo: visão geral do produto + documentos de referência + pendências estratégicas
 
-1. O que é
+1. Visão geral do produto
 1.1. Classificação do negócio
 • Segmento: Marketing digital.
 • Nicho: plataforma SaaS de comunicação comercial por nicho.
@@ -15,33 +16,26 @@
 • O produto entrega canais de comunicação como landing pages, Instagram, WhatsApp e e-mail.
 • O dashboard deve priorizar automações internas com IA para reduzir operação, validar processos e identificar quais automações podem virar funcionalidades de produto para venda ou retenção.
 
-2. Proposta de valor
-• Oferecer landing pages por nicho com acompanhamento contínuo de performance.
-• Reduzir esforço, tempo e dependência para criar, medir, ajustar e otimizar LPs.
+1.3. Proposta de valor
+• Oferecer canais de comunicação comercial por nicho com acompanhamento contínuo de performance.
+• Reduzir esforço, tempo e dependência para criar, medir, ajustar e otimizar a comunicação comercial.
 • Transformar dados de uso e conversão em leitura prática para orientar melhorias.
-• Ajudar o cliente a evoluir a landing page com mais clareza, autonomia e direção.
+• Ajudar o cliente a evoluir sua comunicação comercial com mais clareza, autonomia e direção.
 
-3. Produto (alto nível)
-3.1. Prático
+1.4. Produto
+1.4.1. Prático
 • Templates por nicho e criação fácil.
 
-3.2. Inteligente
+1.4.2. Inteligente
 • Recursos orientados por dados (tracking/coleta e recomendações).
 
-3.3. Dashboard
+1.4.3. Dashboard
 • Suporte para ajustes e testes guiados por dados.
 
-4. Modelo de oferta
+1.5. Modelo de oferta
 • Planos em camadas (Starter → Lite → Pro → Ultra), com capacidades escalando ao longo do tempo.
 
-5. Pendências estratégicas (em aberto)
-5.1. Definições do MVP
-• Starter mínimo • Tracking mínimo • Atendimento no MVP • Primeira recomendação concreta da IA
-
-5.2. Padrões de entrega
-• Definir regra de “o que é uma LP entregue”, com checklist.
-
-6. Referências oficiais
+2. Documentos de referência
 • docs/base-tecnica.md — regras técnicas de runtime, implementação segura, arquitetura, adapters, imports, SSR, observability e anti-regressão.
 • docs/platform-config.md — configurações operacionais de plataformas, variáveis, secrets por nome, endpoints, URLs, redirects, SMTP, DNS e regras de redeploy.
 • docs/schema.md — contrato de banco: tabelas, colunas, constraints, views, RPCs/functions, triggers, RLS, policies e grants.
@@ -50,4 +44,9 @@
 • docs/services.md — catálogo humano dos services implantáveis, MCPs, endpoints e infraestrutura reutilizável com identidade própria.
 • docs/automations.md — camada de automações operacionais, integrações, componentes consumidores, credenciais por nome e aprendizados operacionais sem expor segredos.
 
+3. Pendências estratégicas (em aberto)
+3.1. Definições do MVP
+• Starter mínimo • Tracking mínimo • Atendimento no MVP • Primeira recomendação concreta da IA
 
+3.2. Padrões de entrega
+• Definir regra de “o que é uma LP entregue”, com checklist.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 0. Introdução
 0.1. Cabeçalho
 • Documento: README — LP Factory 10 (MVP)
-• Versão: 0.2 — 10/06/2026
+• Versão: 2 — 10/06/2026
 • Data: 10/06/2026
 • Escopo: visão geral do produto + documentos de referência + pendências estratégicas
 


### PR DESCRIPTION
### Motivation
- Clarify and simplify the README to state the product objective as a SaaS communication platform focused on acquisition, sales and lead nurturing and to prioritize internal IA automations. 
- Remove an outdated strategy subsection that described an initial consultative account approach and an intended evolution to SaaS self-serve.

### Description
- Replace the text in `1.2. Descrição` with the approved wording about acquisition, sales, lead nurturing, communication channels and dashboard IA automations. 
- Remove the entire `2. Estratégia (atual e evolutiva)` section and its subsections. 
- Renumber subsequent sections so `2. Proposta de valor` and following headings keep the correct sequence and original content is preserved. 
- Only `README.md` was modified and the change was committed on branch `work`.

### Testing
- Executed `npm ci` successfully (installed 485 packages) with a non-blocking npm warning. 
- Executed `npm run check` successfully: `tsc` completed with no errors and `eslint` reported 24 warnings and no errors. 
- Ran `git diff --check` with no issues and validated the working tree before committing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2969de7c3c832989c7e35c1313a82d)