### PR TITLE
docs: registrar GitHub Plugin no gestor Codex

### DIFF
--- a/docs/gestor-codex.md
+++ b/docs/gestor-codex.md
@@ -44,7 +44,14 @@ Plugins aproximam serviços externos das tarefas de investigação e execução.
 **Valor:** acelera a investigação de schema, tabelas, RLS, policies, views, functions, índices, extensões e migrations.
 **Limite:** escrita não testada nem aprovada.
 
-**Disponíveis não adotados:** GitHub Plugin e Slack.
+### GitHub Plugin
+
+**Aptidão:** acessar repositórios, branches remotas, PRs, issues, checks e Actions no GitHub.
+**Estado:** em teste.
+**Valor:** permite investigar branches/PRs e falhas de CI diretamente no GitHub remoto, inclusive quando a branch não está disponível no clone local.
+**Limite:** não substitui o fluxo Git local para implementar código nem o GitHub Web como referência final para PR, Actions, preview e merge.
+
+**Disponíveis não adotados:** Slack.
 
 ## 5. Skills
 


### PR DESCRIPTION
### Motivation

- Registrar no documento de gestão que o GitHub Plugin está em teste e descrever sua aptidão, estado, valor e limites para investigação remota de branches/PRs e falhas de CI.
- Remover o GitHub Plugin da lista “Disponíveis não adotados” para evitar informação contraditória e manter apenas o Slack nessa lista.

### Description

- Adiciona a subseção `### GitHub Plugin` em `docs/gestor-codex.md` com campos `Aptidão`, `Estado`, `Valor` e `Limite` conforme solicitado.
- Atualiza a linha de “Disponíveis não adotados” reduzindo-a para `Slack` e removendo o `GitHub Plugin` da listagem anterior.
- A alteração foi limitada a um único arquivo (`docs/gestor-codex.md`) na branch `codex/ajustar-gestor-codex-github-plugin` e registrada com o commit `b4bc29c`.

### Testing

- Executado `git diff --check` para validar o diff e não foram encontrados erros.
- Verificado com `git diff --name-only` e `rg` que apenas `docs/gestor-codex.md` foi alterado.
- Confirmado `git status --short --branch` e commit local com mensagem `docs: registrar github plugin no gestor codex` retornando árvore de trabalho limpa.
- Tentativa de `git push -u origin codex/ajustar-gestor-codex-github-plugin` falhou porque o clone não tem o remote `origin` configurado; `npm ci` e `npm run check` foram considerados não aplicáveis por se tratar de alteração exclusivamente documental.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29706329588329968fa53df0b934f1)