### PR TITLE
docs: planejar geração automatizada de página comercial por taxon

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -712,7 +712,7 @@
 • Não depende, nesta fase, de dados comerciais ricos da conta; oferta, provas, diferenciais, imagens e CTA específico podem estar ausentes.
 • Primeira aplicação prática dos templates universais da E18.
 • Consome a resolução do template comercial definida em 10.5.6.7.
-• Deve consumir a página comercial gerada e arquivada para o taxon aplicável da conta, quando houver artefato específico válido.
+• Deve consumir a versão ativa e válida da página comercial gerada para o taxon aplicável da conta, quando houver artefato específico válido.
 • Usa o taxon resolvido da conta apenas para personalização, quando existir, com itens estruturados de audience_scope = business_buyer.
 • Se não houver artefato específico válido, deve usar o mesmo template universal com fallback genérico determinístico.
 • A página não chama IA ou API durante a renderização; apenas exibe campos finais já gerados ou o fallback determinístico.
@@ -969,12 +969,14 @@ Ajustados:
 • Os campos finais podem incluir headline, promessa, contexto, cards comerciais, CTAs e blocos de benefício ou prova exigidos pelo template.
 • Primeira aplicação prevista: Account Dashboard — Página comercial.
 • O primeiro recorte deve ser compartilhado por taxon, sem dados específicos da conta.
-• A chave conceitual do artefato deve considerar template_key, versão do template, researchTaxon efetivamente usado, audience_scope, versão da pesquisa, versão do prompt/schema de saída, locale e modo genérico ou específico por taxon.
+• O artefato deve possuir identidade suficiente para detectar equivalência, versão, origem da pesquisa utilizada e necessidade de regeneração.
+• A composição técnica da chave será definida na etapa futura de contrato, persistência e validação dos artefatos gerados.
 • Se dados específicos do cliente forem usados em etapa futura, a saída deixa de ser compartilhada por nicho e passa a exigir identidade por conta e fingerprint/versionamento dessas entradas.
 • Quando houver necessidade de reutilização, versionamento, aprovação ou histórico, as saídas devem ser tratadas como artefatos persistidos, não como cache simples.
 • O sistema deve evitar chamada repetida de IA/API para a mesma combinação válida de template, taxon, audience_scope e versão de pesquisa.
 • Nova geração só deve ocorrer quando não existir artefato válido ou quando houver solicitação administrativa de regeneração.
 • Taxons sem pesquisa estruturada suficiente devem usar fallback genérico válido.
+• Pendência: definir a etapa técnica responsável por runtime de geração, persistência dos artefatos, schema, validação estrutural, versionamento, invalidação e regras de consumo antes da implementação consumidora da E10.6.
 • Fora de escopo desta etapa: provider de IA, gateway, tabelas, migrations, runtime de geração, UI administrativa e renderização da E10.6.
 
 19. E19 — LP Builder
@@ -1011,7 +1013,7 @@ Ajustados:
 • Definir o primeiro recorte funcional do LP Builder no roadmap
 
 99. Changelog
-v1.5.61 — 10/06/2026 — Roadmap registra a página comercial da E10.6 como primeiro laboratório controlado da geração automatizada por taxon, com visão planejada na E18.5, futura operação administrativa na E12.7 e consumo de artefato pronto ou fallback sem IA em renderização.
+v1.5.61 — 10/06/2026 — Roadmap registra a página comercial da E10.6 como primeiro laboratório controlado da geração automatizada por taxon, com visão planejada na E18.5, futura operação administrativa na E12.7, consumo da versão ativa e válida ou fallback sem IA em renderização e pendência da etapa técnica responsável pelos artefatos.
 v1.5.60 — 09/06/2026 — E10.5.6.7 concluído com template comercial universal, contrato e exports da family `conversion-content`, resolução pura, adapter server-only, fallback taxon/pai/ancestral/genérico e grants read-only validados para pesquisa `business_buyer`.
 v1.5.59 — 09/06/2026 — E10.5.6.7 e E10.6 alinhados para explicitar que a página comercial é interna ao Account Dashboard e possui conta existente, mas não depende de taxon nem de dados comerciais ricos; o taxon é opcional para personalização e o fallback genérico usa o mesmo template universal.
 v1.5.58 — 28/05/2026 — Roadmap atualizado em E10.5.5 para refletir o novo modelo de pesquisa bruta por taxon, mantendo `taxon_market_research` como registro-pai e `taxon_market_research_items` como itens estruturados da pesquisa, sem criação de bloco agregado, nova tabela ou nova camada.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -671,6 +671,7 @@
 • Resolução por fallback: taxon resolvido → taxon pai → ancestral disponível → fallback genérico.
 • O fallback genérico usa o mesmo template universal, sem criar template paralelo.
 • Fora de escopo: renderização da página, LP Builder, criação de motor universal e persistência de briefings.
+• Observação: esta etapa resolve template, taxon, pesquisa e fallback; não gera nem persiste a copy final.
 • Validação: núcleo puro aprovado para taxon direto, pai, ancestral, ausência de taxon e pesquisa ausente/incompleta; grants de leitura do `service_role` confirmados no Supabase; integração Next do adapter fica para o consumo real na E10.6.
 
 • ARTEFATOS_REPO:
@@ -707,13 +708,16 @@
 10.6 Página comercial do Account Dashboard
 • Status: Planejado
 • Objetivo: apresentar uma vitrine persuasiva para contas active sem entitlements, com experiência semelhante a uma LP interna e cards comerciais para compra, solicitação, briefing ou ativação da primeira entrega.
-• Contexto: página interna do Account Dashboard para uma conta existente.
+• Contexto: página interna do Account Dashboard para uma conta existente e primeiro laboratório controlado da futura geração automatizada de páginas por nicho.
 • Não depende, nesta fase, de dados comerciais ricos da conta; oferta, provas, diferenciais, imagens e CTA específico podem estar ausentes.
 • Primeira aplicação prática dos templates universais da E18.
 • Consome a resolução do template comercial definida em 10.5.6.7.
+• Deve consumir a página comercial gerada e arquivada para o taxon aplicável da conta, quando houver artefato específico válido.
 • Usa o taxon resolvido da conta apenas para personalização, quando existir, com itens estruturados de audience_scope = business_buyer.
-• Deve funcionar com o mesmo template universal e fallback genérico quando não houver taxon, pesquisa suficiente ou dados comerciais do cliente.
-• Fora de escopo: LP Builder, templates universais completos, automação completa do Admin Dashboard, tabelas de briefing e alterações em billing, entitlements, schema, migrations, RLS ou policies.
+• Se não houver artefato específico válido, deve usar o mesmo template universal com fallback genérico determinístico.
+• A página não chama IA ou API durante a renderização; apenas exibe campos finais já gerados ou o fallback determinístico.
+• A geração e a regeneração pertencem ao fluxo administrativo futuro previsto em 12.7.
+• Fora de escopo: LP Builder, criação de motor universal completo, automação completa do Admin Dashboard, tabelas de briefing e alterações em billing, entitlements, schema, migrations, RLS ou policies.
 
 11. E11 — Gestão de Usuários e Convites
 
@@ -783,6 +787,16 @@ Ajustados:
 • Templates e Auditoria permanecem como áreas previstas.
 • Mutações administrativas ficam fora do escopo atual.
 • Billing e operações de suspensão/reativação dependem de recorte futuro.
+
+12.7 Geração administrativa de página comercial por taxon
+• Status: Planejado
+• Objetivo: permitir que o Admin Dashboard gere, valide, aprove, arquive e regenere artefatos de página comercial por template/taxon.
+• A operação administrativa deve usar taxons com pesquisa estruturada suficiente e audience_scope adequado.
+• Primeiro caso previsto: Account Dashboard — Página comercial com audience_scope = business_buyer.
+• A geração deve produzir campos finais compatíveis com o contrato do template.
+• A versão gerada deve poder ser marcada como ativa e substituir a versão anterior, arquivando a versão substituída.
+• Falhas de geração devem ser tratadas como execução e auditoria, não como conteúdo consumível.
+• O Admin Dashboard continua sem mutações na fase atual; este subitem registra apenas o recorte futuro.
 
 13. E13 — Partner Dashboard
 
@@ -947,6 +961,22 @@ Ajustados:
 • responsabilidades de E10, E12 ou E19
 • detalhamento dos prompts finais de cada canal
 
+18.5 Geração automatizada sobre templates universais
+• Status: Planejado
+• Objetivo: definir a futura camada de geração automatizada de conteúdo sobre templates universais, usando a página comercial do Account Dashboard como primeiro laboratório controlado.
+• A geração deve transformar templates universais, itens estruturados da pesquisa, contexto do canal e dados opcionais do cliente em campos finais de comunicação comercial.
+• A estrutura continua definida pelo template universal; o mecanismo de geração apenas preenche, adapta, revisa ou varia os campos dentro do contrato do template.
+• Os campos finais podem incluir headline, promessa, contexto, cards comerciais, CTAs e blocos de benefício ou prova exigidos pelo template.
+• Primeira aplicação prevista: Account Dashboard — Página comercial.
+• O primeiro recorte deve ser compartilhado por taxon, sem dados específicos da conta.
+• A chave conceitual do artefato deve considerar template_key, versão do template, researchTaxon efetivamente usado, audience_scope, versão da pesquisa, versão do prompt/schema de saída, locale e modo genérico ou específico por taxon.
+• Se dados específicos do cliente forem usados em etapa futura, a saída deixa de ser compartilhada por nicho e passa a exigir identidade por conta e fingerprint/versionamento dessas entradas.
+• Quando houver necessidade de reutilização, versionamento, aprovação ou histórico, as saídas devem ser tratadas como artefatos persistidos, não como cache simples.
+• O sistema deve evitar chamada repetida de IA/API para a mesma combinação válida de template, taxon, audience_scope e versão de pesquisa.
+• Nova geração só deve ocorrer quando não existir artefato válido ou quando houver solicitação administrativa de regeneração.
+• Taxons sem pesquisa estruturada suficiente devem usar fallback genérico válido.
+• Fora de escopo desta etapa: provider de IA, gateway, tabelas, migrations, runtime de geração, UI administrativa e renderização da E10.6.
+
 19. E19 — LP Builder
 
 19.1 Status
@@ -981,6 +1011,7 @@ Ajustados:
 • Definir o primeiro recorte funcional do LP Builder no roadmap
 
 99. Changelog
+v1.5.61 — 10/06/2026 — Roadmap registra a página comercial da E10.6 como primeiro laboratório controlado da geração automatizada por taxon, com visão planejada na E18.5, futura operação administrativa na E12.7 e consumo de artefato pronto ou fallback sem IA em renderização.
 v1.5.60 — 09/06/2026 — E10.5.6.7 concluído com template comercial universal, contrato e exports da family `conversion-content`, resolução pura, adapter server-only, fallback taxon/pai/ancestral/genérico e grants read-only validados para pesquisa `business_buyer`.
 v1.5.59 — 09/06/2026 — E10.5.6.7 e E10.6 alinhados para explicitar que a página comercial é interna ao Account Dashboard e possui conta existente, mas não depende de taxon nem de dados comerciais ricos; o taxon é opcional para personalização e o fallback genérico usa o mesmo template universal.
 v1.5.58 — 28/05/2026 — Roadmap atualizado em E10.5.5 para refletir o novo modelo de pesquisa bruta por taxon, mantendo `taxon_market_research` como registro-pai e `taxon_market_research_items` como itens estruturados da pesquisa, sem criação de bloco agregado, nova tabela ou nova camada.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -976,7 +976,7 @@ Ajustados:
 • O sistema deve evitar chamada repetida de IA/API para a mesma combinação válida de template, taxon, audience_scope e versão de pesquisa.
 • Nova geração só deve ocorrer quando não existir artefato válido ou quando houver solicitação administrativa de regeneração.
 • Taxons sem pesquisa estruturada suficiente devem usar fallback genérico válido.
-• Pendência: definir a etapa técnica responsável por runtime de geração, persistência dos artefatos, schema, validação estrutural, versionamento, invalidação e regras de consumo antes da implementação consumidora da E10.6.
+• Pendência: definir a etapa técnica responsável por runtime de geração, persistência dos artefatos, schema, validação estrutural, versionamento, invalidação e regras de consumo antes da integração da E10.6 com artefatos gerados.
 • Fora de escopo desta etapa: provider de IA, gateway, tabelas, migrations, runtime de geração, UI administrativa e renderização da E10.6.
 
 19. E19 — LP Builder


### PR DESCRIPTION
### Motivation
- Registrar no roadmap a evolução estratégica para usar a página comercial do Account Dashboard como primeiro laboratório controlado da futura geração automatizada de páginas por taxon.
- Preservar o escopo atual (sem runtime, sem tabelas/migrations/rollbacks, sem mudanças em `docs/conversion-content.md` ou `docs/base-tecnica.md`) enquanto documenta visão, limites e responsabilidades.

### Description
- Alterado apenas `docs/roadmap.md` para incluir uma observação em `10.5.6.7` deixando explícito que a resolução é pura e não gera nem persiste a copy final.  
- Atualizada `10.6` para explicitar que a página comercial será o laboratório controlado, que deve consumir artefato gerado/arquivado por taxon ou usar fallback determinístico, e que não chama IA/API durante a renderização.  
- Adicionada `12.7` como recorte planejado para geração/validação/aprovação/arquivamento/regeneração administrativa de páginas comerciais por template/taxon (Admin Dashboard permanece sem mutações nesta fase).  
- Adicionada `18.5` como visão planejada da camada de geração automatizada sobre templates universais e registrada entrada no changelog `v1.5.61` datada `10/06/2026`.

### Testing
- Executado `npm ci` com sucesso.  
- Executado `npm run check` com sucesso (0 erros; linter reportou 24 warnings preexistentes fora do escopo documental).  
- Verificações de escopo confirmaram que somente `docs/roadmap.md` foi alterado.  
- Commit realizado na branch `work` com a mensagem `docs: plan automated commercial pages by taxon` (commit `6d4371f`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29876bb51c832985c1edd00d20c984)