### PR TITLE
docs: registrar Vercel Plugin no gestor Codex

### DIFF
--- a/docs/gestor-codex.md
+++ b/docs/gestor-codex.md
@@ -51,6 +51,13 @@ Plugins aproximam serviços externos das tarefas de investigação e execução.
 **Valor:** permite investigar branches/PRs e falhas de CI diretamente no GitHub remoto, inclusive quando a branch não está disponível no clone local.
 **Limite:** não substitui o fluxo Git local para implementar código nem o GitHub Web como referência final para PR, Actions, preview e merge.
 
+### Vercel Plugin
+
+**Aptidão:** leitura e possível operação/configuração na Vercel.
+**Estado:** em teste; leitura aprovada.
+**Valor:** acelera diagnóstico de deploys, previews, build logs, runtime, endpoints e configurações Vercel.
+**Limite:** escrita, deploy manual, variáveis de ambiente, domínios, settings e ações em produção não testados nem aprovados.
+
 **Disponíveis não adotados:** Slack.
 
 ## 5. Skills


### PR DESCRIPTION
### Motivation
- Registrar no documento de gestão de agentes a existência do Vercel Plugin e seu estado atual de teste, aptidão, valor e limitações conhecidas para orientar investigações futuras.

### Description
- Inserida uma seção `### Vercel Plugin` em `docs/gestor-codex.md` contendo as linhas `Aptidão`, `Estado`, `Valor` e `Limite` conforme solicitado, sem alterar outros arquivos.

### Testing
- Verificado com `git diff --check` e inspeção do diff que apenas `docs/gestor-codex.md` foi alterado, `npm ci` e `npm run check` foram considerados não aplicáveis, e o push não foi concluído porque o clone local não possui o remote `origin` configurado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2992d2d1d08329a37ec52191e94d32)