### PR TITLE
fix: isolate lpf-10-services Vercel runtime

### DIFF
--- a/services/mcp-supabase-inspect/README.md
+++ b/services/mcp-supabase-inspect/README.md
@@ -53,10 +53,13 @@ No estado atual do subprojeto:
 ```json
 {
   "scripts": {
-    "check": "node --check api/mcp.js"
+    "check": "node --check api/mcp.js && node --test test/*.test.js"
   }
 }
 ```
+
+O projeto força o Framework Preset `Other` e Node.js `22.x` por configuração
+versionada, evitando herdar o preset Next.js ou a versão de Node do dashboard.
 
 ## Status
 

--- a/services/mcp-supabase-inspect/package-lock.json
+++ b/services/mcp-supabase-inspect/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "pg": "^8.16.0"
+      },
+      "engines": {
+        "node": "22.x"
       }
     },
     "node_modules/pg": {

--- a/services/mcp-supabase-inspect/package.json
+++ b/services/mcp-supabase-inspect/package.json
@@ -2,8 +2,11 @@
   "name": "mcp-supabase-inspect",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "22.x"
+  },
   "scripts": {
-    "check": "node --check api/mcp.js"
+    "check": "node --check api/mcp.js && node --test test/*.test.js"
   },
   "dependencies": {
     "pg": "^8.16.0"

--- a/services/mcp-supabase-inspect/test/mcp.test.js
+++ b/services/mcp-supabase-inspect/test/mcp.test.js
@@ -1,0 +1,84 @@
+const assert = require('node:assert/strict')
+const { afterEach, test } = require('node:test')
+
+const handler = require('../api/mcp')
+
+const originalSecret = process.env.LPF_MCP_SECRET
+
+afterEach(() => {
+  if (originalSecret === undefined) {
+    delete process.env.LPF_MCP_SECRET
+  } else {
+    process.env.LPF_MCP_SECRET = originalSecret
+  }
+})
+
+function createResponse() {
+  return {
+    body: undefined,
+    headers: {},
+    statusCode: 200,
+    status(code) {
+      this.statusCode = code
+      return this
+    },
+    setHeader(name, value) {
+      this.headers[name] = value
+      return this
+    },
+    json(payload) {
+      this.body = payload
+      return this
+    },
+    send(payload) {
+      this.body = payload
+      return this
+    },
+  }
+}
+
+test('returns 401 when authorization is missing', async () => {
+  process.env.LPF_MCP_SECRET = 'test-secret'
+  const req = { headers: {}, method: 'GET' }
+  const res = createResponse()
+
+  await handler(req, res)
+
+  assert.equal(res.statusCode, 401)
+  assert.deepEqual(res.body, { error: 'Unauthorized' })
+})
+
+test('returns 401 when bearer token is invalid', async () => {
+  process.env.LPF_MCP_SECRET = 'test-secret'
+  const req = {
+    headers: { authorization: 'Bearer invalid-secret' },
+    method: 'GET',
+  }
+  const res = createResponse()
+
+  await handler(req, res)
+
+  assert.equal(res.statusCode, 401)
+  assert.deepEqual(res.body, { error: 'Unauthorized' })
+})
+
+test('preserves authenticated MCP initialization', async () => {
+  process.env.LPF_MCP_SECRET = 'test-secret'
+  const req = {
+    body: {
+      id: 1,
+      jsonrpc: '2.0',
+      method: 'initialize',
+    },
+    headers: { authorization: 'Bearer test-secret' },
+    method: 'POST',
+  }
+  const res = createResponse()
+
+  await handler(req, res)
+
+  assert.equal(res.statusCode, 200)
+  assert.equal(res.body.jsonrpc, '2.0')
+  assert.equal(res.body.id, 1)
+  assert.equal(res.body.result.serverInfo.name, 'lpf-supabase-mcp')
+})

--- a/services/mcp-supabase-inspect/vercel.json
+++ b/services/mcp-supabase-inspect/vercel.json
@@ -1,9 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "framework": null,
-  "functions": {
-    "api/mcp.js": {
-      "runtime": "nodejs22.x"
-    }
-  }
+  "framework": null
 }

--- a/services/mcp-supabase-inspect/vercel.json
+++ b/services/mcp-supabase-inspect/vercel.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
   "functions": {
     "api/mcp.js": {
       "runtime": "nodejs22.x"


### PR DESCRIPTION
## Diagnóstico

O domínio `lpf-10-services.vercel.app` estava associado a um deployment antigo construído na raiz do repositório. Esse artefato detectou Next.js e publicou o middleware do Core, que falhava antes de alcançar `services/mcp-supabase-inspect/api/mcp.js`.

## Alterações

- força Framework Preset `Other` via `services/mcp-supabase-inspect/vercel.json`;
- fixa Node.js `22.x` via `engines.node` no subprojeto;
- remove configuração de runtime incompatível com a Vercel CLI atual;
- adiciona testes para 401 sem token, 401 com token inválido e `initialize` autenticado;
- atualiza o README técnico do serviço.

## Validação

- `npm ci` no root: ok;
- `npm run check` no root: ok, com warnings preexistentes;
- `npm ci` no subprojeto: ok;
- `npm run check` no subprojeto: 3 testes aprovados;
- smoke HTTP local: 401 sem token e 200 no `initialize` com token fictício;
- Preview Vercel: READY, contendo uma função Node;
- smoke remoto via Vercel Plugin: 401 `Unauthorized`, corpo JSON do handler e header `MCP-Protocol-Version: 2025-06-18`.

Nenhum secret foi lido, exposto ou commitado. Nenhuma configuração externa da Vercel foi alterada e nenhum deployment foi promovido para produção.