### PR TITLE
chore: pin Supabase migration workflow CLI

### DIFF
--- a/.github/workflows/pipeline-supabase-apply-migrations.yml
+++ b/.github/workflows/pipeline-supabase-apply-migrations.yml
@@ -19,8 +19,6 @@ jobs:
   apply:
     runs-on: ubuntu-latest
     env:
-      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
       SUPABASE_PROJECT_REF: dpikmjgiteuafsbaubue
       SUPABASE_MIGRATIONS_DIR: supabase/migrations
       SUPABASE_APPLY_MIGRATIONS_ENABLED: ${{ vars.SUPABASE_APPLY_MIGRATIONS_ENABLED }}
@@ -30,13 +28,37 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Report disabled migration gate
+        if: ${{ vars.SUPABASE_APPLY_MIGRATIONS_ENABLED != 'true' }}
+        shell: bash
+        run: |
+          {
+            echo "## Pipeline Supabase — Apply Migrations"
+            echo ""
+            echo "- branch: \`${GITHUB_REF_NAME}\`"
+            echo "- commit: \`${GITHUB_SHA}\`"
+            echo "- evento: \`${GITHUB_EVENT_NAME}\`"
+            echo "- apply habilitado: \`false\`"
+            echo "- status final: \`skipped\`"
+            echo ""
+            echo "### Gate de migrations"
+            echo ""
+            echo "- Apply nao executado porque \`SUPABASE_APPLY_MIGRATIONS_ENABLED\` nao esta definido como \`true\`."
+            echo "- Supabase CLI, \`supabase link\` e \`supabase db push\` nao foram executados."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Setup Supabase CLI
-        uses: supabase/setup-cli@v1
+        if: ${{ vars.SUPABASE_APPLY_MIGRATIONS_ENABLED == 'true' }}
+        uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf # v2.1.1
         with:
-          version: latest
+          version: 2.106.0
 
       - name: Apply migrations
+        if: ${{ vars.SUPABASE_APPLY_MIGRATIONS_ENABLED == 'true' }}
         shell: bash
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
         run: |
           set -uo pipefail
 
@@ -46,7 +68,7 @@ jobs:
           apply_enabled="${SUPABASE_APPLY_MIGRATIONS_ENABLED:-false}"
 
           if [ "$apply_enabled" != "true" ]; then
-            status="skipped"
+            status="failure"
             failure_step="baseline gate disabled"
           fi
 
@@ -106,16 +128,6 @@ jobs:
             printf '%s\n' "$changed_migrations"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
-
-          if [ "$status" = "skipped" ]; then
-            {
-              echo ""
-              echo "### Gate de baseline"
-              echo ""
-              echo "- Apply nao executado porque \`SUPABASE_APPLY_MIGRATIONS_ENABLED\` nao esta definido como \`true\`."
-            } >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
 
           if [ "$status" != "success" ]; then
             {

--- a/docs/base-tecnica.md
+++ b/docs/base-tecnica.md
@@ -2,8 +2,8 @@
 
 0.1. Cabeçalho
 • Documento: Base Técnica LP Factory 10
-• Versão: v2.0.38
-• Data: 09/06/2026
+• Versão: v2.0.39
+• Data: 11/06/2026
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -150,6 +150,20 @@
 • Secrets (job): OPENAI_API_KEY e SUPABASE_DB_URL_READONLY.
 • Detalhamento operacional, evolução funcional e posicionamento na camada de automações: consultar docs/automacoes.md.
 • Contrato técnico detalhado do pipeline: automations/supabase-inspect/README.md.
+
+3.4.4 Migrations Supabase versionadas
+• Fonte canônica: `supabase/migrations/`, com arquivos no padrão `<timestamp>_<nome>.sql`.
+• A baseline oficial é o ponto inicial do histórico versionado; alterações posteriores de schema devem entrar como migrations incrementais novas.
+• Migrations legadas preservadas fora de `supabase/migrations/` são somente evidência histórica e não integram o fluxo ativo da CLI.
+• Toda baseline ou migration incremental deve ser reconstruída e validada em ambiente isolado antes de qualquer apply remoto.
+• Antes de apply remoto, executar `supabase migration list --linked` e `supabase db push --linked --dry-run` e revisar exatamente as migrations pendentes.
+• O workflow `.github/workflows/pipeline-supabase-apply-migrations.yml` usa `supabase/setup-cli` v2.1.1 fixada pelo SHA completo `3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf`, com Supabase CLI `2.106.0`.
+• A Action é fixada por SHA imutável para garantir reprodutibilidade e impedir mudança silenciosa da referência móvel `@v2`.
+• O workflow permanece bloqueado enquanto `SUPABASE_APPLY_MIGRATIONS_ENABLED` for diferente de `true`; gate fechado não autoriza apply automático.
+• Os secrets de apply ficam disponíveis somente no passo `Apply migrations`, condicionado explicitamente ao gate aberto.
+• Com gate fechado, um passo separado sem secrets registra o bloqueio e não instala a CLI nem executa `supabase link` ou `supabase db push`.
+• Alterar a versão da CLI, liberar o gate ou executar apply remoto exige revisão e autorização operacional próprias.
+• Configuração de gatilhos, secrets e variável do gate: ver `docs/platform-config.md`.
 
 3.5 Secrets & Variáveis
 • Código client nunca deve acessar secrets server-side.
@@ -432,6 +446,8 @@ Fonte normativa da allowlist SULB para exceções de Auth. Qualquer novo arquivo
 • Tipos canônicos e adapters vNext: validar por 3.6 e 3.14.
 
 99. Changelog
+v2.0.39 — 11/06/2026 — Registrado o fluxo canônico de migrations Supabase versionadas, com baseline, incrementais, validação isolada, dry-run obrigatório e workflow mantido sob gate fechado; `supabase/setup-cli` v2.1.1 fixada por SHA completo e CLI `2.106.0`.
+
 v2.0.38 — 09/06/2026 — Registrado o runtime inicial de `conversion-content`, com template comercial universal, resolução pura, adapter server-only, fallback hierárquico/genérico e grants read-only para pesquisa comercial.
 
 v2.0.37 — 08/06/2026 — Consolidadas em 3.3 as regras estruturais e registrada a family `conversion-content`.

--- a/docs/platform-config.md
+++ b/docs/platform-config.md
@@ -2,8 +2,8 @@
 
 0.1 Cabeçalho
 • Documento: LP Factory 10 — Platform Config
-• Versão: v0.1.2
-• Data: 27/05/2026
+• Versão: v0.1.3
+• Data: 11/06/2026
 
 0.2 Contrato do documento
 • O QUE É: snapshot operacional e fonte única das configurações de plataformas externas do LP Factory 10, refletindo o estado conhecido/cadastrado nas plataformas conforme indicado.
@@ -32,14 +32,14 @@
 • Regra: investigações operacionais podem usar GitHub Connector, GitHub Web ou `gh` autenticado no ambiente autorizado; não há secret nomeado `GH_TOKEN` registrado para essa finalidade neste documento.
 
 2.2 GitHub Actions
-• Secrets conhecidos:
+• Secrets e variáveis conhecidos:
 • `OPENAI_API_KEY`: usado por automações/CI que chamam OpenAI. Consumidor atual: `pipeline-supabase-inspect`.
 • `SUPABASE_DB_URL_READONLY`: conexão read-only para inspeções/automação de banco. Consumidores atuais: `pipeline-supabase-inspect` e `automation-niche-runtime-tests` quando houver verificação de banco.
 • `MAILBOX_EMAIL`: e-mail usado por automações de autenticação/mailbox. Consumidores atuais: `automation-validador-final` e `automation-niche-runtime-tests`.
 • `MAILBOX_PASSWORD`: senha/app password da mailbox usada por automações de autenticação/mailbox. Consumidores atuais: `automation-validador-final` e `automation-niche-runtime-tests`.
 • `SUPABASE_ACCESS_TOKEN`: token usado pelo workflow de apply de migrations Supabase.
 • `SUPABASE_DB_PASSWORD`: senha do banco usada pelo workflow de apply de migrations Supabase.
-• `SUPABASE_APPLY_MIGRATIONS_ENABLED`: variável/gate operacional para habilitar ou bloquear o apply automático de migrations.
+• `SUPABASE_APPLY_MIGRATIONS_ENABLED`: variável de repositório usada como gate operacional; o apply permanece bloqueado quando seu valor é diferente de `true`.
 • Regra: valores reais de secrets não devem ser versionados.
 • Regra: secrets de mailbox devem existir apenas nos escopos necessários dos workflows que os consomem.
 • Regra: `SUPABASE_DB_URL_READONLY` deve autenticar com role/usuário read-only e usar preferencialmente session pooler.
@@ -51,7 +51,16 @@
 • `.github/workflows/pipeline-docs-apply-report.yml`: aplicação automatizada de reports em documentos Markdown e criação de Pull Request automático.
 • `.github/workflows/automation-validador-final.yml`: validação ponta a ponta de fluxos reais de autenticação, com mailbox operacional via `MAILBOX_EMAIL` e `MAILBOX_PASSWORD`.
 • `.github/workflows/automation-niche-runtime-tests.yml`: testes runtime de criação de conta e preenchimento de `pending_setup`, com mailbox operacional e uso opcional de `SUPABASE_DB_URL_READONLY` conforme modo de verificação.
-• `.github/workflows/pipeline-supabase-apply-migrations.yml`: apply controlado de migrations Supabase em `main` quando há mudanças em `supabase/migrations/**`, com `workflow_dispatch` e gate por `SUPABASE_APPLY_MIGRATIONS_ENABLED`.
+• `.github/workflows/pipeline-supabase-apply-migrations.yml`: workflow preparado, mas não liberado, para apply controlado de migrations Supabase.
+• Gatilhos: push em `main` com mudanças em `supabase/migrations/**` e execução manual por `workflow_dispatch`.
+• Setup: `supabase/setup-cli` v2.1.1 fixada pelo SHA completo `3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf`, com Supabase CLI `2.106.0`.
+• Motivo do pin por SHA: reprodutibilidade e proteção contra alteração futura da referência móvel `@v2`.
+• Gate: `SUPABASE_APPLY_MIGRATIONS_ENABLED` deve permanecer diferente de `true` até autorização operacional específica.
+• Com o gate fechado, um passo separado sem secrets registra `skipped`; a CLI não é instalada e `supabase link` e `supabase db push` não são executados.
+• `Setup Supabase CLI` e `Apply migrations` possuem condição explícita de gate aberto.
+• Secrets exigidos somente para apply autorizado com gate aberto: `SUPABASE_ACCESS_TOKEN` e `SUPABASE_DB_PASSWORD`, disponíveis apenas no passo `Apply migrations`.
+• Projeto alvo: definido no workflow por `SUPABASE_PROJECT_REF`; o valor não é credencial, mas deve apontar somente para o projeto aprovado.
+• A execução manual do workflow, mesmo com resultado esperado `skipped`, exige autorização explícita enquanto o fluxo não estiver liberado.
 • `.github/workflows/upgrade-next-16-1-1.yml`: manutenção de Next.js + lockfile.
 
 2.4 Mailbox operacional para automações
@@ -318,6 +327,12 @@
 • Configurações de plataformas, secrets por nome, workflows, ambientes e endpoints usados por automações devem ser registrados neste documento.
 
 99. Changelog
+v0.1.3 (11/06/2026) — Workflow de migrations Supabase reproduzível e mantido bloqueado
+• Registrados `supabase/setup-cli` v2.1.1 fixada por SHA completo, Supabase CLI `2.106.0`, gatilhos, secrets e variável de gate do workflow.
+• Documentado que gate fechado usa passo separado sem secrets, sem instalar a CLI nem executar `supabase link` ou `supabase db push`.
+• Restringidos os secrets de apply ao passo condicionado ao gate aberto.
+• Reforçado que o workflow e o apply automático ainda não estão liberados.
+
 v0.1.2 (27/05/2026) — Clarificação de snapshot operacional
 • Clarificado que o Platform Config reflete o estado conhecido/cadastrado nas plataformas.
 • Definida a leitura operacional para secrets, variáveis, workflows, endpoints e conectores listados.


### PR DESCRIPTION
## Objetivo

Torna reproduzível e restringe por menor privilégio a preparação do workflow de migrations Supabase, mantendo o apply bloqueado.

## Alterações

- fixa `supabase/setup-cli` v2.1.1 pelo SHA imutável `3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf`;
- mantém a Supabase CLI em `2.106.0`;
- remove `SUPABASE_ACCESS_TOKEN` e `SUPABASE_DB_PASSWORD` do `env` do job;
- condiciona `Setup Supabase CLI` e `Apply migrations` a `SUPABASE_APPLY_MIGRATIONS_ENABLED == 'true'`;
- disponibiliza os secrets somente no passo `Apply migrations`;
- adiciona passo separado, sem secrets, para registrar o gate fechado como `skipped`;
- atualiza `docs/base-tecnica.md` e `docs/platform-config.md`.

## Gate e limites

- `SUPABASE_APPLY_MIGRATIONS_ENABLED` não foi alterada;
- com gate fechado, a CLI não é instalada e `supabase link`/`supabase db push` não são executados;
- o workflow não foi executado por `workflow_dispatch`;
- nenhuma operação foi executada no Supabase remoto;
- `docs/automations.md` não foi alterado;
- `actions/checkout@v4` permanece fora do escopo deste pin específico.

## Validação

- YAML parseado com sucesso;
- scripts do gate fechado e apply aprovados por `bash -n`;
- secrets ausentes em `jobs.apply.env`;
- condições explícitas de gate aberto confirmadas nos passos de setup e apply;
- passo de gate fechado confirmado sem secrets;
- `git diff --check`: OK;
- `npm ci`: OK; 11 vulnerabilidades preexistentes (2 low, 5 moderate, 4 high), sem novas dependências;
- `npm run check`: OK, com 24 warnings preexistentes e 0 erros;
- varredura de secrets nos três arquivos alterados: 0 correspondências.

A execução manual do workflow, abertura do gate e qualquer apply remoto continuam dependentes de autorização separada.