### PR TITLE
feat: add E18.5 generated content artifacts migration

### DIFF
--- a/docs/conversion-content.md
+++ b/docs/conversion-content.md
@@ -201,7 +201,9 @@ Tabelas só devem ser avaliadas quando houver necessidade real de salvar dados o
 - histórico;
 - status como `draft`, `approved` ou `published`.
 
-O caso real de reutilização foi definido pela E18.5. A estrutura transversal proposta usa `generated_content_artifacts`, com uma sequência de versões por `scope_key` estável e no máximo uma versão ativa por escopo. O `scope_key` separa o fallback genérico do conteúdo por `researchTaxon`, sem fragmentar o histórico quando template, schema ou pesquisa mudarem. O `input_fingerprint` registra essas entradas mutáveis e permite rejeitar um ativo desatualizado até sua regeneração. A proveniência completa fica em `provenance_json`; a forma como uma conta alcançou a pesquisa não participa do escopo persistido. O SQL operacional e a verificação estão em `supabase/snippets/`; a tabela ainda depende de aplicação e validação no Supabase.
+O caso real de reutilização foi definido pela E18.5. A estrutura transversal usa `generated_content_artifacts`, com uma sequência de versões por `scope_key` estável e no máximo uma versão ativa por escopo. O `scope_key` separa o fallback genérico do conteúdo por `researchTaxon`, sem fragmentar o histórico quando template, schema ou pesquisa mudarem. O `input_fingerprint` registra essas entradas mutáveis e permite rejeitar um ativo desatualizado até sua regeneração. A proveniência completa fica em `provenance_json`; a forma como uma conta alcançou a pesquisa não participa do escopo persistido.
+
+A criação dos objetos tem como fonte canônica a migration incremental `supabase/migrations/20260611235653_generated_content_artifacts.sql`. A migration foi preparada para falhar diante de colisões inesperadas e validada em PostgreSQL 17.10 descartável sobre a baseline oficial, incluindo verificação estrutural, smoke funcional, rollback e reconstrução. O snippet `supabase/snippets/e18_5_generated_content_artifacts_verification.sql` permanece somente para verificação read-only; a aplicação remota depende de autorização separada.
 
 ## 11. Fronteiras
 
@@ -224,8 +226,9 @@ Ficam fora desta fase:
 
 ## 12. Próximos passos
 
-1. Aplicar e validar o SQL operacional de persistência no Supabase.
-2. Criar migration histórica após a validação operacional.
-3. Definir e implementar o runtime de geração dos campos finais.
-4. Implementar a operação administrativa da E12.7.
-5. Integrar a E10.6 ao artefato ativo, preservando o fallback determinístico já implementado.
+1. Revisar e fazer merge da migration incremental validada da E18.5.
+2. Autorizar separadamente a aplicação remota pelo fluxo de migrations.
+3. Verificar os objetos no ambiente remoto após a aplicação autorizada.
+4. Definir e implementar o runtime de geração dos campos finais.
+5. Implementar a operação administrativa da E12.7.
+6. Integrar a E10.6 ao artefato ativo, preservando o fallback determinístico já implementado.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 0.1 Cabeçalho
 • Data: 11/06/2026
-• Versão: v1.5.68
+• Versão: v1.5.69
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -990,13 +990,14 @@ Ajustados:
 • Implementado: template versionado, proveniência por bloco de pesquisa com versão e `updated_at`, contrato camelCase dos campos finais, identidade inicial do artefato, validação estrutural pura com erros preservados e copy genérica determinística.
 • Evolução planejada do primeiro template: a `version: 2` da página comercial poderá incluir recursos, diferenciais, provas, FAQ, CTA final ampliado e blocos adicionais de benefícios.
 • Cada nova seção deverá integrar o contrato versionado, o fallback determinístico, a validação estrutural e a saída gerada antes de ser consumida pela E10.6; a `version: 1` permanece válida e não deve ser alterada retroativamente.
-• Preparado: `scope_key` e `input_fingerprint` SHA-256 canônicos, adapter server-side para criar draft, ativar versão e recuperar somente artefato ativo com fingerprint esperado, SQL operacional versionado, verificação read-only e rollback.
-• Artefatos: `lib/conversion-content/contracts.ts`, `lib/conversion-content/generatedCommercialContent.ts`, `lib/conversion-content/commercialTemplateResolution.ts`, `lib/conversion-content/templates/accountDashboardCommercialPage.ts`, `lib/conversion-content/adapters/commercialTemplateResolver.ts`, `lib/conversion-content/adapters/commercialGeneratedArtifactAdapter.ts`, `supabase/snippets/e18_5_generated_content_artifacts.sql`, `supabase/snippets/e18_5_generated_content_artifacts_verification.sql` e `supabase/rollbacks/20260611__e18_5_generated_content_artifacts.rollback.sql`.
-• Persistência proposta: tabela transversal `generated_content_artifacts`, estados `draft | active | archived`, versões sequenciais e ativo único por `scope_key`, proveniência em `provenance_json`, RLS sem policies de usuário e acesso exclusivo de `service_role`.
-• Pendência operacional: aplicar e validar o SQL no Supabase; somente depois criar a migration histórica e atualizar o contrato de schema.
+• Preparado: `scope_key` e `input_fingerprint` SHA-256 canônicos, adapter server-side para criar draft, ativar versão e recuperar somente artefato ativo com fingerprint esperado, migration incremental canônica, verificação read-only e rollback isolado.
+• Artefatos: `lib/conversion-content/contracts.ts`, `lib/conversion-content/generatedCommercialContent.ts`, `lib/conversion-content/commercialTemplateResolution.ts`, `lib/conversion-content/templates/accountDashboardCommercialPage.ts`, `lib/conversion-content/adapters/commercialTemplateResolver.ts`, `lib/conversion-content/adapters/commercialGeneratedArtifactAdapter.ts`, `supabase/migrations/20260611235653_generated_content_artifacts.sql`, `supabase/snippets/e18_5_generated_content_artifacts_verification.sql` e `supabase/rollbacks/20260611__e18_5_generated_content_artifacts.rollback.sql`.
+• Persistência versionada: tabela transversal `generated_content_artifacts`, estados `draft | active | archived`, versões sequenciais e ativo único por `scope_key`, proveniência em `provenance_json`, RLS sem policies de usuário e acesso exclusivo de `service_role`.
+• Validação isolada: baseline + migration aplicadas em PostgreSQL 17.10 descartável, verificação estrutural consolidada aprovada, smoke de criação/ativação/arquivamento aprovado, rollback comprovado e reconstrução posterior aprovada.
+• Pendência operacional: revisar e fazer merge da migration; a aplicação remota depende de autorização separada pelo fluxo incremental e deve ser seguida pela atualização do contrato de schema.
 • Pendência de produto: definir runtime e validação da geração/provider e regras de consumo antes da integração da E10.6 com artefatos gerados.
 • Updates previstos para a etapa técnica futura:
-• supa#40: snippets operacional e de verificação preparados; aplicação e validação no Supabase pendentes.
+• supa#40: migration canônica e snippet de verificação read-only preparados; aplicação e verificação remotas pendentes.
 • supa#5: registrar geração, regeneração, falhas, duração, provider/modelo, versão das entradas e `request_id`, sem PII ou conteúdo integral.
 • supa#58: aplicar a regra global de GRANT explícito se forem criadas tabelas `public` acessadas pela Data API; não conceder grants automaticamente a tabelas internas.
 • vercel#1: avaliar AI Gateway quando provider e runtime de geração forem definidos.
@@ -1004,7 +1005,7 @@ Ajustados:
 • supa#53: avaliar apenas se houver necessidade comprovada de fila, retry ou processamento assíncrono.
 • tracking: definir uma única estratégia após a primeira entrega da E10.6, evitando duplicidade entre tracking interno e Vercel.
 • Não adotar neste recorte: supa#52, supa#54 e vercel#3.
-• Fora de escopo desta etapa: aplicação do SQL no Supabase, migration histórica a ser criada somente após a validação operacional, provider de IA, gateway, runtime de geração, UI administrativa e renderização da E10.6.
+• Fora de escopo desta etapa: aplicação remota da migration, provider de IA, gateway, runtime de geração, UI administrativa e habilitação da leitura persistida na E10.6.
 
 19. E19 — LP Builder
 
@@ -1040,6 +1041,7 @@ Ajustados:
 • Definir o primeiro recorte funcional do LP Builder no roadmap
 
 99. Changelog
+v1.5.69 — 11/06/2026 — E18.5 adota o primeiro fluxo incremental pós-baseline: migration canônica estrita de `generated_content_artifacts`, verificação read-only ampliada, validação isolada com smoke, rollback e reconstrução, mantendo aplicação remota e runtime consumidor bloqueados.
 v1.5.68 — 11/06/2026 — E10.6 e E18.5 registram o backlog da página comercial `version: 2`, com recursos, diferenciais, provas, FAQ, CTA final ampliado e evolução coordenada de contrato, fallback, validação, geração e renderização, preservando a `version: 1`.
 v1.5.67 — 11/06/2026 — E10.6 corrige a acentuação da copy fallback e remove o espaço reservado acima da página comercial quando não há card de resolução de nicho.
 v1.5.66 — 11/06/2026 — E10.6 recebe a primeira página comercial funcional e responsiva no Account Dashboard, consumindo o resolver existente e o fallback determinístico sem consultar a persistência ainda não aplicada.

--- a/supabase/migrations/20260611235653_generated_content_artifacts.sql
+++ b/supabase/migrations/20260611235653_generated_content_artifacts.sql
@@ -198,7 +198,6 @@ $$;
 revoke all on table public.generated_content_artifacts from public;
 revoke all on table public.generated_content_artifacts from anon;
 revoke all on table public.generated_content_artifacts from authenticated;
-revoke all on table public.generated_content_artifacts from ai_readonly;
 
 grant usage on schema public to service_role;
 grant select, insert, update
@@ -244,19 +243,6 @@ revoke all on function public.create_generated_content_artifact_draft(
   jsonb,
   jsonb
 ) from authenticated;
-revoke all on function public.create_generated_content_artifact_draft(
-  text,
-  text,
-  text,
-  integer,
-  text,
-  text,
-  text,
-  text,
-  uuid,
-  jsonb,
-  jsonb
-) from ai_readonly;
 grant execute on function public.create_generated_content_artifact_draft(
   text,
   text,
@@ -277,9 +263,39 @@ revoke all on function public.activate_generated_content_artifact(uuid)
   from anon;
 revoke all on function public.activate_generated_content_artifact(uuid)
   from authenticated;
-revoke all on function public.activate_generated_content_artifact(uuid)
-  from ai_readonly;
 grant execute on function public.activate_generated_content_artifact(uuid)
   to service_role;
+
+do $$
+begin
+  if exists (
+    select 1
+    from pg_roles
+    where rolname = 'ai_readonly'
+  ) then
+    execute
+      'revoke all on table public.generated_content_artifacts from ai_readonly';
+
+    execute
+      'revoke all on function public.create_generated_content_artifact_draft(
+        text,
+        text,
+        text,
+        integer,
+        text,
+        text,
+        text,
+        text,
+        uuid,
+        jsonb,
+        jsonb
+      ) from ai_readonly';
+
+    execute
+      'revoke all on function public.activate_generated_content_artifact(uuid)
+       from ai_readonly';
+  end if;
+end
+$$;
 
 commit;

--- a/supabase/migrations/20260611235653_generated_content_artifacts.sql
+++ b/supabase/migrations/20260611235653_generated_content_artifacts.sql
@@ -1,10 +1,9 @@
--- E18.5 - persistencia transversal de artefatos de conteudo gerado
--- Tipo: operacional / execucao manual controlada
--- Nao executar sem autorizacao explicita.
+-- E18.5 - persisted generated content artifacts.
+-- Canonical incremental migration. Apply only through the approved migration flow.
 
 begin;
 
-create table if not exists public.generated_content_artifacts (
+create table public.generated_content_artifacts (
   id uuid primary key default gen_random_uuid(),
   scope_key text not null,
   input_fingerprint text not null,
@@ -53,11 +52,11 @@ create table if not exists public.generated_content_artifacts (
     on delete restrict
 );
 
-create unique index if not exists generated_content_artifacts_one_active_uidx
+create unique index generated_content_artifacts_one_active_uidx
   on public.generated_content_artifacts (scope_key)
   where status = 'active';
 
-create index if not exists generated_content_artifacts_template_lookup_idx
+create index generated_content_artifacts_template_lookup_idx
   on public.generated_content_artifacts (
     template_key,
     audience_scope,
@@ -66,20 +65,17 @@ create index if not exists generated_content_artifacts_template_lookup_idx
     status
   );
 
-create index if not exists generated_content_artifacts_research_taxon_id_idx
+create index generated_content_artifacts_research_taxon_id_idx
   on public.generated_content_artifacts (research_taxon_id);
 
 alter table public.generated_content_artifacts enable row level security;
-
-drop trigger if exists generated_content_artifacts_set_updated_at
-  on public.generated_content_artifacts;
 
 create trigger generated_content_artifacts_set_updated_at
   before update on public.generated_content_artifacts
   for each row
   execute function public.tg_set_updated_at();
 
-create or replace function public.create_generated_content_artifact_draft(
+create function public.create_generated_content_artifact_draft(
   p_scope_key text,
   p_input_fingerprint text,
   p_template_key text,
@@ -148,7 +144,7 @@ begin
 end;
 $$;
 
-create or replace function public.activate_generated_content_artifact(
+create function public.activate_generated_content_artifact(
   p_artifact_id uuid
 )
 returns boolean

--- a/supabase/rollbacks/20260611__e18_5_generated_content_artifacts.rollback.sql
+++ b/supabase/rollbacks/20260611__e18_5_generated_content_artifacts.rollback.sql
@@ -43,7 +43,6 @@ revoke all on table public.generated_content_artifacts from service_role;
 revoke all on table public.generated_content_artifacts from public;
 revoke all on table public.generated_content_artifacts from anon;
 revoke all on table public.generated_content_artifacts from authenticated;
-revoke all on table public.generated_content_artifacts from ai_readonly;
 
 drop index if exists public.generated_content_artifacts_research_taxon_id_idx;
 drop index if exists public.generated_content_artifacts_template_lookup_idx;

--- a/supabase/snippets/e18_5_generated_content_artifacts_verification.sql
+++ b/supabase/snippets/e18_5_generated_content_artifacts_verification.sql
@@ -122,9 +122,97 @@ table_access as (
     values
       ('service_role'),
       ('anon'),
-      ('authenticated'),
-      ('ai_readonly')
+      ('authenticated')
   ) roles(role_name)
+),
+ai_readonly_access as (
+  select
+    exists (
+      select 1
+      from pg_roles
+      where rolname = 'ai_readonly'
+    ) as role_exists,
+    coalesce((
+      select has_table_privilege(
+        r.oid,
+        'public.generated_content_artifacts',
+        'SELECT'
+      )
+      from pg_roles r
+      where r.rolname = 'ai_readonly'
+    ), false) as can_select,
+    coalesce((
+      select has_table_privilege(
+        r.oid,
+        'public.generated_content_artifacts',
+        'INSERT'
+      )
+      from pg_roles r
+      where r.rolname = 'ai_readonly'
+    ), false) as can_insert,
+    coalesce((
+      select has_table_privilege(
+        r.oid,
+        'public.generated_content_artifacts',
+        'UPDATE'
+      )
+      from pg_roles r
+      where r.rolname = 'ai_readonly'
+    ), false) as can_update,
+    coalesce((
+      select has_table_privilege(
+        r.oid,
+        'public.generated_content_artifacts',
+        'DELETE'
+      )
+      from pg_roles r
+      where r.rolname = 'ai_readonly'
+    ), false) as can_delete,
+    coalesce((
+      select has_table_privilege(
+        r.oid,
+        'public.generated_content_artifacts',
+        'TRUNCATE'
+      )
+      from pg_roles r
+      where r.rolname = 'ai_readonly'
+    ), false) as can_truncate,
+    coalesce((
+      select has_table_privilege(
+        r.oid,
+        'public.generated_content_artifacts',
+        'REFERENCES'
+      )
+      from pg_roles r
+      where r.rolname = 'ai_readonly'
+    ), false) as can_reference,
+    coalesce((
+      select has_table_privilege(
+        r.oid,
+        'public.generated_content_artifacts',
+        'TRIGGER'
+      )
+      from pg_roles r
+      where r.rolname = 'ai_readonly'
+    ), false) as can_trigger,
+    coalesce((
+      select has_function_privilege(
+        r.oid,
+        'public.create_generated_content_artifact_draft(text,text,text,integer,text,text,text,text,uuid,jsonb,jsonb)',
+        'EXECUTE'
+      )
+      from pg_roles r
+      where r.rolname = 'ai_readonly'
+    ), false) as can_execute_create,
+    coalesce((
+      select has_function_privilege(
+        r.oid,
+        'public.activate_generated_content_artifact(uuid)',
+        'EXECUTE'
+      )
+      from pg_roles r
+      where r.rolname = 'ai_readonly'
+    ), false) as can_execute_activate
 ),
 checks as (
   select
@@ -244,6 +332,58 @@ checks as (
   union all
 
   select
+    'ai_readonly_access',
+    case
+      when not role_exists then 'pass'
+      when not (
+        can_select
+        or can_insert
+        or can_update
+        or can_delete
+        or can_truncate
+        or can_reference
+        or can_trigger
+        or can_execute_create
+        or can_execute_activate
+      ) then 'pass'
+      else 'fail'
+    end,
+    jsonb_build_object(
+      'role_exists', role_exists,
+      'role_status', case
+        when not role_exists then 'role_absent'
+        when not (
+          can_select
+          or can_insert
+          or can_update
+          or can_delete
+          or can_truncate
+          or can_reference
+          or can_trigger
+          or can_execute_create
+          or can_execute_activate
+        ) then 'role_present_without_privileges'
+        else 'role_present_with_privileges'
+      end,
+      'table_privileges', jsonb_build_object(
+        'select', can_select,
+        'insert', can_insert,
+        'update', can_update,
+        'delete', can_delete,
+        'truncate', can_truncate,
+        'references', can_reference,
+        'trigger', can_trigger
+      ),
+      'function_execute', jsonb_build_object(
+        'create_generated_content_artifact_draft', can_execute_create,
+        'activate_generated_content_artifact', can_execute_activate
+      )
+    )::text
+  from ai_readonly_access
+
+  union all
+
+  select
     'function_security_and_grants',
     case
       when count(*) = 2
@@ -251,7 +391,6 @@ checks as (
         and bool_and(has_function_privilege('service_role', p.oid, 'EXECUTE'))
         and bool_and(not has_function_privilege('anon', p.oid, 'EXECUTE'))
         and bool_and(not has_function_privilege('authenticated', p.oid, 'EXECUTE'))
-        and bool_and(not has_function_privilege('ai_readonly', p.oid, 'EXECUTE'))
       then 'pass'
       else 'fail'
     end,
@@ -268,10 +407,6 @@ checks as (
       ),
       'authenticated_execute', coalesce(
         bool_or(has_function_privilege('authenticated', p.oid, 'EXECUTE')),
-        false
-      ),
-      'ai_readonly_execute', coalesce(
-        bool_or(has_function_privilege('ai_readonly', p.oid, 'EXECUTE')),
         false
       )
     )::text

--- a/supabase/snippets/e18_5_generated_content_artifacts_verification.sql
+++ b/supabase/snippets/e18_5_generated_content_artifacts_verification.sql
@@ -1,9 +1,51 @@
 -- E18.5 - verificacao read-only consolidada
 -- Retorna um unico result set para uso no Supabase SQL Editor.
 -- O comportamento de criacao e ativacao deve ser validado separadamente pelo
--- smoke transacional integrado, executado somente apos autorizacao.
+-- smoke transacional integrado em PostgreSQL descartavel.
 
 with
+expected_columns(
+  ordinal_position,
+  column_name,
+  formatted_type,
+  is_not_null,
+  column_default
+) as (
+  values
+    (1, 'id', 'uuid', true, 'gen_random_uuid()'),
+    (2, 'scope_key', 'text', true, null),
+    (3, 'input_fingerprint', 'text', true, null),
+    (4, 'artifact_version', 'integer', true, null),
+    (5, 'status', 'text', true, '''draft''::text'),
+    (6, 'template_key', 'text', true, null),
+    (7, 'template_version', 'integer', true, null),
+    (8, 'content_schema_version', 'text', true, null),
+    (9, 'audience_scope', 'text', true, null),
+    (10, 'locale', 'text', true, null),
+    (11, 'scope_type', 'text', true, null),
+    (12, 'research_taxon_id', 'uuid', false, null),
+    (13, 'provenance_json', 'jsonb', true, null),
+    (14, 'content_json', 'jsonb', true, null),
+    (15, 'created_at', 'timestamp with time zone', true, 'now()'),
+    (16, 'updated_at', 'timestamp with time zone', true, 'now()'),
+    (17, 'activated_at', 'timestamp with time zone', false, null),
+    (18, 'archived_at', 'timestamp with time zone', false, null)
+),
+actual_columns as (
+  select
+    a.attnum as ordinal_position,
+    a.attname::text as column_name,
+    format_type(a.atttypid, a.atttypmod) as formatted_type,
+    a.attnotnull as is_not_null,
+    pg_get_expr(ad.adbin, ad.adrelid) as column_default
+  from pg_attribute a
+  left join pg_attrdef ad
+    on ad.adrelid = a.attrelid
+   and ad.adnum = a.attnum
+  where a.attrelid = to_regclass('public.generated_content_artifacts')
+    and a.attnum > 0
+    and not a.attisdropped
+),
 expected_constraints(constraint_name) as (
   values
     ('generated_content_artifacts_pkey'),
@@ -26,6 +68,17 @@ expected_indexes(index_name) as (
     ('generated_content_artifacts_one_active_uidx'),
     ('generated_content_artifacts_template_lookup_idx'),
     ('generated_content_artifacts_research_taxon_id_idx')
+),
+actual_constraints as (
+  select c.conname
+  from pg_constraint c
+  where c.conrelid = to_regclass('public.generated_content_artifacts')
+),
+actual_indexes as (
+  select i.indexname, i.indexdef
+  from pg_indexes i
+  where i.schemaname = 'public'
+    and i.tablename = 'generated_content_artifacts'
 ),
 table_access as (
   select
@@ -89,6 +142,44 @@ checks as (
   where n.nspname = 'public'
     and c.relname = 'generated_content_artifacts'
     and c.relkind = 'r'
+
+  union all
+
+  select
+    'columns',
+    case
+      when (select count(*) from actual_columns) =
+        (select count(*) from expected_columns)
+       and count(*) = (select count(*) from expected_columns)
+       and bool_and(
+         a.column_name is not null
+         and a.ordinal_position = e.ordinal_position
+         and a.formatted_type = e.formatted_type
+         and a.is_not_null = e.is_not_null
+         and a.column_default is not distinct from e.column_default
+       )
+      then 'pass'
+      else 'fail'
+    end,
+    jsonb_build_object(
+      'expected_count', (select count(*) from expected_columns),
+      'actual_count', (select count(*) from actual_columns),
+      'columns', coalesce(
+        jsonb_agg(
+          jsonb_build_object(
+            'name', coalesce(a.column_name, e.column_name),
+            'position', a.ordinal_position,
+            'type', a.formatted_type,
+            'not_null', a.is_not_null,
+            'default', a.column_default
+          )
+          order by e.ordinal_position
+        ),
+        '[]'::jsonb
+      )
+    )::text
+  from expected_columns e
+  left join actual_columns a on a.column_name = e.column_name
 
   union all
 
@@ -195,14 +286,67 @@ checks as (
   union all
 
   select
+    'trigger',
+    case
+      when count(*) = 1
+       and bool_and(t.tgname = 'generated_content_artifacts_set_updated_at')
+       and bool_and(p.proname = 'tg_set_updated_at')
+      then 'pass'
+      else 'fail'
+    end,
+    jsonb_build_object(
+      'trigger_count', count(*),
+      'triggers', coalesce(
+        jsonb_agg(
+          jsonb_build_object(
+            'name', t.tgname,
+            'function', p.proname
+          )
+          order by t.tgname
+        ),
+        '[]'::jsonb
+      )
+    )::text
+  from pg_trigger t
+  join pg_proc p on p.oid = t.tgfoid
+  where t.tgrelid = to_regclass('public.generated_content_artifacts')
+    and not t.tgisinternal
+
+  union all
+
+  select
+    'dependencies',
+    case
+      when to_regclass('public.business_taxons') is not null
+       and to_regprocedure('public.tg_set_updated_at()') is not null
+       and to_regprocedure('gen_random_uuid()') is not null
+       and to_regprocedure('hashtextextended(text,bigint)') is not null
+      then 'pass'
+      else 'fail'
+    end,
+    jsonb_build_object(
+      'business_taxons', to_regclass('public.business_taxons') is not null,
+      'tg_set_updated_at',
+        to_regprocedure('public.tg_set_updated_at()') is not null,
+      'gen_random_uuid', to_regprocedure('gen_random_uuid()') is not null,
+      'hashtextextended',
+        to_regprocedure('hashtextextended(text,bigint)') is not null
+    )::text
+
+  union all
+
+  select
     'constraints',
     case
       when count(c.conname) = (select count(*) from expected_constraints)
+       and (select count(*) from actual_constraints) =
+         (select count(*) from expected_constraints)
       then 'pass'
       else 'fail'
     end,
     jsonb_build_object(
       'expected_count', (select count(*) from expected_constraints),
+      'actual_count', (select count(*) from actual_constraints),
       'found', coalesce(
         jsonb_agg(c.conname order by c.conname)
           filter (where c.conname is not null),
@@ -220,6 +364,8 @@ checks as (
     'indexes',
     case
       when count(i.indexname) = (select count(*) from expected_indexes)
+        and (select count(*) from actual_indexes) =
+          (select count(*) from expected_indexes)
         and bool_or(
           i.indexname = 'generated_content_artifacts_one_active_uidx'
           and i.indexdef ilike '%where%status%active%'
@@ -229,6 +375,7 @@ checks as (
     end,
     jsonb_build_object(
       'expected_count', (select count(*) from expected_indexes),
+      'actual_count', (select count(*) from actual_indexes),
       'found', coalesce(
         jsonb_agg(i.indexname order by i.indexname)
           filter (where i.indexname is not null),


### PR DESCRIPTION
## Escopo

- promove `generated_content_artifacts` de snippet operacional para migration incremental canônica e estrita;
- mantém o snippet consolidado apenas para verificação read-only e amplia checks de colunas, defaults, constraints, índices, trigger, dependências, grants, RLS e policies;
- mantém `ai_readonly` como role operacional opcional, coerente com a baseline oficial;
- atualiza `docs/conversion-content.md` e `docs/roadmap.md` para o fluxo migration versionada -> validação isolada -> dry-run -> PR -> autorização separada para apply;
- não habilita o runtime consumidor e não executa aplicação remota.

## Correção após revisão

- os três `REVOKE ... FROM ai_readonly` da migration agora são executados em bloco dinâmico somente quando o role existe;
- `service_role`, `anon`, `authenticated` e `public` permanecem obrigatórios e com comandos estritos;
- a verificação removeu `ai_readonly` das chamadas genéricas por nome e adicionou o check separado `ai_readonly_access`;
- o rollback não referencia mais `ai_readonly`, pois o `DROP` dos objetos remove suas ACLs.

## Validação isolada

### Cenário A: sem `ai_readonly`

- baseline: aprovada;
- migration: aprovada sem criar o role;
- verificação: 11/11 checks `pass`;
- `ai_readonly_access`: `role_absent`;
- smoke: 2 ativos em escopos independentes, 1 arquivado, versão genérica 2, fingerprint atual aceito e antigo rejeitado;
- rollback: tabela e duas funções removidas;
- reconstrução baseline + migration: aprovada novamente sem `ai_readonly`.

### Cenário B: com `ai_readonly`

- role criado somente no bootstrap descartável;
- default privileges simularam `SELECT` em tabelas novas e `EXECUTE` em funções novas;
- migration removeu todos os privilégios herdados;
- verificação: 11/11 checks `pass`;
- `ai_readonly_access`: `role_present_without_privileges`, sem acesso à tabela e sem `EXECUTE` nas duas funções;
- smoke: versionamento, ativação, arquivamento, escopos e fingerprint aprovados;
- rollback: tabela e duas funções removidas.

## Diagnóstico remoto permitido

- `supabase migration list --linked`: baseline alinhada e exatamente uma migration pendente;
- `supabase db push --linked --dry-run`: somente `20260611235653_generated_content_artifacts.sql` seria aplicada.

## Validações finais

- `git diff --check`: aprovado;
- `npm ci`: aprovado, com 11 vulnerabilidades já reportadas pelo audit;
- `npm run check`: aprovado com 0 erros e 24 warnings preexistentes;
- revisão de `main..HEAD` e `main...HEAD`: escopo esperado;
- varredura de secrets: aprovada.

## Segurança operacional

Nenhum `migration repair`, `db push` real, workflow dispatch, alteração de gate, SQL remoto, criação remota de role, rollback remoto ou habilitação de runtime foi executado.