### PR TITLE
test: add migration workflow smoke table

### DIFF
--- a/supabase/migrations/20260612143820_migration_workflow_smoke_create.sql
+++ b/supabase/migrations/20260612143820_migration_workflow_smoke_create.sql
@@ -1,0 +1,21 @@
+create table public.migration_workflow_smoke (
+  id bigint generated always as identity primary key,
+  created_at timestamptz not null default now()
+);
+
+alter table public.migration_workflow_smoke enable row level security;
+
+revoke all on table public.migration_workflow_smoke
+  from public, anon, authenticated, service_role;
+
+do $$
+begin
+  if exists (
+    select 1
+    from pg_roles
+    where rolname = 'ai_readonly'
+  ) then
+    execute 'revoke all on table public.migration_workflow_smoke from ai_readonly';
+  end if;
+end
+$$;


### PR DESCRIPTION
## Objetivo

Primeira etapa do teste operacional do fluxo universal de migrations: criar uma tabela descartável por migration versionada e comprovar, após merge humano, o apply automático pelo workflow.

## Migration

`supabase/migrations/20260612143820_migration_workflow_smoke_create.sql`

Cria somente `public.migration_workflow_smoke` com:

- `id bigint generated always as identity primary key`;
- `created_at timestamptz not null default now()`;
- RLS habilitada;
- zero policies e zero dados;
- revogação de acessos para `PUBLIC`, `anon`, `authenticated` e `service_role`;
- revogação condicional para `ai_readonly`, sem criar ou alterar roles.

## Estado inicial confirmado

- base `main`: `c83b8d5bb329e53ddfa10fc405fd12b5af15b3d2`;
- somente a baseline ativa e alinhada no histórico remoto;
- `supabase db push --linked --dry-run`: banco remoto atualizado;
- E18.5 ausente local e remotamente;
- gate relatado como `true` e secrets obrigatórios confirmados por nome, sem valores expostos.

## Validações

- `git diff --check`: OK;
- validação estrutural SQL: OK;
- varredura de secrets: 0 ocorrências;
- `npm ci`: OK; 11 vulnerabilidades preexistentes, sem alteração de dependências;
- `npm run check`: OK, 0 erros e 24 warnings preexistentes.

## Limites

- não executar `workflow_dispatch`;
- não aplicar SQL manualmente;
- não alterar o workflow ou o gate;
- não fazer merge sem revisão humana;
- após o merge, o push na `main` deve disparar automaticamente o workflow e aplicar somente esta migration.