### PR TITLE
test: drop migration workflow smoke table

### DIFF
--- a/supabase/migrations/20260612221253_migration_workflow_smoke_drop.sql
+++ b/supabase/migrations/20260612221253_migration_workflow_smoke_drop.sql
@@ -1,0 +1,1 @@
+drop table public.migration_workflow_smoke;


### PR DESCRIPTION
## Objetivo

Segunda etapa do teste operacional do fluxo universal de migrations: remover a tabela descartável por uma migration corretiva posterior e comprovar, após merge humano, o apply automático pelo workflow.

## Migration

`supabase/migrations/20260612221253_migration_workflow_smoke_drop.sql`

Conteúdo integral:

```sql
drop table public.migration_workflow_smoke;
```

## Pré-condições confirmadas

- base `main`: `0bc9c9b7eb668eef4be2780e97622dd691eee260`;
- migration de criação `20260612143820` alinhada local/remoto;
- `supabase db push --linked --dry-run`: banco remoto atualizado;
- tabela remota existente;
- RLS habilitada, zero policies, duas colunas e zero registros.

## Garantias

- sem `if exists`;
- migration de criação não editada nem removida;
- nenhum arquivo em `supabase/rollbacks/` alterado;
- nenhum SQL manual executado no Supabase;
- workflow e gate não alterados.

## Validações

- conteúdo estrito confirmado;
- blob da migration de criação idêntico ao da `main`;
- `git diff --check`: OK;
- varredura de secrets: 0 ocorrências;
- `npm ci`: OK; 11 vulnerabilidades preexistentes, sem alteração de dependências;
- `npm run check`: OK, 0 erros e 24 warnings preexistentes.

## Limites

- não executar `workflow_dispatch`;
- não aplicar SQL manualmente;
- não fazer merge sem revisão humana;
- após o merge, o push na `main` deve disparar automaticamente o workflow e aplicar somente esta migration.