### PR TITLE
[codex] concluir fluxo de migrations Supabase

### DIFF
--- a/docs/automations.md
+++ b/docs/automations.md
@@ -1,6 +1,6 @@
 0.1 Cabeçalho
-Data: 26/05/2026
-Versão: v1.8
+Data: 12/06/2026
+Versão: v1.9
 Status: Alinhado ao Platform Config
 
 0.2 Função do documento
@@ -212,32 +212,24 @@ O contrato funcional, status, escopo, critérios e artefatos do caso ficam no ro
 3.6 Apply automático de migrations no Supabase
 
 Objetivo:
-Manter o apply automático como fluxo preparado, mas bloqueado até a conclusão da baseline oficial de migrations e do alinhamento remoto.
+Aplicar migrations versionadas do Supabase automaticamente após merge humano na `main`, substituindo o uso manual do SQL Editor para alterações de schema.
 
 Status:
-Proposto / bloqueado por baseline oficial
+Implementada e validada
+
+Acesso:
+GitHub → Actions → workflow `pipeline-supabase-apply-migrations`
+
+Como usar:
+Criar migration em `supabase/migrations/<timestamp>_<nome>.sql`, validar em PR exclusivo e fazer merge humano na `main`. O push na `main` dispara o apply automático.
 
 Resumo de controle:
-O workflow de apply não deve ser tratado como liberado enquanto a baseline A3.6.1 estiver pendente. A orientação operacional detalhada fica centralizada nas lousas de referência, sem duplicação neste índice.
+A baseline oficial foi concluída, o histórico remoto foi alinhado e o smoke de criação/remoção foi validado. O gate `SUPABASE_APPLY_MIGRATIONS_ENABLED` permanece `true` no fluxo normal. O SQL Editor não faz parte do fluxo normal. Migration já aplicada não deve ser editada, apagada ou substituída; correções e reversões devem ser feitas por nova migration incremental.
 
 Referências / dependências:
-`docs/lousa-automations3-6.md`
-`docs/lousa-automations3-6-1.md`
-
-3.6.1 Baseline de migrations no Supabase
-
-Objetivo:
-Consolidar o baseline real do banco remoto atual como novo histórico oficial de migrations antes de liberar o apply automático.
-
-Status:
-Proposto / pendente
-
-Resumo de controle:
-A lousa operacional principal da baseline é `docs/lousa-automations3-6-1.md`. O contexto de controle do apply automático permanece em `docs/lousa-automations3-6.md`.
-
-Referências / dependências:
-`docs/lousa-automations3-6.md`
-`docs/lousa-automations3-6-1.md`
+`docs/base-tecnica.md`
+`docs/platform-config.md`
+`docs/lousa-automations3-6-1.md` — registro histórico da baseline concluída.
 
 3.7 Niche Runtime Tests
 

--- a/docs/base-tecnica.md
+++ b/docs/base-tecnica.md
@@ -2,7 +2,7 @@
 
 0.1. Cabeçalho
 • Documento: Base Técnica LP Factory 10
-• Versão: v2.0.40
+• Versão: v2.0.41
 • Data: 12/06/2026
 
 0.2 Contrato do documento (consulta)
@@ -139,17 +139,21 @@
 • Contrato técnico detalhado do pipeline: automations/supabase-inspect/README.md.
 
 3.4.4 Migrations Supabase versionadas
-• Fonte canônica: `supabase/migrations/`, com arquivos no padrão `<timestamp>_<nome>.sql`.
+• Fonte canônica: `supabase/migrations/<timestamp>_<nome>.sql`.
 • A baseline oficial é o ponto inicial do histórico versionado; alterações posteriores de schema devem entrar como migrations incrementais novas.
 • Migrations legadas preservadas fora de `supabase/migrations/` são somente evidência histórica e não integram o fluxo ativo da CLI.
 • Toda baseline ou migration incremental deve ser reconstruída e validada em ambiente isolado antes de qualquer apply remoto.
 • Antes de apply remoto, executar `supabase migration list --linked` e `supabase db push --linked --dry-run` e revisar exatamente as migrations pendentes.
 • O workflow `.github/workflows/pipeline-supabase-apply-migrations.yml` usa `supabase/setup-cli` v2.1.1 fixada pelo SHA completo `3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf`, com Supabase CLI `2.106.0`.
 • A Action é fixada por SHA imutável para garantir reprodutibilidade e impedir mudança silenciosa da referência móvel `@v2`.
-• O workflow permanece bloqueado enquanto `SUPABASE_APPLY_MIGRATIONS_ENABLED` for diferente de `true`; gate fechado não autoriza apply automático.
+• O merge de migration na `main` dispara o apply automático pelo workflow; o gate operacional `SUPABASE_APPLY_MIGRATIONS_ENABLED` deve permanecer em `true` no fluxo normal.
+• Alterar o gate para valor diferente de `true` é medida excepcional de bloqueio para incidente ou manutenção, pois impede o apply automático.
 • Os secrets de apply ficam disponíveis somente no passo `Apply migrations`, condicionado explicitamente ao gate aberto.
 • Com gate fechado, um passo separado sem secrets registra o bloqueio e não instala a CLI nem executa `supabase link` ou `supabase db push`.
-• Alterar a versão da CLI, liberar o gate ou executar apply remoto exige revisão e autorização operacional próprias.
+• O SQL Editor não deve ser usado para alterações de schema no fluxo normal; toda alteração deve ser versionada por migration e passar por PR e merge na `main`.
+• Migration já aplicada é imutável: não editar, apagar, renomear, substituir conteúdo nem reutilizar seu timestamp.
+• Reversão ou correção deve ser feita por nova migration incremental, preservando o histórico forward-only.
+• Alterar a versão da CLI, a Action ou o contrato do workflow exige revisão e autorização operacional próprias.
 • Configuração de gatilhos, secrets e variável do gate: ver `docs/platform-config.md`.
 
 3.5 Secrets & Variáveis
@@ -433,6 +437,8 @@ Fonte normativa da allowlist SULB para exceções de Auth. Qualquer novo arquivo
 • Tipos canônicos e adapters vNext: validar por 3.6 e 3.14.
 
 99. Changelog
+v2.0.41 — 12/06/2026 — Concluído o fluxo universal de migrations Supabase: merge na `main` aplica migrations automaticamente com gate `true`; SQL Editor excluído do fluxo normal e histórico definido como forward-only, com reversões por nova migration.
+
 v2.0.40 — 12/06/2026 — Retirada a family antecipada `conversion-content` do estado técnico atual; estruturas compartilhadas de conteúdo serão reavaliadas somente após dois casos reais aprovados.
 
 v2.0.39 — 11/06/2026 — Registrado o fluxo canônico de migrations Supabase versionadas, com baseline, incrementais, validação isolada, dry-run obrigatório e workflow mantido sob gate fechado; `supabase/setup-cli` v2.1.1 fixada por SHA completo e CLI `2.106.0`.

--- a/docs/lousa-automations3-6-1.md
+++ b/docs/lousa-automations3-6-1.md
@@ -1,5 +1,7 @@
 # Lousa — 3.6.1 Baseline de migrations no Supabase
 
+> Status final: concluído em 12/06/2026. As seções 1 a 12 preservam o registro histórico da preparação e validação; a seção 13 contém o encerramento definitivo e prevalece sobre estados intermediários.
+
 ## 1) Objetivo da fase baseline
 
 * Extrair o baseline real do banco remoto atual.
@@ -215,3 +217,40 @@ A baseline só pode ser tratada como concluída quando os itens abaixo estiverem
 * escrita remota não autorizada: `supabase db push --linked`
 * escrita remota não autorizada: alteração de `SUPABASE_APPLY_MIGRATIONS_ENABLED`
 * escrita remota não autorizada: execução do workflow de apply ou criação de branch Supabase
+
+## 13) Encerramento definitivo de 12/06/2026
+
+### 13.1 Evidências finais
+
+* `main` confirmada no SHA `9098c1f38b6a6eccf9dab753f9ba55db68f61d2e`
+* migrations ativas e registradas local e remotamente:
+  * `20260611172930_remote_public_baseline.sql`
+  * `20260612143820_migration_workflow_smoke_create.sql`
+  * `20260612221253_migration_workflow_smoke_drop.sql`
+* `supabase migration list --linked`: os três timestamps estão alinhados entre local e remoto
+* `supabase db push --linked --dry-run`: `Remote database is up to date.`
+* `public.migration_workflow_smoke`: ausente após a migration de remoção
+* migration de criação: aplicada automaticamente após merge na `main`
+* migration de remoção: aplicada automaticamente após merge na `main`
+* `SUPABASE_APPLY_MIGRATIONS_ENABLED`: variável de repositório confirmada com valor `true`
+* nenhuma credencial, connection string ou valor de secret foi registrado nesta lousa
+
+### 13.2 Fluxo definitivo
+
+* criar migrations em `supabase/migrations/<timestamp>_<nome>.sql`
+* validar a migration e revisar `migration list --linked` e `db push --linked --dry-run`
+* abrir PR exclusivo e aguardar merge humano na `main`
+* o merge na `main` dispara o apply automático pelo workflow
+* manter `SUPABASE_APPLY_MIGRATIONS_ENABLED = true` no fluxo normal
+* não usar SQL Editor para alterações de schema no fluxo normal
+* não editar, apagar, renomear ou substituir migration já aplicada
+* fazer correções e reversões por nova migration incremental
+
+### 13.3 Conclusão
+
+* baseline oficial: ativa
+* histórico remoto: alinhado
+* legado: preservado fora do fluxo ativo
+* workflow de apply: operacional
+* smoke de criação e remoção: concluído
+* pendências da fase baseline: nenhuma

--- a/docs/platform-config.md
+++ b/docs/platform-config.md
@@ -2,8 +2,8 @@
 
 0.1 Cabeçalho
 • Documento: LP Factory 10 — Platform Config
-• Versão: v0.1.3
-• Data: 11/06/2026
+• Versão: v0.1.4
+• Data: 12/06/2026
 
 0.2 Contrato do documento
 • O QUE É: snapshot operacional e fonte única das configurações de plataformas externas do LP Factory 10, refletindo o estado conhecido/cadastrado nas plataformas conforme indicado.
@@ -39,7 +39,7 @@
 • `MAILBOX_PASSWORD`: senha/app password da mailbox usada por automações de autenticação/mailbox. Consumidores atuais: `automation-validador-final` e `automation-niche-runtime-tests`.
 • `SUPABASE_ACCESS_TOKEN`: token usado pelo workflow de apply de migrations Supabase.
 • `SUPABASE_DB_PASSWORD`: senha do banco usada pelo workflow de apply de migrations Supabase.
-• `SUPABASE_APPLY_MIGRATIONS_ENABLED`: variável de repositório usada como gate operacional; o apply permanece bloqueado quando seu valor é diferente de `true`.
+• `SUPABASE_APPLY_MIGRATIONS_ENABLED`: variável de repositório usada como gate operacional; valor operacional atual `true`.
 • Regra: valores reais de secrets não devem ser versionados.
 • Regra: secrets de mailbox devem existir apenas nos escopos necessários dos workflows que os consomem.
 • Regra: `SUPABASE_DB_URL_READONLY` deve autenticar com role/usuário read-only e usar preferencialmente session pooler.
@@ -51,16 +51,19 @@
 • `.github/workflows/pipeline-docs-apply-report.yml`: aplicação automatizada de reports em documentos Markdown e criação de Pull Request automático.
 • `.github/workflows/automation-validador-final.yml`: validação ponta a ponta de fluxos reais de autenticação, com mailbox operacional via `MAILBOX_EMAIL` e `MAILBOX_PASSWORD`.
 • `.github/workflows/automation-niche-runtime-tests.yml`: testes runtime de criação de conta e preenchimento de `pending_setup`, com mailbox operacional e uso opcional de `SUPABASE_DB_URL_READONLY` conforme modo de verificação.
-• `.github/workflows/pipeline-supabase-apply-migrations.yml`: workflow preparado, mas não liberado, para apply controlado de migrations Supabase.
+• `.github/workflows/pipeline-supabase-apply-migrations.yml`: workflow operacional para apply automático de migrations Supabase versionadas.
 • Gatilhos: push em `main` com mudanças em `supabase/migrations/**` e execução manual por `workflow_dispatch`.
 • Setup: `supabase/setup-cli` v2.1.1 fixada pelo SHA completo `3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf`, com Supabase CLI `2.106.0`.
 • Motivo do pin por SHA: reprodutibilidade e proteção contra alteração futura da referência móvel `@v2`.
-• Gate: `SUPABASE_APPLY_MIGRATIONS_ENABLED` deve permanecer diferente de `true` até autorização operacional específica.
+• Gate: `SUPABASE_APPLY_MIGRATIONS_ENABLED = true` mantém o apply automático liberado no fluxo normal; valor diferente de `true` bloqueia o apply e deve ser usado apenas em incidente ou manutenção.
+• Fluxo normal: criar migration em `supabase/migrations/<timestamp>_<nome>.sql`, validar, abrir PR e fazer merge humano na `main`; o push resultante dispara o apply automático.
+• Regra: não usar SQL Editor para alterações de schema no fluxo normal.
+• Regra: migration aplicada não pode ser editada, apagada, renomeada ou substituída; correções e reversões exigem nova migration.
 • Com o gate fechado, um passo separado sem secrets registra `skipped`; a CLI não é instalada e `supabase link` e `supabase db push` não são executados.
 • `Setup Supabase CLI` e `Apply migrations` possuem condição explícita de gate aberto.
 • Secrets exigidos somente para apply autorizado com gate aberto: `SUPABASE_ACCESS_TOKEN` e `SUPABASE_DB_PASSWORD`, disponíveis apenas no passo `Apply migrations`.
 • Projeto alvo: definido no workflow por `SUPABASE_PROJECT_REF`; o valor não é credencial, mas deve apontar somente para o projeto aprovado.
-• A execução manual do workflow, mesmo com resultado esperado `skipped`, exige autorização explícita enquanto o fluxo não estiver liberado.
+• `workflow_dispatch` é recurso excepcional; o fluxo normal ocorre automaticamente após merge na `main`.
 • `.github/workflows/upgrade-next-16-1-1.yml`: manutenção de Next.js + lockfile.
 
 2.4 Mailbox operacional para automações
@@ -327,6 +330,11 @@
 • Configurações de plataformas, secrets por nome, workflows, ambientes e endpoints usados por automações devem ser registrados neste documento.
 
 99. Changelog
+v0.1.4 (12/06/2026) — Apply automático de migrations Supabase liberado
+• Registrado `SUPABASE_APPLY_MIGRATIONS_ENABLED = true` como estado operacional normal.
+• Consolidado o fluxo PR, merge na `main` e apply automático.
+• Registradas as regras de não uso do SQL Editor e histórico forward-only com reversão por nova migration.
+
 v0.1.3 (11/06/2026) — Workflow de migrations Supabase reproduzível e mantido bloqueado
 • Registrados `supabase/setup-cli` v2.1.1 fixada por SHA completo, Supabase CLI `2.106.0`, gatilhos, secrets e variável de gate do workflow.
 • Documentado que gate fechado usa passo separado sem secrets, sem instalar a CLI nem executar `supabase link` ou `supabase db push`.


### PR DESCRIPTION
## Resumo

- registra o encerramento definitivo da baseline e do smoke operacional de criação/remoção
- define migrations versionadas e forward-only como fluxo canônico
- registra o apply automático após merge na `main` com `SUPABASE_APPLY_MIGRATIONS_ENABLED = true`
- exclui o SQL Editor do fluxo normal e exige nova migration para correções ou reversões
- atualiza o item 3.6 do catálogo de automações para `Implementada e validada` e remove 3.6.1 como item próprio

## Evidências operacionais

- `main`: `9098c1f38b6a6eccf9dab753f9ba55db68f61d2e`
- `migration list --linked`: baseline, criação e remoção alinhadas local/remoto
- `db push --linked --dry-run`: `Remote database is up to date.`
- `public.migration_workflow_smoke`: ausente

## Validação

- `git diff --check`
- `npm ci`
- `npm run check` (0 erros; 24 warnings preexistentes)
- varredura de secrets nas linhas alteradas
- validação textual da remoção do item 3.6.1

## Escopo

- `docs/automations.md`
- `docs/base-tecnica.md`
- `docs/platform-config.md`
- `docs/lousa-automations3-6-1.md`

Nenhuma migration, workflow, secret ou configuração remota foi alterada.