### PR TITLE
docs: atualizar docs/prod-up.md e docs/vercel-up.md

### DIFF
--- a/docs/prod-up.md
+++ b/docs/prod-up.md
@@ -36,17 +36,18 @@ Admins e desenvolvedores podem criar tokens temporários (30/90 dias) no Dashboa
 2025-06-01  
 
 ### Descrição  
-Monitoramento contínuo de Core Web Vitals (LCP, CLS, FID) com dados reais de usuários.  
+Monitoramento de experiência real com LCP, CLS e INP, além de métricas complementares como FCP, TBT e TTFB. O painel consolida os dados no Real Experience Score e permite filtrar resultados por desktop/mobile e por ambiente, incluindo Preview e produção. A disponibilidade, a janela de retenção, o volume de data points e os custos variam conforme o plano Vercel.
 
 ### Valor para o Projeto  
-- Integra métricas da Vercel para diagnósticos de UX.  
+- Integra métricas da Vercel para diagnósticos de UX com recortes por dispositivo e ambiente.
+- Permite comparar o primeiro Preview funcional com produção sem transformar analytics em requisito de entrega.
 
 ### Valor para o Usuário  
-- Experiência mais fluida e responsiva.  
+- Experiência mais fluida, responsiva e visualmente estável.
 
 ### Registro (Tipo A — Plataforma)  
 - Status: DEFERIDO  
-- Observação: não bloquear E10.4.6; ativar após estabilizar onboarding v0/v1. Primeira rota-alvo: E10.4.  
+- Observação: reavaliar na E10.6 após o primeiro Preview funcional; não bloquear a primeira entrega.
 
 ---
 
@@ -76,6 +77,9 @@ Implementa validações automáticas de segurança e governança (CI + Lint) com
 
 ### Valor para o Usuário  
 - Mais estabilidade e confiança no produto.  
+
+### Ações Recomendadas
+1. Na E10.6, usar os checks existentes; não criar nova suíte neste pacote.
 
 ---
 
@@ -246,10 +250,11 @@ Estabelecer diretrizes de UX e roteiros de teste que privilegiem **ações visí
 2. Padronizar layouts iniciais com CTAs claros e seções prioritárias sempre visíveis na primeira dobra.  
 3. Incluir métricas de sucesso específicas em testes (tempo até a primeira ação, ações descobertas sem ajuda, abandono).  
 4. Incorporar essas diretrizes no checklist de UX dos próximos releases (E10, E12, novos dashboards).
+5. Aplicar diretamente na E10.6 à revisão do hero, primeira dobra, cards e CTAs.
 
-   ---
+---
 
-   ## 15 — Automação de Microeventos em LPs *(🧪 Experimental)*
+## 15 — Automação de Microeventos em LPs *(🧪 Experimental)*
 2025-11-17
 
 ### Descrição
@@ -266,11 +271,33 @@ Implementar um fluxo de marketing que detecta microeventos da Landing Page (ex.:
 - Permite otimizar criativos e mensagens por contexto (interesse em preços, FAQ, scroll avançado).
 
 ### Ações Recomendadas
-1. Definir a taxonomia de microeventos (`scroll_25/50/75`, `cta_click`, `faq_open`, `pricing_view`, `form_submit`) e padrão de nomes (`lp.{slug}.{evento}`).
-2. Registrar esses eventos no `events_analytics` e expor função server‑side para enviá‑los a RD Station e Meta (via Camada de Remarketing).
-3. Configurar tags e fluxos no RD: sequências específicas para quem visualizou preços sem converter, abriu FAQ sem clicar, enviou formulário etc.
-4. Criar públicos de remarketing e lookalike em Meta Ads com base nas tags (`pricing_view`, `scroll_75`, `form_submit`), com criativos adaptados.
-5. Medir KPIs essenciais: tempo até primeiro contato, taxa de qualificação (MQL), CPL/CPA por microevento e redução no ciclo de vendas.
+1. Antes de depender de eventos server-side, verificar o plano Vercel/Analytics e definir uma estratégia única de tracking.
+2. Não aplicar esta automação à primeira entrega genérica da E10.6.
+3. Definir a taxonomia de microeventos (`scroll_25/50/75`, `cta_click`, `faq_open`, `pricing_view`, `form_submit`) e padrão de nomes (`lp.{slug}.{evento}`).
+4. Registrar esses eventos no `events_analytics` e expor função server‑side para enviá‑los a RD Station e Meta (via Camada de Remarketing).
+5. Configurar tags e fluxos no RD: sequências específicas para quem visualizou preços sem converter, abriu FAQ sem clicar, enviou formulário etc.
+6. Criar públicos de remarketing e lookalike em Meta Ads com base nas tags (`pricing_view`, `scroll_75`, `form_submit`), com criativos adaptados.
+7. Medir KPIs essenciais: tempo até primeiro contato, taxa de qualificação (MQL), CPL/CPA por microevento e redução no ciclo de vendas.
+
+---
+
+## 16 — QA visual e validação de UX em Preview *(🟩 Prática de validação)*
+2026-06-12
+
+### Descrição
+Prática de produto para revisar páginas em Preview antes da aprovação, usando comentários localizados e inspeções de acessibilidade, foco, timing de interação e layout shift. Os recursos técnicos — Vercel Toolbar, Comments, Accessibility Audit Tool, Interaction Timing Tool e Layout Shift Tool — estão detalhados no `docs/vercel-up.md`.
+
+### Valor para o Projeto
+- Estrutura a revisão da E10.6 em hero, benefícios, serviços, cards, FAQ, CTAs e responsividade.
+- Centraliza feedback visual e de copy no contexto da página, reduzindo prints soltos e retrabalho.
+
+### Valor para o Usuário
+- Aumenta clareza, acessibilidade, estabilidade visual e resposta percebida antes da publicação.
+
+### Ações Recomendadas
+1. Aplicar como prática de validação no Preview da E10.6 após existir uma página funcional.
+2. Usar os recursos disponíveis no ambiente/plano sem criar nova infraestrutura, banco, IA ou experimento A/B.
+3. Manter validação manual de conteúdo, navegação, foco e responsividade como parte da aprovação.
 
 ---
 

--- a/docs/vercel-up.md
+++ b/docs/vercel-up.md
@@ -469,7 +469,7 @@ Ferramenta da Vercel Toolbar para identificar visualmente elementos que causam C
 - Observação: recurso futuro; não recomenda A/B ativo na primeira entrega da E10.6.
 
 ### Descrição
-Conjunto para definir e avaliar flags em código, aplicar targeting, segmentos e splits, controlar rollouts e testar overrides no navegador pelo Flags Explorer. O Explorer está disponível nos planos da plataforma, mas o uso sem assinatura adicional é limitado a 150 aplicações de overrides por mês; overrides ilimitados custam US$ 250/mês em Pro/Enterprise. O Vercel Flags possui cobrança e limites próprios por requisições, flags e segmentos.
+Conjunto para definir e avaliar flags em código, aplicar targeting, segmentos e splits, controlar rollouts e testar overrides no navegador pelo Flags Explorer. O Explorer está disponível nos planos da plataforma, mas o uso sem assinatura adicional é limitado a 150 aplicações de overrides por mês; overrides ilimitados custam US$ 250/mês em Pro/Enterprise. O Vercel Flags e o Flags Explorer possuem limites e custos que devem ser confirmados na documentação oficial e no plano vigente antes de adoção.
 
 ### Valor para o Projeto
 - Pode apoiar rollouts controlados, inspeção de estados e experimentos futuros quando houver hipótese, governança e medição aprovadas.

--- a/docs/vercel-up.md
+++ b/docs/vercel-up.md
@@ -23,20 +23,23 @@
 - Observação: monitoramento de mercado; disponibilidade varia por recurso/plano.
 
 ### Descrição
-Conjunto de capacidades de IA na Vercel com disponibilidade por recurso/plano, incluindo AI Gateway, Fluid Compute com Active CPU pricing, Rolling Releases e BotID.
+Conjunto de capacidades de plataforma com disponibilidade e cobrança próprias por recurso/plano:
+- **AI Gateway:** endpoint unificado para acessar múltiplos modelos, acompanhar uso e orçamento, aplicar balanceamento e fallbacks.
+- **Fluid Compute:** execução de Functions otimizada para concorrência e workloads com espera de I/O, com cobrança que distingue CPU ativa do tempo de espera/memória.
+- **Sandbox:** ambientes Linux efêmeros e isolados para executar código não confiável, scripts gerados por agentes, testes e servidores temporários.
+- **BotID:** proteção invisível contra bots para rotas sensíveis, com validação client-side e verificação server-side.
 
 ### Valor para o Projeto
-- Pode reduzir custo em workloads intermitentes.
-- Pode ampliar segurança/controle de rollout em ciclos de deploy.
-- Cria base para iniciativas IA-ready quando houver caso de uso aprovado.
+- Pode apoiar workloads de IA, execução isolada e proteção de endpoints quando existir um caso de uso aprovado.
+- Permite avaliar custo, segurança e operação por capacidade, sem tratar “AI Cloud” como adoção única ou automática.
 
 ### Valor para o Usuário
-- Potencial de desempenho mais previsível em cargas variáveis.
-- Maior resiliência em mudanças progressivas de release.
+- Benefícios potenciais de resiliência, segurança e desempenho dependem de uma aplicação concreta e validada.
 
 ### Ações Recomendadas
-1. Acompanhar maturidade e requisitos de plano de AI Gateway, Fluid Compute, Rolling Releases e BotID.
-2. Só planejar adoção quando houver caso de uso priorizado no roadmap.
+1. Manter AI Gateway, Fluid Compute, Sandbox e BotID sem adoção no LP Factory 10 enquanto não houver caso aprovado.
+2. Avaliar separadamente requisitos de plano, custos, dados e segurança antes de qualquer implementação.
+3. Não transformar essas capacidades em requisito da primeira entrega da E10.6.
 
 ---
 
@@ -136,10 +139,11 @@ Capacidades de navegação e roteamento do framework evoluídas no ciclo atual d
 - Evidência: inexistência de configuração/adoção explícita no repositório atual (sem registro de uso operacional no roadmap/base técnica).
 
 ### Descrição
-Integração MCP do ecossistema Next.js 16+ para suporte a inspeção e depuração assistida em desenvolvimento.
+Integração MCP do Next.js para conectar agentes ao servidor de desenvolvimento e permitir acesso a erros de build, runtime e tipos, logs do navegador/servidor, metadados de projeto e páginas, rotas, componentes, Server Actions e informações de runtime em tempo real.
 
 ### Valor para o Projeto
-- Pode acelerar diagnóstico técnico quando incorporado ao fluxo de desenvolvimento.
+- Pode acelerar diagnóstico técnico e dar mais contexto aos agentes durante o desenvolvimento.
+- É uma avaliação futura de produtividade técnica, não uma feature de produto.
 
 ### Valor para o Usuário
 - Indiretamente reduz tempo de resolução de incidentes.
@@ -180,17 +184,18 @@ Versão estável do React já usada no stack atual do LP Factory 10.
 - Evidência: não há integração explícita no projeto para fluxo com `updateTag()`/`revalidateTag()` como padrão operacional.
 
 ### Descrição
-APIs do framework para invalidação de cache mais precisa, incluindo `revalidateTag()` e `updateTag()` em cenários específicos.
+APIs do framework para invalidação de cache por tag. `revalidateTag()` deve receber um profile como `"max"` ou `"stale"`, conforme a política desejada; a chamada sem segundo argumento usa o comportamento legado de expiração imediata e está deprecada. `updateTag()` invalida imediatamente para cenários de read-your-own-writes e só pode ser usado em Server Actions.
 
 ### Valor para o Projeto
-- Possibilita atualização pontual de dados sem estratégia global de rebuild.
+- Possibilita atualização pontual de dados sem estratégia global de rebuild, desde que exista cache real e uma política de consistência definida.
 
 ### Valor para o Usuário
 - Pode melhorar frescor de dados em áreas com atualização frequente.
 
 ### Ações Recomendadas
-1. Mapear casos reais que se beneficiem de invalidação por tag.
-2. Adotar apenas com critérios de consistência e observabilidade definidos.
+1. Manter sem adoção no projeto até existir cache real que justifique invalidação por tag.
+2. Ao adotar, escolher explicitamente o profile de `revalidateTag()` e reservar `updateTag()` a Server Actions que exijam atualização imediata.
+3. Não introduzir cache dinâmico na primeira entrega da E10.6.
 
 ---
 
@@ -225,7 +230,7 @@ No ciclo atual do Next.js, `middleware.ts` foi substituído/deprecado em favor d
 - Observação: visibilidade disponível para clientes; profundidade de métricas pode variar conforme plano/Observability Plus.
 
 ### Descrição
-Painel de Observability da Vercel com visibilidade de tráfego, incluindo rotas com redirects/rewrites.
+Painel de Observability da Vercel com métricas básicas de redirects e rewrites disponíveis nos planos da plataforma. Em Pro/Enterprise, o Observability Plus acrescenta métricas avançadas, como latência de conexão, recortes por origem/destino e rotas de destino do redirect. Logs de runtime estão disponíveis no dashboard; exportação por Drains, inclusive de redirects e rewrites, é um recurso de Pro/Enterprise e pode ter cobrança própria.
 
 ### Valor para o Projeto
 - Diagnóstico mais rápido de comportamento de rotas e latência.
@@ -234,8 +239,8 @@ Painel de Observability da Vercel com visibilidade de tráfego, incluindo rotas 
 - Maior consistência de navegação com monitoramento contínuo.
 
 ### Ações Recomendadas
-1. Manter validações periódicas em smoke de preview para rotas críticas.
-2. Evoluir alertas de latência conforme maturidade de observabilidade do time.
+1. Manter validações periódicas em smoke de Preview para rotas críticas usando as métricas básicas já disponíveis.
+2. Avaliar Observability Plus, logs e Drains apenas se a necessidade operacional justificar plano, retenção e custo adicionais.
 
 ### Registro (Tipo A — Plataforma)
 - Status: OK
@@ -252,10 +257,10 @@ Painel de Observability da Vercel com visibilidade de tráfego, incluindo rotas 
 ### Status no Projeto
 - Status: Não implementado
 - Evidência: roadmap/base técnica registram tracking interno em planejamento, sem adoção explícita de `@vercel/analytics/server` no projeto.
-- Observação: custom events server-side dependem de disponibilidade/plano (tipicamente Pro/Enterprise).
+- Observação: custom events server-side estão disponíveis em planos Pro/Enterprise.
 
 ### Descrição
-Capacidade de envio de eventos customizados server-side via stack de analytics da Vercel, sem depender apenas de eventos client-side.
+Capacidade de envio de eventos customizados server-side via `@vercel/analytics/server`, sem depender apenas de eventos client-side. Requer `@vercel/analytics >= 1.1.0`; em deploy protegido, a requisição de tracking pode exigir `VERCEL_AUTOMATION_BYPASS_SECRET` ou configuração equivalente de bypass para alcançar o endpoint de coleta.
 
 ### Valor para o Projeto
 - Pode melhorar confiabilidade de telemetria em fluxos sensíveis.
@@ -264,8 +269,9 @@ Capacidade de envio de eventos customizados server-side via stack de analytics d
 - Melhora indireta na qualidade de produto por decisões guiadas por eventos mais consistentes.
 
 ### Ações Recomendadas
-1. Avaliar desenho de eventos server-side alinhado ao modelo de observabilidade interno.
-2. Evitar pressupor integração nativa pronta com APIs de Ads sem fonte oficial específica.
+1. Não adotar na primeira entrega da E10.6.
+2. Antes de implementar, confirmar plano Pro/Enterprise, versão do pacote, proteção do deploy e estratégia única de tracking.
+3. Evitar pressupor integração nativa pronta com APIs de Ads sem fonte oficial específica.
 
 ---
 
@@ -278,7 +284,7 @@ Capacidade de envio de eventos customizados server-side via stack de analytics d
 - Observação: Duplicado / Superado por item mais novo (manter referência no `#1`).
 
 ### Descrição
-Duplicado do item 1.
+Item deprecado por ser duplicado e ter sido superado pelo detalhamento consolidado no `vercel#1`.
 
 ---
 
@@ -343,5 +349,137 @@ Configuração opcional da Vercel para permitir uso de código e chats de agente
 - Ambiente: Vercel Team/Project Settings / Data Preferences
 - Evidência: —
 - Observação: tratar como decisão consciente de governança; não como feature de produto.
+
+---
+
+## 15 — Vercel Toolbar *(🟩 Disponível na plataforma)*
+2026-06-12
+
+### Status no Projeto
+- Status: Não implementado
+- Evidência: não há configuração ou registro local que comprove adoção operacional no LP Factory 10.
+- Observação: avaliar como hub técnico/operacional de Preview, sem tratá-lo como feature do produto.
+
+### Descrição
+Hub de inspeção e colaboração em deployments que centraliza Comments, Accessibility Audit Tool, Interaction Timing Tool, Layout Shift Tool, Flags Explorer e outras ferramentas de navegação e revisão.
+
+### Valor para o Projeto
+- Reúne validações de Preview no contexto da página e reduz a dispersão entre feedback, inspeção e dashboard.
+
+### Valor para o Usuário
+- Contribui indiretamente para páginas mais claras, acessíveis, estáveis e responsivas antes da publicação.
+
+### Ações Recomendadas
+1. Avaliar após existir o primeiro Preview funcional da E10.6.
+2. Usar como prática operacional, sem criar nova infraestrutura.
+
+---
+
+## 16 — Vercel Comments *(🟩 Disponível na plataforma)*
+2026-06-12
+
+### Status no Projeto
+- Status: Não implementado
+- Evidência: não há registro local de Comments habilitado ou adotado no fluxo de aprovação.
+
+### Descrição
+Feedback localizado diretamente em deployments de Preview, associado ao ponto visual revisado e compartilhável com o time.
+
+### Valor para o Projeto
+- Facilita revisão visual e alinhamento de design/copy sem depender de prints soltos.
+
+### Valor para o Usuário
+- Reduz ambiguidades e retrabalho na correção de conteúdo e interface antes da publicação.
+
+### Ações Recomendadas
+1. Avaliar para validação operacional do Preview da E10.6, sem torná-lo bloqueio da primeira entrega.
+
+---
+
+## 17 — Accessibility Audit Tool *(🟩 Disponível na plataforma)*
+2026-06-12
+
+### Status no Projeto
+- Status: Não implementado
+- Evidência: não há registro local de uso da ferramenta no fluxo de QA.
+
+### Descrição
+Ferramenta da Vercel Toolbar para checar regras de acessibilidade, incluindo WCAG, contraste, semântica e estados de foco no contexto da página.
+
+### Valor para o Projeto
+- Apoia QA de páginas antes da aprovação e ajuda a localizar problemas diretamente no Preview.
+
+### Valor para o Usuário
+- Melhora legibilidade, navegação por teclado e compreensão da interface.
+
+### Ações Recomendadas
+1. Usar como apoio à revisão da E10.6 quando disponível no ambiente/plano.
+2. Não substituir validação manual de teclado, foco, conteúdo e tecnologias assistivas.
+
+---
+
+## 18 — Interaction Timing Tool *(🟩 Disponível na plataforma)*
+2026-06-12
+
+### Status no Projeto
+- Status: Não implementado
+- Evidência: não há registro local de uso da ferramenta no fluxo de QA.
+
+### Descrição
+Ferramenta da Vercel Toolbar para inspecionar a latência de cada interação da sessão e apoiar a análise de INP.
+
+### Valor para o Projeto
+- Ajuda a revisar CTAs, FAQ, cards e outros componentes interativos no Preview.
+
+### Valor para o Usuário
+- Favorece respostas mais rápidas e previsíveis após cliques, toques e comandos de teclado.
+
+### Ações Recomendadas
+1. Aplicar como diagnóstico no Preview funcional, sem converter analytics em requisito da primeira entrega da E10.6.
+
+---
+
+## 19 — Layout Shift Tool *(🟩 Disponível na plataforma)*
+2026-06-12
+
+### Status no Projeto
+- Status: Não implementado
+- Evidência: não há registro local de uso da ferramenta no fluxo de QA.
+
+### Descrição
+Ferramenta da Vercel Toolbar para identificar visualmente elementos que causam CLS e deslocamentos de layout durante a sessão.
+
+### Valor para o Projeto
+- Apoia a revisão de hero, imagens, fontes, cards, FAQ e responsividade.
+
+### Valor para o Usuário
+- Reduz mudanças inesperadas de posição que prejudicam leitura e interação.
+
+### Ações Recomendadas
+1. Usar no QA do Preview quando disponível, mantendo inspeção manual em diferentes larguras de tela.
+
+---
+
+## 20 — Vercel Flags / Flags SDK / Flags Explorer *(🟨 Avaliação futura)*
+2026-06-12
+
+### Status no Projeto
+- Status: Não implementado
+- Evidência: não há flags, SDK, provider ou configuração do Flags Explorer registrados como adoção no LP Factory 10.
+- Observação: recurso futuro; não recomenda A/B ativo na primeira entrega da E10.6.
+
+### Descrição
+Conjunto para definir e avaliar flags em código, aplicar targeting, segmentos e splits, controlar rollouts e testar overrides no navegador pelo Flags Explorer. O Explorer está disponível nos planos da plataforma, mas o uso sem assinatura adicional é limitado a 150 aplicações de overrides por mês; overrides ilimitados custam US$ 250/mês em Pro/Enterprise. O Vercel Flags possui cobrança e limites próprios por requisições, flags e segmentos.
+
+### Valor para o Projeto
+- Pode apoiar rollouts controlados, inspeção de estados e experimentos futuros quando houver hipótese, governança e medição aprovadas.
+
+### Valor para o Usuário
+- Pode reduzir risco de lançamentos futuros ao permitir exposição gradual e segmentada.
+
+### Ações Recomendadas
+1. Manter como avaliação futura e separar decisão de provider, SDK, Flags Explorer e experimentação.
+2. Antes de adotar, validar limites, custos, targeting, privacidade, estratégia de medição e processo de remoção de flags.
+3. Não implementar A/B, splits ou infraestrutura de flags na primeira entrega da E10.6.
 
 ---


### PR DESCRIPTION
### Motivation
- Atualizar os catálogos documentais para refletir o estado atual das capacidades da Vercel, Next.js e React conforme o relatório de auditoria, sem ampliar o escopo da E10.6. 
- Separar claramente preocupação de produto (UX/validação) em `prod-up` e detalhes técnicos/operacionais em `vercel-up`. 
- Registrar dependências por plano, limitações operacionais e evitar indicar adoção no projeto sem evidência local. 

### Description
- Atualizei `prod#3 — Speed Insights` para substituir FID por INP, incluir LCP/CLS/INP (e FCP/TBT/TTFB), mencionar o Real Experience Score, filtros por desktop/mobile e ambiente (Preview/produção) e reavaliação na E10.6 sem bloquear entrega. 
- Ajustei `prod#5` com nota de uso dos checks existentes, acrescentei contexto em `prod#14` sobre priorização do hero/primeira dobra/cards e atualizei `prod#15` para exigir verificação de plano Vercel/Analytics e estratégia única de tracking antes de depender de eventos server-side; adicionei `prod#16 — QA visual e validação de UX em Preview` com referência curta às ferramentas técnicas. 
- No `docs/vercel-up.md` detalhei `vercel#1` (AI Gateway, Fluid Compute, Sandbox, BotID) mantendo status não implementado, refinei `vercel#6` (DevTools MCP) e `vercel#8` (com `revalidateTag()` profiles, depreciação de chamada sem argumento e `updateTag()` restrito a Server Actions), e atualizei `vercel#10`/`vercel#11` com diferenças por plano, Observability Plus, logs/Drains e requisitos de `@vercel/analytics >= 1.1.0` e bypass em deploys protegidos. 
- Mantive `vercel#12` como deprecado/duplicado, e adicionei novos itens técnicos não implementados: Vercel Toolbar, Vercel Comments, Accessibility Audit Tool, Interaction Timing Tool, Layout Shift Tool e Vercel Flags / Flags SDK / Flags Explorer (incluindo nota de limites/custos de overrides). 
- Arquivos alterados: `docs/prod-up.md` e `docs/vercel-up.md`. 

### Testing
- Executadas assertions documentais que confirmaram a presença dos termos obrigatórios, referências curtas em `prod-up` e ausência de declaração de implementação nos novos itens, e todas passaram com sucesso. 
- Executados cheques de escopo que confirmaram que apenas `docs/prod-up.md` e `docs/vercel-up.md` foram modificados e que `docs/roadmap.md` permaneceu inalterado, com sucesso. 
- Foi rodado um `diff --check` para detectar problemas de formatação/trailing whitespace e as ocorrências encontradas foram corrigidas; verificação final passou. 
- `npm ci` e `npm run check` não foram executados porque a alteração é exclusivamente documental e ambas foram consideradas não aplicáveis.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c974058088329b0a828611c9ea96c)