### PR TITLE
docs: alinhar prompts do Executor ao fluxo canônico de migrations

### DIFF
--- a/docs/prompt-codex-app-executor.md
+++ b/docs/prompt-codex-app-executor.md
@@ -35,12 +35,13 @@ Examinar, conforme aplicavel:
 
 Se houver impacto visual/frontend, usar tambem `docs/template-briefing-codex-frontend.md`.
 
-Quando houver BD, usar `docs/schema.md` como fonte inicial e investigar o BD real somente se os documentos canonicos forem insuficientes.
+Quando houver BD:
 
-- quando o Codex App tiver o Supabase Plugin disponivel, usa-lo como caminho preferencial em teste para investigacao read-only de BD;
-- limitar a investigacao aos metadados necessarios ao caso: schema, tabelas, colunas, PKs, FKs, RLS/policies, views, functions, indices, extensoes e migrations;
-- nao usar o plugin para SQL de escrita, DDL/DML, migrations, deploy de Edge Functions, operacoes de branches Supabase, pause/restore, acesso a secrets ou objetos sensiveis;
-- se o plugin nao estiver disponivel, for insuficiente ou houver necessidade de artefato auditavel, manter o fluxo de SQLs read-only para Supabase Inspect, pronto para execucao e limitado ao objetivo do caso.
+* usar primeiro o Supabase Plugin para investigação read-only do estado real;
+* consultar `docs/schema.md` como referência canônica e verificar divergências relevantes;
+* limitar a investigação ao necessário para o caso;
+* não usar o plugin para escrita, migrations, secrets ou operações administrativas;
+* se o plugin estiver indisponível, falhar ou for insuficiente, entregar SQLs read-only para execução pelo Supabase Inspect.
 
 ### Formato dos SQLs de inspecao
 

--- a/docs/prompt-codex-app-executor.md
+++ b/docs/prompt-codex-app-executor.md
@@ -31,7 +31,7 @@ Examinar, conforme aplicavel:
 - `docs/schema.md`, quando houver impacto ou dependencia de BD;
 - documentos citados no plano-base;
 - arquivos, rotas, componentes, servicos, testes, contratos e padroes relacionados;
-- riscos de regressao, migrations e rollbacks relacionados.
+- riscos de regressao, migrations e correcoes incrementais relacionadas.
 
 Se houver impacto visual/frontend, usar tambem `docs/template-briefing-codex-frontend.md`.
 
@@ -77,13 +77,15 @@ Evitar refatoracao ampla, alteracoes nao relacionadas ou remocao de comportament
 
 ## 6. Etapa 4 - Supabase e migrations
 
-Quando houver alteracao de BD:
+Quando houver alteracao de schema:
 
-- entregar SQL de implementacao quando a execucao depender do Gestor/Supabase;
-- criar migration historica e rollback quando o caso exigir alteracao versionada;
-- seguir os padroes vigentes em `supabase/migrations/` e `supabase/rollbacks/`;
-- nao tratar SQL avulso como substituto da migration historica final;
-- considerar a migration pronta somente apos validacao suficiente ou confirmacao humana, quando depender de ambiente externo.
+- criar diretamente a migration canonica em `supabase/migrations/<timestamp>_<nome>.sql`, seguindo `docs/base-tecnica.md` e `docs/platform-config.md`;
+- usar SQL avulso somente para inspecao, verificacao read-only ou excecao expressamente autorizada; nao usar o SQL Editor como fluxo normal;
+- nao tratar `supabase/rollbacks/` como entrega obrigatoria;
+- nao executar `supabase db push` real manualmente fora do workflow;
+- antes do PR, quando aplicavel e autorizado, registrar `supabase migration list --linked` e `supabase db push --linked --dry-run`;
+- manter migration aplicada imutavel e fazer correcao ou reversao por nova migration incremental;
+- entregar a migration em PR exclusivo para merge humano na `main`, que dispara o apply automatico pelo workflow.
 
 ## 7. Etapa 5 - Observability
 
@@ -131,7 +133,8 @@ Registrar apenas o que efetivamente ocorreu, usando N/A quando nao se aplicar.
 
 - Estruturas de BD: [resumo] | N/A
 - Arquivos criados/ajustados: [paths] | N/A
-- SQL, migration e rollback: [paths/resumo] | N/A
+- SQL de inspecao ou excecao autorizada: [resumo] | N/A
+- Migration, validacao e evidencia: [path/resumo] | N/A
 
 ### Validacao
 

--- a/docs/prompt-codex-app-executor.md
+++ b/docs/prompt-codex-app-executor.md
@@ -133,8 +133,7 @@ Registrar apenas o que efetivamente ocorreu, usando N/A quando nao se aplicar.
 
 - Estruturas de BD: [resumo] | N/A
 - Arquivos criados/ajustados: [paths] | N/A
-- SQL de inspecao ou excecao autorizada: [resumo] | N/A
-- Migration, validacao e evidencia: [path/resumo] | N/A
+- SQL de inspecao, migration, validacao e evidencia: [paths/resumo] | N/A
 
 ### Validacao
 

--- a/docs/prompt-executor.md
+++ b/docs/prompt-executor.md
@@ -47,7 +47,7 @@ Registrar a observability mínima compatível com o caso, quando aplicável.
 Definir QA, smoke e a evidência funcional esperada. A execução deve ser iniciada por humanos; analisar os resultados retornados e só marcar o caso funcionando com confirmação humana ou evidência objetiva.
 
 ## Etapa 6 — Relatório final
-Registrar apenas o que ocorreu, manter os rótulos abaixo e marcar `N/A` quando não se aplicar. Em “Arquivos ajustados”, listar somente arquivos preexistentes; arquivos criados pertencem apenas a “Arquivos criados”. Em alteração de schema, registrar a migration, a validação e a evidência, sem tratar SQL manual como fluxo normal.
+Registrar apenas o que ocorreu, manter os rótulos abaixo e marcar `N/A` quando não se aplicar. Em “Arquivos ajustados”, listar somente arquivos preexistentes; arquivos criados pertencem apenas a “Arquivos criados”. Em alteração de banco, registrar a migration, a validação e a evidência, sem tratar SQL manual como fluxo normal.
 
 ### Implementado / Definido
 - [1–5 bullets]

--- a/docs/prompt-executor.md
+++ b/docs/prompt-executor.md
@@ -46,13 +46,8 @@ Registrar a observability mínima compatível com o caso, quando aplicável.
 ## Etapa 5 — Testes
 Definir QA, smoke e a evidência funcional esperada. A execução deve ser iniciada por humanos; analisar os resultados retornados e só marcar o caso funcionando com confirmação humana ou evidência objetiva.
 
-## Etapa 6 — Migration
-Quando houver alteração de schema, criar a migration canônica em `supabase/migrations/<timestamp>_<nome>.sql`, seguindo `docs/base-tecnica.md`, `docs/platform-config.md` e o padrão vigente do diretório. A entrega deve seguir em PR exclusivo para merge humano na `main`; o apply remoto ocorre automaticamente pelo workflow.
-
-Migration aplicada é imutável. Correção ou reversão deve ser feita por nova migration incremental, sem rollback obrigatório ou `db push` real executado manualmente pelo Executor fora do workflow.
-
-## Etapa 7 — Relatório final
-Registrar apenas o que ocorreu, manter os rótulos abaixo e marcar `N/A` quando não se aplicar. Em “Arquivos ajustados”, listar somente arquivos preexistentes; arquivos criados pertencem apenas a “Arquivos criados”. Em alteração de schema, entregar o relatório somente após a Etapa 6 e registrar a migration, a validação e a evidência, sem tratar SQL manual como fluxo normal.
+## Etapa 6 — Relatório final
+Registrar apenas o que ocorreu, manter os rótulos abaixo e marcar `N/A` quando não se aplicar. Em “Arquivos ajustados”, listar somente arquivos preexistentes; arquivos criados pertencem apenas a “Arquivos criados”. Em alteração de schema, registrar a migration, a validação e a evidência, sem tratar SQL manual como fluxo normal.
 
 ### Implementado / Definido
 - [1–5 bullets]

--- a/docs/prompt-executor.md
+++ b/docs/prompt-executor.md
@@ -32,13 +32,13 @@ Consolidar, com base no plano-base e nas investigações:
 Em conflito aparente entre investigação e plano-base, preservar o objetivo explícito do plano-base, salvo evidência concreta em contrário.
 
 ## Etapa 3 — Entregas de implementação
-Entregar apenas o artefato aplicável, limpo para copiar e colar, sem introdução, explicações, observações ou pergunta para continuar.
+Entregar somente os artefatos exigidos pelo caso, prontos para uso, sem introdução, explicações, observações ou pergunta para continuar.
 
 ### Briefing para Codex
 Usar `docs/template-briefing-codex.md` com base no plano de implementação. Quando houver impacto visual, UI, rota, tela, componente, responsividade ou design system, usar também `docs/template-briefing-codex-frontend.md`. Não duplicar regras do `AGENTS.md`.
 
 ### Implementação no Supabase
-Quando houver alteração de schema, entregar diretamente a migration versionada em `supabase/migrations/<timestamp>_<nome>.sql`. SQL avulso só pode ser usado para inspeção, verificação read-only ou exceção expressamente autorizada; o SQL Editor não faz parte do fluxo normal.
+Quando houver alteração de banco, a implementação deve ser feita diretamente por migration versionada em `supabase/migrations/<timestamp>_<nome>.sql`. SQL avulso só pode ser usado para inspeção, verificação read-only ou exceção expressamente autorizada; o SQL Editor não faz parte do fluxo normal.
 
 ## Etapa 4 — Observability
 Registrar a observability mínima compatível com o caso, quando aplicável.

--- a/docs/prompt-executor.md
+++ b/docs/prompt-executor.md
@@ -38,7 +38,7 @@ Entregar apenas o artefato aplicável, limpo para copiar e colar, sem introduç�
 Usar `docs/template-briefing-codex.md` com base no plano de implementação. Quando houver impacto visual, UI, rota, tela, componente, responsividade ou design system, usar também `docs/template-briefing-codex-frontend.md`. Não duplicar regras do `AGENTS.md`.
 
 ### Implementação no Supabase
-Quando houver alteração de BD, entregar apenas os SQLs de implementação. Esse SQL não substitui a migration histórica final nem o rollback da Etapa 6.
+Quando houver alteração de schema, entregar diretamente a migration versionada em `supabase/migrations/<timestamp>_<nome>.sql`. SQL avulso só pode ser usado para inspeção, verificação read-only ou exceção expressamente autorizada; o SQL Editor não faz parte do fluxo normal.
 
 ## Etapa 4 — Observability
 Registrar a observability mínima compatível com o caso, quando aplicável.
@@ -47,12 +47,12 @@ Registrar a observability mínima compatível com o caso, quando aplicável.
 Definir QA, smoke e a evidência funcional esperada. A execução deve ser iniciada por humanos; analisar os resultados retornados e só marcar o caso funcionando com confirmação humana ou evidência objetiva.
 
 ## Etapa 6 — Migration
-Quando houver alteração de BD, gerar migration e rollback após a validação dos testes e antes do relatório final. Inspecionar antes `supabase/migrations/` e `supabase/rollbacks/` para seguir o padrão vigente de naming, cabeçalho, estrutura e idempotência.
+Quando houver alteração de schema, criar a migration canônica em `supabase/migrations/<timestamp>_<nome>.sql`, seguindo `docs/base-tecnica.md`, `docs/platform-config.md` e o padrão vigente do diretório. A entrega deve seguir em PR exclusivo para merge humano na `main`; o apply remoto ocorre automaticamente pelo workflow.
 
-Entregar migration e rollback juntos, com path completo, nome e conteúdo. O rollback é um artefato e não deve ser orientado para execução sem pedido explícito.
+Migration aplicada é imutável. Correção ou reversão deve ser feita por nova migration incremental, sem rollback obrigatório ou `db push` real executado manualmente pelo Executor fora do workflow.
 
 ## Etapa 7 — Relatório final
-Registrar apenas o que ocorreu, manter os rótulos abaixo e marcar `N/A` quando não se aplicar. Em “Arquivos ajustados”, listar somente arquivos preexistentes; arquivos criados pertencem apenas a “Arquivos criados”. Em alteração de BD, entregar o relatório somente após a Etapa 6 e registrar migration e rollback.
+Registrar apenas o que ocorreu, manter os rótulos abaixo e marcar `N/A` quando não se aplicar. Em “Arquivos ajustados”, listar somente arquivos preexistentes; arquivos criados pertencem apenas a “Arquivos criados”. Em alteração de schema, entregar o relatório somente após a Etapa 6 e registrar a migration, a validação e a evidência, sem tratar SQL manual como fluxo normal.
 
 ### Implementado / Definido
 - [1–5 bullets]
@@ -75,9 +75,9 @@ Registrar apenas o que ocorreu, manter os rótulos abaixo e marcar `N/A` quando 
 ### Artefatos
 - Arquivos criados: [paths] | N/A
 - Arquivos ajustados: [paths] | N/A
-- SQL de implementação: sim | não | N/A
+- SQL de inspeção ou exceção autorizada: [resumo] | N/A
 - Migration: [path] | N/A
-- Rollback: [path] | N/A
+- Validação e evidência da migration: [resumo] | N/A
 ### Pendências
 - [bullets] | N/A
 ### Sugestões de novos casos


### PR DESCRIPTION
### Motivation

- Atualizar os prompts do Executor para refletir o fluxo canônico já validado de migrations Supabase: migration versionada → PR exclusivo → merge humano na main → apply automático pelo workflow.
- Remover diretrizes antigas que sugeriam entrega de SQL avulso como implementação normal, criação de migration histórica posterior e rollback obrigatório.

### Description

- Ajusta `docs/prompt-executor.md` para exigir que alterações de schema sejam entregues como migration versionada em `supabase/migrations/<timestamp>_<nome>.sql`, limitar SQL avulso a inspeção/read-only ou exceção autorizada, proibir o SQL Editor no fluxo normal e declarar que correções/reversões são novas migrations incrementais; registra migration, validação e evidência no relatório final.
- Ajusta `docs/prompt-codex-app-executor.md` para criar a migration canônica diretamente, seguir `docs/base-tecnica.md` e `docs/platform-config.md`, não tratar `supabase/rollbacks/` como entrega obrigatória, proibir execução manual de `supabase db push` fora do workflow e recomendar `supabase migration list --linked` e `supabase db push --linked --dry-run` antes do PR quando aplicável.
- Separa explicitamente no relatório os artefatos de SQL de inspeção/exceção autorizada das migrations, validação e evidência.
- Alterações restritas aos dois arquivos de prompt indicados; nenhuma alteração em `AGENTS.md`, workflows, migrations, secrets ou outros arquivos foi feita.

### Testing

- Executado `npm run check`, que completou com exit code 0 (lint retornou 24 warnings preexistentes e nenhum erro; typecheck passou).
- Verificação textual automatizada para padrões antigos (busca por instruções incompatíveis como “entregar apenas os SQLs de implementação”, “rollback obrigatório”, etc.) retornou nenhuma ocorrência.
- Verificação automatizada de presença das regras canônicas (ex.: `supabase/migrations/<timestamp>_<nome>.sql`, `SQL Editor`, `nova migration incremental`, `db push --linked --dry-run`, `PR exclusivo`, `merge humano`) confirmou as inserções esperadas nos prompts.
- `git diff --check` e checagem de diff escopado não mostraram problemas de formatação e limitaram o escopo às duas arquivos modificados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d3aec22548329994909c844405c24)