### PR TITLE
docs: padroniza identificadores de referência em supa-up e vercel-up

### DIFF
--- a/docs/supa-up.md
+++ b/docs/supa-up.md
@@ -11,6 +11,12 @@
 
 ---
 
+## Convenção de referência
+
+O identificador canônico dos itens deste catálogo é `supa#n`.
+
+Esse identificador deve ser usado no roadmap, Base Técnica, briefings, relatórios e referências cruzadas. A numeração não deve ser reutilizada após remoção, depreciação ou substituição de um item.
+
 ## 1 — JWT Signing Keys *(🟦 Estável)*  
 
 2025-08-01  

--- a/docs/vercel-up.md
+++ b/docs/vercel-up.md
@@ -14,6 +14,12 @@
 
 ---
 
+## Convenção de referência
+
+O identificador canônico dos itens deste catálogo é `vercel#n`.
+
+Esse identificador deve ser usado no roadmap, Base Técnica, briefings, relatórios e referências cruzadas. A numeração não deve ser reutilizada após remoção, depreciação ou substituição de um item.
+
 ## 1 — Vercel AI Cloud *(🟨 Disponibilidade por recurso/plano)*
 2025-06-30
 


### PR DESCRIPTION
### Motivation

- Formalizar a convenção de referências usada nos catálogos existentes adicionando as seções que declaram `supa#n` e `vercel#n` como identificadores canônicos e proibindo a reutilização de números após remoção, depreciação ou substituição.
- Preservar integralmente a numeração, títulos, itens e status existentes sem renumerar ou alterar conteúdo pré-existente.

### Description

- Inserção da seção "Convenção de referência" em `docs/supa-up.md` imediatamente após a convenção de status e antes do item 1, declarando `supa#n` como identificador canônico e proibindo a reutilização de números. 
- Inserção da seção "Convenção de referência" em `docs/vercel-up.md` imediatamente após a convenção de leitura e antes do item 1, declarando `vercel#n` como identificador canônico e proibindo a reutilização de números. 
- Alterações limitadas somente a `docs/supa-up.md` e `docs/vercel-up.md` na branch `codex/padronizar-identificadores-updates` com commit `3bdd370` e PR criado com o título `docs: padroniza identificadores de referência` (sem URL de PR disponível no ambiente por falta de remote configurado). 

### Testing

- Executado script Python que comparou os arquivos atuais com `HEAD` e confirmou que cada documento difere do original apenas pelo bloco de convenção solicitado, e o script retornou OK. 
- Executados `git diff --name-only`, `git diff --check`, `git diff-tree --no-commit-id --name-only -r HEAD` e `git status --short --branch`, todos confirmando que apenas `docs/supa-up.md` e `docs/vercel-up.md` foram modificados e sem erros. 
- `npm ci` e `npm run check` não foram executados por se tratar de alteração exclusivamente documental e foram considerados não aplicáveis.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d49c93b288329b213aaf3e0f3d06a)