### PR TITLE
docs: add GitHub updates catalog (docs/github-up.md)

### DIFF
--- a/docs/github-up.md
+++ b/docs/github-up.md
@@ -1,0 +1,24 @@
+# LP Factory 10 — GitHub Updates
+
+Este documento registra recursos oficiais do GitHub com valor concreto para desenvolvimento, segurança, automação e governança do LP Factory 10.
+
+Fontes prioritárias: GitHub Docs, GitHub Changelog e GitHub Blog.
+
+Escopo principal:
+
+* Actions, workflows, checks e artefatos;
+* branches, PRs, reviews e releases;
+* Models, Copilot, Apps, OAuth e Codespaces;
+* Dependabot, secret scanning e code scanning.
+
+Recursos específicos de Supabase, Vercel, produto ou agentes permanecem nos respectivos catálogos, com referência curta quando necessário.
+
+O estado da plataforma deve ser separado do estado no projeto: `Não implementado`, `Em implementação por casos de uso` ou `Implementado globalmente no projeto`.
+
+Identificador canônico: `github#n`. A numeração não deve ser reutilizada.
+
+Antes de registrar um item, confirmar fonte oficial, valor para o projeto, plano, limites, dependências e evidência de implementação.
+
+## Updates registrados
+
+Nenhum update registrado nesta criação inicial.


### PR DESCRIPTION
### Motivation

- Centralizar e padronizar um catálogo de novidades oficiais do GitHub para orientar decisões de desenvolvimento, segurança, automação e governança no projeto, incluindo a definição do identificador canônico sem registrar updates numerados nesta etapa.

### Description

- Adiciona `docs/github-up.md` contendo introdução, fontes prioritárias, escopo, fronteiras com outros catálogos, estados de implementação e o identificador canônico `github#n`, sem incluir entradas numeradas.

### Testing

- Executadas validações de repositório (checagem de diff e status) e buscas de padrão que confirmaram a presença do identificador canônico e a ausência de updates numerados; `npm ci` e `npm run check` foram marcados como não aplicáveis.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d559ecac88329beba50450f2c50ca)