### PR TITLE
docs: require ABC prompt for DOC_ALVO-covered documents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 * Para execução no Codex App, usar `docs/prompt-codex-app-executor.md`.
 * Para impacto visual/frontend, usar também `docs/template-briefing-codex-frontend.md`.
 * Para estado, decisões e aprendizados sobre Codex, usar `docs/gestor-codex.md`.
+* Ao criar ou ajustar documentos cobertos pelo `DOC_ALVO`, usar obrigatoriamente `docs/prompt-abc.md` para definir residência, escopo e conteúdo permitido.
 
 ## Regra geral de execução
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 * Para execução no Codex App, usar `docs/prompt-codex-app-executor.md`.
 * Para impacto visual/frontend, usar também `docs/template-briefing-codex-frontend.md`.
 * Para estado, decisões e aprendizados sobre Codex, usar `docs/gestor-codex.md`.
-* Ao criar ou ajustar documentos cobertos pelo `DOC_ALVO`, usar obrigatoriamente `docs/prompt-abc.md` para definir residência, escopo e conteúdo permitido.
+* Ao consolidar o estado final ou ajustar conteúdo canônico dos documentos cobertos pelo `DOC_ALVO`, usar obrigatoriamente `docs/prompt-abc.md` para definir residência, escopo e conteúdo permitido. No `docs/roadmap.md`, casos em planejamento ou andamento podem manter debates, alternativas, planejamento, trabalho em execução, faltas e próximos passos; ao serem implementados ou concluídos, devem ser consolidados conforme o prompt ABC.
 
 ## Regra geral de execução
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,8 @@
 * Para execução no Codex App, usar `docs/prompt-codex-app-executor.md`.
 * Para impacto visual/frontend, usar também `docs/template-briefing-codex-frontend.md`.
 * Para estado, decisões e aprendizados sobre Codex, usar `docs/gestor-codex.md`.
-* Ao consolidar o estado final ou ajustar conteúdo canônico dos documentos cobertos pelo `DOC_ALVO`, usar obrigatoriamente `docs/prompt-abc.md` para definir residência, escopo e conteúdo permitido. No `docs/roadmap.md`, casos em planejamento ou andamento podem manter debates, alternativas, planejamento, trabalho em execução, faltas e próximos passos; ao serem implementados ou concluídos, devem ser consolidados conforme o prompt ABC.
+* Ao consolidar conteúdo canônico dos documentos cobertos pelo `DOC_ALVO`, usar `docs/prompt-abc.md` para definir residência, escopo e conteúdo permitido.
+* Em `docs/roadmap.md`, casos em planejamento ou andamento podem manter planejamento, decisões provisórias, trabalho em execução, faltas e próximos passos. Nessa fase, não alterar cabeçalho, versão ou changelog e não marcar como implementado ou concluído. Ao concluir ou incorporar a implementação à `main`, consolidar o caso conforme `docs/prompt-abc.md`.
 
 ## Regra geral de execução
 


### PR DESCRIPTION
### Motivation
* Garantir que, ao criar ou ajustar qualquer documento coberto pelo `DOC_ALVO`, a residência, o escopo e o conteúdo permitido sejam definidos seguindo o fluxo e as allowlists descritas em `docs/prompt-abc.md`.

### Description
* Adicionada uma linha em `AGENTS.md` (seção `## Referências`) que exige o uso obrigatório de `docs/prompt-abc.md` ao criar ou ajustar documentos cobertos pelo `DOC_ALVO`, sem copiar regras ou allowlists do ABC.

### Testing
* Executados `git diff --check`, `git diff --name-only`, um matcher para confirmar a presença conjunta de `DOC_ALVO` e `docs/prompt-abc.md` em `AGENTS.md`, e `git status --short --branch`, e todos retornaram sucesso; `npm ci` e `npm run check` foram considerados não aplicáveis por se tratar de alteração exclusivamente documental.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d5eff63a883299fab817d36a54f63)