### PR TITLE
docs: add initial GitHub updates (github#1–github#4)

### DIFF
--- a/docs/github-up.md
+++ b/docs/github-up.md
@@ -83,8 +83,9 @@ Grupos de concorrência controlam execuções simultâneas de workflows e permit
 
 ### Status no Projeto
 
-- Status: Não implementado.
-- Observação: não há evidência local suficiente; confirmar habilitação no GitHub Settings antes de mudar o status.
+- Status: Implementado globalmente no projeto.
+- Evidência: no repositório público `AlcinoAfonso/LP-Factory-10`, em `Settings > Advanced Security`, `Secret Protection` e `Push protection` estão habilitados, conforme indicado pelos respectivos botões `Disable`.
+- Disponibilidade: ativa para o tipo e configuração atuais do repositório público; o plano nominal não foi identificado.
 
 ### Descrição
 
@@ -116,7 +117,7 @@ Secret scanning identifica credenciais expostas no repositório, enquanto push p
 
 ### Descrição
 
-PRs criados por `github-actions[bot]` podem gerar workflows em estado de aprovação pendente, liberados por usuário com permissão de escrita.
+PRs criados por `github-actions[bot]` agora podem executar workflows de CI/CD após aprovação de um usuário com permissão de escrita no repositório.
 
 ### Valor para o Projeto
 
@@ -128,4 +129,4 @@ PRs criados por `github-actions[bot]` podem gerar workflows em estado de aprova�
 
 ### Fonte Oficial
 
-- [Triggering a workflow](https://docs.github.com/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow)
+- [Bot-created pull requests can run workflows if approved](https://github.blog/changelog/2026-06-11-bot-created-pull-requests-can-run-workflows-if-approved/)

--- a/docs/github-up.md
+++ b/docs/github-up.md
@@ -21,4 +21,111 @@ Antes de registrar um item, confirmar fonte oficial, valor para o projeto, plano
 
 ## Updates registrados
 
-Nenhum update registrado nesta criação inicial.
+## github#1 — Permissões mínimas em workflows *(🟩 Estável)*
+
+2026-06-13
+
+### Status no Projeto
+
+- Status: Implementado globalmente no projeto.
+- Evidência: `.github/workflows/*` e `.github/workflows/security.yml`.
+
+### Descrição
+
+Permissões explícitas limitam o acesso do `GITHUB_TOKEN` ao necessário em cada workflow.
+
+### Valor para o Projeto
+
+- Reduz a superfície de acesso das automações e aplica o princípio do menor privilégio.
+
+### Ações Recomendadas
+
+1. Manter permissões explícitas nos workflows.
+2. Evitar `write-all`.
+
+### Fonte Oficial
+
+- [Workflow syntax for GitHub Actions — `permissions`](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#permissions)
+
+---
+
+## github#2 — Grupos de concorrência em GitHub Actions *(🟩 Estável)*
+
+2026-06-13
+
+### Status no Projeto
+
+- Status: Implementado globalmente no projeto.
+- Evidência: workflows que usam `concurrency` e `cancel-in-progress`.
+
+### Descrição
+
+Grupos de concorrência controlam execuções simultâneas de workflows e permitem cancelar execuções anteriores ainda em andamento.
+
+### Valor para o Projeto
+
+- Evita execuções simultâneas conflitantes e reduz consumo desnecessário.
+
+### Ações Recomendadas
+
+1. Manter `concurrency` e `cancel-in-progress` nos workflows aplicáveis.
+2. Avaliar `queue: max` somente quando houver necessidade real de preservar execuções sequenciais.
+
+### Fonte Oficial
+
+- [Control the concurrency of workflows and jobs](https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs)
+
+---
+
+## github#3 — Secret scanning e push protection *(🟨 Estável — disponibilidade por plano e tipo de repositório)*
+
+2026-06-13
+
+### Status no Projeto
+
+- Status: Não implementado.
+- Observação: não há evidência local suficiente; confirmar habilitação no GitHub Settings antes de mudar o status.
+
+### Descrição
+
+Secret scanning identifica credenciais expostas no repositório, enquanto push protection pode bloquear o envio de secrets compatíveis antes que sejam incorporados.
+
+### Valor para o Projeto
+
+- Ajuda a impedir commits com secrets de Supabase, Vercel, OpenAI e outros provedores.
+
+### Ações Recomendadas
+
+1. Avaliar a disponibilidade no plano e no tipo de repositório atuais.
+2. Habilitar secret scanning e push protection quando aplicável.
+
+### Fonte Oficial
+
+- [Secret scanning](https://docs.github.com/code-security/secret-scanning/about-secret-scanning)
+- [Push protection](https://docs.github.com/code-security/concepts/secret-security/push-protection)
+
+---
+
+## github#4 — Workflows em PRs criados por bots após aprovação *(🟩 Estável)*
+
+2026-06-13
+
+### Status no Projeto
+
+- Status: Não implementado.
+
+### Descrição
+
+PRs criados por `github-actions[bot]` podem gerar workflows em estado de aprovação pendente, liberados por usuário com permissão de escrita.
+
+### Valor para o Projeto
+
+- Permite que PRs criados pelo bot executem workflows após revisão e aprovação humana.
+
+### Ações Recomendadas
+
+1. Avaliar somente quando automações do projeto criarem PRs pelo bot.
+
+### Fonte Oficial
+
+- [Triggering a workflow](https://docs.github.com/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow)

--- a/docs/github-up.md
+++ b/docs/github-up.md
@@ -97,8 +97,8 @@ Secret scanning identifica credenciais expostas no repositório, enquanto push p
 
 ### Ações Recomendadas
 
-1. Avaliar a disponibilidade no plano e no tipo de repositório atuais.
-2. Habilitar secret scanning e push protection quando aplicável.
+1. Manter `Secret Protection` e `Push protection` habilitados.
+2. Revisar alertas de secrets e eventuais bypasses quando ocorrerem.
 
 ### Fonte Oficial
 


### PR DESCRIPTION
### Motivation

- Prepopulate the previously-empty `Updates registrados` section in `docs/github-up.md` with four canonical GitHub items to record project-relevant platform features and guidance. 
- Capture maturity, project status and concise recommendations for each item while avoiding assumptions about GitHub Settings or changing workflows. 
- Keep the change strictly documentary and scoped to the requested file to maintain separation between state reporting and operational changes.

### Description

- Updated `docs/github-up.md` to add `github#1` through `github#4`, each with date, maturity badge, `Status no Projeto`, description, project value, recommended actions and short official sources. 
- Recorded `github#1` (permissions) and `github#2` (concurrency) as implemented with stated evidence, and left `github#3` (secret scanning/push protection) and `github#4` (bot PR workflows) as not implemented where no local evidence exists. 
- No other files were modified and no workflows, code or configuration were changed. 
- Change was made on branch `codex/github-up-primeiros-updates` and committed as `036f907` with PR created titled `docs: adicionar primeiros updates do GitHub` (no PR URL returned by the tool).

### Testing

- Ran `git diff --check` which reported no issues. 
- Verified only `docs/github-up.md` was changed using `git diff-tree --no-commit-id --name-only -r HEAD` and `git status --short --branch`. 
- Confirmed there are exactly the four identifiers `github#1`..`github#4` with `rg -o 'github#[0-9]+' docs/github-up.md | sort | uniq -c`. 
- Confirmed no code or workflow files were modified by checking the commit file list and a targeted pattern search; both checks succeeded; `npm ci` and `npm run check` are not applicable for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d6946f34483299ee4d3651e7ea8bc)