### PR TITLE
docs: clarify roadmap final consolidation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 * Para impacto visual/frontend, usar também `docs/template-briefing-codex-frontend.md`.
 * Para estado, decisões e aprendizados sobre Codex, usar `docs/gestor-codex.md`.
 * Ao consolidar conteúdo canônico dos documentos cobertos pelo `DOC_ALVO`, usar `docs/prompt-abc.md` para definir residência, escopo e conteúdo permitido.
-* Em `docs/roadmap.md`, casos em planejamento ou andamento podem manter planejamento, decisões provisórias, trabalho em execução, faltas e próximos passos. Nessa fase, não alterar cabeçalho, versão ou changelog e não marcar como implementado ou concluído. Ao concluir ou incorporar a implementação à `main`, consolidar o caso conforme `docs/prompt-abc.md`.
+* Em docs/roadmap.md, casos em planejamento ou andamento podem manter planejamento, decisões provisórias, trabalho em execução, faltas e próximos passos. Nessa fase, não alterar cabeçalho, versão ou changelog e não marcar como implementado ou concluído. Ao concluir ou incorporar a implementação à main, remover o conteúdo provisório e consolidar o caso somente com o estado final permitido pela allowlist de docs/prompt-abc.md.
 
 ## Regra geral de execução
 


### PR DESCRIPTION
### Motivation
* Clarify how provisional content in `docs/roadmap.md` should be handled when an implementation is completed and ensure final consolidation follows the allowlist in `docs/prompt-abc.md`.

### Description
* Update a single bullet in `## Referências` of `AGENTS.md` to require removal of provisional roadmap content upon incorporation to `main` and to mandate final consolidation only with the state allowed by `docs/prompt-abc.md`; the change is limited to `AGENTS.md` on branch `codex/clarify-roadmap-final-consolidation`.

### Testing
* Ran `git diff --check` (no issues), `git diff --name-only` (only `AGENTS.md`), `git status --short --branch` (clean), `git log --oneline main..HEAD` (single commit on the branch), `git diff --name-only main...HEAD` (only `AGENTS.md`), attempted `git push -u origin codex/clarify-roadmap-final-consolidation` which failed because remote `origin` is not configured, and `npm ci`/`npm run check` were not applicable for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d6e2f68f48329b0177bfce67e6dae)