### PR TITLE
Simplifica a avaliação documental por branch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 * Para impacto visual/frontend, usar também `docs/template-briefing-codex-frontend.md`.
 * Para estado, decisões e aprendizados sobre Codex, usar `docs/gestor-codex.md`.
 * Ao consolidar conteúdo canônico dos documentos cobertos pelo `DOC_ALVO`, usar `docs/prompt-abc.md` para definir residência, escopo e conteúdo permitido.
-* Em docs/roadmap.md, casos em planejamento ou andamento podem manter planejamento, decisões provisórias, trabalho em execução, faltas e próximos passos. Nessa fase, não alterar cabeçalho, versão ou changelog e não marcar como implementado ou concluído. Ao concluir ou incorporar a implementação à main, remover o conteúdo provisório e consolidar o caso somente com o estado final permitido pela allowlist de docs/prompt-abc.md.
+* Em `docs/roadmap.md`, casos em planejamento, andamento ou implementação parcial devem preservar planejamento, decisões provisórias, trabalho em execução, faltas e próximos passos. Nessa fase, não alterar cabeçalho, versão ou changelog e não marcar como implementado ou concluído. Aplicar a consolidação final de `docs/prompt-abc.md` somente quando o caso completo ou um recorte autônomo estiver totalmente implementado e validado; então remover apenas o conteúdo provisório superado pelo escopo concluído e consolidar seu estado final conforme a allowlist.
 
 ## Regra geral de execução
 

--- a/docs/prompt-codex-app-executor.md
+++ b/docs/prompt-codex-app-executor.md
@@ -7,7 +7,7 @@ Referencia no repositorio: `docs/prompt-codex-app-executor.md`.
 
 Voce e o Codex App Executor do LP Factory 10.
 
-Sua funcao e receber um plano-base de caso, investigar o necessario no repositorio, consolidar o plano de implementacao, executar o que for permitido no Codex App, validar a entrega e produzir relatorio final objetivo.
+Sua funcao e receber um plano-base de caso, investigar o necessario no repositorio, consolidar o plano de implementacao, executar o que for permitido no Codex App, validar a entrega e realizar a avaliacao documental da branch.
 
 Siga obrigatoriamente o `AGENTS.md` vigente, fonte oficial para regras operacionais, Git, publicacao, branch, validacao tecnica e entrega. Este prompt define apenas o papel e as etapas proprias do Executor.
 
@@ -92,7 +92,7 @@ Quando houver alteracao de schema:
 
 Aplicar observability minima compativel com o caso, quando relevante, preservando ou ajustando sinais como logs, tratamento de erros, estados rastreaveis e mensagens uteis para operacao.
 
-Registrar a evidencia minima de sucesso ou falha. Se nao houver aplicacao real, marcar N/A no relatorio final.
+Registrar a evidencia minima de sucesso ou falha. Se nao houver aplicacao real, considerar observability nao aplicavel na avaliacao da branch.
 
 ## 8. Etapa 6 - Validacao funcional e smoke
 
@@ -112,51 +112,14 @@ Quando nao puder validar diretamente:
 
 Nao marcar o caso como funcionando nem pronto para merge se a validacao tecnica aplicavel falhar, o smoke nao tiver evidencia suficiente ou houver bloqueio externo pendente.
 
-## 9. Etapa 7 - Relatorio final
+## 9. Etapa 7 - Avaliacao documental da branch
 
-Registrar apenas o que efetivamente ocorreu, usando N/A quando nao se aplicar.
+Ao fim de cada branch, avaliar somente se o diff implementado e validado exige atualizacao dos documentos cobertos pelo `DOC_ALVO`, usando `docs/prompt-abc.md` para residencia, escopo e conteudo permitido.
 
-### Implementado / Definido
-
-- [1-5 bullets]
-
-### Investigacao e plano
-
-- Docs e fontes examinados: [paths/fontes]
-- SQL de inspecao ou outputs externos: [resumo] | N/A
-- Plano de implementacao consolidado: sim | nao
-
-### Execucao
-
-- Modo de execucao, branch, PR, publicacao e fallback: conforme `AGENTS.md` - [resumo] | N/A
-
-### BD e artefatos
-
-- Estruturas de BD: [resumo] | N/A
-- Arquivos criados/ajustados: [paths] | N/A
-- SQL de inspecao, migration, validacao e evidencia: [paths/resumo] | N/A
-
-### Validacao
-
-- Validacao tecnica do `AGENTS.md`: executada | nao executada | nao aplicavel - [resumo]
-- Smoke funcional: executado | orientado para humano | confirmado por humano | nao executado
-- Evidencia funcional: [resumo] | pendente | N/A
-- Caso de uso funcionando: sim | nao | depende validacao
-- Pronto para merge: sim | nao
-
-### Observability
-
-- Aplicou: sim | nao | N/A
-- Sinal observado: [resumo] | N/A
-
-### Pendencias e risco residual
-
-- [bullets] | N/A
-
-### Sugestoes de novos casos
-
-- [bullets] | N/A
-
-### Status final
-
-`pronto` | `bloqueado` | `depende validacao`
+- nao produzir relatorio final extenso;
+- registrar apenas quais documentos exigem ajuste ou que nao ha alteracoes documentais necessarias, com motivo curto;
+- em `docs/roadmap.md`, preservar planejamento, decisoes provisorias, trabalho em execucao, faltas e proximos passos enquanto o caso estiver parcial;
+- durante estado parcial, nao alterar cabecalho, versao ou changelog do roadmap e nao marcar o caso como implementado ou concluido;
+- aplicar a consolidacao final de `docs/prompt-abc.md` somente quando o caso completo ou um recorte autonomo estiver totalmente implementado e validado;
+- ao consolidar um recorte autonomo, remover apenas o conteudo provisorio superado pelo recorte concluido e preservar o restante do caso parcial;
+- manter a entrega final curta no formato definido pelo `AGENTS.md`.

--- a/docs/prompt-codex-app-executor.md
+++ b/docs/prompt-codex-app-executor.md
@@ -117,7 +117,7 @@ Nao marcar o caso como funcionando nem pronto para merge se a validacao tecnica 
 Ao fim de cada branch, avaliar somente se o diff implementado e validado exige atualizacao dos documentos cobertos pelo `DOC_ALVO`, usando `docs/prompt-abc.md` para residencia, escopo e conteudo permitido.
 
 - nao produzir relatorio final extenso;
-- registrar apenas quais documentos exigem ajuste ou que nao ha alteracoes documentais necessarias, com motivo curto;
+- atualizar na propria branch os documentos necessarios; quando nao houver delta documental, informar isso brevemente na entrega final;
 - em `docs/roadmap.md`, preservar planejamento, decisoes provisorias, trabalho em execucao, faltas e proximos passos enquanto o caso estiver parcial;
 - durante estado parcial, nao alterar cabecalho, versao ou changelog do roadmap e nao marcar o caso como implementado ou concluido;
 - aplicar a consolidacao final de `docs/prompt-abc.md` somente quando o caso completo ou um recorte autonomo estiver totalmente implementado e validado;


### PR DESCRIPTION
### Motivation

- Remover o relatório final extenso do Executor e exigir apenas uma avaliação documental objetiva por branch. 
- Preservar o conteúdo provisório de `docs/roadmap.md` enquanto um caso estiver parcial e só aplicar a consolidação via `docs/prompt-abc.md` quando o caso ou recorte autônomo estiver totalmente implementado e validado. 
- Manter a entrega final curta definida em `AGENTS.md` e não alterar as demais regras operacionais.

### Description

- Atualiza `AGENTS.md` para explicitar que `docs/roadmap.md` deve preservar planejamento, decisões provisórias, trabalho em execução, faltas e próximos passos durante implementações parciais e que a consolidação final só se aplica quando o escopo estiver concluído e validado. 
- Ajusta `docs/prompt-codex-app-executor.md` para incluir a `avaliacao documental da branch` no papel do Executor, considerar observability como N/A quando não houver aplicação real e substituir o bloco de relatório final extenso por bullets objetivos de avaliação documental. 
- Mantém o formato de entrega curto e todas as outras regras e gates existentes sem alterações.

### Testing

- Revisão do diff com `git diff` para validar as mudanças no conteúdo (sucesso). 
- Verificações de integridade com `git diff --check` e `git diff --cached --check` sem erros de formatação (sucesso). 
- Confirmação do estado de trabalho com `git status --short --branch`, arquivos alterados `AGENTS.md` e `docs/prompt-codex-app-executor.md`, branch usada `work`, e PR criado; por se tratar de alteração exclusivamente documental, `npm ci` e `npm run check` foram considerados não aplicáveis.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d754d78e08329a8824b82a107c260)