### PR TITLE
fix(db): corrigir destino do evento em audit_context_event

### DIFF
--- a/supabase/migrations/20260614124000_fix_audit_context_event_event_column.sql
+++ b/supabase/migrations/20260614124000_fix_audit_context_event_event_column.sql
@@ -1,0 +1,41 @@
+create or replace function public.audit_context_event(
+  p_event text,
+  p_entity text,
+  p_entity_id uuid,
+  p_diff jsonb,
+  p_account_id uuid
+)
+returns void
+language plpgsql
+set search_path to 'public', 'extensions'
+as $function$
+declare
+  v_ip inet := inet_client_addr();
+  v_event text := lower(p_event);
+begin
+  insert into public.audit_logs(
+    table_name,
+    record_id,
+    action,
+    user_id,
+    actor_user_id,
+    changes_json,
+    ip_address,
+    created_at,
+    account_id,
+    event
+  )
+  values (
+    p_entity,
+    coalesce(p_entity_id, gen_random_uuid()),
+    'insert',
+    coalesce(auth.uid(), null),
+    coalesce(auth.uid(), null),
+    coalesce(p_diff, '{}'::jsonb),
+    v_ip,
+    now(),
+    p_account_id,
+    v_event
+  );
+end
+$function$;


### PR DESCRIPTION
## Objetivo
Corrigir exclusivamente a RPC `public.audit_context_event` para preservar `audit_logs.action` como operação de auditoria e gravar o nome do evento em `audit_logs.event`.

## Alteração
- mantém `audit_logs.action = 'insert'`;
- grava `lower(p_event)` em `audit_logs.event`;
- preserva assinatura da RPC, tabela e constraint existente;
- não amplia `audit_logs_action_check`.

## Validação já realizada
A mesma definição foi validada no Supabase real em transação com rollback, confirmando os três eventos da E10.6:
- `commercial_page_view`;
- `commercial_primary_cta_click`;
- `commercial_plan_cta_click`.

## Importante
Este PR deve parar antes do merge humano. A E10.6 só deve ser liberada depois desta migration ser aplicada pela `main` e confirmada no banco real.