### PR TITLE
docs: reaplicar princípios de runtime e planejamento por histórico

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@
 1.4.3. Dashboard
 • Suporte para ajustes e testes guiados por dados.
 
+1.4.4. Princípios de implementação
+• O MVP prioriza simplicidade, não fragilidade.
+• Runtime não pode depender de objetos ou comportamentos de banco ainda não aplicados e validados no ambiente alvo.
+
 1.5. Modelo de oferta
 • Planos em camadas (Starter → Lite → Pro → Ultra), com capacidades escalando ao longo do tempo.
 

--- a/docs/base-tecnica.md
+++ b/docs/base-tecnica.md
@@ -139,6 +139,10 @@
 • Contrato técnico detalhado do pipeline: automations/supabase-inspect/README.md.
 
 3.4.4 Migrations Supabase versionadas
+• Runtime não pode depender de objeto ou comportamento de banco ainda não aplicado e validado no ambiente alvo.
+• Snippet operacional ou SQL avulso não equivale a migration histórica nem substitui migration versionada.
+• SQL avulso é permitido apenas para inspeção, verificação read-only ou exceção expressamente autorizada.
+• Avaliação de banco exige migration, validação e evidência aplicável ao ambiente alvo.
 • Fonte canônica: `supabase/migrations/<timestamp>_<nome>.sql`.
 • A baseline oficial é o ponto inicial do histórico versionado; alterações posteriores de schema devem entrar como migrations incrementais novas.
 • Migrations legadas preservadas fora de `supabase/migrations/` são somente evidência histórica e não integram o fluxo ativo da CLI.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -851,7 +851,7 @@
 • A página genérica da E10.6 servirá futuramente como fallback quando não houver página nichada publicada.
 • A modelagem de persistência e edição da E10.7 não deve ser antecipada na E10.6.
 
-10.6.8 Personalização por histórico da conta
+10.6.10 Personalização por histórico da conta
 
 • Status: Futuro — avaliar após validação da primeira versão.
 • Usar eventos vinculados ao `account_id` para reconhecer contas recorrentes.
@@ -860,7 +860,7 @@
 • Manter a página genérica como fallback.
 • Não exigir identificação individual do usuário nem CRM completo.
 
-10.6.9 Evoluções futuras de UX dos CTAs
+10.6.11 Evoluções futuras de UX dos CTAs
 
 • Status: Futuro — avaliar após validação da primeira versão.
 • Avaliar `web.whatsapp.com/send` no desktop para reduzir a tela intermediária.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -852,26 +852,21 @@
 • A modelagem de persistência e edição da E10.7 não deve ser antecipada na E10.6.
 
 10.6.8 Personalização por histórico da conta
+
 • Status: Futuro — avaliar após validação da primeira versão.
-• Objetivo: usar o histórico de eventos da conta para adaptar mensagens e CTAs em novos acessos.
-• Possíveis sinais:
-  • conta recorrente;
-  • último plano clicado;
-  • quantidade de visitas;
-  • último acesso;
-  • CTA já utilizado.
-• Primeira evolução recomendada:
-  • reconhecer retorno da conta;
-  • destacar o último plano clicado;
-  • adaptar headline, mensagem de retorno ou CTA.
-• Não exige CRM completo na primeira etapa.
-• Pode futuramente alimentar módulo comercial ou integração com CRM.
-• Regras:
-  • usar account_id;
-  • não exigir identificação individual do usuário;
-  • manter a página genérica como fallback;
-  • não implementar antes da aprovação da E10.6 atual;
-  • definir privacidade, retenção e limites antes de ampliar o tracking.
+• Usar eventos vinculados ao `account_id` para reconhecer contas recorrentes.
+• Considerar último acesso, quantidade de visitas, plano clicado e CTAs utilizados.
+• Futuramente adaptar mensagem, plano destacado e CTA.
+• Manter a página genérica como fallback.
+• Não exigir identificação individual do usuário nem CRM completo.
+
+10.6.9 Evoluções futuras de UX dos CTAs
+
+• Status: Futuro — avaliar após validação da primeira versão.
+• Avaliar `web.whatsapp.com/send` no desktop para reduzir a tela intermediária.
+• Manter `wa.me` no celular e como fallback geral.
+• Não realizar envio automático sem confirmação do usuário.
+• Implementar detecção por ambiente somente se o ganho de UX justificar a complexidade.
 
 10.7 Páginas comerciais personalizadas por nicho
 • Status: Planejado — iniciar somente após a aprovação da E10.6.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -851,6 +851,28 @@
 • A página genérica da E10.6 servirá futuramente como fallback quando não houver página nichada publicada.
 • A modelagem de persistência e edição da E10.7 não deve ser antecipada na E10.6.
 
+10.6.8 Personalização por histórico da conta
+• Status: Futuro — avaliar após validação da primeira versão.
+• Objetivo: usar o histórico de eventos da conta para adaptar mensagens e CTAs em novos acessos.
+• Possíveis sinais:
+  • conta recorrente;
+  • último plano clicado;
+  • quantidade de visitas;
+  • último acesso;
+  • CTA já utilizado.
+• Primeira evolução recomendada:
+  • reconhecer retorno da conta;
+  • destacar o último plano clicado;
+  • adaptar headline, mensagem de retorno ou CTA.
+• Não exige CRM completo na primeira etapa.
+• Pode futuramente alimentar módulo comercial ou integração com CRM.
+• Regras:
+  • usar account_id;
+  • não exigir identificação individual do usuário;
+  • manter a página genérica como fallback;
+  • não implementar antes da aprovação da E10.6 atual;
+  • definir privacidade, retenção e limites antes de ampliar o tracking.
+
 10.7 Páginas comerciais personalizadas por nicho
 • Status: Planejado — iniciar somente após a aprovação da E10.6.
 • Objetivo: criar páginas comerciais personalizadas conforme o taxon da conta, usando pesquisas com `audience_scope = business_buyer`.


### PR DESCRIPTION
### Motivation
- Reaplicar pequenos ajustes documentais sem preservar o erro da branch anterior e reforçar regras operacionais de runtime e migrations.
- Garantir que o runtime não dependa de objetos ou comportamentos de banco ainda não aplicados e validados no ambiente alvo.
- Registrar uma evolução futura de personalização por histórico da conta antes da E10.7, com limites e regras de privacidade.

### Description
- Adiciona em `README.md` a seção `1.4.4. Princípios de implementação` com as regras de simplicidade do MVP e a exigência de validação do banco no ambiente alvo.
- Inclui quatro bullets em `docs/base-tecnica.md` na seção `3.4.4 Migrations Supabase versionadas` reforçando que snippets SQL avulsos não substituem migrations e que avaliação exige migration e evidência aplicável ao ambiente alvo.
- Insere em `docs/roadmap.md` o bloco `10.6.8 Personalização por histórico da conta` com objetivo, sinais possíveis, primeira evolução recomendada e regras operacionais e de privacidade.
- Alterações limitadas aos arquivos `README.md`, `docs/base-tecnica.md` e `docs/roadmap.md` na branch `codex/reapply-readme-bt-roadmap-rules`, PR aberto contra `main`.

### Testing
- Executado `git diff --check` sem erros detectados.
- Executado `git diff --name-only` que retornou apenas `README.md`, `docs/base-tecnica.md` e `docs/roadmap.md`.
- Verificado com `git diff --stat` que há `30` inserções e `0` deleções, e com `git diff --numstat` os números correspondentes por arquivo.
- Conferido com `git diff --unified=0 | sed -n '/^---/d; /^-/p'` que não houve remoções inesperadas e com `git status --porcelain` que a árvore está limpa após commit.
- `npm ci` e `npm run check` não são aplicáveis pois a alteração é exclusivamente documental.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2edd529a1c8329be273c7f147dc74b)