### PR TITLE
docs: centraliza regra de atualização do roadmap em docs/prompt-abc.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 * Para impacto visual/frontend, usar também `docs/template-briefing-codex-frontend.md`.
 * Para estado, decisões e aprendizados sobre Codex, usar `docs/gestor-codex.md`.
 * Ao consolidar conteúdo canônico dos documentos cobertos pelo `DOC_ALVO`, usar `docs/prompt-abc.md` para definir residência, escopo e conteúdo permitido.
-* Em `docs/roadmap.md`, casos em planejamento, andamento ou implementação parcial devem preservar planejamento, decisões provisórias, trabalho em execução, faltas e próximos passos. Nessa fase, não alterar cabeçalho, versão ou changelog e não marcar como implementado ou concluído. Aplicar a consolidação final de `docs/prompt-abc.md` somente quando o caso completo ou um recorte autônomo estiver totalmente implementado e validado; então remover apenas o conteúdo provisório superado pelo escopo concluído e consolidar seu estado final conforme a allowlist.
+* Para atualizar casos em `docs/roadmap.md`, aplicar a regra de atualização do roadmap definida em `docs/prompt-abc.md`.
 
 ## Regra geral de execução
 

--- a/docs/prompt-abc.md
+++ b/docs/prompt-abc.md
@@ -67,6 +67,7 @@ ALLOWLISTS POR DOC_ALVO
 
 `docs/roadmap.md` — CONTRATO_DE_CASOS
 * ENTRA: status com data, escopo final em bullets curtos, dependências entre casos E*, decisões explícitas, pendências marcadas no RELATÓRIO e estruturas/artefatos vinculados ao estado final do caso.
+* REGRA DE ATUALIZAÇÃO: como exceção às regras de consolidação de estado final deste prompt, casos em planejamento, andamento ou implementação parcial devem preservar debates, planos, decisões provisórias, trabalho em execução, faltas e próximos passos. Nessa fase, não alterar cabeçalho, versão ou changelog nem marcar o caso como implementado ou concluído. Somente quando o caso completo ou um recorte autônomo estiver totalmente implementado e validado, remover o conteúdo provisório superado pelo escopo concluído e consolidar apenas o estado final permitido por esta allowlist.
 * REGRA: “E” só no título principal do caso; subitens sem repetir “E”.
 * ESTRUTURAS E ARTEFATOS: em cada caso implementado, registrar quando aplicável somente os nomes dos objetos de banco e os paths dos arquivos de repositório criados, ajustados ou removidos.
 * CATEGORIAS:


### PR DESCRIPTION
### Motivation

* Centralizar a regra que orienta atualizações de casos no `docs/roadmap.md` dentro de `docs/prompt-abc.md` para evitar duplicação e garantir que a regra sobre preservação de conteúdo provisório seja aplicada de forma consistente.

### Description

* Inserida a `REGRA DE ATUALIZAÇÃO` completa em `docs/prompt-abc.md` e substituída a regra detalhada em `AGENTS.md` por uma referência curta a `docs/prompt-abc.md`, alterando apenas `AGENTS.md` e `docs/prompt-abc.md` na branch `codex/alinha-regra-roadmap-abc` (commit `a1dbfc0`).

### Testing

* Executados `git diff --check`, `git diff -- AGENTS.md docs/prompt-abc.md`, `rg -n 'REGRA DE ATUALIZAÇÃO|regra de atualização do roadmap|casos em planejamento' AGENTS.md docs/prompt-abc.md` e `git status --short --branch`, todos com sucesso, e `npm ci`/`npm run check` considerados não aplicáveis por se tratar de alteração documental.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ffc208b7c8329b42bc73415883fee)