### PR TITLE
docs: adiciona diretrizes de conteúdo para o laboratório imobiliário

### DIFF
--- a/labs/imobiliario/README.md
+++ b/labs/imobiliario/README.md
@@ -206,3 +206,7 @@ Para qualquer entrada no core da LP Factory, exigir:
 • Avaliação estratégica.
 • Criação de caso E* específico.
 • Atualização aprovada do roadmap.
+
+11. Documentos operacionais do laboratório
+
+• `labs/imobiliario/diretrizes-conteudo.md` — posicionamento, princípios editoriais, regras de transparência e limites para conteúdos imobiliários.

--- a/labs/imobiliario/diretrizes-conteudo.md
+++ b/labs/imobiliario/diretrizes-conteudo.md
@@ -1,0 +1,326 @@
+0. Introdução
+
+0.1 Cabeçalho
+• Documento: Diretrizes de Conteúdo — Laboratório Imobiliário
+• Data: 16/06/2026
+• Status: ativo
+• Escopo: posicionamento, regras editoriais e limites de comunicação
+• Classificação: prescritivo dentro do laboratório imobiliário
+
+0.2 Contrato do documento
+• O QUE É: documento prescritivo do laboratório imobiliário para orientar posicionamento, público, oferta atual, princípios editoriais, critérios de transparência, limites de comunicação, papel da Cury e estrutura recorrente dos conteúdos.
+• POR QUE CONSULTAR: para garantir que qualquer conteúdo imobiliário do laboratório seja criado com clareza, transparência comercial, foco no comprador e respeito aos limites do estágio atual.
+• QUANDO CONSULTAR: antes da criação de qualquer conteúdo imobiliário do laboratório, incluindo Instagram, TikTok, Stories, WhatsApp, landing pages e outros canais.
+• QUANDO ATUALIZAR: quando houver decisão aprovada sobre posicionamento, público, oferta, critérios editoriais, limites de comunicação, vínculo comercial, aprendizados recorrentes ou estrutura mínima de conteúdo.
+• QUANDO NÃO USAR: não usar como documentação canônica do core da LP Factory, roadmap, especificação técnica, promessa comercial, manual institucional da Cury, autorização para uso da marca Cury, roteiro, calendário editorial, prompt de geração ou template da LP Factory.
+• NOTA DE LIMITES: este documento orienta conteúdos do laboratório imobiliário, mas não autoriza publicação de dados variáveis sem verificação, não substitui validação jurídica/comercial quando necessária e não transforma hipóteses do laboratório em funcionalidades, templates ou compromissos do core da LP Factory.
+
+Este documento deve ser consultado antes da criação de qualquer conteúdo imobiliário do laboratório.
+
+1. Posicionamento
+
+Posicionamento principal:
+
+```text
+Orientação para a compra do primeiro imóvel.
+```
+
+A corretora deve ser percebida como alguém que ajuda compradores iniciantes a:
+
+• compreender o processo;
+• avaliar custos;
+• identificar riscos;
+• comparar possibilidades;
+• tomar decisões com mais segurança.
+
+A comunicação deve evitar posicioná-la apenas como vendedora de empreendimentos. A venda pode ser consequência de uma orientação adequada, mas não deve ser o eixo central da percepção pública.
+
+2. Público inicial
+
+Público inicial:
+
+```text
+Compradores iniciantes interessados na aquisição do primeiro imóvel.
+```
+
+Temas mais relevantes para esse público:
+
+• entrada;
+• financiamento;
+• FGTS;
+• documentação;
+• análise de crédito;
+• compra na planta;
+• evolução de obra;
+• custos adicionais;
+• localização;
+• prazo de entrega;
+• adequação da parcela;
+• preparação financeira;
+• comparação entre opções.
+
+3. Oferta atual
+
+Oferta atual:
+
+```text
+Empreendimentos da Cury.
+```
+
+Regras de enquadramento da oferta:
+
+• a Cury é a oferta comercial disponível no estágio atual;
+• a marca não deve ser o centro da identidade da corretora;
+• a comunicação não deve parecer propaganda institucional;
+• a corretora não deve se apresentar como consultora totalmente independente se trabalha apenas com essa oferta;
+• deve existir transparência sobre o vínculo comercial atual.
+
+Formulação de referência:
+
+```text
+A corretora orienta compradores iniciantes sobre a compra do primeiro imóvel e, atualmente, trabalha com empreendimentos da Cury.
+```
+
+4. Princípio central
+
+Princípio central:
+
+```text
+O interesse do comprador deve orientar a recomendação.
+```
+
+Esse princípio deve prevalecer sobre:
+
+• pressão por venda;
+• promoção de empreendimento;
+• urgência comercial;
+• comissão;
+• defesa automática da incorporadora.
+
+5. Risco editorial principal
+
+Risco central:
+
+```text
+A corretora ser percebida como defensora dos interesses da Cury, em vez de defensora dos interesses do comprador.
+```
+
+Para reduzir esse risco, os conteúdos devem:
+
+• reconhecer limites;
+• apresentar critérios de adequação;
+• explicar riscos;
+• indicar custos;
+• evitar superioridade automática da Cury;
+• admitir quando determinado imóvel pode não ser adequado.
+
+6. Regra editorial de transparência
+
+Todo conteúdo comercial ou sobre empreendimento deve apresentar, quando aplicável:
+
+```text
+Para quem pode fazer sentido
+Para quem pode não fazer sentido
+Pontos positivos
+Cuidados necessários
+Custos ou condições relevantes
+Próximo passo seguro
+```
+
+Bloco editorial recorrente:
+
+```text
+Atenção: este imóvel pode não ser para você se...
+```
+
+Outras formulações permitidas:
+
+```text
+Antes de decidir, considere...
+Para quem faz sentido — e para quem pode não fazer.
+O ponto positivo é...
+O cuidado necessário é...
+```
+
+O alerta deve refletir um limite real. Não deve ser usado apenas como técnica artificial de persuasão.
+
+7. Exemplos de aplicação
+
+Exemplo para imóvel na planta:
+
+```text
+Pode fazer sentido para:
+- quem não precisa se mudar imediatamente;
+- quem consegue planejar entrada e custos;
+- quem aceita aguardar o prazo de entrega;
+- quem busca condições disponíveis no lançamento.
+
+Pode não fazer sentido para:
+- quem precisa de moradia imediata;
+- quem não possui margem para custos adicionais;
+- quem ainda não organizou renda, entrada e documentação;
+- quem não aceita riscos relacionados a prazo e evolução de obra.
+```
+
+Exemplo de fala:
+
+```text
+Este imóvel pode ser uma boa opção para quem busca o primeiro imóvel e aceita esperar a entrega. Mas pode não ser para você se precisa se mudar logo, se o deslocamento não funciona para sua rotina ou se a entrada comprometer sua reserva financeira.
+```
+
+8. Pilares editoriais
+
+8.1 Educação
+
+Explicar conceitos, etapas e custos.
+
+8.2 Objeções e medos
+
+Responder dúvidas reais dos compradores.
+
+8.3 Adequação
+
+Mostrar para quem cada opção faz ou não faz sentido.
+
+8.4 Transparência comercial
+
+Explicar vínculo, oferta disponível e limites.
+
+8.5 Preparação do comprador
+
+Ajudar a pessoa a organizar renda, documentos, entrada e expectativas.
+
+8.6 Decisão segura
+
+Evitar pressão e orientar próximos passos proporcionais ao momento do comprador.
+
+9. Tom de comunicação
+
+O tom de comunicação deve ser:
+
+• claro;
+• educativo;
+• transparente;
+• acolhedor;
+• direto;
+• respeitoso;
+• sem pressão;
+• sem linguagem excessivamente técnica;
+• sem aparência de propaganda institucional;
+• sem promessas.
+
+Evitar:
+
+• urgência falsa;
+• exageros;
+• frases absolutas;
+• superioridade automática;
+• medo artificial;
+• escassez não comprovada;
+• promessas de aprovação;
+• promessas de valorização;
+• promessas de economia;
+• promessas de venda ou entrega sem base oficial.
+
+10. Limites de comunicação
+
+Os conteúdos não devem:
+
+• prometer aprovação de crédito;
+• prometer condições financeiras;
+• esconder custos;
+• afirmar que um imóvel serve para todos;
+• apresentar conteúdo geral como recomendação individual;
+• usar dados não confirmados;
+• publicar preços, prazos ou condições sem fonte atualizada;
+• divulgar materiais da Cury sem autorização;
+• usar marca, imagens ou identidade da Cury fora das regras aplicáveis;
+• comparar concorrentes de forma ofensiva ou sem evidência;
+• fingir independência comercial inexistente;
+• induzir decisão precipitada.
+
+11. Tratamento de informações variáveis
+
+Informações como:
+
+• preços;
+• disponibilidade;
+• condições de entrada;
+• taxas;
+• subsídios;
+• regras de financiamento;
+• prazos;
+• campanhas;
+• unidades disponíveis;
+
+devem ser verificadas antes da publicação.
+
+Essas informações não devem ser transformadas em regra permanente neste documento.
+
+12. Estrutura mínima de conteúdo
+
+Cada conteúdo futuro deve registrar:
+
+```text
+Tema
+Público
+Dúvida ou problema de origem
+Objetivo
+Canal
+Formato
+Gancho
+Conteúdo principal
+Ponto de atenção
+Para quem faz sentido
+Para quem pode não fazer sentido
+CTA
+Fonte
+Status
+Resultado
+Aprendizado
+```
+
+Não criar roteiros nesta execução.
+
+13. Relação com a LP Factory
+
+Fluxo de aprendizado:
+
+```text
+dúvida real
+→ conteúdo educativo
+→ publicação
+→ reação do público
+→ aprendizado
+→ possível template reutilizável
+```
+
+Exemplo:
+
+```text
+Tema:
+entrada para o primeiro imóvel
+
+Problema:
+compradores acreditam que precisam ter toda a entrada disponível imediatamente.
+
+Conteúdo:
+explicação sobre variáveis que podem alterar a forma de pagamento.
+
+Possível reaproveitamento:
+template de conteúdo para corretores que atuam com primeiro imóvel.
+```
+
+Nenhum conteúdo, estrutura, hipótese, automação, roteiro ou template identificado no laboratório entra automaticamente no core da LP Factory. Qualquer reaproveitamento exige validação, avaliação estratégica e atualização aprovada nos documentos aplicáveis.
+
+14. Relação com futuros roteiros
+
+Futuros roteiros devem ser armazenados em:
+
+```text
+labs/imobiliario/roteiros-social.md
+```
+
+Esse arquivo ainda não deve ser criado nesta execução.
+
+As diretrizes deste documento são obrigatórias para qualquer roteiro futuro.


### PR DESCRIPTION
### Motivation

- Criar a base editorial prescritiva do Laboratório Imobiliário para orientar futuros conteúdos (Instagram, TikTok, Stories, WhatsApp, landing pages e canais correlatos). 
- Garantir posicionamento, público-alvo, oferta atual, princípios editoriais, regras de transparência, limites de comunicação e estrutura mínima de conteúdo em um documento obrigatório para o laboratório.

### Description

- Adiciona `labs/imobiliario/diretrizes-conteudo.md` com cabeçalho, contrato do documento e seções 1–14 cobrindo posicionamento, público, oferta atual (Cury), princípio central, risco editorial, regra de transparência, exemplos, pilares editoriais, tom, limites, tratamento de informações variáveis, estrutura mínima de conteúdo e relação com a LP Factory.  
- Atualiza `labs/imobiliario/README.md` com uma referência mínima ao novo documento na seção "Documentos operacionais do laboratório".  
- Alterações restritas aos dois arquivos solicitados e classificadas como documento prescritivo do laboratório.  
- Branch usada: `codex/base-editorial-imobiliario`.

### Testing

- Executados checks e validações automatizadas de escopo: `git status` / branch inspection, `git diff` entre arquivos afetados, verificação de lista de arquivos em `labs/imobiliario/`, e teste de inexistência de `labs/imobiliario/roteiros-social.md`, todos concluídos com sucesso.  
- As mudanças foram adicionadas ao índice e commitadas com a mensagem de documentação; o diff mostrou apenas os dois arquivos autorizados e a criação do novo documento.  
- `npm ci`: não aplicável (alteração exclusivamente documental).  
- `npm run check`: não aplicável (alteração exclusivamente documental).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a316301a7608329bc83b209daa1cf7c)