### PR TITLE
[codex] Implement E18 commercial activation renderer phase 1

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1218,6 +1218,7 @@ Repositório — Criados
 • `lib/conversion-content/commercial-activation/renderer.tsx`
 • `lib/conversion-content/commercial-activation/resolve.ts`
 • `lib/conversion-content/commercial-activation/schemas.ts`
+• `lib/conversion-content/commercial-activation/validation-cases.ts`
 
 Repositório — Ajustados
 • `lib/conversion-content/index.ts`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1156,7 +1156,7 @@ Repositório — Criados
 
 18.12 Fase 1 — Contratos e renderer de `commercial_activation`
 
-• Status: Planejado.
+• Status: Em PR — implementação da Fase 1 preparada no repositório, pendente de revisão e merge.
 • Execução exclusiva no repositório, sem migration ou alteração no Supabase.
 • Objetivo: validar e renderizar composições da família `commercial_activation` com dados sintéticos.
 
@@ -1210,6 +1210,19 @@ Limites:
 Critério de passagem:
 
 • a Fase 2 só começa após aprovação e merge da Fase 1.
+
+Repositório — Criados
+• `lib/conversion-content/commercial-activation/fixture.ts`
+• `lib/conversion-content/commercial-activation/index.ts`
+• `lib/conversion-content/commercial-activation/registry.ts`
+• `lib/conversion-content/commercial-activation/renderer.tsx`
+• `lib/conversion-content/commercial-activation/resolve.ts`
+• `lib/conversion-content/commercial-activation/schemas.ts`
+
+Repositório — Ajustados
+• `lib/conversion-content/index.ts`
+• `package.json`
+• `package-lock.json`
 
 18.13 Fase 2 — Registros-base de `commercial_activation`
 

--- a/lib/conversion-content/commercial-activation/fixture.ts
+++ b/lib/conversion-content/commercial-activation/fixture.ts
@@ -1,0 +1,267 @@
+import type { ContentComposition, ContentTemplate } from "../contracts";
+import type { CommercialActivationContentV1 } from "./schemas";
+
+const pageTemplate: ContentTemplate = {
+  id: "11111111-1111-4111-8111-111111111111",
+  key: "commercial_activation_page",
+  slug: "commercial-activation-page",
+  name: "Commercial activation page",
+  family: "commercial_activation",
+  scope: "page",
+  status: "active",
+  version: 1,
+  isActive: true,
+  payload: {},
+};
+
+function sectionTemplate(key: string, name: string): ContentTemplate {
+  return {
+    id: cryptoIdForKey(key),
+    key,
+    slug: key.replaceAll("_", "-"),
+    name,
+    family: "commercial_activation",
+    scope: "section",
+    status: "active",
+    version: 1,
+    isActive: true,
+    payload: {},
+  };
+}
+
+export const commercialActivationFixtureComposition: ContentComposition = {
+  id: "22222222-2222-4222-8222-222222222222",
+  template: pageTemplate,
+  taxonId: "33333333-3333-4333-8333-333333333333",
+  version: 1,
+  status: "active",
+  items: [
+    {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1",
+      module: sectionTemplate("hero", "Hero"),
+      variantKey: "hero.default",
+      sortOrder: 10,
+      isRequired: true,
+      config: {},
+    },
+    {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2",
+      module: sectionTemplate("benefits", "Benefits"),
+      variantKey: "benefits.cards",
+      sortOrder: 20,
+      isRequired: true,
+      config: {},
+    },
+    {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa3",
+      module: sectionTemplate("services", "Services"),
+      variantKey: "services.list",
+      sortOrder: 30,
+      isRequired: true,
+      config: {},
+    },
+    {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa4",
+      module: sectionTemplate("plans", "Plans"),
+      variantKey: "plans.cards",
+      sortOrder: 40,
+      isRequired: true,
+      config: {},
+    },
+    {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa5",
+      module: sectionTemplate("differentials", "Differentials"),
+      variantKey: "differentials.cards",
+      sortOrder: 50,
+      isRequired: false,
+      config: {},
+    },
+    {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa6",
+      module: sectionTemplate("how_it_works", "How it works"),
+      variantKey: "how_it_works.steps",
+      sortOrder: 60,
+      isRequired: true,
+      config: {},
+    },
+    {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa7",
+      module: sectionTemplate("faq", "FAQ"),
+      variantKey: "faq.accordion",
+      sortOrder: 70,
+      isRequired: false,
+      config: {},
+    },
+    {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa8",
+      module: sectionTemplate("final_cta", "Final CTA"),
+      variantKey: "final_cta.simple",
+      sortOrder: 80,
+      isRequired: true,
+      config: {},
+    },
+  ],
+};
+
+export const commercialActivationFixtureContent: CommercialActivationContentV1 = {
+  schema_version: 1,
+  sections: [
+    {
+      composition_item_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1",
+      variant_key: "hero.default",
+      eyebrow: "Synthetic commercial page",
+      title: "A focused page for a specific business audience.",
+      description:
+        "This fixture validates the renderer contract without reading from Supabase or publishing real niche content.",
+      primary_cta: { label: "View plans", href: "#plans" },
+      secondary_cta: { label: "How it works", href: "#how-it-works" },
+    },
+    {
+      composition_item_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2",
+      variant_key: "benefits.cards",
+      eyebrow: "Benefits",
+      title: "Clear reasons to continue the conversation",
+      items: [
+        {
+          title: "Audience-specific copy",
+          description:
+            "The content can explain the offer with language matched to the selected taxon.",
+        },
+        {
+          title: "Reusable structure",
+          description:
+            "The same renderer can consume different compositions when the registry allows each variant.",
+        },
+        {
+          title: "Server validation",
+          description:
+            "Invalid required sections stop the artifact before it reaches the UI.",
+        },
+      ],
+    },
+    {
+      composition_item_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa3",
+      variant_key: "services.list",
+      eyebrow: "Services",
+      title: "A concise package for the first page",
+      items: [
+        "Offer positioning",
+        "Landing page sections",
+        "Plan comparison",
+        "Final contact path",
+      ],
+    },
+    {
+      composition_item_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa4",
+      variant_key: "plans.cards",
+      eyebrow: "Plans",
+      title: "Synthetic plans for layout validation",
+      disclaimer:
+        "Fixture-only values. They do not represent a public commercial offer.",
+      plans: [
+        {
+          key: "starter",
+          name: "Starter",
+          price: "R$ 50",
+          period: "/mo",
+          description: "One essential landing page.",
+          features: ["Responsive page", "Primary CTA", "Basic sections"],
+          highlighted: false,
+          cta: { label: "Choose starter", href: "#contact" },
+        },
+        {
+          key: "pro",
+          name: "Pro",
+          price: "R$ 200",
+          period: "/mo",
+          description: "More sections for a complete commercial story.",
+          features: ["Responsive page", "Plan cards", "FAQ", "Final CTA"],
+          highlighted: true,
+          cta: { label: "Choose pro", href: "#contact" },
+        },
+      ],
+    },
+    {
+      composition_item_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa5",
+      variant_key: "differentials.cards",
+      eyebrow: "Differentials",
+      title: "Controlled flexibility without free-form components",
+      items: [
+        {
+          title: "Closed registry",
+          description:
+            "Only approved module and variant pairs can be rendered.",
+        },
+        {
+          title: "No raw HTML",
+          description:
+            "The artifact carries structured content only, not scripts, CSS, or component names.",
+        },
+      ],
+    },
+    {
+      composition_item_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa6",
+      variant_key: "how_it_works.steps",
+      eyebrow: "How it works",
+      title: "From composition to rendered sections",
+      steps: [
+        {
+          label: "01",
+          title: "Load composition",
+          description: "The server receives ordered items and approved variants.",
+        },
+        {
+          label: "02",
+          title: "Validate content",
+          description: "Each content block must reference a valid composition item.",
+        },
+        {
+          label: "03",
+          title: "Render safely",
+          description: "Only registry-approved sections reach the React renderer.",
+        },
+      ],
+    },
+    {
+      composition_item_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa7",
+      variant_key: "faq.accordion",
+      eyebrow: "FAQ",
+      title: "Renderer contract questions",
+      questions: [
+        {
+          question: "Does this fixture read Supabase data?",
+          answer:
+            "No. It uses synthetic local data to validate Fase 1 without records or migrations.",
+        },
+        {
+          question: "Can the database choose an arbitrary component?",
+          answer:
+            "No. The registry only accepts known section and variant pairs.",
+        },
+      ],
+    },
+    {
+      composition_item_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa8",
+      variant_key: "final_cta.simple",
+      title: "Ready for the next validation step",
+      description:
+        "After this repository-only contract is approved, real base records can be handled in a separate phase.",
+      cta: { label: "Continue", href: "#plans" },
+    },
+  ],
+};
+
+function cryptoIdForKey(key: string) {
+  const knownIds: Record<string, string> = {
+    hero: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb1",
+    benefits: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb2",
+    services: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb3",
+    plans: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb4",
+    differentials: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb5",
+    how_it_works: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb6",
+    faq: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb7",
+    final_cta: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb8",
+  };
+
+  return knownIds[key] ?? "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb0";
+}

--- a/lib/conversion-content/commercial-activation/fixture.ts
+++ b/lib/conversion-content/commercial-activation/fixture.ts
@@ -16,7 +16,7 @@ const pageTemplate: ContentTemplate = {
 
 function sectionTemplate(key: string, name: string): ContentTemplate {
   return {
-    id: cryptoIdForKey(key),
+    id: sectionTemplateIds[key] ?? "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb0",
     key,
     slug: key.replaceAll("_", "-"),
     name,
@@ -28,6 +28,17 @@ function sectionTemplate(key: string, name: string): ContentTemplate {
     payload: {},
   };
 }
+
+const sectionTemplateIds: Record<string, string> = {
+  hero: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb1",
+  benefits: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb2",
+  services: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb3",
+  plans: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb4",
+  differentials: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb5",
+  how_it_works: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb6",
+  faq: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb7",
+  final_cta: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb8",
+};
 
 export const commercialActivationFixtureComposition: ContentComposition = {
   id: "22222222-2222-4222-8222-222222222222",
@@ -108,160 +119,153 @@ export const commercialActivationFixtureContent: CommercialActivationContentV1 =
   sections: [
     {
       composition_item_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1",
-      variant_key: "hero.default",
-      eyebrow: "Synthetic commercial page",
-      title: "A focused page for a specific business audience.",
-      description:
-        "This fixture validates the renderer contract without reading from Supabase or publishing real niche content.",
-      primary_cta: { label: "View plans", href: "#plans" },
-      secondary_cta: { label: "How it works", href: "#how-it-works" },
+      content: {
+        eyebrow: "Synthetic commercial page",
+        title: "A focused page for a specific business audience.",
+        description:
+          "This fixture validates the renderer contract without reading from Supabase or publishing real niche content.",
+        primary_cta: { label: "View plans", href: "/commercial/plans" },
+        secondary_cta: { label: "How it works", href: "/commercial/process" },
+      },
     },
     {
       composition_item_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2",
-      variant_key: "benefits.cards",
-      eyebrow: "Benefits",
-      title: "Clear reasons to continue the conversation",
-      items: [
-        {
-          title: "Audience-specific copy",
-          description:
-            "The content can explain the offer with language matched to the selected taxon.",
-        },
-        {
-          title: "Reusable structure",
-          description:
-            "The same renderer can consume different compositions when the registry allows each variant.",
-        },
-        {
-          title: "Server validation",
-          description:
-            "Invalid required sections stop the artifact before it reaches the UI.",
-        },
-      ],
+      content: {
+        eyebrow: "Benefits",
+        title: "Clear reasons to continue the conversation",
+        items: [
+          {
+            title: "Audience-specific copy",
+            description:
+              "The content can explain the offer with language matched to the selected taxon.",
+          },
+          {
+            title: "Reusable structure",
+            description:
+              "The same renderer can consume different compositions when the registry allows each variant.",
+          },
+          {
+            title: "Server validation",
+            description:
+              "Invalid required sections stop the artifact before it reaches the UI.",
+          },
+        ],
+      },
     },
     {
       composition_item_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa3",
-      variant_key: "services.list",
-      eyebrow: "Services",
-      title: "A concise package for the first page",
-      items: [
-        "Offer positioning",
-        "Landing page sections",
-        "Plan comparison",
-        "Final contact path",
-      ],
+      content: {
+        eyebrow: "Services",
+        title: "A concise package for the first page",
+        items: [
+          "Offer positioning",
+          "Landing page sections",
+          "Plan comparison",
+          "Final contact path",
+        ],
+      },
     },
     {
       composition_item_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa4",
-      variant_key: "plans.cards",
-      eyebrow: "Plans",
-      title: "Synthetic plans for layout validation",
-      disclaimer:
-        "Fixture-only values. They do not represent a public commercial offer.",
-      plans: [
-        {
-          key: "starter",
-          name: "Starter",
-          price: "R$ 50",
-          period: "/mo",
-          description: "One essential landing page.",
-          features: ["Responsive page", "Primary CTA", "Basic sections"],
-          highlighted: false,
-          cta: { label: "Choose starter", href: "#contact" },
-        },
-        {
-          key: "pro",
-          name: "Pro",
-          price: "R$ 200",
-          period: "/mo",
-          description: "More sections for a complete commercial story.",
-          features: ["Responsive page", "Plan cards", "FAQ", "Final CTA"],
-          highlighted: true,
-          cta: { label: "Choose pro", href: "#contact" },
-        },
-      ],
+      content: {
+        eyebrow: "Plans",
+        title: "Synthetic plans for layout validation",
+        disclaimer:
+          "Fixture-only values. They do not represent a public commercial offer.",
+        plans: [
+          {
+            key: "starter",
+            name: "Starter",
+            price: "R$ 50",
+            period: "/mo",
+            description: "One essential landing page.",
+            features: ["Responsive page", "Primary CTA", "Basic sections"],
+            highlighted: false,
+            cta: { label: "Choose starter", href: "/commercial/contact" },
+          },
+          {
+            key: "pro",
+            name: "Pro",
+            price: "R$ 200",
+            period: "/mo",
+            description: "More sections for a complete commercial story.",
+            features: ["Responsive page", "Plan cards", "FAQ", "Final CTA"],
+            highlighted: true,
+            cta: { label: "Choose pro", href: "/commercial/contact" },
+          },
+        ],
+      },
     },
     {
       composition_item_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa5",
-      variant_key: "differentials.cards",
-      eyebrow: "Differentials",
-      title: "Controlled flexibility without free-form components",
-      items: [
-        {
-          title: "Closed registry",
-          description:
-            "Only approved module and variant pairs can be rendered.",
-        },
-        {
-          title: "No raw HTML",
-          description:
-            "The artifact carries structured content only, not scripts, CSS, or component names.",
-        },
-      ],
+      content: {
+        eyebrow: "Differentials",
+        title: "Controlled flexibility without free-form components",
+        items: [
+          {
+            title: "Closed registry",
+            description:
+              "Only approved module and variant pairs can be rendered.",
+          },
+          {
+            title: "No raw HTML",
+            description:
+              "The artifact carries structured content only, not scripts, CSS, or component names.",
+          },
+        ],
+      },
     },
     {
       composition_item_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa6",
-      variant_key: "how_it_works.steps",
-      eyebrow: "How it works",
-      title: "From composition to rendered sections",
-      steps: [
-        {
-          label: "01",
-          title: "Load composition",
-          description: "The server receives ordered items and approved variants.",
-        },
-        {
-          label: "02",
-          title: "Validate content",
-          description: "Each content block must reference a valid composition item.",
-        },
-        {
-          label: "03",
-          title: "Render safely",
-          description: "Only registry-approved sections reach the React renderer.",
-        },
-      ],
+      content: {
+        eyebrow: "How it works",
+        title: "From composition to rendered sections",
+        steps: [
+          {
+            label: "01",
+            title: "Load composition",
+            description: "The server receives ordered items and approved variants.",
+          },
+          {
+            label: "02",
+            title: "Validate content",
+            description: "Each content block must reference a valid composition item.",
+          },
+          {
+            label: "03",
+            title: "Render safely",
+            description: "Only registry-approved sections reach the React renderer.",
+          },
+        ],
+      },
     },
     {
       composition_item_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa7",
-      variant_key: "faq.accordion",
-      eyebrow: "FAQ",
-      title: "Renderer contract questions",
-      questions: [
-        {
-          question: "Does this fixture read Supabase data?",
-          answer:
-            "No. It uses synthetic local data to validate Fase 1 without records or migrations.",
-        },
-        {
-          question: "Can the database choose an arbitrary component?",
-          answer:
-            "No. The registry only accepts known section and variant pairs.",
-        },
-      ],
+      content: {
+        eyebrow: "FAQ",
+        title: "Renderer contract questions",
+        questions: [
+          {
+            question: "Does this fixture read Supabase data?",
+            answer:
+              "No. It uses synthetic local data to validate Fase 1 without records or migrations.",
+          },
+          {
+            question: "Can the database choose an arbitrary component?",
+            answer:
+              "No. The registry only accepts known section and variant pairs.",
+          },
+        ],
+      },
     },
     {
       composition_item_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa8",
-      variant_key: "final_cta.simple",
-      title: "Ready for the next validation step",
-      description:
-        "After this repository-only contract is approved, real base records can be handled in a separate phase.",
-      cta: { label: "Continue", href: "#plans" },
+      content: {
+        title: "Ready for the next validation step",
+        description:
+          "After this repository-only contract is approved, real base records can be handled in a separate phase.",
+        cta: { label: "Continue", href: "/commercial/plans" },
+      },
     },
   ],
 };
-
-function cryptoIdForKey(key: string) {
-  const knownIds: Record<string, string> = {
-    hero: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb1",
-    benefits: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb2",
-    services: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb3",
-    plans: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb4",
-    differentials: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb5",
-    how_it_works: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb6",
-    faq: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb7",
-    final_cta: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb8",
-  };
-
-  return knownIds[key] ?? "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb0";
-}

--- a/lib/conversion-content/commercial-activation/index.ts
+++ b/lib/conversion-content/commercial-activation/index.ts
@@ -1,0 +1,5 @@
+export * from "./fixture";
+export * from "./registry";
+export * from "./renderer";
+export * from "./resolve";
+export * from "./schemas";

--- a/lib/conversion-content/commercial-activation/registry.ts
+++ b/lib/conversion-content/commercial-activation/registry.ts
@@ -1,4 +1,16 @@
-import type { CommercialActivationSectionVariant } from "./schemas";
+import type { ZodType } from "zod";
+import {
+  benefitsCardsContentSchema,
+  differentialsCardsContentSchema,
+  faqAccordionContentSchema,
+  finalCtaSimpleContentSchema,
+  heroDefaultContentSchema,
+  howItWorksStepsContentSchema,
+  plansCardsContentSchema,
+  servicesListContentSchema,
+  type CommercialActivationSectionContentByVariant,
+  type CommercialActivationSectionVariant,
+} from "./schemas";
 
 export type CommercialActivationModuleKey =
   | "hero"
@@ -10,21 +22,49 @@ export type CommercialActivationModuleKey =
   | "faq"
   | "final_cta";
 
-type RegistryEntry = {
+type RegistryEntry<Variant extends CommercialActivationSectionVariant> = {
   moduleKey: CommercialActivationModuleKey;
-  required: boolean;
+  schema: ZodType<CommercialActivationSectionContentByVariant[Variant]>;
+};
+
+type Registry = {
+  [Variant in CommercialActivationSectionVariant]: RegistryEntry<Variant>;
 };
 
 export const commercialActivationSectionRegistry = {
-  "hero.default": { moduleKey: "hero", required: true },
-  "benefits.cards": { moduleKey: "benefits", required: true },
-  "services.list": { moduleKey: "services", required: true },
-  "plans.cards": { moduleKey: "plans", required: true },
-  "differentials.cards": { moduleKey: "differentials", required: false },
-  "how_it_works.steps": { moduleKey: "how_it_works", required: true },
-  "faq.accordion": { moduleKey: "faq", required: false },
-  "final_cta.simple": { moduleKey: "final_cta", required: true },
-} satisfies Record<CommercialActivationSectionVariant, RegistryEntry>;
+  "hero.default": {
+    moduleKey: "hero",
+    schema: heroDefaultContentSchema,
+  },
+  "benefits.cards": {
+    moduleKey: "benefits",
+    schema: benefitsCardsContentSchema,
+  },
+  "services.list": {
+    moduleKey: "services",
+    schema: servicesListContentSchema,
+  },
+  "plans.cards": {
+    moduleKey: "plans",
+    schema: plansCardsContentSchema,
+  },
+  "differentials.cards": {
+    moduleKey: "differentials",
+    schema: differentialsCardsContentSchema,
+  },
+  "how_it_works.steps": {
+    moduleKey: "how_it_works",
+    schema: howItWorksStepsContentSchema,
+  },
+  "faq.accordion": {
+    moduleKey: "faq",
+    schema: faqAccordionContentSchema,
+  },
+  "final_cta.simple": {
+    moduleKey: "final_cta",
+    schema: finalCtaSimpleContentSchema,
+  },
+} satisfies Registry;
 
 export function isCommercialActivationSectionVariant(
   value: string,

--- a/lib/conversion-content/commercial-activation/registry.ts
+++ b/lib/conversion-content/commercial-activation/registry.ts
@@ -1,0 +1,33 @@
+import type { CommercialActivationSectionVariant } from "./schemas";
+
+export type CommercialActivationModuleKey =
+  | "hero"
+  | "benefits"
+  | "services"
+  | "plans"
+  | "differentials"
+  | "how_it_works"
+  | "faq"
+  | "final_cta";
+
+type RegistryEntry = {
+  moduleKey: CommercialActivationModuleKey;
+  required: boolean;
+};
+
+export const commercialActivationSectionRegistry = {
+  "hero.default": { moduleKey: "hero", required: true },
+  "benefits.cards": { moduleKey: "benefits", required: true },
+  "services.list": { moduleKey: "services", required: true },
+  "plans.cards": { moduleKey: "plans", required: true },
+  "differentials.cards": { moduleKey: "differentials", required: false },
+  "how_it_works.steps": { moduleKey: "how_it_works", required: true },
+  "faq.accordion": { moduleKey: "faq", required: false },
+  "final_cta.simple": { moduleKey: "final_cta", required: true },
+} satisfies Record<CommercialActivationSectionVariant, RegistryEntry>;
+
+export function isCommercialActivationSectionVariant(
+  value: string,
+): value is CommercialActivationSectionVariant {
+  return value in commercialActivationSectionRegistry;
+}

--- a/lib/conversion-content/commercial-activation/renderer.tsx
+++ b/lib/conversion-content/commercial-activation/renderer.tsx
@@ -1,20 +1,83 @@
+import type { ComponentType } from "react";
+
 import { cn } from "@/lib/utils";
 import type { ContentComposition } from "../contracts";
+import { commercialActivationSectionRegistry } from "./registry";
 import {
   resolveCommercialActivationRenderModel,
   type CommercialActivationRenderModel,
+  type CommercialActivationRenderSection,
 } from "./resolve";
-import type { CommercialActivationSectionContent } from "./schemas";
+import type {
+  BenefitsCardsContent,
+  CommercialActivationSectionContentByVariant,
+  CommercialActivationSectionVariant,
+  DifferentialsCardsContent,
+  FaqAccordionContent,
+  FinalCtaSimpleContent,
+  HeroDefaultContent,
+  HowItWorksStepsContent,
+  PlansCardsContent,
+  ServicesListContent,
+} from "./schemas";
 
 type RendererProps = {
   composition: ContentComposition;
   contentJson: unknown;
 };
 
+type SectionComponentProps<Variant extends CommercialActivationSectionVariant> = {
+  section: CommercialActivationRenderSection & {
+    variantKey: Variant;
+    content: CommercialActivationSectionContentByVariant[Variant];
+  };
+};
+
+type RendererRegistry = {
+  [Variant in CommercialActivationSectionVariant]: (typeof commercialActivationSectionRegistry)[Variant] & {
+    component: ComponentType<SectionComponentProps<Variant>>;
+  };
+};
+
 const primaryButton =
   "inline-flex min-h-11 items-center justify-center rounded-md bg-primary px-5 py-3 text-sm font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2";
 const secondaryButton =
   "inline-flex min-h-11 items-center justify-center rounded-md border border-graytech-300 bg-white px-5 py-3 text-sm font-semibold text-ink-900 shadow-sm transition-colors hover:bg-surface-app focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2";
+
+export const commercialActivationRendererRegistry = {
+  "hero.default": {
+    ...commercialActivationSectionRegistry["hero.default"],
+    component: HeroDefault,
+  },
+  "benefits.cards": {
+    ...commercialActivationSectionRegistry["benefits.cards"],
+    component: BenefitsCards,
+  },
+  "services.list": {
+    ...commercialActivationSectionRegistry["services.list"],
+    component: ServicesList,
+  },
+  "plans.cards": {
+    ...commercialActivationSectionRegistry["plans.cards"],
+    component: PlansCards,
+  },
+  "differentials.cards": {
+    ...commercialActivationSectionRegistry["differentials.cards"],
+    component: DifferentialsCards,
+  },
+  "how_it_works.steps": {
+    ...commercialActivationSectionRegistry["how_it_works.steps"],
+    component: HowItWorksSteps,
+  },
+  "faq.accordion": {
+    ...commercialActivationSectionRegistry["faq.accordion"],
+    component: FaqAccordion,
+  },
+  "final_cta.simple": {
+    ...commercialActivationSectionRegistry["final_cta.simple"],
+    component: FinalCtaSimple,
+  },
+} satisfies RendererRegistry;
 
 export function CommercialActivationRenderer({
   composition,
@@ -50,45 +113,47 @@ export function CommercialActivationSections({
       data-content-schema-version={model.schemaVersion}
     >
       {model.sections.map((section) => (
-        <SectionRenderer
-          key={section.compositionItemId}
-          content={section.content}
-        />
+        <SectionRenderer key={section.compositionItemId} section={section} />
       ))}
     </article>
   );
 }
 
-function SectionRenderer({
-  content,
-}: {
-  content: CommercialActivationSectionContent;
-}) {
-  switch (content.variant_key) {
+function SectionRenderer({ section }: { section: CommercialActivationRenderSection }) {
+  switch (section.variantKey) {
     case "hero.default":
-      return <HeroDefault content={content} />;
+      return <HeroDefault section={narrowSection(section, "hero.default")} />;
     case "benefits.cards":
-      return <CardsSection content={content} muted={false} />;
+      return <BenefitsCards section={narrowSection(section, "benefits.cards")} />;
     case "services.list":
-      return <ServicesList content={content} />;
+      return <ServicesList section={narrowSection(section, "services.list")} />;
     case "plans.cards":
-      return <PlansCards content={content} />;
+      return <PlansCards section={narrowSection(section, "plans.cards")} />;
     case "differentials.cards":
-      return <CardsSection content={content} muted />;
+      return (
+        <DifferentialsCards
+          section={narrowSection(section, "differentials.cards")}
+        />
+      );
     case "how_it_works.steps":
-      return <HowItWorksSteps content={content} />;
+      return (
+        <HowItWorksSteps
+          section={narrowSection(section, "how_it_works.steps")}
+        />
+      );
     case "faq.accordion":
-      return <FaqAccordion content={content} />;
+      return <FaqAccordion section={narrowSection(section, "faq.accordion")} />;
     case "final_cta.simple":
-      return <FinalCtaSimple content={content} />;
+      return (
+        <FinalCtaSimple section={narrowSection(section, "final_cta.simple")} />
+      );
   }
 }
 
 function HeroDefault({
-  content,
-}: {
-  content: Extract<CommercialActivationSectionContent, { variant_key: "hero.default" }>;
-}) {
+  section,
+}: SectionComponentProps<"hero.default">) {
+  const content = section.content;
   return (
     <section className="bg-gradient-to-br from-brand-dark-900 via-brand-dark-800 to-brand-700 px-6 py-14 text-white sm:px-10 sm:py-16 lg:px-14 lg:py-20">
       <div className="max-w-3xl">
@@ -122,14 +187,23 @@ function HeroDefault({
   );
 }
 
+function BenefitsCards({
+  section,
+}: SectionComponentProps<"benefits.cards">) {
+  return <CardsSection content={section.content} muted={false} />;
+}
+
+function DifferentialsCards({
+  section,
+}: SectionComponentProps<"differentials.cards">) {
+  return <CardsSection content={section.content} muted />;
+}
+
 function CardsSection({
   content,
   muted,
 }: {
-  content: Extract<
-    CommercialActivationSectionContent,
-    { variant_key: "benefits.cards" | "differentials.cards" }
-  >;
+  content: BenefitsCardsContent | DifferentialsCardsContent;
   muted: boolean;
 }) {
   return (
@@ -148,10 +222,9 @@ function CardsSection({
 }
 
 function ServicesList({
-  content,
-}: {
-  content: Extract<CommercialActivationSectionContent, { variant_key: "services.list" }>;
-}) {
+  section,
+}: SectionComponentProps<"services.list">) {
+  const content: ServicesListContent = section.content;
   return (
     <PageSection eyebrow={content.eyebrow} title={content.title} muted>
       <ul className="grid gap-3 sm:grid-cols-2">
@@ -160,9 +233,10 @@ function ServicesList({
             key={service}
             className="flex items-start gap-3 rounded-xl border border-surface-border bg-white p-4 text-sm font-medium leading-6 text-ink-800 shadow-card"
           >
-            <span aria-hidden="true" className="font-bold text-state-success">
-              {"OK"}
-            </span>
+            <span
+              aria-hidden="true"
+              className="mt-2 size-2 rounded-full bg-state-success"
+            />
             {service}
           </li>
         ))}
@@ -172,10 +246,9 @@ function ServicesList({
 }
 
 function PlansCards({
-  content,
-}: {
-  content: Extract<CommercialActivationSectionContent, { variant_key: "plans.cards" }>;
-}) {
+  section,
+}: SectionComponentProps<"plans.cards">) {
+  const content: PlansCardsContent = section.content;
   return (
     <PageSection eyebrow={content.eyebrow} title={content.title} centered>
       <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-4">
@@ -187,11 +260,6 @@ function PlansCards({
               plan.highlighted && "border-brand-500 ring-2 ring-brand-500/20",
             )}
           >
-            {plan.highlighted ? (
-              <span className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-brand-600 px-3 py-1 text-xs font-semibold text-white">
-                Highlight
-              </span>
-            ) : null}
             <h3 className="text-xl font-semibold text-ink-900">{plan.name}</h3>
             <p className="mt-2 min-h-10 text-sm leading-5 text-graytech-600">
               {plan.description}
@@ -208,9 +276,10 @@ function PlansCards({
                   key={feature}
                   className="flex items-start gap-2 text-sm text-graytech-600"
                 >
-                  <span aria-hidden="true" className="font-bold text-state-success">
-                    {"OK"}
-                  </span>
+                  <span
+                    aria-hidden="true"
+                    className="mt-2 size-2 rounded-full bg-state-success"
+                  />
                   {feature}
                 </li>
               ))}
@@ -237,13 +306,9 @@ function PlansCards({
 }
 
 function HowItWorksSteps({
-  content,
-}: {
-  content: Extract<
-    CommercialActivationSectionContent,
-    { variant_key: "how_it_works.steps" }
-  >;
-}) {
+  section,
+}: SectionComponentProps<"how_it_works.steps">) {
+  const content: HowItWorksStepsContent = section.content;
   return (
     <PageSection eyebrow={content.eyebrow} title={content.title} centered>
       <ol className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
@@ -269,10 +334,9 @@ function HowItWorksSteps({
 }
 
 function FaqAccordion({
-  content,
-}: {
-  content: Extract<CommercialActivationSectionContent, { variant_key: "faq.accordion" }>;
-}) {
+  section,
+}: SectionComponentProps<"faq.accordion">) {
+  const content: FaqAccordionContent = section.content;
   return (
     <PageSection eyebrow={content.eyebrow} title={content.title} muted>
       <div className="space-y-3">
@@ -303,10 +367,9 @@ function FaqAccordion({
 }
 
 function FinalCtaSimple({
-  content,
-}: {
-  content: Extract<CommercialActivationSectionContent, { variant_key: "final_cta.simple" }>;
-}) {
+  section,
+}: SectionComponentProps<"final_cta.simple">) {
+  const content: FinalCtaSimpleContent = section.content;
   return (
     <section className="bg-brand-50 px-6 py-12 text-center sm:px-10 lg:px-14">
       <h2 className="text-2xl font-bold tracking-tight text-brand-dark-900 sm:text-3xl">
@@ -372,4 +435,16 @@ function InfoCard({
       </p>
     </div>
   );
+}
+
+function narrowSection<Variant extends CommercialActivationSectionVariant>(
+  section: CommercialActivationRenderSection,
+  variantKey: Variant,
+) {
+  return {
+    ...section,
+    variantKey,
+    content:
+      section.content as CommercialActivationSectionContentByVariant[Variant],
+  };
 }

--- a/lib/conversion-content/commercial-activation/renderer.tsx
+++ b/lib/conversion-content/commercial-activation/renderer.tsx
@@ -120,34 +120,10 @@ export function CommercialActivationSections({
 }
 
 function SectionRenderer({ section }: { section: CommercialActivationRenderSection }) {
-  switch (section.variantKey) {
-    case "hero.default":
-      return <HeroDefault section={narrowSection(section, "hero.default")} />;
-    case "benefits.cards":
-      return <BenefitsCards section={narrowSection(section, "benefits.cards")} />;
-    case "services.list":
-      return <ServicesList section={narrowSection(section, "services.list")} />;
-    case "plans.cards":
-      return <PlansCards section={narrowSection(section, "plans.cards")} />;
-    case "differentials.cards":
-      return (
-        <DifferentialsCards
-          section={narrowSection(section, "differentials.cards")}
-        />
-      );
-    case "how_it_works.steps":
-      return (
-        <HowItWorksSteps
-          section={narrowSection(section, "how_it_works.steps")}
-        />
-      );
-    case "faq.accordion":
-      return <FaqAccordion section={narrowSection(section, "faq.accordion")} />;
-    case "final_cta.simple":
-      return (
-        <FinalCtaSimple section={narrowSection(section, "final_cta.simple")} />
-      );
-  }
+  const Component = commercialActivationRendererRegistry[section.variantKey]
+    .component as ComponentType<{ section: CommercialActivationRenderSection }>;
+
+  return <Component section={section} />;
 }
 
 function HeroDefault({
@@ -435,16 +411,4 @@ function InfoCard({
       </p>
     </div>
   );
-}
-
-function narrowSection<Variant extends CommercialActivationSectionVariant>(
-  section: CommercialActivationRenderSection,
-  variantKey: Variant,
-) {
-  return {
-    ...section,
-    variantKey,
-    content:
-      section.content as CommercialActivationSectionContentByVariant[Variant],
-  };
 }

--- a/lib/conversion-content/commercial-activation/renderer.tsx
+++ b/lib/conversion-content/commercial-activation/renderer.tsx
@@ -1,0 +1,375 @@
+import { cn } from "@/lib/utils";
+import type { ContentComposition } from "../contracts";
+import {
+  resolveCommercialActivationRenderModel,
+  type CommercialActivationRenderModel,
+} from "./resolve";
+import type { CommercialActivationSectionContent } from "./schemas";
+
+type RendererProps = {
+  composition: ContentComposition;
+  contentJson: unknown;
+};
+
+const primaryButton =
+  "inline-flex min-h-11 items-center justify-center rounded-md bg-primary px-5 py-3 text-sm font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2";
+const secondaryButton =
+  "inline-flex min-h-11 items-center justify-center rounded-md border border-graytech-300 bg-white px-5 py-3 text-sm font-semibold text-ink-900 shadow-sm transition-colors hover:bg-surface-app focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2";
+
+export function CommercialActivationRenderer({
+  composition,
+  contentJson,
+}: RendererProps) {
+  const resolved = resolveCommercialActivationRenderModel({
+    composition,
+    contentJson,
+    logSafeWarning: (message, details) => {
+      console.warn(message, details);
+    },
+  });
+
+  if (resolved.status !== "ready") {
+    console.error("CommercialActivationRenderer invalid artifact", {
+      reason: resolved.reason,
+      compositionId: composition.id,
+    });
+    return null;
+  }
+
+  return <CommercialActivationSections model={resolved.model} />;
+}
+
+export function CommercialActivationSections({
+  model,
+}: {
+  model: CommercialActivationRenderModel;
+}) {
+  return (
+    <article
+      className="overflow-hidden rounded-2xl border border-surface-border bg-white shadow-card"
+      data-content-schema-version={model.schemaVersion}
+    >
+      {model.sections.map((section) => (
+        <SectionRenderer
+          key={section.compositionItemId}
+          content={section.content}
+        />
+      ))}
+    </article>
+  );
+}
+
+function SectionRenderer({
+  content,
+}: {
+  content: CommercialActivationSectionContent;
+}) {
+  switch (content.variant_key) {
+    case "hero.default":
+      return <HeroDefault content={content} />;
+    case "benefits.cards":
+      return <CardsSection content={content} muted={false} />;
+    case "services.list":
+      return <ServicesList content={content} />;
+    case "plans.cards":
+      return <PlansCards content={content} />;
+    case "differentials.cards":
+      return <CardsSection content={content} muted />;
+    case "how_it_works.steps":
+      return <HowItWorksSteps content={content} />;
+    case "faq.accordion":
+      return <FaqAccordion content={content} />;
+    case "final_cta.simple":
+      return <FinalCtaSimple content={content} />;
+  }
+}
+
+function HeroDefault({
+  content,
+}: {
+  content: Extract<CommercialActivationSectionContent, { variant_key: "hero.default" }>;
+}) {
+  return (
+    <section className="bg-gradient-to-br from-brand-dark-900 via-brand-dark-800 to-brand-700 px-6 py-14 text-white sm:px-10 sm:py-16 lg:px-14 lg:py-20">
+      <div className="max-w-3xl">
+        <p className="text-sm font-semibold uppercase tracking-[0.18em] text-brand-50">
+          {content.eyebrow}
+        </p>
+        <h1 className="mt-4 text-3xl font-bold leading-tight tracking-tight sm:text-4xl lg:text-5xl">
+          {content.title}
+        </h1>
+        <p className="mt-5 max-w-2xl text-base leading-7 text-white/80 sm:text-lg">
+          {content.description}
+        </p>
+        <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+          <a
+            href={content.primary_cta.href}
+            className="inline-flex min-h-11 items-center justify-center rounded-md bg-white px-5 py-3 text-sm font-semibold text-brand-dark-900 shadow-sm hover:bg-brand-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-brand-dark-900"
+          >
+            {content.primary_cta.label}
+          </a>
+          {content.secondary_cta ? (
+            <a
+              href={content.secondary_cta.href}
+              className="inline-flex min-h-11 items-center justify-center rounded-md border border-white/40 px-5 py-3 text-sm font-semibold text-white hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-brand-dark-900"
+            >
+              {content.secondary_cta.label}
+            </a>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function CardsSection({
+  content,
+  muted,
+}: {
+  content: Extract<
+    CommercialActivationSectionContent,
+    { variant_key: "benefits.cards" | "differentials.cards" }
+  >;
+  muted: boolean;
+}) {
+  return (
+    <PageSection eyebrow={content.eyebrow} title={content.title} muted={muted}>
+      <div className="grid gap-4 md:grid-cols-3">
+        {content.items.map((item) => (
+          <InfoCard
+            key={item.title}
+            title={item.title}
+            description={item.description}
+          />
+        ))}
+      </div>
+    </PageSection>
+  );
+}
+
+function ServicesList({
+  content,
+}: {
+  content: Extract<CommercialActivationSectionContent, { variant_key: "services.list" }>;
+}) {
+  return (
+    <PageSection eyebrow={content.eyebrow} title={content.title} muted>
+      <ul className="grid gap-3 sm:grid-cols-2">
+        {content.items.map((service) => (
+          <li
+            key={service}
+            className="flex items-start gap-3 rounded-xl border border-surface-border bg-white p-4 text-sm font-medium leading-6 text-ink-800 shadow-card"
+          >
+            <span aria-hidden="true" className="font-bold text-state-success">
+              {"OK"}
+            </span>
+            {service}
+          </li>
+        ))}
+      </ul>
+    </PageSection>
+  );
+}
+
+function PlansCards({
+  content,
+}: {
+  content: Extract<CommercialActivationSectionContent, { variant_key: "plans.cards" }>;
+}) {
+  return (
+    <PageSection eyebrow={content.eyebrow} title={content.title} centered>
+      <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-4">
+        {content.plans.map((plan) => (
+          <div
+            key={plan.key}
+            className={cn(
+              "relative flex flex-col rounded-xl border border-surface-border bg-white p-5 shadow-card",
+              plan.highlighted && "border-brand-500 ring-2 ring-brand-500/20",
+            )}
+          >
+            {plan.highlighted ? (
+              <span className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-brand-600 px-3 py-1 text-xs font-semibold text-white">
+                Highlight
+              </span>
+            ) : null}
+            <h3 className="text-xl font-semibold text-ink-900">{plan.name}</h3>
+            <p className="mt-2 min-h-10 text-sm leading-5 text-graytech-600">
+              {plan.description}
+            </p>
+            <p className="mt-4 text-3xl font-bold tracking-tight text-ink-900">
+              {plan.price}
+              <span className="text-sm font-medium text-graytech-600">
+                {plan.period}
+              </span>
+            </p>
+            <ul className="mt-5 flex-1 space-y-3">
+              {plan.features.map((feature) => (
+                <li
+                  key={feature}
+                  className="flex items-start gap-2 text-sm text-graytech-600"
+                >
+                  <span aria-hidden="true" className="font-bold text-state-success">
+                    {"OK"}
+                  </span>
+                  {feature}
+                </li>
+              ))}
+            </ul>
+            <a
+              href={plan.cta.href}
+              className={cn(
+                "mt-6 w-full",
+                plan.highlighted ? primaryButton : secondaryButton,
+              )}
+            >
+              {plan.cta.label}
+            </a>
+          </div>
+        ))}
+      </div>
+      {content.disclaimer ? (
+        <p className="rounded-lg border border-state-warning/30 bg-amber-50 px-4 py-3 text-center text-sm font-medium leading-6 text-amber-900">
+          {content.disclaimer}
+        </p>
+      ) : null}
+    </PageSection>
+  );
+}
+
+function HowItWorksSteps({
+  content,
+}: {
+  content: Extract<
+    CommercialActivationSectionContent,
+    { variant_key: "how_it_works.steps" }
+  >;
+}) {
+  return (
+    <PageSection eyebrow={content.eyebrow} title={content.title} centered>
+      <ol className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {content.steps.map((step) => (
+          <li
+            key={step.label}
+            className="rounded-xl border border-surface-border p-5 shadow-card"
+          >
+            <span className="text-sm font-bold text-brand-700">
+              {step.label}
+            </span>
+            <h3 className="mt-3 text-lg font-semibold text-ink-900">
+              {step.title}
+            </h3>
+            <p className="mt-2 text-sm leading-6 text-graytech-600">
+              {step.description}
+            </p>
+          </li>
+        ))}
+      </ol>
+    </PageSection>
+  );
+}
+
+function FaqAccordion({
+  content,
+}: {
+  content: Extract<CommercialActivationSectionContent, { variant_key: "faq.accordion" }>;
+}) {
+  return (
+    <PageSection eyebrow={content.eyebrow} title={content.title} muted>
+      <div className="space-y-3">
+        {content.questions.map((item) => (
+          <details
+            key={item.question}
+            className="group rounded-xl border border-surface-border bg-white shadow-card"
+          >
+            <summary className="cursor-pointer list-none px-5 py-4 font-semibold text-ink-900 outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
+              <span className="flex items-center justify-between gap-4">
+                {item.question}
+                <span
+                  aria-hidden="true"
+                  className="text-xl text-brand-700 transition-transform group-open:rotate-45"
+                >
+                  +
+                </span>
+              </span>
+            </summary>
+            <p className="border-t border-surface-border px-5 py-4 text-sm leading-6 text-graytech-600">
+              {item.answer}
+            </p>
+          </details>
+        ))}
+      </div>
+    </PageSection>
+  );
+}
+
+function FinalCtaSimple({
+  content,
+}: {
+  content: Extract<CommercialActivationSectionContent, { variant_key: "final_cta.simple" }>;
+}) {
+  return (
+    <section className="bg-brand-50 px-6 py-12 text-center sm:px-10 lg:px-14">
+      <h2 className="text-2xl font-bold tracking-tight text-brand-dark-900 sm:text-3xl">
+        {content.title}
+      </h2>
+      <p className="mx-auto mt-4 max-w-2xl text-sm leading-6 text-graytech-600 sm:text-base">
+        {content.description}
+      </p>
+      <a href={content.cta.href} className={cn(primaryButton, "mt-7")}>
+        {content.cta.label}
+      </a>
+    </section>
+  );
+}
+
+type PageSectionProps = {
+  eyebrow: string;
+  title: string;
+  centered?: boolean;
+  muted?: boolean;
+  children: React.ReactNode;
+};
+
+function PageSection({
+  eyebrow,
+  title,
+  centered,
+  muted,
+  children,
+}: PageSectionProps) {
+  return (
+    <section
+      className={cn(
+        "px-6 py-12 sm:px-10 lg:px-14",
+        muted && "border-y border-surface-border bg-surface-app",
+      )}
+    >
+      <div className={cn("max-w-2xl", centered && "mx-auto text-center")}>
+        <p className="text-sm font-semibold uppercase tracking-[0.16em] text-brand-700">
+          {eyebrow}
+        </p>
+        <h2 className="mt-3 text-2xl font-bold tracking-tight text-ink-900 sm:text-3xl">
+          {title}
+        </h2>
+      </div>
+      <div className="mt-8">{children}</div>
+    </section>
+  );
+}
+
+function InfoCard({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="rounded-xl border border-surface-border bg-white p-5 shadow-card">
+      <h3 className="text-lg font-semibold text-ink-900">{title}</h3>
+      <p className="mt-2 text-sm leading-6 text-graytech-600">
+        {description}
+      </p>
+    </div>
+  );
+}

--- a/lib/conversion-content/commercial-activation/resolve.ts
+++ b/lib/conversion-content/commercial-activation/resolve.ts
@@ -1,0 +1,122 @@
+import type { ContentComposition } from "../contracts";
+import { commercialActivationSectionRegistry } from "./registry";
+import {
+  commercialActivationContentV1Schema,
+  commercialActivationSectionSchemas,
+  type CommercialActivationSectionContent,
+  type CommercialActivationSectionVariant,
+} from "./schemas";
+
+export type CommercialActivationRenderSection = {
+  compositionItemId: string;
+  sortOrder: number;
+  moduleKey: string;
+  variantKey: CommercialActivationSectionVariant;
+  content: CommercialActivationSectionContent;
+};
+
+export type CommercialActivationRenderModel = {
+  schemaVersion: 1;
+  sections: CommercialActivationRenderSection[];
+};
+
+export type CommercialActivationRenderResult =
+  | { status: "ready"; model: CommercialActivationRenderModel }
+  | {
+      status: "invalid";
+      reason:
+        | "content_schema_invalid"
+        | "composition_item_duplicate"
+        | "composition_item_unknown"
+        | "composition_item_missing"
+        | "section_registry_invalid"
+        | "section_content_invalid";
+    };
+
+export function resolveCommercialActivationRenderModel(input: {
+  composition: ContentComposition;
+  contentJson: unknown;
+  logSafeWarning?: (message: string, details: Record<string, unknown>) => void;
+}): CommercialActivationRenderResult {
+  const parsedContent =
+    commercialActivationContentV1Schema.safeParse(input.contentJson);
+  if (!parsedContent.success) {
+    return { status: "invalid", reason: "content_schema_invalid" };
+  }
+
+  const compositionItems = new Map(
+    input.composition.items.map((item) => [item.id, item]),
+  );
+  const contentItems = new Map<string, CommercialActivationSectionContent>();
+
+  for (const section of parsedContent.data.sections) {
+    if (contentItems.has(section.composition_item_id)) {
+      return { status: "invalid", reason: "composition_item_duplicate" };
+    }
+    if (!compositionItems.has(section.composition_item_id)) {
+      return { status: "invalid", reason: "composition_item_unknown" };
+    }
+    contentItems.set(section.composition_item_id, section);
+  }
+
+  const sections: CommercialActivationRenderSection[] = [];
+
+  for (const item of input.composition.items) {
+    if (!isRegisteredVariant(item.variantKey)) {
+      return { status: "invalid", reason: "section_registry_invalid" };
+    }
+
+    const registryEntry = commercialActivationSectionRegistry[item.variantKey];
+    const isRequired = item.isRequired || registryEntry.required;
+    if (item.module.key !== registryEntry.moduleKey) {
+      return { status: "invalid", reason: "section_registry_invalid" };
+    }
+
+    const section = contentItems.get(item.id);
+    if (!section) {
+      if (isRequired) {
+        return { status: "invalid", reason: "composition_item_missing" };
+      }
+      continue;
+    }
+
+    if (section.variant_key !== item.variantKey) {
+      return { status: "invalid", reason: "section_content_invalid" };
+    }
+
+    const schema = commercialActivationSectionSchemas[item.variantKey];
+    const parsedSection = schema.safeParse(section);
+    if (!parsedSection.success) {
+      if (isRequired) {
+        return { status: "invalid", reason: "section_content_invalid" };
+      }
+      input.logSafeWarning?.("optional commercial activation section omitted", {
+        compositionItemId: item.id,
+        variantKey: item.variantKey,
+      });
+      continue;
+    }
+
+    sections.push({
+      compositionItemId: item.id,
+      sortOrder: item.sortOrder,
+      moduleKey: item.module.key,
+      variantKey: item.variantKey,
+      content: parsedSection.data,
+    });
+  }
+
+  return {
+    status: "ready",
+    model: {
+      schemaVersion: parsedContent.data.schema_version,
+      sections: sections.sort((left, right) => left.sortOrder - right.sortOrder),
+    },
+  };
+}
+
+function isRegisteredVariant(
+  value: string,
+): value is CommercialActivationSectionVariant {
+  return value in commercialActivationSectionRegistry;
+}

--- a/lib/conversion-content/commercial-activation/resolve.ts
+++ b/lib/conversion-content/commercial-activation/resolve.ts
@@ -1,8 +1,10 @@
 import type { ContentComposition } from "../contracts";
-import { commercialActivationSectionRegistry } from "./registry";
+import {
+  commercialActivationSectionRegistry,
+  isCommercialActivationSectionVariant,
+} from "./registry";
 import {
   commercialActivationContentV1Schema,
-  commercialActivationSectionSchemas,
   type CommercialActivationSectionContent,
   type CommercialActivationSectionVariant,
 } from "./schemas";
@@ -47,7 +49,10 @@ export function resolveCommercialActivationRenderModel(input: {
   const compositionItems = new Map(
     input.composition.items.map((item) => [item.id, item]),
   );
-  const contentItems = new Map<string, CommercialActivationSectionContent>();
+  const contentItems = new Map<
+    string,
+    (typeof parsedContent.data.sections)[number]
+  >();
 
   for (const section of parsedContent.data.sections) {
     if (contentItems.has(section.composition_item_id)) {
@@ -62,32 +67,26 @@ export function resolveCommercialActivationRenderModel(input: {
   const sections: CommercialActivationRenderSection[] = [];
 
   for (const item of input.composition.items) {
-    if (!isRegisteredVariant(item.variantKey)) {
+    if (!isCommercialActivationSectionVariant(item.variantKey)) {
       return { status: "invalid", reason: "section_registry_invalid" };
     }
 
     const registryEntry = commercialActivationSectionRegistry[item.variantKey];
-    const isRequired = item.isRequired || registryEntry.required;
     if (item.module.key !== registryEntry.moduleKey) {
       return { status: "invalid", reason: "section_registry_invalid" };
     }
 
     const section = contentItems.get(item.id);
     if (!section) {
-      if (isRequired) {
+      if (item.isRequired) {
         return { status: "invalid", reason: "composition_item_missing" };
       }
       continue;
     }
 
-    if (section.variant_key !== item.variantKey) {
-      return { status: "invalid", reason: "section_content_invalid" };
-    }
-
-    const schema = commercialActivationSectionSchemas[item.variantKey];
-    const parsedSection = schema.safeParse(section);
+    const parsedSection = registryEntry.schema.safeParse(section.content);
     if (!parsedSection.success) {
-      if (isRequired) {
+      if (item.isRequired) {
         return { status: "invalid", reason: "section_content_invalid" };
       }
       input.logSafeWarning?.("optional commercial activation section omitted", {
@@ -113,10 +112,4 @@ export function resolveCommercialActivationRenderModel(input: {
       sections: sections.sort((left, right) => left.sortOrder - right.sortOrder),
     },
   };
-}
-
-function isRegisteredVariant(
-  value: string,
-): value is CommercialActivationSectionVariant {
-  return value in commercialActivationSectionRegistry;
 }

--- a/lib/conversion-content/commercial-activation/schemas.ts
+++ b/lib/conversion-content/commercial-activation/schemas.ts
@@ -1,0 +1,160 @@
+import { z } from "zod";
+
+const nonEmptyText = z.string().trim().min(1).max(220);
+const shortText = z.string().trim().min(1).max(96);
+const bodyText = z.string().trim().min(1).max(480);
+const ctaLabel = z.string().trim().min(1).max(40);
+const safeHref = z
+  .string()
+  .trim()
+  .min(1)
+  .max(500)
+  .refine(
+    (value) =>
+      value.startsWith("/") ||
+      value.startsWith("#") ||
+      value.startsWith("https://"),
+    "href must be relative, anchor, or https",
+  );
+
+const sectionBase = z.object({
+  composition_item_id: z.string().uuid(),
+});
+
+const ctaSchema = z.object({
+  label: ctaLabel,
+  href: safeHref,
+});
+
+const cardSchema = z.object({
+  title: shortText,
+  description: bodyText,
+});
+
+const heroDefaultSchema = sectionBase.extend({
+  variant_key: z.literal("hero.default"),
+  eyebrow: shortText,
+  title: z.string().trim().min(1).max(140),
+  description: bodyText,
+  primary_cta: ctaSchema,
+  secondary_cta: ctaSchema.optional(),
+});
+
+const benefitsCardsSchema = sectionBase.extend({
+  variant_key: z.literal("benefits.cards"),
+  eyebrow: shortText.default("Benefits"),
+  title: nonEmptyText,
+  items: z.array(cardSchema).min(2).max(6),
+});
+
+const servicesListSchema = sectionBase.extend({
+  variant_key: z.literal("services.list"),
+  eyebrow: shortText.default("Services"),
+  title: nonEmptyText,
+  items: z.array(shortText).min(3).max(8),
+});
+
+const plansCardsSchema = sectionBase.extend({
+  variant_key: z.literal("plans.cards"),
+  eyebrow: shortText.default("Plans"),
+  title: nonEmptyText,
+  disclaimer: bodyText.optional(),
+  plans: z
+    .array(
+      z.object({
+        key: z.string().trim().min(1).max(40),
+        name: shortText,
+        price: shortText,
+        period: z.string().trim().min(1).max(24),
+        description: bodyText,
+        features: z.array(shortText).min(2).max(8),
+        highlighted: z.boolean().default(false),
+        cta: ctaSchema,
+      }),
+    )
+    .min(1)
+    .max(4),
+});
+
+const differentialsCardsSchema = sectionBase.extend({
+  variant_key: z.literal("differentials.cards"),
+  eyebrow: shortText.default("Differentials"),
+  title: nonEmptyText,
+  items: z.array(cardSchema).min(2).max(6),
+});
+
+const howItWorksStepsSchema = sectionBase.extend({
+  variant_key: z.literal("how_it_works.steps"),
+  eyebrow: shortText.default("How it works"),
+  title: nonEmptyText,
+  steps: z
+    .array(
+      z.object({
+        label: z.string().trim().min(1).max(12),
+        title: shortText,
+        description: bodyText,
+      }),
+    )
+    .min(2)
+    .max(6),
+});
+
+const faqAccordionSchema = sectionBase.extend({
+  variant_key: z.literal("faq.accordion"),
+  eyebrow: shortText.default("FAQ"),
+  title: nonEmptyText,
+  questions: z
+    .array(
+      z.object({
+        question: nonEmptyText,
+        answer: bodyText,
+      }),
+    )
+    .min(2)
+    .max(8),
+});
+
+const finalCtaSimpleSchema = sectionBase.extend({
+  variant_key: z.literal("final_cta.simple"),
+  title: nonEmptyText,
+  description: bodyText,
+  cta: ctaSchema,
+});
+
+export const commercialActivationSectionSchemas = {
+  "hero.default": heroDefaultSchema,
+  "benefits.cards": benefitsCardsSchema,
+  "services.list": servicesListSchema,
+  "plans.cards": plansCardsSchema,
+  "differentials.cards": differentialsCardsSchema,
+  "how_it_works.steps": howItWorksStepsSchema,
+  "faq.accordion": faqAccordionSchema,
+  "final_cta.simple": finalCtaSimpleSchema,
+} as const;
+
+export const commercialActivationContentV1Schema = z.object({
+  schema_version: z.literal(1),
+  sections: z
+    .array(
+      z.discriminatedUnion("variant_key", [
+        heroDefaultSchema,
+        benefitsCardsSchema,
+        servicesListSchema,
+        plansCardsSchema,
+        differentialsCardsSchema,
+        howItWorksStepsSchema,
+        faqAccordionSchema,
+        finalCtaSimpleSchema,
+      ]),
+    )
+    .min(1)
+    .max(16),
+});
+
+export type CommercialActivationSectionVariant =
+  keyof typeof commercialActivationSectionSchemas;
+export type CommercialActivationContentV1 = z.infer<
+  typeof commercialActivationContentV1Schema
+>;
+export type CommercialActivationSectionContent =
+  CommercialActivationContentV1["sections"][number];

--- a/lib/conversion-content/commercial-activation/schemas.ts
+++ b/lib/conversion-content/commercial-activation/schemas.ts
@@ -4,157 +4,195 @@ const nonEmptyText = z.string().trim().min(1).max(220);
 const shortText = z.string().trim().min(1).max(96);
 const bodyText = z.string().trim().min(1).max(480);
 const ctaLabel = z.string().trim().min(1).max(40);
-const safeHref = z
+
+const internalPath = z
   .string()
   .trim()
-  .min(1)
-  .max(500)
-  .refine(
-    (value) =>
-      value.startsWith("/") ||
-      value.startsWith("#") ||
-      value.startsWith("https://"),
-    "href must be relative, anchor, or https",
-  );
+  .regex(/^\/(?!\/).+/, "href must start with a single slash");
 
-const sectionBase = z.object({
-  composition_item_id: z.string().uuid(),
-});
+const httpsUrl = z
+  .string()
+  .trim()
+  .url()
+  .refine((value) => {
+    try {
+      const url = new URL(value);
+      return url.protocol === "https:" && Boolean(url.hostname);
+    } catch {
+      return false;
+    }
+  }, "href must be a valid https URL");
 
-const ctaSchema = z.object({
-  label: ctaLabel,
-  href: safeHref,
-});
+const safeHref = z.union([internalPath, httpsUrl]);
 
-const cardSchema = z.object({
-  title: shortText,
-  description: bodyText,
-});
+export const ctaSchema = z
+  .object({
+    label: ctaLabel,
+    href: safeHref,
+  })
+  .strict();
 
-const heroDefaultSchema = sectionBase.extend({
-  variant_key: z.literal("hero.default"),
-  eyebrow: shortText,
-  title: z.string().trim().min(1).max(140),
-  description: bodyText,
-  primary_cta: ctaSchema,
-  secondary_cta: ctaSchema.optional(),
-});
+export const cardSchema = z
+  .object({
+    title: shortText,
+    description: bodyText,
+  })
+  .strict();
 
-const benefitsCardsSchema = sectionBase.extend({
-  variant_key: z.literal("benefits.cards"),
-  eyebrow: shortText.default("Benefits"),
-  title: nonEmptyText,
-  items: z.array(cardSchema).min(2).max(6),
-});
+export const heroDefaultContentSchema = z
+  .object({
+    eyebrow: shortText,
+    title: z.string().trim().min(1).max(140),
+    description: bodyText,
+    primary_cta: ctaSchema,
+    secondary_cta: ctaSchema.optional(),
+  })
+  .strict();
 
-const servicesListSchema = sectionBase.extend({
-  variant_key: z.literal("services.list"),
-  eyebrow: shortText.default("Services"),
-  title: nonEmptyText,
-  items: z.array(shortText).min(3).max(8),
-});
+export const benefitsCardsContentSchema = z
+  .object({
+    eyebrow: shortText,
+    title: nonEmptyText,
+    items: z.array(cardSchema).min(2).max(6),
+  })
+  .strict();
 
-const plansCardsSchema = sectionBase.extend({
-  variant_key: z.literal("plans.cards"),
-  eyebrow: shortText.default("Plans"),
-  title: nonEmptyText,
-  disclaimer: bodyText.optional(),
-  plans: z
-    .array(
-      z.object({
-        key: z.string().trim().min(1).max(40),
-        name: shortText,
-        price: shortText,
-        period: z.string().trim().min(1).max(24),
-        description: bodyText,
-        features: z.array(shortText).min(2).max(8),
-        highlighted: z.boolean().default(false),
-        cta: ctaSchema,
-      }),
-    )
-    .min(1)
-    .max(4),
-});
+export const servicesListContentSchema = z
+  .object({
+    eyebrow: shortText,
+    title: nonEmptyText,
+    items: z.array(shortText).min(3).max(8),
+  })
+  .strict();
 
-const differentialsCardsSchema = sectionBase.extend({
-  variant_key: z.literal("differentials.cards"),
-  eyebrow: shortText.default("Differentials"),
-  title: nonEmptyText,
-  items: z.array(cardSchema).min(2).max(6),
-});
+export const plansCardsContentSchema = z
+  .object({
+    eyebrow: shortText,
+    title: nonEmptyText,
+    disclaimer: bodyText.optional(),
+    plans: z
+      .array(
+        z
+          .object({
+            key: z.string().trim().min(1).max(40),
+            name: shortText,
+            price: shortText,
+            period: z.string().trim().min(1).max(24),
+            description: bodyText,
+            features: z.array(shortText).min(2).max(8),
+            highlighted: z.boolean().default(false),
+            cta: ctaSchema,
+          })
+          .strict(),
+      )
+      .min(1)
+      .max(4),
+  })
+  .strict();
 
-const howItWorksStepsSchema = sectionBase.extend({
-  variant_key: z.literal("how_it_works.steps"),
-  eyebrow: shortText.default("How it works"),
-  title: nonEmptyText,
-  steps: z
-    .array(
-      z.object({
-        label: z.string().trim().min(1).max(12),
-        title: shortText,
-        description: bodyText,
-      }),
-    )
-    .min(2)
-    .max(6),
-});
+export const differentialsCardsContentSchema = z
+  .object({
+    eyebrow: shortText,
+    title: nonEmptyText,
+    items: z.array(cardSchema).min(2).max(6),
+  })
+  .strict();
 
-const faqAccordionSchema = sectionBase.extend({
-  variant_key: z.literal("faq.accordion"),
-  eyebrow: shortText.default("FAQ"),
-  title: nonEmptyText,
-  questions: z
-    .array(
-      z.object({
-        question: nonEmptyText,
-        answer: bodyText,
-      }),
-    )
-    .min(2)
-    .max(8),
-});
+export const howItWorksStepsContentSchema = z
+  .object({
+    eyebrow: shortText,
+    title: nonEmptyText,
+    steps: z
+      .array(
+        z
+          .object({
+            label: z.string().trim().min(1).max(12),
+            title: shortText,
+            description: bodyText,
+          })
+          .strict(),
+      )
+      .min(2)
+      .max(6),
+  })
+  .strict();
 
-const finalCtaSimpleSchema = sectionBase.extend({
-  variant_key: z.literal("final_cta.simple"),
-  title: nonEmptyText,
-  description: bodyText,
-  cta: ctaSchema,
-});
+export const faqAccordionContentSchema = z
+  .object({
+    eyebrow: shortText,
+    title: nonEmptyText,
+    questions: z
+      .array(
+        z
+          .object({
+            question: nonEmptyText,
+            answer: bodyText,
+          })
+          .strict(),
+      )
+      .min(2)
+      .max(8),
+  })
+  .strict();
 
-export const commercialActivationSectionSchemas = {
-  "hero.default": heroDefaultSchema,
-  "benefits.cards": benefitsCardsSchema,
-  "services.list": servicesListSchema,
-  "plans.cards": plansCardsSchema,
-  "differentials.cards": differentialsCardsSchema,
-  "how_it_works.steps": howItWorksStepsSchema,
-  "faq.accordion": faqAccordionSchema,
-  "final_cta.simple": finalCtaSimpleSchema,
-} as const;
+export const finalCtaSimpleContentSchema = z
+  .object({
+    title: nonEmptyText,
+    description: bodyText,
+    cta: ctaSchema,
+  })
+  .strict();
 
-export const commercialActivationContentV1Schema = z.object({
-  schema_version: z.literal(1),
-  sections: z
-    .array(
-      z.discriminatedUnion("variant_key", [
-        heroDefaultSchema,
-        benefitsCardsSchema,
-        servicesListSchema,
-        plansCardsSchema,
-        differentialsCardsSchema,
-        howItWorksStepsSchema,
-        faqAccordionSchema,
-        finalCtaSimpleSchema,
-      ]),
-    )
-    .min(1)
-    .max(16),
-});
+export const commercialActivationSectionEnvelopeSchema = z
+  .object({
+    composition_item_id: z.string().uuid(),
+    content: z.record(z.string(), z.unknown()),
+  })
+  .strict();
+
+export const commercialActivationContentV1Schema = z
+  .object({
+    schema_version: z.literal(1),
+    sections: z.array(commercialActivationSectionEnvelopeSchema).min(1).max(16),
+  })
+  .strict();
 
 export type CommercialActivationSectionVariant =
-  keyof typeof commercialActivationSectionSchemas;
+  | "hero.default"
+  | "benefits.cards"
+  | "services.list"
+  | "plans.cards"
+  | "differentials.cards"
+  | "how_it_works.steps"
+  | "faq.accordion"
+  | "final_cta.simple";
+
+export type HeroDefaultContent = z.infer<typeof heroDefaultContentSchema>;
+export type BenefitsCardsContent = z.infer<typeof benefitsCardsContentSchema>;
+export type ServicesListContent = z.infer<typeof servicesListContentSchema>;
+export type PlansCardsContent = z.infer<typeof plansCardsContentSchema>;
+export type DifferentialsCardsContent = z.infer<
+  typeof differentialsCardsContentSchema
+>;
+export type HowItWorksStepsContent = z.infer<
+  typeof howItWorksStepsContentSchema
+>;
+export type FaqAccordionContent = z.infer<typeof faqAccordionContentSchema>;
+export type FinalCtaSimpleContent = z.infer<typeof finalCtaSimpleContentSchema>;
 export type CommercialActivationContentV1 = z.infer<
   typeof commercialActivationContentV1Schema
 >;
+
+export type CommercialActivationSectionContentByVariant = {
+  "hero.default": HeroDefaultContent;
+  "benefits.cards": BenefitsCardsContent;
+  "services.list": ServicesListContent;
+  "plans.cards": PlansCardsContent;
+  "differentials.cards": DifferentialsCardsContent;
+  "how_it_works.steps": HowItWorksStepsContent;
+  "faq.accordion": FaqAccordionContent;
+  "final_cta.simple": FinalCtaSimpleContent;
+};
+
 export type CommercialActivationSectionContent =
-  CommercialActivationContentV1["sections"][number];
+  CommercialActivationSectionContentByVariant[CommercialActivationSectionVariant];

--- a/lib/conversion-content/commercial-activation/validation-cases.ts
+++ b/lib/conversion-content/commercial-activation/validation-cases.ts
@@ -1,0 +1,233 @@
+import assert from "node:assert/strict";
+
+import {
+  commercialActivationFixtureComposition,
+  commercialActivationFixtureContent,
+} from "./fixture";
+import { resolveCommercialActivationRenderModel } from "./resolve";
+import type { CommercialActivationContentV1 } from "./schemas";
+import type { ContentComposition } from "../contracts";
+
+type Case = {
+  name: string;
+  run: () => void;
+};
+
+const requiredHeroId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1";
+const optionalDifferentialsId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa5";
+const optionalFaqId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa7";
+
+const cases: Case[] = [
+  {
+    name: "valid content resolves all fixture sections",
+    run: () => {
+      const result = resolveCommercialActivationRenderModel({
+        composition: clone(commercialActivationFixtureComposition),
+        contentJson: clone(commercialActivationFixtureContent),
+      });
+
+      assert.equal(result.status, "ready");
+      assert.equal(result.model.sections.length, 8);
+    },
+  },
+  {
+    name: "duplicate composition item id invalidates artifact",
+    run: () => {
+      const content = clone(commercialActivationFixtureContent);
+      content.sections[1].composition_item_id = requiredHeroId;
+
+      const result = resolveCommercialActivationRenderModel({
+        composition: clone(commercialActivationFixtureComposition),
+        contentJson: content,
+      });
+
+      assert.deepEqual(result, {
+        status: "invalid",
+        reason: "composition_item_duplicate",
+      });
+    },
+  },
+  {
+    name: "unknown composition item id invalidates artifact",
+    run: () => {
+      const content = clone(commercialActivationFixtureContent);
+      content.sections[0].composition_item_id =
+        "99999999-9999-4999-8999-999999999999";
+
+      const result = resolveCommercialActivationRenderModel({
+        composition: clone(commercialActivationFixtureComposition),
+        contentJson: content,
+      });
+
+      assert.deepEqual(result, {
+        status: "invalid",
+        reason: "composition_item_unknown",
+      });
+    },
+  },
+  {
+    name: "module and variant mismatch invalidates artifact",
+    run: () => {
+      const composition = clone(commercialActivationFixtureComposition);
+      composition.items[0].module.key = "services";
+
+      const result = resolveCommercialActivationRenderModel({
+        composition,
+        contentJson: clone(commercialActivationFixtureContent),
+      });
+
+      assert.deepEqual(result, {
+        status: "invalid",
+        reason: "section_registry_invalid",
+      });
+    },
+  },
+  {
+    name: "missing required section invalidates artifact",
+    run: () => {
+      const content = withoutSection(requiredHeroId);
+
+      const result = resolveCommercialActivationRenderModel({
+        composition: clone(commercialActivationFixtureComposition),
+        contentJson: content,
+      });
+
+      assert.deepEqual(result, {
+        status: "invalid",
+        reason: "composition_item_missing",
+      });
+    },
+  },
+  {
+    name: "invalid required section invalidates artifact",
+    run: () => {
+      const content = clone(commercialActivationFixtureContent);
+      const hero = content.sections.find(
+        (section) => section.composition_item_id === requiredHeroId,
+      );
+      assert.ok(hero);
+      hero.content = { title: "Missing required hero fields" };
+
+      const result = resolveCommercialActivationRenderModel({
+        composition: clone(commercialActivationFixtureComposition),
+        contentJson: content,
+      });
+
+      assert.deepEqual(result, {
+        status: "invalid",
+        reason: "section_content_invalid",
+      });
+    },
+  },
+  {
+    name: "missing optional section is omitted",
+    run: () => {
+      const content = withoutSection(optionalFaqId);
+
+      const result = resolveCommercialActivationRenderModel({
+        composition: clone(commercialActivationFixtureComposition),
+        contentJson: content,
+      });
+
+      assert.equal(result.status, "ready");
+      assert.equal(
+        result.model.sections.some(
+          (section) => section.compositionItemId === optionalFaqId,
+        ),
+        false,
+      );
+    },
+  },
+  {
+    name: "invalid optional section is omitted with safe log",
+    run: () => {
+      const content = clone(commercialActivationFixtureContent);
+      const optional = content.sections.find(
+        (section) => section.composition_item_id === optionalDifferentialsId,
+      );
+      assert.ok(optional);
+      optional.content = { title: "Missing cards" };
+
+      const warnings: Array<Record<string, unknown>> = [];
+      const result = resolveCommercialActivationRenderModel({
+        composition: clone(commercialActivationFixtureComposition),
+        contentJson: content,
+        logSafeWarning: (_message, details) => warnings.push(details),
+      });
+
+      assert.equal(result.status, "ready");
+      assert.equal(
+        result.model.sections.some(
+          (section) => section.compositionItemId === optionalDifferentialsId,
+        ),
+        false,
+      );
+      assert.deepEqual(warnings, [
+        {
+          compositionItemId: optionalDifferentialsId,
+          variantKey: "differentials.cards",
+        },
+      ]);
+    },
+  },
+  {
+    name: "unknown root field fails strict schema",
+    run: () => {
+      const content = {
+        ...clone(commercialActivationFixtureContent),
+        unexpected: true,
+      };
+
+      const result = resolveCommercialActivationRenderModel({
+        composition: clone(commercialActivationFixtureComposition),
+        contentJson: content,
+      });
+
+      assert.deepEqual(result, {
+        status: "invalid",
+        reason: "content_schema_invalid",
+      });
+    },
+  },
+  {
+    name: "invalid URL fails section schema",
+    run: () => {
+      const content = clone(commercialActivationFixtureContent);
+      const hero = content.sections.find(
+        (section) => section.composition_item_id === requiredHeroId,
+      );
+      assert.ok(hero);
+      hero.content = {
+        ...hero.content,
+        primary_cta: { label: "Broken", href: "https://" },
+      };
+
+      const result = resolveCommercialActivationRenderModel({
+        composition: clone(commercialActivationFixtureComposition),
+        contentJson: content,
+      });
+
+      assert.deepEqual(result, {
+        status: "invalid",
+        reason: "section_content_invalid",
+      });
+    },
+  },
+];
+
+for (const validationCase of cases) {
+  validationCase.run();
+  console.log(`ok - ${validationCase.name}`);
+}
+
+function withoutSection(compositionItemId: string): CommercialActivationContentV1 {
+  const content = clone(commercialActivationFixtureContent);
+  content.sections = content.sections.filter(
+    (section) => section.composition_item_id !== compositionItemId,
+  );
+  return content;
+}
+
+function clone<T>(value: T): T {
+  return globalThis.structuredClone(value);
+}

--- a/lib/conversion-content/index.ts
+++ b/lib/conversion-content/index.ts
@@ -1,3 +1,4 @@
 export * from "./contracts";
 export * from "./validation";
+export * from "./commercial-activation";
 export { getCommercialActivationBundle } from "./adapters/commercialActivationAdapter";

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "eslint": "^9.39.1",
         "postcss": "8.4.41",
         "tailwindcss": "3.4.10",
+        "tsx": "^4.22.4",
         "typescript": "5.5.4"
       }
     },
@@ -315,6 +316,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1235,23 +1678,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
-      }
-    },
-    "node_modules/@playwright/test": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "playwright": "1.58.2"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/primitive": {
@@ -3336,6 +3762,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -5349,55 +5817,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "playwright-core": "1.58.2"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOB+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -6497,6 +6916,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "next": "^16.1.1",
         "react": "19.2.1",
         "react-dom": "19.2.1",
-        "tailwindcss-animate": "1.0.7"
+        "tailwindcss-animate": "1.0.7",
+        "zod": "^4.2.1"
       },
       "devDependencies": {
         "@types/react": "^19.0.0",
@@ -5385,7 +5386,7 @@
     "node_modules/playwright/node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOB+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "next": "^16.1.1",
     "react": "19.2.1",
     "react-dom": "19.2.1",
-    "tailwindcss-animate": "1.0.7"
+    "tailwindcss-animate": "1.0.7",
+    "zod": "^4.2.1"
   },
   "devDependencies": {
     "@types/react": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "eslint .",
     "check": "npm run lint && npm run typecheck",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "validate:commercial-activation": "tsx lib/conversion-content/commercial-activation/validation-cases.ts"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "1.1.7",
@@ -32,6 +33,7 @@
     "eslint": "^9.39.1",
     "postcss": "8.4.41",
     "tailwindcss": "3.4.10",
+    "tsx": "^4.22.4",
     "typescript": "5.5.4"
   }
 }


### PR DESCRIPTION
## Summary

- Adds the repository-only E18 Fase 1 contract for `commercial_activation` content JSON v1 using Zod.
- Uses the artifact shape `{ schema_version, sections: [{ composition_item_id, content }] }`; module, variant, order, and requiredness come only from composition items.
- Adds a canonical typed registry for `variantKey -> moduleKey -> schema -> component`, a resolver, reusable renderer components, and a complete synthetic fixture.
- Adds executable validation cases for valid content, duplicate/unknown IDs, registry mismatch, required/optional failures, strict unknown fields, and invalid URLs.
- Updates the E18.12 roadmap entry with the Fase 1 PR artifact paths.

## Scope boundaries

- No Supabase migration was created.
- No Supabase data was written or changed.
- No integration with `/a/[account]` or E10.7 runtime display was added.
- No Fase 2 records, real taxon data, published artifact, or tracking changes were implemented.

## Validation

- `npm ci` passed.
- `npm run validate:commercial-activation` passed.
- `npm run check` passed with existing warnings only.
- `git diff --check` passed.
- Manual harness smoke passed and the temporary harness was removed before commit:
  - Desktop `1440x900`: rendered 8 sections, no visible error, no horizontal overflow, no console errors.
  - Mobile `390x844`: rendered 8 sections, no visible error, no horizontal overflow, no console errors.
- `npm run build` was not run locally because AGENTS.md says not to include build in the Codex sandbox check routine.
- Remote status after push: Vercel `lpf-10-services` passed; Vercel `lp-factory-10` was still pending at the time of this update.