### PR TITLE
E18 Phase 2 commercial activation base records

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1156,7 +1156,7 @@ Repositório — Criados
 
 18.12 Fase 1 — Contratos e renderer de `commercial_activation`
 
-• Status: Em PR — implementação da Fase 1 preparada no repositório, pendente de revisão e merge.
+• Status: Concluída e mergeada no PR #392.
 • Execução exclusiva no repositório, sem migration ou alteração no Supabase.
 • Objetivo: validar e renderizar composições da família `commercial_activation` com dados sintéticos.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1227,7 +1227,7 @@ Repositório — Ajustados
 
 18.13 Fase 2 — Registros-base de `commercial_activation`
 
-• Status: Planejado.
+• Status: Em PR — migration e snippet preparados, aguardando merge e aplicação no Supabase real.
 • Execução restrita ao provisionamento de banco e aos artefatos de verificação correspondentes.
 • Depende da Fase 1 aprovada e mergeada.
 • Objetivo: provisionar os registros transversais correspondentes ao código aprovado.
@@ -1251,6 +1251,11 @@ Escopo:
 • manter identificadores e versões iguais aos contratos da Fase 1;
 • manter `payload_json` mínimo, declarativo e sem função operacional no renderer;
 • criar snippet read-only de verificação.
+
+Artefatos preparados:
+
+• `supabase/migrations/20260616142000_e18_commercial_activation_base_records.sql`
+• `supabase/snippets/e18_commercial_activation_base_records_verify.sql`
 
 Limites:
 

--- a/supabase/migrations/20260616142000_e18_commercial_activation_base_records.sql
+++ b/supabase/migrations/20260616142000_e18_commercial_activation_base_records.sql
@@ -1,0 +1,180 @@
+begin;
+
+insert into public.content_templates (
+  id,
+  template_key,
+  name,
+  slug,
+  template_family,
+  template_scope,
+  status,
+  version,
+  is_active,
+  payload_json,
+  notes
+)
+values
+  (
+    '11111111-1111-4111-8111-111111111111',
+    'commercial_activation_page',
+    'Commercial activation page',
+    'commercial-activation-page',
+    'commercial_activation',
+    'page',
+    'active',
+    1,
+    true,
+    '{}'::jsonb,
+    'E18 Fase 2 base page template for commercial_activation.'
+  ),
+  (
+    'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb1',
+    'hero',
+    'Hero',
+    'hero',
+    'commercial_activation',
+    'section',
+    'active',
+    1,
+    true,
+    '{}'::jsonb,
+    'E18 Fase 2 base section module.'
+  ),
+  (
+    'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb2',
+    'benefits',
+    'Benefits',
+    'benefits',
+    'commercial_activation',
+    'section',
+    'active',
+    1,
+    true,
+    '{}'::jsonb,
+    'E18 Fase 2 base section module.'
+  ),
+  (
+    'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb3',
+    'services',
+    'Services',
+    'services',
+    'commercial_activation',
+    'section',
+    'active',
+    1,
+    true,
+    '{}'::jsonb,
+    'E18 Fase 2 base section module.'
+  ),
+  (
+    'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb4',
+    'plans',
+    'Plans',
+    'plans',
+    'commercial_activation',
+    'section',
+    'active',
+    1,
+    true,
+    '{}'::jsonb,
+    'E18 Fase 2 base section module.'
+  ),
+  (
+    'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb5',
+    'differentials',
+    'Differentials',
+    'differentials',
+    'commercial_activation',
+    'section',
+    'active',
+    1,
+    true,
+    '{}'::jsonb,
+    'E18 Fase 2 base section module.'
+  ),
+  (
+    'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb6',
+    'how_it_works',
+    'How it works',
+    'how-it-works',
+    'commercial_activation',
+    'section',
+    'active',
+    1,
+    true,
+    '{}'::jsonb,
+    'E18 Fase 2 base section module.'
+  ),
+  (
+    'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb7',
+    'faq',
+    'FAQ',
+    'faq',
+    'commercial_activation',
+    'section',
+    'active',
+    1,
+    true,
+    '{}'::jsonb,
+    'E18 Fase 2 base section module.'
+  ),
+  (
+    'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb8',
+    'final_cta',
+    'Final CTA',
+    'final-cta',
+    'commercial_activation',
+    'section',
+    'active',
+    1,
+    true,
+    '{}'::jsonb,
+    'E18 Fase 2 base section module.'
+  );
+
+do $$
+declare
+  inserted_count integer;
+begin
+  with expected_records (
+    id,
+    template_key,
+    slug,
+    template_family,
+    template_scope,
+    version,
+    status,
+    is_active,
+    payload_json
+  ) as (
+    values
+      ('11111111-1111-4111-8111-111111111111'::uuid, 'commercial_activation_page', 'commercial-activation-page', 'commercial_activation', 'page', 1, 'active', true, '{}'::jsonb),
+      ('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb1'::uuid, 'hero', 'hero', 'commercial_activation', 'section', 1, 'active', true, '{}'::jsonb),
+      ('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb2'::uuid, 'benefits', 'benefits', 'commercial_activation', 'section', 1, 'active', true, '{}'::jsonb),
+      ('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb3'::uuid, 'services', 'services', 'commercial_activation', 'section', 1, 'active', true, '{}'::jsonb),
+      ('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb4'::uuid, 'plans', 'plans', 'commercial_activation', 'section', 1, 'active', true, '{}'::jsonb),
+      ('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb5'::uuid, 'differentials', 'differentials', 'commercial_activation', 'section', 1, 'active', true, '{}'::jsonb),
+      ('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb6'::uuid, 'how_it_works', 'how-it-works', 'commercial_activation', 'section', 1, 'active', true, '{}'::jsonb),
+      ('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb7'::uuid, 'faq', 'faq', 'commercial_activation', 'section', 1, 'active', true, '{}'::jsonb),
+      ('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb8'::uuid, 'final_cta', 'final-cta', 'commercial_activation', 'section', 1, 'active', true, '{}'::jsonb)
+  )
+  select count(*)
+  into inserted_count
+  from expected_records
+  join public.content_templates
+    on content_templates.id = expected_records.id
+   and content_templates.template_key = expected_records.template_key
+   and content_templates.slug = expected_records.slug
+   and content_templates.template_family = expected_records.template_family
+   and content_templates.template_scope = expected_records.template_scope
+   and content_templates.version = expected_records.version
+   and content_templates.status = expected_records.status
+   and content_templates.is_active = expected_records.is_active
+   and content_templates.payload_json = expected_records.payload_json;
+
+  if inserted_count <> 9 then
+    raise exception 'E18 Fase 2 base records were not fully inserted';
+  end if;
+end $$;
+
+commit;

--- a/supabase/migrations/20260616142000_e18_commercial_activation_base_records.sql
+++ b/supabase/migrations/20260616142000_e18_commercial_activation_base_records.sql
@@ -1,7 +1,6 @@
 begin;
 
 insert into public.content_templates (
-  id,
   template_key,
   name,
   slug,
@@ -15,7 +14,6 @@ insert into public.content_templates (
 )
 values
   (
-    '11111111-1111-4111-8111-111111111111',
     'commercial_activation_page',
     'Commercial activation page',
     'commercial-activation-page',
@@ -28,7 +26,6 @@ values
     'E18 Fase 2 base page template for commercial_activation.'
   ),
   (
-    'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb1',
     'hero',
     'Hero',
     'hero',
@@ -41,7 +38,6 @@ values
     'E18 Fase 2 base section module.'
   ),
   (
-    'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb2',
     'benefits',
     'Benefits',
     'benefits',
@@ -54,7 +50,6 @@ values
     'E18 Fase 2 base section module.'
   ),
   (
-    'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb3',
     'services',
     'Services',
     'services',
@@ -67,7 +62,6 @@ values
     'E18 Fase 2 base section module.'
   ),
   (
-    'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb4',
     'plans',
     'Plans',
     'plans',
@@ -80,7 +74,6 @@ values
     'E18 Fase 2 base section module.'
   ),
   (
-    'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb5',
     'differentials',
     'Differentials',
     'differentials',
@@ -93,7 +86,6 @@ values
     'E18 Fase 2 base section module.'
   ),
   (
-    'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb6',
     'how_it_works',
     'How it works',
     'how-it-works',
@@ -106,7 +98,6 @@ values
     'E18 Fase 2 base section module.'
   ),
   (
-    'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb7',
     'faq',
     'FAQ',
     'faq',
@@ -119,7 +110,6 @@ values
     'E18 Fase 2 base section module.'
   ),
   (
-    'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb8',
     'final_cta',
     'Final CTA',
     'final-cta',
@@ -137,7 +127,6 @@ declare
   inserted_count integer;
 begin
   with expected_records (
-    id,
     template_key,
     slug,
     template_family,
@@ -148,26 +137,25 @@ begin
     payload_json
   ) as (
     values
-      ('11111111-1111-4111-8111-111111111111'::uuid, 'commercial_activation_page', 'commercial-activation-page', 'commercial_activation', 'page', 1, 'active', true, '{}'::jsonb),
-      ('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb1'::uuid, 'hero', 'hero', 'commercial_activation', 'section', 1, 'active', true, '{}'::jsonb),
-      ('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb2'::uuid, 'benefits', 'benefits', 'commercial_activation', 'section', 1, 'active', true, '{}'::jsonb),
-      ('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb3'::uuid, 'services', 'services', 'commercial_activation', 'section', 1, 'active', true, '{}'::jsonb),
-      ('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb4'::uuid, 'plans', 'plans', 'commercial_activation', 'section', 1, 'active', true, '{}'::jsonb),
-      ('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb5'::uuid, 'differentials', 'differentials', 'commercial_activation', 'section', 1, 'active', true, '{}'::jsonb),
-      ('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb6'::uuid, 'how_it_works', 'how-it-works', 'commercial_activation', 'section', 1, 'active', true, '{}'::jsonb),
-      ('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb7'::uuid, 'faq', 'faq', 'commercial_activation', 'section', 1, 'active', true, '{}'::jsonb),
-      ('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb8'::uuid, 'final_cta', 'final-cta', 'commercial_activation', 'section', 1, 'active', true, '{}'::jsonb)
+      ('commercial_activation_page', 'commercial-activation-page', 'commercial_activation', 'page', 1, 'active', true, '{}'::jsonb),
+      ('hero', 'hero', 'commercial_activation', 'section', 1, 'active', true, '{}'::jsonb),
+      ('benefits', 'benefits', 'commercial_activation', 'section', 1, 'active', true, '{}'::jsonb),
+      ('services', 'services', 'commercial_activation', 'section', 1, 'active', true, '{}'::jsonb),
+      ('plans', 'plans', 'commercial_activation', 'section', 1, 'active', true, '{}'::jsonb),
+      ('differentials', 'differentials', 'commercial_activation', 'section', 1, 'active', true, '{}'::jsonb),
+      ('how_it_works', 'how-it-works', 'commercial_activation', 'section', 1, 'active', true, '{}'::jsonb),
+      ('faq', 'faq', 'commercial_activation', 'section', 1, 'active', true, '{}'::jsonb),
+      ('final_cta', 'final-cta', 'commercial_activation', 'section', 1, 'active', true, '{}'::jsonb)
   )
   select count(*)
   into inserted_count
   from expected_records
   join public.content_templates
-    on content_templates.id = expected_records.id
-   and content_templates.template_key = expected_records.template_key
+    on content_templates.template_key = expected_records.template_key
+   and content_templates.version = expected_records.version
    and content_templates.slug = expected_records.slug
    and content_templates.template_family = expected_records.template_family
    and content_templates.template_scope = expected_records.template_scope
-   and content_templates.version = expected_records.version
    and content_templates.status = expected_records.status
    and content_templates.is_active = expected_records.is_active
    and content_templates.payload_json = expected_records.payload_json;

--- a/supabase/snippets/e18_commercial_activation_base_records_verify.sql
+++ b/supabase/snippets/e18_commercial_activation_base_records_verify.sql
@@ -1,169 +1,172 @@
 -- e18_commercial_activation_base_records_verify.sql
 -- Objetivo: verificar os 9 registros-base da E18 Fase 2 para commercial_activation.
 -- Tipo: read-only / execucao manual no Supabase SQL Editor.
--- Escopo: registros em content_templates, unicidade, status, familia, escopo, RLS e grants.
+-- Escopo: registros em content_templates, unicidade, status, familia, escopo, payload, RLS, grants e ausencia de vinculos em content_template_taxons.
 
 with expected_records as (
   select *
   from (
     values
       (
-        '11111111-1111-4111-8111-111111111111'::uuid,
         'commercial_activation_page'::text,
         'commercial-activation-page'::text,
         'Commercial activation page'::text,
         'commercial_activation'::text,
         'page'::text,
         1::integer,
-        true::boolean
+        '{}'::jsonb
       ),
       (
-        'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb1'::uuid,
         'hero'::text,
         'hero'::text,
         'Hero'::text,
         'commercial_activation'::text,
         'section'::text,
         1::integer,
-        true::boolean
+        '{}'::jsonb
       ),
       (
-        'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb2'::uuid,
         'benefits'::text,
         'benefits'::text,
         'Benefits'::text,
         'commercial_activation'::text,
         'section'::text,
         1::integer,
-        true::boolean
+        '{}'::jsonb
       ),
       (
-        'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb3'::uuid,
         'services'::text,
         'services'::text,
         'Services'::text,
         'commercial_activation'::text,
         'section'::text,
         1::integer,
-        true::boolean
+        '{}'::jsonb
       ),
       (
-        'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb4'::uuid,
         'plans'::text,
         'plans'::text,
         'Plans'::text,
         'commercial_activation'::text,
         'section'::text,
         1::integer,
-        true::boolean
+        '{}'::jsonb
       ),
       (
-        'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb5'::uuid,
         'differentials'::text,
         'differentials'::text,
         'Differentials'::text,
         'commercial_activation'::text,
         'section'::text,
         1::integer,
-        true::boolean
+        '{}'::jsonb
       ),
       (
-        'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb6'::uuid,
         'how_it_works'::text,
         'how-it-works'::text,
         'How it works'::text,
         'commercial_activation'::text,
         'section'::text,
         1::integer,
-        true::boolean
+        '{}'::jsonb
       ),
       (
-        'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb7'::uuid,
         'faq'::text,
         'faq'::text,
         'FAQ'::text,
         'commercial_activation'::text,
         'section'::text,
         1::integer,
-        true::boolean
+        '{}'::jsonb
       ),
       (
-        'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb8'::uuid,
         'final_cta'::text,
         'final-cta'::text,
         'Final CTA'::text,
         'commercial_activation'::text,
         'section'::text,
         1::integer,
-        true::boolean
+        '{}'::jsonb
       )
   ) as records(
-    id,
     template_key,
     slug,
     name,
     template_family,
     template_scope,
     version,
-    expect_empty_payload
+    payload_json
   )
+),
+
+matched_templates as (
+  select
+    expected_records.template_key,
+    expected_records.slug,
+    expected_records.name,
+    expected_records.template_family,
+    expected_records.template_scope,
+    expected_records.version,
+    expected_records.payload_json,
+    content_templates.id,
+    content_templates.slug as actual_slug,
+    content_templates.name as actual_name,
+    content_templates.template_family as actual_template_family,
+    content_templates.template_scope as actual_template_scope,
+    content_templates.status as actual_status,
+    content_templates.is_active as actual_is_active,
+    content_templates.payload_json as actual_payload_json
+  from expected_records
+  left join public.content_templates
+    on content_templates.template_key = expected_records.template_key
+   and content_templates.version = expected_records.version
 ),
 
 record_status as (
   select
     'record'::text as check_group,
-    expected_records.template_key as object_name,
+    matched_templates.template_key as object_name,
     case
-      when content_templates.id is null then 'missing'
-      when content_templates.id <> expected_records.id then 'id_mismatch'
-      when content_templates.slug <> expected_records.slug then 'slug_mismatch'
-      when content_templates.name <> expected_records.name then 'name_mismatch'
-      when content_templates.template_family <> expected_records.template_family then 'family_mismatch'
-      when content_templates.template_scope <> expected_records.template_scope then 'scope_mismatch'
-      when content_templates.version <> expected_records.version then 'version_mismatch'
-      when content_templates.status <> 'active' then 'status_mismatch'
-      when content_templates.is_active is not true then 'inactive'
-      when expected_records.expect_empty_payload
-        and content_templates.payload_json <> '{}'::jsonb then 'payload_not_empty'
-      when jsonb_typeof(content_templates.payload_json) <> 'object' then 'payload_not_object'
+      when matched_templates.id is null then 'missing'
+      when matched_templates.actual_slug <> matched_templates.slug then 'slug_mismatch'
+      when matched_templates.actual_name <> matched_templates.name then 'name_mismatch'
+      when matched_templates.actual_template_family <> matched_templates.template_family then 'family_mismatch'
+      when matched_templates.actual_template_scope <> matched_templates.template_scope then 'scope_mismatch'
+      when matched_templates.actual_status <> 'active' then 'status_mismatch'
+      when matched_templates.actual_is_active is not true then 'inactive'
+      when matched_templates.actual_payload_json <> matched_templates.payload_json then 'payload_mismatch'
       else 'ok'
     end as check_status,
     jsonb_build_object(
       'id',
-      content_templates.id,
+      matched_templates.id,
       'template_key',
-      content_templates.template_key,
+      matched_templates.template_key,
       'slug',
-      content_templates.slug,
+      matched_templates.actual_slug,
       'template_family',
-      content_templates.template_family,
+      matched_templates.actual_template_family,
       'template_scope',
-      content_templates.template_scope,
+      matched_templates.actual_template_scope,
       'version',
-      content_templates.version,
+      matched_templates.version,
       'status',
-      content_templates.status,
+      matched_templates.actual_status,
       'is_active',
-      content_templates.is_active,
+      matched_templates.actual_is_active,
       'payload_json',
-      content_templates.payload_json
+      matched_templates.actual_payload_json
     ) as details
-  from expected_records
-  left join public.content_templates
-    on content_templates.template_key = expected_records.template_key
-   and content_templates.version = expected_records.version
+  from matched_templates
 ),
 
 count_status as (
   select
     'count'::text as check_group,
     'expected_base_records'::text as object_name,
-    case when count(content_templates.id) = 9 then 'ok' else 'count_mismatch' end as check_status,
-    jsonb_build_object('count', count(content_templates.id)) as details
-  from expected_records
-  left join public.content_templates
-    on content_templates.template_key = expected_records.template_key
-   and content_templates.version = expected_records.version
+    case when count(matched_templates.id) = 9 then 'ok' else 'count_mismatch' end as check_status,
+    jsonb_build_object('count', count(matched_templates.id)) as details
+  from matched_templates
 ),
 
 duplicate_status as (
@@ -193,6 +196,18 @@ duplicate_status as (
     )
     group by content_templates.slug, content_templates.version
   ) duplicates
+),
+
+taxon_link_status as (
+  select
+    'taxon_links'::text as check_group,
+    matched_templates.template_key as object_name,
+    case when count(content_template_taxons.id) = 0 then 'ok' else 'unexpected_taxon_link' end as check_status,
+    jsonb_build_object('count', count(content_template_taxons.id)) as details
+  from matched_templates
+  left join public.content_template_taxons
+    on content_template_taxons.template_id = matched_templates.id
+  group by matched_templates.template_key
 ),
 
 rls_status as (
@@ -234,6 +249,9 @@ from count_status
 union all
 select *
 from duplicate_status
+union all
+select *
+from taxon_link_status
 union all
 select *
 from rls_status

--- a/supabase/snippets/e18_commercial_activation_base_records_verify.sql
+++ b/supabase/snippets/e18_commercial_activation_base_records_verify.sql
@@ -1,0 +1,245 @@
+-- e18_commercial_activation_base_records_verify.sql
+-- Objetivo: verificar os 9 registros-base da E18 Fase 2 para commercial_activation.
+-- Tipo: read-only / execucao manual no Supabase SQL Editor.
+-- Escopo: registros em content_templates, unicidade, status, familia, escopo, RLS e grants.
+
+with expected_records as (
+  select *
+  from (
+    values
+      (
+        '11111111-1111-4111-8111-111111111111'::uuid,
+        'commercial_activation_page'::text,
+        'commercial-activation-page'::text,
+        'Commercial activation page'::text,
+        'commercial_activation'::text,
+        'page'::text,
+        1::integer,
+        true::boolean
+      ),
+      (
+        'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb1'::uuid,
+        'hero'::text,
+        'hero'::text,
+        'Hero'::text,
+        'commercial_activation'::text,
+        'section'::text,
+        1::integer,
+        true::boolean
+      ),
+      (
+        'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb2'::uuid,
+        'benefits'::text,
+        'benefits'::text,
+        'Benefits'::text,
+        'commercial_activation'::text,
+        'section'::text,
+        1::integer,
+        true::boolean
+      ),
+      (
+        'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb3'::uuid,
+        'services'::text,
+        'services'::text,
+        'Services'::text,
+        'commercial_activation'::text,
+        'section'::text,
+        1::integer,
+        true::boolean
+      ),
+      (
+        'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb4'::uuid,
+        'plans'::text,
+        'plans'::text,
+        'Plans'::text,
+        'commercial_activation'::text,
+        'section'::text,
+        1::integer,
+        true::boolean
+      ),
+      (
+        'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb5'::uuid,
+        'differentials'::text,
+        'differentials'::text,
+        'Differentials'::text,
+        'commercial_activation'::text,
+        'section'::text,
+        1::integer,
+        true::boolean
+      ),
+      (
+        'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb6'::uuid,
+        'how_it_works'::text,
+        'how-it-works'::text,
+        'How it works'::text,
+        'commercial_activation'::text,
+        'section'::text,
+        1::integer,
+        true::boolean
+      ),
+      (
+        'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb7'::uuid,
+        'faq'::text,
+        'faq'::text,
+        'FAQ'::text,
+        'commercial_activation'::text,
+        'section'::text,
+        1::integer,
+        true::boolean
+      ),
+      (
+        'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb8'::uuid,
+        'final_cta'::text,
+        'final-cta'::text,
+        'Final CTA'::text,
+        'commercial_activation'::text,
+        'section'::text,
+        1::integer,
+        true::boolean
+      )
+  ) as records(
+    id,
+    template_key,
+    slug,
+    name,
+    template_family,
+    template_scope,
+    version,
+    expect_empty_payload
+  )
+),
+
+record_status as (
+  select
+    'record'::text as check_group,
+    expected_records.template_key as object_name,
+    case
+      when content_templates.id is null then 'missing'
+      when content_templates.id <> expected_records.id then 'id_mismatch'
+      when content_templates.slug <> expected_records.slug then 'slug_mismatch'
+      when content_templates.name <> expected_records.name then 'name_mismatch'
+      when content_templates.template_family <> expected_records.template_family then 'family_mismatch'
+      when content_templates.template_scope <> expected_records.template_scope then 'scope_mismatch'
+      when content_templates.version <> expected_records.version then 'version_mismatch'
+      when content_templates.status <> 'active' then 'status_mismatch'
+      when content_templates.is_active is not true then 'inactive'
+      when expected_records.expect_empty_payload
+        and content_templates.payload_json <> '{}'::jsonb then 'payload_not_empty'
+      when jsonb_typeof(content_templates.payload_json) <> 'object' then 'payload_not_object'
+      else 'ok'
+    end as check_status,
+    jsonb_build_object(
+      'id',
+      content_templates.id,
+      'template_key',
+      content_templates.template_key,
+      'slug',
+      content_templates.slug,
+      'template_family',
+      content_templates.template_family,
+      'template_scope',
+      content_templates.template_scope,
+      'version',
+      content_templates.version,
+      'status',
+      content_templates.status,
+      'is_active',
+      content_templates.is_active,
+      'payload_json',
+      content_templates.payload_json
+    ) as details
+  from expected_records
+  left join public.content_templates
+    on content_templates.template_key = expected_records.template_key
+   and content_templates.version = expected_records.version
+),
+
+count_status as (
+  select
+    'count'::text as check_group,
+    'expected_base_records'::text as object_name,
+    case when count(content_templates.id) = 9 then 'ok' else 'count_mismatch' end as check_status,
+    jsonb_build_object('count', count(content_templates.id)) as details
+  from expected_records
+  left join public.content_templates
+    on content_templates.template_key = expected_records.template_key
+   and content_templates.version = expected_records.version
+),
+
+duplicate_status as (
+  select
+    'uniqueness'::text as check_group,
+    duplicate_key as object_name,
+    case when duplicate_count = 1 then 'ok' else 'duplicate' end as check_status,
+    jsonb_build_object('count', duplicate_count) as details
+  from (
+    select
+      'template_key_version:' || content_templates.template_key || ':' || content_templates.version::text as duplicate_key,
+      count(*) as duplicate_count
+    from public.content_templates
+    where (content_templates.template_key, content_templates.version) in (
+      select expected_records.template_key, expected_records.version
+      from expected_records
+    )
+    group by content_templates.template_key, content_templates.version
+    union all
+    select
+      'slug_version:' || content_templates.slug || ':' || content_templates.version::text as duplicate_key,
+      count(*) as duplicate_count
+    from public.content_templates
+    where (content_templates.slug, content_templates.version) in (
+      select expected_records.slug, expected_records.version
+      from expected_records
+    )
+    group by content_templates.slug, content_templates.version
+  ) duplicates
+),
+
+rls_status as (
+  select
+    'rls'::text as check_group,
+    'content_templates'::text as object_name,
+    case when pg_class.relrowsecurity then 'ok' else 'rls_disabled' end as check_status,
+    jsonb_build_object('rls_enabled', pg_class.relrowsecurity) as details
+  from pg_class
+  where pg_class.oid = 'public.content_templates'::regclass
+),
+
+grant_status as (
+  select
+    'grants'::text as check_group,
+    'content_templates'::text as object_name,
+    case
+      when has_table_privilege('service_role', 'public.content_templates', 'SELECT')
+        and not has_table_privilege('anon', 'public.content_templates', 'SELECT')
+        and not has_table_privilege('authenticated', 'public.content_templates', 'SELECT')
+      then 'ok'
+      else 'grant_mismatch'
+    end as check_status,
+    jsonb_build_object(
+      'service_role_select',
+      has_table_privilege('service_role', 'public.content_templates', 'SELECT'),
+      'anon_select',
+      has_table_privilege('anon', 'public.content_templates', 'SELECT'),
+      'authenticated_select',
+      has_table_privilege('authenticated', 'public.content_templates', 'SELECT')
+    ) as details
+)
+
+select *
+from record_status
+union all
+select *
+from count_status
+union all
+select *
+from duplicate_status
+union all
+select *
+from rls_status
+union all
+select *
+from grant_status
+order by
+  check_group,
+  object_name;


### PR DESCRIPTION
## Summary
- Adds the E18 Phase 2 data-only migration for the 9 `commercial_activation` base `content_templates` records.
- Adds a read-only verification snippet for records, uniqueness, active status, family/scope/version, RLS, and current grants.
- Updates `docs/roadmap.md` to mark 18.13 as in PR, still awaiting merge and real Supabase application.

## Scope boundaries
- No renderer, schemas, components, runtime, taxons, compositions, artifacts, or E10.7 changes.
- No Supabase data was changed from Codex; migration was not applied.
- No grants are added or repeated. Existing grants were validated from the applied E18 minimum migration (`supa#58`): `service_role` has SELECT and `anon`/`authenticated` are revoked for `content_templates`.

## Validation
- `npm ci` passed; npm audit reported existing vulnerabilities but exit code was 0.
- `npm run check` passed with existing lint warnings and no errors.
- `git diff --check` passed.
- Supabase CLI is not installed in this environment, so the migration file was created manually and not applied locally or remotely.