### PR TITLE
docs: update E18 commercial_activation ABCs (roadmap v1.5.74, schema v1.0.23, base-tecnica v2.0.42)

### DIFF
--- a/docs/base-tecnica.md
+++ b/docs/base-tecnica.md
@@ -2,8 +2,8 @@
 
 0.1. Cabeçalho
 • Documento: Base Técnica LP Factory 10
-• Versão: v2.0.41
-• Data: 12/06/2026
+• Versão: v2.0.42
+• Data: 16/06/2026
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -34,6 +34,7 @@
 • Next.js 16.1.1 (App Router, SSR, Server Components)
 • React 19.2.x + React DOM 19.2.x
 • TypeScript 5.5.4 (strict)
+• Zod 4.2.1 para contratos tipados e validação runtime de conteúdo persistido.
 • Node.js 22.x
 • Package manager: npm
 • Lockfile canônico: package-lock.json (deve ficar commitado e alinhado ao package.json)
@@ -294,6 +295,20 @@
 • Regra: logs do fluxo devem permanecer sem PII e não devem registrar `raw_input`, nicho bruto, query, aliases, candidatos completos ou dados de formulário.
 • Regra: timestamps da resolução operacional devem ser controlados pelo banco.
 
+3.15 Conteúdo composicional de `commercial_activation`
+• Path canônico: `lib/conversion-content/commercial-activation/`.
+• `content_json` v1 usa `schema_version = 1` e `sections` com `composition_item_id` e `content`.
+• Módulo, variante, ordem e obrigatoriedade pertencem ao item da composição e não devem ser duplicados no artefato.
+• O registry fechado é a fonte canônica de `variantKey → moduleKey → schema Zod → componente`.
+• Envelope, seções e objetos internos devem usar validação estrita, rejeitando campos desconhecidos.
+• Seção obrigatória ausente ou inválida invalida o artefato.
+• Seção opcional ausente é omitida; seção opcional inválida é omitida com log seguro.
+• IDs duplicados ou desconhecidos e combinações de módulo/variante não registradas invalidam o artefato.
+• Conteúdo persistido deve ser estruturado; não aceitar HTML bruto, scripts, CSS, Tailwind ou nomes livres de componentes.
+• CTAs v1 aceitam somente URL HTTPS válida ou caminho interno iniciado por uma única `/`; rejeitar `//`, âncoras e protocolos não aprovados.
+• A validação deve ocorrer no servidor antes da renderização.
+• Casos executáveis: `npm run validate:commercial-activation`.
+
 4. DB Contract - Fonte única: PATH: docs/schema.md
 • Este documento não lista mais tabelas/views/functions/triggers/policies; isso está em PATH: docs/schema.md.
 • Trigger Hub é regra do contrato de DB (governança/auditoria). Fonte única e detalhes: PATH: docs/schema.md (seções 3.5 e 4.1).
@@ -441,6 +456,8 @@ Fonte normativa da allowlist SULB para exceções de Auth. Qualquer novo arquivo
 • Tipos canônicos e adapters vNext: validar por 3.6 e 3.14.
 
 99. Changelog
+v2.0.42 — 16/06/2026 — Registrado o contrato técnico do renderer composicional de `commercial_activation`, com `content_json` v1, validação Zod estrita, registry fechado, regras de falha e conteúdo estruturado seguro.
+
 v2.0.41 — 12/06/2026 — Concluído o fluxo universal de migrations Supabase: merge na `main` aplica migrations automaticamente com gate `true`; SQL Editor excluído do fluxo normal e histórico definido como forward-only, com reversões por nova migration.
 
 v2.0.40 — 12/06/2026 — Retirada a family antecipada `conversion-content` do estado técnico atual; estruturas compartilhadas de conteúdo serão reavaliadas somente após dois casos reais aprovados.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1184,7 +1184,8 @@ Repositório — Ajustados
 • Status: Concluída e mergeada no PR #393 em 16/06/2026.
 • Migration aplicada e confirmada no Supabase real.
 • Registrados um template-base de página e oito módulos de seção, todos na versão 1, ativos e com `payload_json = {}`.
-• Confirmados nove registros, unicidade funcional, zero vínculos com taxons, RLS ativa e leitura exclusiva por `service_role`.
+• Confirmados nove registros, unicidade funcional, zero vínculos com taxons e RLS ativa.
+• Grants confirmados: `service_role` com `SELECT`; `anon` e `authenticated` sem `SELECT`.
 
 Banco — Ajustados
 • `content_templates`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data: 15/06/2026
-• Versão: v1.5.73
+• Data: 16/06/2026
+• Versão: v1.5.74
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -1064,9 +1064,9 @@ Ajustados:
 18. E18 — Base transversal de templates, módulos, composições e artefatos
 
 18.1 Status
-• Em andamento — primeiro recorte autônomo da base transversal mínima implementado e validado em 15/06/2026.
-• Banco aplicado e confirmado no Supabase real.
-• Runtime server-side mergeado; dados do primeiro consumidor e integração com a E10.7 permanecem pendentes.
+• Base transversal mínima de `commercial_activation` concluída e validada em 16/06/2026.
+• Primeiro recorte de banco/runtime e segundo recorte de contratos, renderer e registros-base aplicados.
+• E10.7 desbloqueada como primeiro consumidor real; composição, conteúdo por taxon, integração, fallback e tracking permanecem sob responsabilidade da E10.7.
 
 18.2 Objetivo
 • Definir infraestrutura e contratos reutilizáveis para famílias de templates por canal, templates versionados, módulos de conteúdo, seções de página, variantes, composições e artefatos finais persistidos.
@@ -1086,11 +1086,17 @@ Ajustados:
 • O contrato detalhado dos objetos e permissões está em `docs/schema.md`.
 
 18.5 Módulos, seções e variantes
-• A base transversal será formada por módulos de conteúdo; em canais de página, esses módulos assumem a forma de seções.
-• Catálogo inicial candidato para a E10.7: `hero`, `problem`, `benefits`, `services`, `use_cases`, `plans`, `differentials`, `how_it_works`, `comparison`, `integrations`, `proof`, `credentials`, `faq` e `final_cta`.
-• Incluir no primeiro recorte somente as seções realmente necessárias para a E10.7.
-• Cada módulo ou seção poderá ter variantes estruturais ou funcionais reutilizáveis com identificadores descritivos, como `hero.default`, `hero.centered`, `hero.split`, `hero.with_proof`, `hero.with_form`, `proof.testimonials`, `proof.credentials` e `proof.operational_demo`.
-• Não usar identificadores numéricos como `hero.1` ou `hero.2`.
+• Catálogo inicial v1 da família `commercial_activation`:
+• `hero.default`
+• `benefits.cards`
+• `services.list`
+• `plans.cards`
+• `differentials.cards`
+• `how_it_works.steps`
+• `faq.accordion`
+• `final_cta.simple`
+• As variantes descrevem comportamento estrutural ou funcional e não podem representar nichos.
+• A ampliação do catálogo depende de necessidade comprovada por consumidores reais.
 
 18.6 Contrato entre código e banco
 • Código: contrato, validação, componente visual e comportamento responsivo.
@@ -1155,61 +1161,10 @@ Repositório — Criados
 • A E10.6 permanece fora dessa infraestrutura e continua como fallback genérico concluído.
 
 18.12 Fase 1 — Contratos e renderer de `commercial_activation`
-
-• Status: Concluída e mergeada no PR #392.
-• Execução exclusiva no repositório, sem migration ou alteração no Supabase.
-• Objetivo: validar e renderizar composições da família `commercial_activation` com dados sintéticos.
-
-Escopo:
-
-• adicionar Zod como dependência direta;
-• definir `content_json` v1 com `schema_version = 1`;
-• associar cada conteúdo ao respectivo `composition_item_id`;
-• implementar o catálogo inicial:
-• `hero.default`;
-• `benefits.cards`;
-• `services.list`;
-• `plans.cards`;
-• `differentials.cards`;
-• `how_it_works.steps`;
-• `faq.accordion`;
-• `final_cta.simple`;
-• criar schemas, tipos e limites editoriais iniciais;
-• criar componentes reutilizáveis;
-• criar registry fechado de seção + variante;
-• criar `CommercialActivationRenderer`;
-• validar composição e conteúdo no servidor;
-• usar fixture sintética completa, sem consulta ao Supabase.
-
-Regras principais:
-
-• item obrigatório ausente ou inválido invalida o artefato;
-• item opcional ausente pode ser omitido;
-• item opcional inválido deve ser omitido com log seguro;
-• ID inexistente, duplicado, módulo desconhecido ou variante desconhecida invalida o artefato;
-• o banco não fornecerá HTML bruto, scripts, CSS, Tailwind ou nomes livres de componentes.
-
-Validação:
-
-• `npm ci`;
-• `npm run check`;
-• `npm run build`;
-• `git diff --check`;
-• teste manual desktop e mobile;
-• validação dos limites e estados de falha.
-
-Limites:
-
-• sem migration;
-• sem registros reais;
-• sem taxon ou pesquisa real;
-• sem composição ou artefato de nicho;
-• sem integração com `/a/[account]`;
-• sem tracking da E10.7.
-
-Critério de passagem:
-
-• a Fase 2 só começa após aprovação e merge da Fase 1.
+• Status: Concluída e mergeada no PR #392 em 16/06/2026.
+• Implementados `content_json` v1, validação Zod server-side, registry fechado, resolver e `CommercialActivationRenderer`.
+• Catálogo inicial com oito variantes transversais.
+• Fixture sintética, casos executáveis de validação e testes manuais desktop/mobile aprovados.
 
 Repositório — Criados
 • `lib/conversion-content/commercial-activation/fixture.ts`
@@ -1226,57 +1181,17 @@ Repositório — Ajustados
 • `package-lock.json`
 
 18.13 Fase 2 — Registros-base de `commercial_activation`
+• Status: Concluída e mergeada no PR #393 em 16/06/2026.
+• Migration aplicada e confirmada no Supabase real.
+• Registrados um template-base de página e oito módulos de seção, todos na versão 1, ativos e com `payload_json = {}`.
+• Confirmados nove registros, unicidade funcional, zero vínculos com taxons, RLS ativa e leitura exclusiva por `service_role`.
 
-• Status: Em PR — migration e snippet preparados, aguardando merge e aplicação no Supabase real.
-• Execução restrita ao provisionamento de banco e aos artefatos de verificação correspondentes.
-• Depende da Fase 1 aprovada e mergeada.
-• Objetivo: provisionar os registros transversais correspondentes ao código aprovado.
+Banco — Ajustados
+• `content_templates`
 
-Escopo:
-
-• criar migration de dados versionada e exclusiva;
-• Template-base:
-• `template_family = commercial_activation`;
-• `template_scope = page`;
-• `version = 1`;
-• `status = active`;
-• `is_active = true`.
-• Oito módulos:
-• `template_family = commercial_activation`;
-• `template_scope = section`;
-• `version = 1`;
-• `status = active`;
-• `is_active = true`;
-• `payload_json = {}`.
-• manter identificadores e versões iguais aos contratos da Fase 1;
-• manter `payload_json` mínimo, declarativo e sem função operacional no renderer;
-• criar snippet read-only de verificação.
-
-Artefatos preparados:
-
+Repositório — Criados
 • `supabase/migrations/20260616142000_e18_commercial_activation_base_records.sql`
 • `supabase/snippets/e18_commercial_activation_base_records_verify.sql`
-
-Limites:
-
-• sem alterações em componentes ou renderer;
-• sem `content_template_taxons`;
-• sem composição ou itens de composição por taxon;
-• sem artefato publicado;
-• sem pesquisa ou conteúdo de nicho;
-• sem integração com a E10.7.
-
-Regra de parada:
-
-• se os registros não forem compatíveis com a Fase 1, interromper;
-• não corrigir runtime no PR de banco.
-
-Critério de conclusão:
-
-• migration mergeada e aplicada;
-• nove registros confirmados no Supabase real;
-• snippet aprovado;
-• documentação do banco atualizada após confirmação do estado real.
 
 18.14 Fora do segundo recorte
 • implementação de e-mail, WhatsApp, Instagram ou TikTok
@@ -1329,6 +1244,8 @@ Critério de conclusão:
 • Definir o primeiro recorte funcional do LP Builder no roadmap
 
 99. Changelog
+v1.5.74 — 16/06/2026 — E18 conclui o segundo recorte da base transversal de `commercial_activation`: contrato `content_json` v1, validação Zod, registry, renderer, catálogo inicial de oito seções e nove registros-base aplicados e confirmados no Supabase; a E10.7 fica desbloqueada como primeiro consumidor real.
+
 v1.5.73 — 15/06/2026 — E18 consolida o primeiro recorte autônomo implementado e validado: banco de composições e artefatos aplicado no Supabase, runtime server-side mergeado e seleção determinística de template por taxon; dados do primeiro consumidor e integração com a E10.7 permanecem pendentes.
 v1.5.72 — 15/06/2026 — E10.6 concluída com página comercial genérica responsiva em `/a/[account]`, planos e CTAs ilustrativos, tracking server-side validado, correção de `public.audit_context_event` e registro dos artefatos finais; personalização por nicho permanece na E10.7.
 v1.5.71 — 12/06/2026 — Separadas a E10.6, agora dedicada à primeira página comercial genérica sem banco novo, pesquisa ou IA, e a futura E10.7, responsável por páginas comerciais personalizadas por nicho após a aprovação da E10.6; referências ao consumo direto de pesquisas pela E10.6 foram corrigidas.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -262,7 +262,7 @@
 • Slugs especiais: `how-it-works` e `final-cta`; os demais coincidem com `template_key`.
 • Todos pertencem à família `commercial_activation`, versão 1, status `active`, `is_active = true` e `payload_json = {}`.
 • IDs físicos são UUIDs gerados pelo banco; a identidade funcional é protegida por `template_key + version` e `slug + version`.
-• Estado confirmado: nove registros e zero vínculos correspondentes em `content_template_taxons`.
+• O provisionamento inicial cria nove registros-base e não cria vínculos em `content_template_taxons`; esses vínculos pertencem aos consumidores por taxon.
 • Migration: `supabase/migrations/20260616142000_e18_commercial_activation_base_records.sql`.
 • Verificação: `supabase/snippets/e18_commercial_activation_base_records_verify.sql`.
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data da última atualização: 15/06/2026
-• Documento: LP Factory 10 — Schema (DB Contract) v1.0.22
+• Data da última atualização: 16/06/2026
+• Documento: LP Factory 10 — Schema (DB Contract) v1.0.23
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -255,6 +255,16 @@
 • content_templates_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
 • content_templates_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
 • content_templates_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
+
+1.13.5 Registros-base de `commercial_activation`
+• Template de página: `commercial_activation_page`, slug `commercial-activation-page`, escopo `page`.
+• Módulos de seção: `hero`, `benefits`, `services`, `plans`, `differentials`, `how_it_works`, `faq` e `final_cta`.
+• Slugs especiais: `how-it-works` e `final-cta`; os demais coincidem com `template_key`.
+• Todos pertencem à família `commercial_activation`, versão 1, status `active`, `is_active = true` e `payload_json = {}`.
+• IDs físicos são UUIDs gerados pelo banco; a identidade funcional é protegida por `template_key + version` e `slug + version`.
+• Estado confirmado: nove registros e zero vínculos correspondentes em `content_template_taxons`.
+• Migration: `supabase/migrations/20260616142000_e18_commercial_activation_base_records.sql`.
+• Verificação: `supabase/snippets/e18_commercial_activation_base_records_verify.sql`.
 
 1.14 content_template_taxons
 
@@ -757,6 +767,11 @@
 • Rollback: não remove automaticamente a extensão, pois pode ser reutilizada por outros recursos
 
 99. Changelog
+v1.0.23 (16/06/2026) — E18: registros-base de `commercial_activation`
+• Registrados o template-base de página e os oito módulos de seção da versão 1.
+• Confirmados nove registros ativos, identidade funcional por chave/slug + versão e ausência de vínculos com taxons.
+• RLS e grants preservados: `service_role` com SELECT; `anon` e `authenticated` sem SELECT.
+
 v1.0.22 (15/06/2026) — E18: índices e triggers complementares
 • Registrados os índices auxiliares das composições, itens, artefatos e fontes de pesquisa.
 • Registrados os triggers de atualização automática de `updated_at` das composições, itens e artefatos.


### PR DESCRIPTION
### Motivation
- Record the implemented second cut of E18 (`commercial_activation`) across documentation to reflect the final state after code and DB work. 
- Ensure `docs/schema.md` and `docs/base-tecnica.md` contain the DB evidence and runtime contract required for consumers and ops. 
- Keep the roadmap, schema and technical base consistent with the applied migration and renderer/registry work described in the repository.

### Description
- Updated `docs/roadmap.md` to v1.5.74 by replacing the header, marking E18 as completed on 16/06/2026, consolidating the v1 catalog for `commercial_activation`, summarizing Phase 1 (PR #392) and Phase 2 (PR #393) outcomes, and adding a changelog entry. 
- Updated `docs/schema.md` to v1.0.23 by replacing the header and adding section `1.13.5 Registros-base de commercial_activation` that documents the template and eight section modules, migration path and verification snippet, and added a changelog entry. 
- Updated `docs/base-tecnica.md` to v2.0.42 by bumping header/date, adding `Zod 4.2.1` to the Framework block and inserting section `3.15 Conteúdo composicional de commercial_activation` that records the server-side validation and compositional contract and added a changelog entry. 
- Files modified: `docs/roadmap.md`, `docs/schema.md`, `docs/base-tecnica.md`.

### Testing
- `git diff --check` was run and passed without whitespace/check errors. 
- `git status --short` was inspected to confirm only the intended docs were modified. 
- `npm ci` was not executed because this is a documentation-only change and considered not applicable. 
- `npm run check` was not executed because this is a documentation-only change and considered not applicable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31aebf10cc8329a496cfc0b29e8525)