### PR TITLE
Add Supabase migration preflight checks to apply workflow

### DIFF
--- a/.github/workflows/pipeline-supabase-apply-migrations.yml
+++ b/.github/workflows/pipeline-supabase-apply-migrations.yml
@@ -39,12 +39,15 @@ jobs:
             echo "- commit: \`${GITHUB_SHA}\`"
             echo "- evento: \`${GITHUB_EVENT_NAME}\`"
             echo "- apply habilitado: \`false\`"
+            echo "- resultado do migration list: \`not-run\`"
+            echo "- resultado do dry-run: \`not-run\`"
+            echo "- resultado do apply: \`not-run\`"
             echo "- status final: \`skipped\`"
             echo ""
             echo "### Gate de migrations"
             echo ""
             echo "- Apply nao executado porque \`SUPABASE_APPLY_MIGRATIONS_ENABLED\` nao esta definido como \`true\`."
-            echo "- Supabase CLI, \`supabase link\` e \`supabase db push\` nao foram executados."
+            echo "- Supabase CLI, \`supabase link\`, \`supabase migration list\` e \`supabase db push\` nao foram executados."
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Setup Supabase CLI
@@ -65,6 +68,9 @@ jobs:
           status="success"
           failure_step=""
           changed_migrations=""
+          migration_list_result="not-run"
+          dry_run_result="not-run"
+          apply_result="not-run"
           apply_enabled="${SUPABASE_APPLY_MIGRATIONS_ENABLED:-false}"
 
           if [ "$apply_enabled" != "true" ]; then
@@ -105,10 +111,39 @@ jobs:
           fi
 
           if [ "$status" = "success" ]; then
+            migration_list_result="running"
+            supabase migration list --linked || {
+              status="failure"
+              failure_step="supabase migration list"
+              migration_list_result="failure"
+            }
+            if [ "$status" = "success" ]; then
+              migration_list_result="success"
+            fi
+          fi
+
+          if [ "$status" = "success" ]; then
+            dry_run_result="running"
+            supabase db push --linked --dry-run || {
+              status="failure"
+              failure_step="supabase db push dry-run"
+              dry_run_result="failure"
+            }
+            if [ "$status" = "success" ]; then
+              dry_run_result="success"
+            fi
+          fi
+
+          if [ "$status" = "success" ]; then
+            apply_result="running"
             supabase db push --linked || {
               status="failure"
               failure_step="supabase db push"
+              apply_result="failure"
             }
+            if [ "$status" = "success" ]; then
+              apply_result="success"
+            fi
           fi
 
           {
@@ -120,6 +155,9 @@ jobs:
             echo "- diretório de migrations: \`${SUPABASE_MIGRATIONS_DIR}\`"
             echo "- evento: \`${GITHUB_EVENT_NAME}\`"
             echo "- apply habilitado: \`${apply_enabled}\`"
+            echo "- resultado do migration list: \`${migration_list_result}\`"
+            echo "- resultado do dry-run: \`${dry_run_result}\`"
+            echo "- resultado do apply: \`${apply_result}\`"
             echo "- status final: \`${status}\`"
             echo ""
             echo "### Migrations alteradas"


### PR DESCRIPTION
### Motivation

- Align the migrations pipeline with the Base Técnica requirement to list pending migrations and run a dry-run before applying changes remotely. 
- Prevent accidental remote applies by ensuring `migration list` and `db push --dry-run` succeed before `db push --linked` runs. 
- Keep existing gate behavior, pinned `supabase/setup-cli` SHA and Supabase CLI version while adding explicit preflight reporting. 

### Description

- Added an explicit `supabase migration list --linked` step after `supabase link` and before any `db push` so failures block subsequent steps. 
- Added `supabase db push --linked --dry-run` and made the real `supabase db push --linked` conditional on the dry-run success. 
- Track `migration_list_result`, `dry_run_result` and `apply_result` and `failure_step` and write a concise `GITHUB_STEP_SUMMARY` without exposing secrets or connection strings. 
- Preserved triggers (`push` to `main` + `workflow_dispatch`), path filter `supabase/migrations/**`, `permissions: contents: read`, concurrency group, gate `SUPABASE_APPLY_MIGRATIONS_ENABLED`, pinned action SHA and CLI `2.106.0`. 

### Testing

- Validated YAML syntax with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/pipeline-supabase-apply-migrations.yml')"` which returned `YAML OK`.
- Checked focused invariants with `rg` for triggers, gate, action SHA and CLI version and confirmed presence of `supabase migration list --linked` and `supabase db push --linked --dry-run` and preserved settings. 
- `actionlint` was not installed in the environment so that check was skipped and reported as not installed. 
- Git checks `git diff --check`, `git diff --name-only`, `git status` and commit were executed and the change was committed on branch `codex/supabase-migrations-preflight` as `e6e08b2`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31c24ac5588329b75ec86ab55e6878)