### PR TITLE
[codex] Implementar Fase 1 da E10.7

### DIFF
--- a/lib/conversion-content/adapters/commercialActivationAdapter.ts
+++ b/lib/conversion-content/adapters/commercialActivationAdapter.ts
@@ -143,12 +143,12 @@ export async function getCommercialActivationHierarchicalBundle(input: {
 }): Promise<CommercialActivationHierarchicalResolutionResult> {
   return resolveCommercialActivationHierarchicalBundle({
     taxonId: input.taxonId,
-    readTaxon: getActiveCommercialActivationTaxon,
+    readTaxon: getCommercialActivationTaxon,
     readBundle: getCommercialActivationBundle,
   });
 }
 
-async function getActiveCommercialActivationTaxon(
+async function getCommercialActivationTaxon(
   taxonId: string,
 ): Promise<CommercialActivationContentTaxon | null> {
   const normalizedTaxonId = taxonId.trim();

--- a/lib/conversion-content/adapters/commercialActivationAdapter.ts
+++ b/lib/conversion-content/adapters/commercialActivationAdapter.ts
@@ -5,11 +5,14 @@ import {
   COMMERCIAL_ACTIVATION_AUDIENCE_SCOPE,
   COMMERCIAL_ACTIVATION_TEMPLATE_FAMILY,
   type CommercialActivationBundleResult,
+  type CommercialActivationContentTaxon,
+  type CommercialActivationHierarchicalResolutionResult,
 } from "../contracts";
 import {
   mapContentComposition,
   mapPublishedContentArtifact,
 } from "../validation";
+import { resolveCommercialActivationHierarchicalBundle } from "../commercial-activation/hierarchical-resolve";
 
 const TEMPLATE_COLUMNS =
   "id,template_key,name,slug,template_family,template_scope,status,version,is_active,payload_json";
@@ -133,4 +136,40 @@ export async function getCommercialActivationBundle(input: {
     });
     return { status: "read_failed" };
   }
+}
+
+export async function getCommercialActivationHierarchicalBundle(input: {
+  taxonId: string;
+}): Promise<CommercialActivationHierarchicalResolutionResult> {
+  return resolveCommercialActivationHierarchicalBundle({
+    taxonId: input.taxonId,
+    readTaxon: getActiveCommercialActivationTaxon,
+    readBundle: getCommercialActivationBundle,
+  });
+}
+
+async function getActiveCommercialActivationTaxon(
+  taxonId: string,
+): Promise<CommercialActivationContentTaxon | null> {
+  const normalizedTaxonId = taxonId.trim();
+  if (!normalizedTaxonId) return null;
+
+  const supabase = createServiceClient();
+
+  const { data, error } = await supabase
+    .from("business_taxons")
+    .select("id,parent_id,is_active")
+    .eq("id", normalizedTaxonId)
+    .maybeSingle();
+
+  if (error) throw error;
+
+  const row = data as Record<string, unknown> | null;
+  if (!row || typeof row.id !== "string") return null;
+
+  return {
+    id: row.id,
+    parentId: typeof row.parent_id === "string" ? row.parent_id : null,
+    isActive: row.is_active === true,
+  };
 }

--- a/lib/conversion-content/commercial-activation/hierarchical-resolve.ts
+++ b/lib/conversion-content/commercial-activation/hierarchical-resolve.ts
@@ -1,0 +1,90 @@
+import type {
+  CommercialActivationBundleResult,
+  CommercialActivationContentTaxon,
+  CommercialActivationHierarchicalResolutionResult,
+} from "../contracts";
+
+export type CommercialActivationTaxonReader = (
+  taxonId: string,
+) => Promise<CommercialActivationContentTaxon | null>;
+
+export type CommercialActivationBundleReader = (
+  input: { taxonId: string },
+) => Promise<CommercialActivationBundleResult>;
+
+export async function resolveCommercialActivationHierarchicalBundle(input: {
+  taxonId: string;
+  readTaxon: CommercialActivationTaxonReader;
+  readBundle: CommercialActivationBundleReader;
+}): Promise<CommercialActivationHierarchicalResolutionResult> {
+  const originalTaxonId = input.taxonId.trim();
+
+  if (!originalTaxonId) {
+    return fallback("fallback_taxon_not_found", originalTaxonId);
+  }
+
+  const visited = new Set<string>();
+  let currentTaxonId: string | null = originalTaxonId;
+
+  while (currentTaxonId) {
+    if (visited.has(currentTaxonId)) {
+      return fallback("fallback_cycle_detected", originalTaxonId);
+    }
+    visited.add(currentTaxonId);
+
+    let taxon: CommercialActivationContentTaxon | null;
+    try {
+      taxon = await input.readTaxon(currentTaxonId);
+    } catch {
+      return fallback("fallback_read_failed", originalTaxonId);
+    }
+
+    if (!taxon) {
+      return currentTaxonId === originalTaxonId
+        ? fallback("fallback_taxon_not_found", originalTaxonId)
+        : fallback("fallback_no_ready_bundle", originalTaxonId);
+    }
+
+    if (!taxon.isActive) {
+      return currentTaxonId === originalTaxonId
+        ? fallback("fallback_taxon_inactive", originalTaxonId)
+        : fallback("fallback_no_ready_bundle", originalTaxonId);
+    }
+
+    let bundleResult: CommercialActivationBundleResult;
+    try {
+      bundleResult = await input.readBundle({ taxonId: taxon.id });
+    } catch {
+      return fallback("fallback_read_failed", originalTaxonId);
+    }
+
+    if (bundleResult.status === "ready") {
+      return {
+        status: "ready",
+        original_taxon_id: originalTaxonId,
+        resolved_content_taxon_id: taxon.id,
+        bundle: bundleResult.bundle,
+      };
+    }
+
+    if (bundleResult.status === "read_failed") {
+      return fallback("fallback_read_failed", originalTaxonId);
+    }
+
+    currentTaxonId = taxon.parentId;
+  }
+
+  return fallback("fallback_no_ready_bundle", originalTaxonId);
+}
+
+function fallback(
+  status: Exclude<CommercialActivationHierarchicalResolutionResult["status"], "ready">,
+  originalTaxonId: string,
+): CommercialActivationHierarchicalResolutionResult {
+  return {
+    status,
+    original_taxon_id: originalTaxonId,
+    resolved_content_taxon_id: null,
+    bundle: null,
+  };
+}

--- a/lib/conversion-content/commercial-activation/hierarchical-resolve.ts
+++ b/lib/conversion-content/commercial-activation/hierarchical-resolve.ts
@@ -46,9 +46,12 @@ export async function resolveCommercialActivationHierarchicalBundle(input: {
     }
 
     if (!taxon.isActive) {
-      return currentTaxonId === originalTaxonId
-        ? fallback("fallback_taxon_inactive", originalTaxonId)
-        : fallback("fallback_no_ready_bundle", originalTaxonId);
+      if (currentTaxonId === originalTaxonId) {
+        return fallback("fallback_taxon_inactive", originalTaxonId);
+      }
+
+      currentTaxonId = taxon.parentId;
+      continue;
     }
 
     let bundleResult: CommercialActivationBundleResult;

--- a/lib/conversion-content/commercial-activation/index.ts
+++ b/lib/conversion-content/commercial-activation/index.ts
@@ -1,4 +1,5 @@
 export * from "./fixture";
+export * from "./hierarchical-resolve";
 export * from "./registry";
 export * from "./renderer";
 export * from "./resolve";

--- a/lib/conversion-content/commercial-activation/validation-cases.ts
+++ b/lib/conversion-content/commercial-activation/validation-cases.ts
@@ -4,13 +4,19 @@ import {
   commercialActivationFixtureComposition,
   commercialActivationFixtureContent,
 } from "./fixture";
+import { resolveCommercialActivationHierarchicalBundle } from "./hierarchical-resolve";
 import { resolveCommercialActivationRenderModel } from "./resolve";
 import type { CommercialActivationContentV1 } from "./schemas";
-import type { ContentComposition } from "../contracts";
+import type {
+  CommercialActivationBundle,
+  CommercialActivationBundleResult,
+  CommercialActivationContentTaxon,
+  ContentComposition,
+} from "../contracts";
 
 type Case = {
   name: string;
-  run: () => void;
+  run: () => void | Promise<void>;
 };
 
 const requiredHeroId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1";
@@ -213,11 +219,123 @@ const cases: Case[] = [
       });
     },
   },
+  {
+    name: "hierarchical resolver selects exact ready bundle",
+    run: async () => {
+      const result = await runHierarchicalCase({
+        originalTaxonId: taxonIds.original,
+        readyTaxonId: taxonIds.original,
+      });
+
+      assert.equal(result.status, "ready");
+      assert.equal(result.original_taxon_id, taxonIds.original);
+      assert.equal(result.resolved_content_taxon_id, taxonIds.original);
+      assert.equal(result.bundle?.composition.taxonId, taxonIds.original);
+      assert.equal(result.bundle?.artifact.taxonId, taxonIds.original);
+    },
+  },
+  {
+    name: "hierarchical resolver falls back to parent ready bundle",
+    run: async () => {
+      const result = await runHierarchicalCase({
+        originalTaxonId: taxonIds.original,
+        readyTaxonId: taxonIds.parent,
+      });
+
+      assert.equal(result.status, "ready");
+      assert.equal(result.original_taxon_id, taxonIds.original);
+      assert.equal(result.resolved_content_taxon_id, taxonIds.parent);
+      assert.equal(result.bundle?.composition.taxonId, taxonIds.parent);
+      assert.equal(result.bundle?.artifact.taxonId, taxonIds.parent);
+    },
+  },
+  {
+    name: "hierarchical resolver falls back to ancestor ready bundle",
+    run: async () => {
+      const result = await runHierarchicalCase({
+        originalTaxonId: taxonIds.original,
+        readyTaxonId: taxonIds.ancestor,
+      });
+
+      assert.equal(result.status, "ready");
+      assert.equal(result.original_taxon_id, taxonIds.original);
+      assert.equal(result.resolved_content_taxon_id, taxonIds.ancestor);
+      assert.equal(result.bundle?.composition.taxonId, taxonIds.ancestor);
+      assert.equal(result.bundle?.artifact.taxonId, taxonIds.ancestor);
+    },
+  },
+  {
+    name: "hierarchical resolver returns safe fallback when no bundle is ready",
+    run: async () => {
+      const result = await runHierarchicalCase({
+        originalTaxonId: taxonIds.original,
+        readyTaxonId: null,
+      });
+
+      assert.deepEqual(result, {
+        status: "fallback_no_ready_bundle",
+        original_taxon_id: taxonIds.original,
+        resolved_content_taxon_id: null,
+        bundle: null,
+      });
+    },
+  },
+  {
+    name: "hierarchical resolver returns safe fallback on read error",
+    run: async () => {
+      const result = await resolveCommercialActivationHierarchicalBundle({
+        taxonId: taxonIds.original,
+        readTaxon: async (taxonId) => taxonHierarchy.get(taxonId) ?? null,
+        readBundle: async () => {
+          throw new Error("synthetic read failure");
+        },
+      });
+
+      assert.deepEqual(result, {
+        status: "fallback_read_failed",
+        original_taxon_id: taxonIds.original,
+        resolved_content_taxon_id: null,
+        bundle: null,
+      });
+    },
+  },
+  {
+    name: "hierarchical resolver returns safe fallback on taxon cycle",
+    run: async () => {
+      const cyclicTaxons = new Map<string, CommercialActivationContentTaxon>([
+        [
+          taxonIds.original,
+          { id: taxonIds.original, parentId: taxonIds.parent, isActive: true },
+        ],
+        [
+          taxonIds.parent,
+          { id: taxonIds.parent, parentId: taxonIds.original, isActive: true },
+        ],
+      ]);
+
+      const result = await resolveCommercialActivationHierarchicalBundle({
+        taxonId: taxonIds.original,
+        readTaxon: async (taxonId) => cyclicTaxons.get(taxonId) ?? null,
+        readBundle: async () => ({ status: "composition_not_found" }),
+      });
+
+      assert.deepEqual(result, {
+        status: "fallback_cycle_detected",
+        original_taxon_id: taxonIds.original,
+        resolved_content_taxon_id: null,
+        bundle: null,
+      });
+    },
+  },
 ];
 
-for (const validationCase of cases) {
-  validationCase.run();
-  console.log(`ok - ${validationCase.name}`);
+void main();
+
+async function main() {
+  for (const validationCase of cases) {
+    await validationCase.run();
+    console.log(`ok - ${validationCase.name}`);
+  }
 }
 
 function withoutSection(compositionItemId: string): CommercialActivationContentV1 {
@@ -230,4 +348,66 @@ function withoutSection(compositionItemId: string): CommercialActivationContentV
 
 function clone<T>(value: T): T {
   return globalThis.structuredClone(value);
+}
+
+const taxonIds = {
+  original: "33333333-3333-4333-8333-333333333333",
+  parent: "44444444-4444-4444-8444-444444444444",
+  ancestor: "55555555-5555-4555-8555-555555555555",
+} as const;
+
+const taxonHierarchy = new Map<string, CommercialActivationContentTaxon>([
+  [
+    taxonIds.original,
+    { id: taxonIds.original, parentId: taxonIds.parent, isActive: true },
+  ],
+  [
+    taxonIds.parent,
+    { id: taxonIds.parent, parentId: taxonIds.ancestor, isActive: true },
+  ],
+  [
+    taxonIds.ancestor,
+    { id: taxonIds.ancestor, parentId: null, isActive: true },
+  ],
+]);
+
+async function runHierarchicalCase(input: {
+  originalTaxonId: string;
+  readyTaxonId: string | null;
+}) {
+  return resolveCommercialActivationHierarchicalBundle({
+    taxonId: input.originalTaxonId,
+    readTaxon: async (taxonId) => taxonHierarchy.get(taxonId) ?? null,
+    readBundle: async ({ taxonId }): Promise<CommercialActivationBundleResult> =>
+      taxonId === input.readyTaxonId
+        ? { status: "ready", bundle: makeBundle(taxonId) }
+        : { status: "composition_not_found" },
+  });
+}
+
+function makeBundle(taxonId: string): CommercialActivationBundle {
+  const composition = clone(commercialActivationFixtureComposition);
+  composition.taxonId = taxonId;
+
+  return {
+    composition,
+    artifact: {
+      id: "66666666-6666-4666-8666-666666666666",
+      templateId: composition.template.id,
+      compositionId: composition.id,
+      taxonId,
+      audienceScope: "business_buyer",
+      templateVersion: composition.template.version,
+      compositionVersion: composition.version,
+      researchVersion: 1,
+      artifactVersion: 1,
+      content: clone(commercialActivationFixtureContent) as unknown as Record<
+        string,
+        unknown
+      >,
+      provenance: {},
+      researchSources: [],
+      publishedAt: "2026-06-16T12:00:00.000Z",
+    },
+  };
 }

--- a/lib/conversion-content/commercial-activation/validation-cases.ts
+++ b/lib/conversion-content/commercial-activation/validation-cases.ts
@@ -265,6 +265,47 @@ const cases: Case[] = [
     },
   },
   {
+    name: "hierarchical resolver skips inactive parent and selects active ancestor",
+    run: async () => {
+      const inactiveParentTaxons = new Map<string, CommercialActivationContentTaxon>([
+        [
+          taxonIds.original,
+          { id: taxonIds.original, parentId: taxonIds.parent, isActive: true },
+        ],
+        [
+          taxonIds.parent,
+          { id: taxonIds.parent, parentId: taxonIds.ancestor, isActive: false },
+        ],
+        [
+          taxonIds.ancestor,
+          { id: taxonIds.ancestor, parentId: null, isActive: true },
+        ],
+      ]);
+      const queriedBundleTaxonIds: string[] = [];
+
+      const result = await resolveCommercialActivationHierarchicalBundle({
+        taxonId: taxonIds.original,
+        readTaxon: async (taxonId) => inactiveParentTaxons.get(taxonId) ?? null,
+        readBundle: async ({ taxonId }): Promise<CommercialActivationBundleResult> => {
+          queriedBundleTaxonIds.push(taxonId);
+          return taxonId === taxonIds.ancestor
+            ? { status: "ready", bundle: makeBundle(taxonId) }
+            : { status: "composition_not_found" };
+        },
+      });
+
+      assert.equal(result.status, "ready");
+      assert.equal(result.original_taxon_id, taxonIds.original);
+      assert.equal(result.resolved_content_taxon_id, taxonIds.ancestor);
+      assert.equal(result.bundle?.composition.taxonId, taxonIds.ancestor);
+      assert.equal(result.bundle?.artifact.taxonId, taxonIds.ancestor);
+      assert.deepEqual(queriedBundleTaxonIds, [
+        taxonIds.original,
+        taxonIds.ancestor,
+      ]);
+    },
+  },
+  {
     name: "hierarchical resolver returns safe fallback when no bundle is ready",
     run: async () => {
       const result = await runHierarchicalCase({

--- a/lib/conversion-content/contracts.ts
+++ b/lib/conversion-content/contracts.ts
@@ -82,3 +82,24 @@ export type CommercialActivationBundleResult =
         | "artifact_invalid"
         | "read_failed";
     };
+
+export type CommercialActivationContentTaxon = {
+  id: string;
+  parentId: string | null;
+  isActive: boolean;
+};
+
+export type CommercialActivationHierarchicalResolutionState =
+  | "ready"
+  | "fallback_taxon_not_found"
+  | "fallback_taxon_inactive"
+  | "fallback_no_ready_bundle"
+  | "fallback_cycle_detected"
+  | "fallback_read_failed";
+
+export type CommercialActivationHierarchicalResolutionResult = {
+  status: CommercialActivationHierarchicalResolutionState;
+  original_taxon_id: string;
+  resolved_content_taxon_id: string | null;
+  bundle: CommercialActivationBundle | null;
+};

--- a/lib/conversion-content/index.ts
+++ b/lib/conversion-content/index.ts
@@ -1,4 +1,7 @@
 export * from "./contracts";
 export * from "./validation";
 export * from "./commercial-activation";
-export { getCommercialActivationBundle } from "./adapters/commercialActivationAdapter";
+export {
+  getCommercialActivationBundle,
+  getCommercialActivationHierarchicalBundle,
+} from "./adapters/commercialActivationAdapter";


### PR DESCRIPTION
## O que mudou

- Adiciona resolver hierarquico para `commercial_activation`, percorrendo taxon original, pai e ancestrais.
- Reutiliza a leitura server-side existente de bundle para selecionar o primeiro resultado `ready`.
- Retorna `original_taxon_id`, `resolved_content_taxon_id` e estados seguros de fallback sem combinar conteudo entre niveis.
- Preserva `fallback_taxon_inactive` quando o taxon original estiver inativo.
- Quando pai ou ancestral estiver inativo, nao consulta seu bundle e continua a caminhada ate a raiz.
- Inclui casos sinteticos para resultado exato, pai, ancestral, nenhum resultado, erro, ciclo e pai inativo com ancestral ativo `ready`.

## Fora do escopo

- Sem migration, registros reais, conteudo comercial, integracao com `/a/[account]`, renderer visual ou tracking.

## Validacao

- `npm ci` passou na criacao inicial do PR, com 13 vulnerabilidades reportadas pelo npm audit.
- `npm run validate:commercial-activation` passou.
- `npm run check` passou com 24 warnings de lint existentes e 0 erros.
- `git diff --check` passou.