### PR TITLE
docs: update executor prompt references

### DIFF
--- a/docs/gestor-codex.md
+++ b/docs/gestor-codex.md
@@ -9,7 +9,7 @@ Este painel resume os recursos do Codex App relevantes para o LP Factory 10, sem
 Estas fontes concentram regras, execução e detalhes que não precisam ser duplicados aqui.
 
 * `AGENTS.md` — regras operacionais.
-* `docs/prompt-codex-app-executor.md` — execução no Codex App.
+* `docs/prompt-executor.md` — execução do Executor.
 * `docs/automations.md` — automações.
 * `docs/platform-config.md` — configuração da plataforma.
 

--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -1,5 +1,5 @@
 18/06/2026 — Fluxo ajustado do Estrategista
-Fontes: chat, docs/prompt-codex-app-executor.md, docs/template-briefing-codex.md, docs/template-prompts.md
+Fontes: chat, docs/prompt-executor.md, docs/template-briefing-codex.md, docs/template-prompts.md
 	1. Debate do caso
 Definir problema, resultado esperado, usuários e limites.
 	2. Fluxo operacional
@@ -32,12 +32,12 @@ Registrar objetivo, escopo, fases, critérios de passagem e limites.
 	9. Instrução ao Executor
 Para caso no roadmap:
 Execute [fase/item] de docs/roadmap.md, seguindo
-docs/prompt-codex-app-executor.md.
+docs/prompt-executor.md.
 Parta da main atualizada, use branch própria e pare antes do merge.
 Não repetir o conteúdo do plano ou do prompt.
 Caso Codex avulso sem plano no roadmap:
 docs/template-briefing-codex.md
-+ docs/prompt-codex-app-executor.md
++ docs/prompt-executor.md
 docs/template-prompts.md fica para prompts gerais de análises, gestores e outras funções.
 	10. Implementação com ponto de retorno
 Diante de decisão ausente, conflito ou ampliação de escopo, o Executor para e devolve o caso.

--- a/docs/prompt-executor.md
+++ b/docs/prompt-executor.md
@@ -1,7 +1,7 @@
 # Prompt para o Executor
 
 Status: vigente.
-Referencia no repositorio: `docs/prompt-codex-app-executor.md`.
+Referencia no repositorio: `docs/prompt-executor.md`.
 
 ## 1. Papel
 


### PR DESCRIPTION
### Motivation

- The repository moved/renamed the Executor prompt and internal references still pointed to the old path, producing stale links and descriptions. 
- Update three documentation files to reference the new `docs/prompt-executor.md` path and adjust the Gestor Codex description to reflect the new wording.

### Description

- Replace the self-reference in `docs/prompt-executor.md` to `docs/prompt-executor.md` (was `docs/prompt-codex-app-executor.md`).
- Replace three occurrences in `docs/prompt-estrategista.md` (sources line, roadmap instruction, and ad-hoc instruction) to point to `docs/prompt-executor.md`.
- Update `docs/gestor-codex.md` to reference `docs/prompt-executor.md` and change the description from "execução no Codex App" to "execução do Executor".
- Files changed: `docs/prompt-executor.md`, `docs/prompt-estrategista.md`, `docs/gestor-codex.md` on branch `docs/update-executor-references`, commit `1fe334d`.

### Testing

- Ran a targeted search with `rg -n "prompt-codex-app-executor|execução no Codex App"` against the three updated files and confirmed matches were removed or updated successfully. (succeeded)
- Ran `git diff --check` and `git status --short --branch` to validate the working tree and found no whitespace issues. (succeeded)
- Attempted to compare to local `main` with `git diff --name-status main..HEAD` but the local `main` branch is unavailable in this clone, so those diffs were not produced. (not applicable due to local repo state)
- Attempted to push branch with `git push -u origin docs/update-executor-references` but the push failed because the clone has no `origin` remote configured, error: `fatal: 'origin' does not appear to be a git repository`. (push failed)
- `npm ci` and `npm run check` are not applicable for this documentation-only change. (not executed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35513ec8f8832980163030aefff89f)