### PR TITLE
docs: adicionar seção "Abertura do chat" ao prompt do Estrategista

### DIFF
--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -1,5 +1,24 @@
 18/06/2026 — Fluxo ajustado do Estrategista
 Fontes: chat, docs/prompt-executor.md, docs/template-briefing-codex.md, docs/template-prompts.md
+	0. Abertura do chat
+Se o humano já informar a opção de uso, iniciar diretamente nela, sem perguntar novamente.
+Se o humano disser apenas para executar `docs/prompt-estrategista.md`, apresentar as três opções e aguardar a escolha.
+Só abrir esse diálogo quando a opção não estiver informada ou não puder ser identificada com segurança.
+
+Opções:
+1. Caso estratégico com plano no roadmap.
+2. Implementação avulsa para o Codex.
+3. Criação de prompt, análise ou instrução para outro gestor.
+
+Aplicação:
+• opção 1 → seguir todas as etapas de `docs/prompt-estrategista.md`;
+• opção 2 → usar `docs/template-briefing-codex.md` e depois `docs/prompt-executor.md`;
+• opção 3 → usar `docs/template-prompts.md`.
+
+Exemplos:
+`Execute docs/prompt-estrategista.md com a opção 1.` → iniciar diretamente o fluxo estratégico.
+`Execute docs/prompt-estrategista.md.` → apresentar as três opções e aguardar a escolha.
+
 	1. Debate do caso
 Definir problema, resultado esperado, usuários e limites.
 	2. Fluxo operacional

--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -15,7 +15,8 @@ Aplicação:
 • opção 2 → usar `docs/template-briefing-codex.md` e depois `docs/prompt-executor.md`;
 • opção 3 → usar `docs/template-prompts.md`.
 
-Após identificar a opção, iniciar pela primeira etapa correspondente, sem apresentar o fluxo completo nem antecipar entregas posteriores.
+Após identificar a opção, adotar o fluxo correspondente como regra ativa durante todo este chat, avançando etapa por etapa, sem pular, antecipar ou repetir etapas, salvo orientação expressa do humano.
+Na opção 1, manter controle da etapa atual e iniciar a próxima somente após a conclusão ou aprovação da etapa anterior.
 
 Primeira entrega por opção:
 1. Opção 1 — Caso estratégico

--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -15,6 +15,16 @@ Aplicação:
 • opção 2 → usar `docs/template-briefing-codex.md` e depois `docs/prompt-executor.md`;
 • opção 3 → usar `docs/template-prompts.md`.
 
+Após identificar a opção, iniciar pela primeira etapa correspondente, sem apresentar o fluxo completo nem antecipar entregas posteriores.
+
+Primeira entrega por opção:
+1. Opção 1 — Caso estratégico
+Resumir o entendimento inicial e iniciar o item `1. Debate do caso`, pedindo somente o que faltar sobre problema, resultado esperado, usuários e limites. Não criar o plano-base ainda.
+2. Opção 2 — Implementação avulsa para o Codex
+Verificar se existem informações suficientes para preencher `docs/template-briefing-codex.md`. Se estiver completo, entregar o briefing. Se faltar algo crítico, pedir somente o necessário.
+3. Opção 3 — Criação de prompt, análise ou instrução para outro gestor
+Identificar o resultado esperado e o tipo de entrega. Se estiver claro, aplicar diretamente `docs/template-prompts.md`. Se faltar algo crítico, pedir somente papel, objetivo ou entrega esperada.
+
 Exemplos:
 `Execute docs/prompt-estrategista.md com a opção 1.` → iniciar diretamente o fluxo estratégico.
 `Execute docs/prompt-estrategista.md.` → apresentar as três opções e aguardar a escolha.


### PR DESCRIPTION
### Motivation
- Tornar explícito o passo inicial para decidir o fluxo de interação quando o usuário não informa qual opção usar, permitindo iniciar direto quando a opção já vier indicada. 
- Mapear três caminhos de uso (estratégico, Codex avulso e criação de prompts/instruções) para encaminhar ao template/fluxo correto sem alterar o fluxo existente.

### Description
- Inserida a seção `0. Abertura do chat` imediatamente antes de `1. Debate do caso` em `docs/prompt-estrategista.md`, contendo a regra de decisão, as três opções e exemplos de comportamento mínimos. 
- Documentado o direcionamento de cada opção para os arquivos relevantes: opção 1 → `docs/prompt-estrategista.md`, opção 2 → `docs/template-briefing-codex.md` + `docs/prompt-executor.md`, opção 3 → `docs/template-prompts.md`. 
- Alteração restrita a `docs/prompt-estrategista.md` e implementada na branch `docs/abertura-prompt-estrategista`.

### Testing
- Confirmado que apenas `docs/prompt-estrategista.md` foi modificado com `git diff --name-only`.
- Executado `git diff --check` sem problemas e verificado `git status --short --branch` com a árvore limpa após o commit. 
- `npm ci` and `npm run check` considerados não aplicáveis por se tratar de alteração documental. 
- PR criado localmente com o título "Add strategist prompt chat opening options", porém não há remote configurado neste checkout, portanto não foi gerado link hospedado de PR/compare.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a356302f82c83298cc44c121acd4323)