### PR TITLE
docs: ajustar fases do prompt estrategista

### DIFF
--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -38,6 +38,8 @@ gatilho → entrada → processamento → validação → persistência → cons
 
 	3. Plano-base v1
 Criar o primeiro rascunho com objetivo, solução, fases, limites e pendências.
+Identificar ajustes necessários em etapas, estruturas ou seções anteriores e registrá-los como pré-requisitos ou fases do plano.
+Quando o caso tiver escopos distintos ou risco de sobrecarregar o Executor, dividir o plano em poucas fases sequenciais, cada uma com objetivo, limites e critério de passagem.
 Quando houver frontend, incluir também:
 
 • superfície afetada;
@@ -65,6 +67,8 @@ Execute [fase/item] de docs/roadmap.md, seguindo
 docs/prompt-executor.md.
 Parta da main atualizada, use branch própria e pare antes do merge.
 Não repetir o conteúdo do plano ou do prompt.
+Enviar somente a fase atual ao Executor.
+A fase seguinte só deve ser instruída após a entrega, avaliação e conclusão da fase anterior, incluindo merge ou aplicação real quando necessários.
 Caso Codex avulso sem plano no roadmap:
 docs/template-briefing-codex.md
 + docs/prompt-executor.md


### PR DESCRIPTION
### Motivation
- Garantir que o Plano-base formalize pré-requisitos e phases quando necessário e que o Executor receba apenas a fase atual para evitar sobrecarga e coordenar entregas sequenciais.

### Description
- Acrescentei duas orientações em `docs/prompt-estrategista.md`: no item `3. Plano-base v1` para registrar ajustes necessários como pré-requisitos e dividir escopos em fases sequenciais, e no item `9. Instrução ao Executor` para `Enviar somente a fase atual ao Executor` e só instruir a fase seguinte após entrega, avaliação e conclusão da anterior.

### Testing
- Confirmei que apenas `docs/prompt-estrategista.md` foi modificado e executei `git diff --check`, que retornou sem erros; `npm ci` e `npm run check` foram considerados não aplicáveis por se tratar de mudança exclusivamente documental.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a358d150b048329892ca3f767aea651)