### PR TITLE
[codex] E10.7 Fase 1 patch estrutural mínimo

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data da última atualização: 16/06/2026
-• Documento: LP Factory 10 — Schema (DB Contract) v1.0.23
+• Data da última atualização: 21/06/2026
+• Documento: LP Factory 10 — Schema (DB Contract) v1.0.24
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -551,8 +551,13 @@
 1.21.3 Segurança
 • Trigger Hub: não
 • RLS: ativo
-• anon/authenticated/public: sem acesso
-• service_role: SELECT
+• public/anon: sem acesso
+• authenticated: SELECT, INSERT e UPDATE restrito às colunas `content_json` e `provenance_json`
+• service_role: SELECT, INSERT, UPDATE
+• Policies:
+  • content_artifacts_select_admin_only (SELECT to authenticated): is_super_admin() OU is_platform_admin()
+  • content_artifacts_insert_admin_draft_only (INSERT to authenticated): is_super_admin() OU is_platform_admin(); somente `status = 'draft'`, `published_at IS NULL` e `archived_at IS NULL`
+  • content_artifacts_update_admin_only (UPDATE to authenticated): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
 
 1.21.4 Índices
 • `content_artifacts_one_published_uidx`: UNIQUE parcial em (`template_id`, `taxon_id`, `audience_scope`) para `status = 'published'`.
@@ -580,8 +585,12 @@
 1.22.3 Segurança
 • Trigger Hub: não
 • RLS: ativo
-• anon/authenticated/public: sem acesso
-• service_role: SELECT
+• public/anon: sem acesso
+• authenticated: SELECT, INSERT
+• service_role: SELECT, INSERT
+• Policies:
+  • content_artifact_research_sources_select_admin_only (SELECT to authenticated): is_super_admin() OU is_platform_admin()
+  • content_artifact_research_sources_insert_admin_business_buyer_only (INSERT to authenticated): is_super_admin() OU is_platform_admin(); somente `audience_scope = 'business_buyer'`
 
 1.22.4 Índices
 • `content_artifact_research_sources_research_id_idx`: btree em `research_id`.
@@ -681,6 +690,15 @@
 3.3.3 SECURITY DEFINER allowlist
 • has_account_min_role (motivo: helper RLS; limites: somente leitura; sem writes)
 • ensure_first_account_for_current_user (motivo: F2 auto 1ª conta; limites: idempotente; cria 1ª conta + owner/active)
+• publish_content_artifact_draft (motivo: publicação transacional E10.7; limites: publica um draft por `id`, arquiva o published anterior do mesmo template/taxon/audience_scope e exige is_super_admin() OU is_platform_admin())
+
+3.3.4 publish_content_artifact_draft(p_artifact_id uuid) → content_artifacts
+• Segurança: SECURITY DEFINER (aprovado; escrita transacional controlada)
+• search_path: public, pg_temp
+• Grants de EXECUTE: authenticated
+• Sem EXECUTE para public/anon
+• Efeito: bloqueia o draft alvo, valida `status = 'draft'`, bloqueia o `published` anterior do mesmo template/taxon/audience_scope, arquiva o anterior e publica o draft na mesma transação.
+• Garantia complementar: `content_artifacts_one_published_uidx` mantém no máximo um `published` por (`template_id`, `taxon_id`, `audience_scope`).
 
 3.4 Convites de Conta
 • accept_account_invite(account_id uuid, ttl_days int) → boolean
@@ -767,6 +785,11 @@
 • Rollback: não remove automaticamente a extensão, pois pode ser reutilizada por outros recursos
 
 99. Changelog
+v1.0.24 (21/06/2026) — E10.7 Fase 1: escrita administrativa e publicação transacional de artefatos
+• Registrados grants e policies admin-only para criação de drafts em `content_artifacts` e registro de fontes `business_buyer` em `content_artifact_research_sources`.
+• Registrado UPDATE direto de `authenticated` restrito às colunas `content_json` e `provenance_json`.
+• Registrada a RPC `publish_content_artifact_draft(uuid)` para arquivar o `published` anterior e publicar o novo `draft` na mesma transação.
+
 v1.0.23 (16/06/2026) — E18: registros-base de `commercial_activation`
 • Registrados o template-base de página e os oito módulos de seção da versão 1.
 • Confirmados nove registros ativos, identidade funcional por chave/slug + versão e ausência de vínculos com taxons.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -552,12 +552,12 @@
 • Trigger Hub: não
 • RLS: ativo
 • public/anon: sem acesso
-• authenticated: SELECT, INSERT e UPDATE restrito às colunas `content_json` e `provenance_json`
+• authenticated: SELECT, INSERT e UPDATE restrito às colunas `content_json` e `provenance_json` somente em artefatos `draft`
 • service_role: SELECT, INSERT, UPDATE
 • Policies:
   • content_artifacts_select_admin_only (SELECT to authenticated): is_super_admin() OU is_platform_admin()
   • content_artifacts_insert_admin_draft_only (INSERT to authenticated): is_super_admin() OU is_platform_admin(); somente `status = 'draft'`, `published_at IS NULL` e `archived_at IS NULL`
-  • content_artifacts_update_admin_only (UPDATE to authenticated): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
+  • content_artifacts_update_admin_draft_content_only (UPDATE to authenticated): is_super_admin() OU is_platform_admin(); somente `status = 'draft'`, `published_at IS NULL` e `archived_at IS NULL` (USING + WITH CHECK)
 
 1.21.4 Índices
 • `content_artifacts_one_published_uidx`: UNIQUE parcial em (`template_id`, `taxon_id`, `audience_scope`) para `status = 'published'`.
@@ -699,6 +699,7 @@
 • Sem EXECUTE para public/anon
 • Efeito: bloqueia o draft alvo, valida `status = 'draft'`, bloqueia o `published` anterior do mesmo template/taxon/audience_scope, arquiva o anterior e publica o draft na mesma transação.
 • Garantia complementar: `content_artifacts_one_published_uidx` mantém no máximo um `published` por (`template_id`, `taxon_id`, `audience_scope`).
+• Risco residual aceito para Fase 2: geração segura da próxima `artifact_version`; a UNIQUE `(template_id, composition_id, taxon_id, audience_scope, research_version, artifact_version)` protege colisão, mas o fluxo de geração ainda deve calcular ou tentar inserir a próxima versão de forma segura.
 
 3.4 Convites de Conta
 • accept_account_invite(account_id uuid, ttl_days int) → boolean
@@ -787,7 +788,7 @@
 99. Changelog
 v1.0.24 (21/06/2026) — E10.7 Fase 1: escrita administrativa e publicação transacional de artefatos
 • Registrados grants e policies admin-only para criação de drafts em `content_artifacts` e registro de fontes `business_buyer` em `content_artifact_research_sources`.
-• Registrado UPDATE direto de `authenticated` restrito às colunas `content_json` e `provenance_json`.
+• Registrado UPDATE direto de `authenticated` restrito às colunas `content_json` e `provenance_json` somente para artefatos `draft`.
 • Registrada a RPC `publish_content_artifact_draft(uuid)` para arquivar o `published` anterior e publicar o novo `draft` na mesma transação.
 
 v1.0.23 (16/06/2026) — E18: registros-base de `commercial_activation`

--- a/supabase/migrations/20260621162400_e10_7_admin_artifact_write_publish.sql
+++ b/supabase/migrations/20260621162400_e10_7_admin_artifact_write_publish.sql
@@ -1,0 +1,133 @@
+begin;
+
+grant select, insert on table public.content_artifacts to authenticated;
+grant update (content_json, provenance_json) on table public.content_artifacts to authenticated;
+grant select, insert, update on table public.content_artifacts to service_role;
+
+grant select, insert on table public.content_artifact_research_sources to authenticated;
+grant select, insert on table public.content_artifact_research_sources to service_role;
+
+drop policy if exists "content_artifacts_select_admin_only" on public.content_artifacts;
+create policy "content_artifacts_select_admin_only"
+  on public.content_artifacts
+  for select
+  to authenticated
+  using (public.is_super_admin() or public.is_platform_admin());
+
+drop policy if exists "content_artifacts_insert_admin_draft_only" on public.content_artifacts;
+create policy "content_artifacts_insert_admin_draft_only"
+  on public.content_artifacts
+  for insert
+  to authenticated
+  with check (
+    (public.is_super_admin() or public.is_platform_admin())
+    and status = 'draft'
+    and published_at is null
+    and archived_at is null
+  );
+
+drop policy if exists "content_artifacts_update_admin_only" on public.content_artifacts;
+create policy "content_artifacts_update_admin_only"
+  on public.content_artifacts
+  for update
+  to authenticated
+  using (public.is_super_admin() or public.is_platform_admin())
+  with check (public.is_super_admin() or public.is_platform_admin());
+
+drop policy if exists "content_artifact_research_sources_select_admin_only"
+  on public.content_artifact_research_sources;
+create policy "content_artifact_research_sources_select_admin_only"
+  on public.content_artifact_research_sources
+  for select
+  to authenticated
+  using (public.is_super_admin() or public.is_platform_admin());
+
+drop policy if exists "content_artifact_research_sources_insert_admin_business_buyer_only"
+  on public.content_artifact_research_sources;
+create policy "content_artifact_research_sources_insert_admin_business_buyer_only"
+  on public.content_artifact_research_sources
+  for insert
+  to authenticated
+  with check (
+    (public.is_super_admin() or public.is_platform_admin())
+    and audience_scope = 'business_buyer'
+  );
+
+create or replace function public.publish_content_artifact_draft(
+  p_artifact_id uuid
+)
+returns public.content_artifacts
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_draft public.content_artifacts%rowtype;
+  v_result public.content_artifacts%rowtype;
+  v_now timestamptz := now();
+begin
+  if not (
+    coalesce(public.is_super_admin(), false)
+    or coalesce(public.is_platform_admin(), false)
+  ) then
+    raise exception 'publish_content_artifact_draft requires platform admin privileges'
+      using errcode = '42501';
+  end if;
+
+  select *
+    into v_draft
+  from public.content_artifacts
+  where id = p_artifact_id
+  for update;
+
+  if not found then
+    raise exception 'content artifact % not found', p_artifact_id
+      using errcode = 'P0002';
+  end if;
+
+  if v_draft.status <> 'draft' then
+    raise exception 'content artifact % must be draft to publish', p_artifact_id
+      using errcode = '23514';
+  end if;
+
+  perform 1
+  from public.content_artifacts
+  where template_id = v_draft.template_id
+    and taxon_id = v_draft.taxon_id
+    and audience_scope = v_draft.audience_scope
+    and status = 'published'
+  for update;
+
+  update public.content_artifacts
+  set status = 'archived',
+      archived_at = v_now
+  where template_id = v_draft.template_id
+    and taxon_id = v_draft.taxon_id
+    and audience_scope = v_draft.audience_scope
+    and status = 'published';
+
+  update public.content_artifacts
+  set status = 'published',
+      published_at = v_now,
+      archived_at = null
+  where id = p_artifact_id
+    and status = 'draft'
+  returning * into v_result;
+
+  if not found then
+    raise exception 'content artifact % was not published', p_artifact_id
+      using errcode = '40001';
+  end if;
+
+  return v_result;
+end;
+$$;
+
+revoke all on function public.publish_content_artifact_draft(uuid) from public;
+revoke all on function public.publish_content_artifact_draft(uuid) from anon;
+grant execute on function public.publish_content_artifact_draft(uuid) to authenticated;
+
+comment on function public.publish_content_artifact_draft(uuid)
+  is 'Publishes one draft content artifact transactionally, archiving the previous published artifact for the same template/taxon/audience scope.';
+
+commit;

--- a/supabase/migrations/20260621162400_e10_7_admin_artifact_write_publish.sql
+++ b/supabase/migrations/20260621162400_e10_7_admin_artifact_write_publish.sql
@@ -27,12 +27,21 @@ create policy "content_artifacts_insert_admin_draft_only"
   );
 
 drop policy if exists "content_artifacts_update_admin_only" on public.content_artifacts;
-create policy "content_artifacts_update_admin_only"
+drop policy if exists "content_artifacts_update_admin_draft_content_only" on public.content_artifacts;
+create policy "content_artifacts_update_admin_draft_content_only"
   on public.content_artifacts
   for update
   to authenticated
-  using (public.is_super_admin() or public.is_platform_admin())
-  with check (public.is_super_admin() or public.is_platform_admin());
+  using (
+    (public.is_super_admin() or public.is_platform_admin())
+    and status = 'draft'
+  )
+  with check (
+    (public.is_super_admin() or public.is_platform_admin())
+    and status = 'draft'
+    and published_at is null
+    and archived_at is null
+  );
 
 drop policy if exists "content_artifact_research_sources_select_admin_only"
   on public.content_artifact_research_sources;

--- a/supabase/snippets/e10_7_admin_artifact_write_publish_verify.sql
+++ b/supabase/snippets/e10_7_admin_artifact_write_publish_verify.sql
@@ -83,7 +83,7 @@ expected_policies as (
     values
       ('content_artifacts'::text, 'content_artifacts_select_admin_only'::text),
       ('content_artifacts'::text, 'content_artifacts_insert_admin_draft_only'::text),
-      ('content_artifacts'::text, 'content_artifacts_update_admin_only'::text),
+      ('content_artifacts'::text, 'content_artifacts_update_admin_draft_content_only'::text),
       ('content_artifact_research_sources'::text, 'content_artifact_research_sources_select_admin_only'::text),
       ('content_artifact_research_sources'::text, 'content_artifact_research_sources_insert_admin_business_buyer_only'::text)
   ) as policies(table_name, policy_name)

--- a/supabase/snippets/e10_7_admin_artifact_write_publish_verify.sql
+++ b/supabase/snippets/e10_7_admin_artifact_write_publish_verify.sql
@@ -1,0 +1,175 @@
+-- e10_7_admin_artifact_write_publish_verify.sql
+-- Objetivo: verificar o patch estrutural minimo da E10.7 Fase 1.
+-- Tipo: read-only / execucao manual no Supabase SQL Editor.
+-- Escopo: grants, RLS, policies, RPC transacional e guarda de published unico.
+
+with expected_table_privileges as (
+  select *
+  from (
+    values
+      ('content_artifacts'::text, 'authenticated'::text, 'SELECT'::text),
+      ('content_artifacts'::text, 'authenticated'::text, 'INSERT'::text),
+      ('content_artifacts'::text, 'service_role'::text, 'SELECT'::text),
+      ('content_artifacts'::text, 'service_role'::text, 'INSERT'::text),
+      ('content_artifacts'::text, 'service_role'::text, 'UPDATE'::text),
+      ('content_artifact_research_sources'::text, 'authenticated'::text, 'SELECT'::text),
+      ('content_artifact_research_sources'::text, 'authenticated'::text, 'INSERT'::text),
+      ('content_artifact_research_sources'::text, 'service_role'::text, 'SELECT'::text),
+      ('content_artifact_research_sources'::text, 'service_role'::text, 'INSERT'::text)
+  ) as privileges(table_name, role_name, privilege_name)
+),
+
+table_privilege_status as (
+  select
+    'table_privilege'::text as check_group,
+    format('%s:%s:%s', table_name, role_name, privilege_name) as object_name,
+    case
+      when has_table_privilege(role_name, format('public.%I', table_name), privilege_name) then 'ok'
+      else 'missing'
+    end as check_status,
+    jsonb_build_object(
+      'table_name', table_name,
+      'role_name', role_name,
+      'privilege_name', privilege_name
+    ) as details
+  from expected_table_privileges
+),
+
+expected_column_privileges as (
+  select *
+  from (
+    values
+      ('content_artifacts'::text, 'content_json'::text, 'authenticated'::text, 'UPDATE'::text),
+      ('content_artifacts'::text, 'provenance_json'::text, 'authenticated'::text, 'UPDATE'::text)
+  ) as privileges(table_name, column_name, role_name, privilege_name)
+),
+
+column_privilege_status as (
+  select
+    'column_privilege'::text as check_group,
+    format('%s.%s:%s:%s', table_name, column_name, role_name, privilege_name) as object_name,
+    case
+      when has_column_privilege(role_name, format('public.%I', table_name), column_name, privilege_name) then 'ok'
+      else 'missing'
+    end as check_status,
+    jsonb_build_object(
+      'table_name', table_name,
+      'column_name', column_name,
+      'role_name', role_name,
+      'privilege_name', privilege_name
+    ) as details
+  from expected_column_privileges
+),
+
+rls_status as (
+  select
+    'rls'::text as check_group,
+    pg_class.relname as object_name,
+    case when pg_class.relrowsecurity then 'ok' else 'disabled' end as check_status,
+    jsonb_build_object('rls_forced', pg_class.relforcerowsecurity) as details
+  from pg_class
+  join pg_namespace
+    on pg_namespace.oid = pg_class.relnamespace
+  where pg_namespace.nspname = 'public'
+    and pg_class.relname in (
+      'content_artifacts',
+      'content_artifact_research_sources'
+    )
+),
+
+expected_policies as (
+  select *
+  from (
+    values
+      ('content_artifacts'::text, 'content_artifacts_select_admin_only'::text),
+      ('content_artifacts'::text, 'content_artifacts_insert_admin_draft_only'::text),
+      ('content_artifacts'::text, 'content_artifacts_update_admin_only'::text),
+      ('content_artifact_research_sources'::text, 'content_artifact_research_sources_select_admin_only'::text),
+      ('content_artifact_research_sources'::text, 'content_artifact_research_sources_insert_admin_business_buyer_only'::text)
+  ) as policies(table_name, policy_name)
+),
+
+policy_status as (
+  select
+    'policy'::text as check_group,
+    expected_policies.policy_name as object_name,
+    case when pg_policies.policyname is not null then 'ok' else 'missing' end as check_status,
+    jsonb_build_object(
+      'table_name', expected_policies.table_name,
+      'cmd', pg_policies.cmd,
+      'roles', pg_policies.roles,
+      'qual', pg_policies.qual,
+      'with_check', pg_policies.with_check
+    ) as details
+  from expected_policies
+  left join pg_policies
+    on pg_policies.schemaname = 'public'
+   and pg_policies.tablename = expected_policies.table_name
+   and pg_policies.policyname = expected_policies.policy_name
+),
+
+function_status as (
+  select
+    'function'::text as check_group,
+    expected_functions.function_name as object_name,
+    case
+      when pg_proc.oid is null then 'missing'
+      when pg_proc.prosecdef is not true then 'not_security_definer'
+      when not has_function_privilege('authenticated', pg_proc.oid, 'EXECUTE') then 'missing_authenticated_execute'
+      when has_function_privilege('anon', pg_proc.oid, 'EXECUTE') then 'anon_can_execute'
+      else 'ok'
+    end as check_status,
+    jsonb_build_object(
+      'security_definer', pg_proc.prosecdef,
+      'authenticated_execute',
+      case when pg_proc.oid is null then null else has_function_privilege('authenticated', pg_proc.oid, 'EXECUTE') end,
+      'anon_execute',
+      case when pg_proc.oid is null then null else has_function_privilege('anon', pg_proc.oid, 'EXECUTE') end
+    ) as details
+  from (
+    values ('publish_content_artifact_draft(uuid)'::text, 'publish_content_artifact_draft'::text)
+  ) as expected_functions(function_name, proname)
+  left join pg_namespace
+    on pg_namespace.nspname = 'public'
+  left join pg_proc
+    on pg_proc.pronamespace = pg_namespace.oid
+   and pg_proc.proname = expected_functions.proname
+),
+
+published_unique_index_status as (
+  select
+    'index'::text as check_group,
+    expected_indexes.index_name as object_name,
+    case
+      when pg_indexes.indexname is null then 'missing'
+      when pg_indexes.indexdef ilike '%WHERE (status = ''published''::text)%' then 'ok'
+      else 'unexpected_definition'
+    end as check_status,
+    jsonb_build_object('index_definition', pg_indexes.indexdef) as details
+  from (
+    values ('content_artifacts_one_published_uidx'::text)
+  ) as expected_indexes(index_name)
+  left join pg_indexes
+    on pg_indexes.schemaname = 'public'
+   and pg_indexes.tablename = 'content_artifacts'
+   and pg_indexes.indexname = expected_indexes.index_name
+)
+
+select *
+from table_privilege_status
+union all
+select *
+from column_privilege_status
+union all
+select *
+from rls_status
+union all
+select *
+from policy_status
+union all
+select *
+from function_status
+union all
+select *
+from published_unique_index_status
+order by check_group, object_name;


### PR DESCRIPTION
## Resumo

Implementa o patch estrutural mínimo da E10.7 Fase 1 para viabilizar escrita administrativa controlada em artefatos comerciais.

## Mudanças

- Adiciona migration com grants mínimos para `content_artifacts` e `content_artifact_research_sources`.
- Adiciona policies admin-only para criação/leitura de drafts e registro de fontes `business_buyer`.
- Adiciona RPC `publish_content_artifact_draft(uuid)` para publicar um draft e arquivar o `published` anterior na mesma transação.
- Adiciona snippet read-only de verificação.
- Atualiza `docs/schema.md` para refletir grants, policies, RPC e changelog.

## Fora de escopo

- Sem nova tabela.
- Sem geração IA.
- Sem alteração do Account Dashboard.
- Sem LP Builder.
- Sem mudança de hierarquia de taxons ou `research_version`.

## Validação

- `git diff --check`
- `npx --yes supabase@2.106.0 db push --linked --dry-run`
- `npx --yes supabase@2.106.0 migration list --linked`

A migration não foi aplicada no banco remoto; o dry-run confirmou que apenas `20260621162400_e10_7_admin_artifact_write_publish.sql` seria enviada.