### PR TITLE
[codex] Corrige nome da policy E10.7 de fontes

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -2,7 +2,7 @@
 
 0.1 Cabeçalho
 • Data da última atualização: 21/06/2026
-• Documento: LP Factory 10 — Schema (DB Contract) v1.0.24
+• Documento: LP Factory 10 — Schema (DB Contract) v1.0.25
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -590,7 +590,7 @@
 • service_role: SELECT, INSERT
 • Policies:
   • content_artifact_research_sources_select_admin_only (SELECT to authenticated): is_super_admin() OU is_platform_admin()
-  • content_artifact_research_sources_insert_admin_business_buyer_only (INSERT to authenticated): is_super_admin() OU is_platform_admin(); somente `audience_scope = 'business_buyer'`
+  • cars_insert_admin_business_buyer_only (INSERT to authenticated): is_super_admin() OU is_platform_admin(); somente `audience_scope = 'business_buyer'`
 
 1.22.4 Índices
 • `content_artifact_research_sources_research_id_idx`: btree em `research_id`.
@@ -786,6 +786,10 @@
 • Rollback: não remove automaticamente a extensão, pois pode ser reutilizada por outros recursos
 
 99. Changelog
+v1.0.25 (21/06/2026) — E10.7 Fase 1: nome estável para policy de fontes de pesquisa
+• Substituída a policy longa/truncável de INSERT em `content_artifact_research_sources` por `cars_insert_admin_business_buyer_only`.
+• Mantida a mesma regra: is_super_admin() OU is_platform_admin(); somente `audience_scope = 'business_buyer'`.
+
 v1.0.24 (21/06/2026) — E10.7 Fase 1: escrita administrativa e publicação transacional de artefatos
 • Registrados grants e policies admin-only para criação de drafts em `content_artifacts` e registro de fontes `business_buyer` em `content_artifact_research_sources`.
 • Registrado UPDATE direto de `authenticated` restrito às colunas `content_json` e `provenance_json` somente para artefatos `draft`.

--- a/supabase/migrations/20260621181742_e10_7_fix_research_sources_policy_name.sql
+++ b/supabase/migrations/20260621181742_e10_7_fix_research_sources_policy_name.sql
@@ -1,0 +1,21 @@
+begin;
+
+drop policy if exists "content_artifact_research_sources_insert_admin_business_buyer_only"
+  on public.content_artifact_research_sources;
+
+drop policy if exists "content_artifact_research_sources_insert_admin_business_buyer_o"
+  on public.content_artifact_research_sources;
+
+drop policy if exists "cars_insert_admin_business_buyer_only"
+  on public.content_artifact_research_sources;
+
+create policy "cars_insert_admin_business_buyer_only"
+  on public.content_artifact_research_sources
+  for insert
+  to authenticated
+  with check (
+    (public.is_super_admin() or public.is_platform_admin())
+    and audience_scope = 'business_buyer'
+  );
+
+commit;

--- a/supabase/snippets/e10_7_admin_artifact_write_publish_verify.sql
+++ b/supabase/snippets/e10_7_admin_artifact_write_publish_verify.sql
@@ -85,7 +85,7 @@ expected_policies as (
       ('content_artifacts'::text, 'content_artifacts_insert_admin_draft_only'::text),
       ('content_artifacts'::text, 'content_artifacts_update_admin_draft_content_only'::text),
       ('content_artifact_research_sources'::text, 'content_artifact_research_sources_select_admin_only'::text),
-      ('content_artifact_research_sources'::text, 'content_artifact_research_sources_insert_admin_business_buyer_only'::text)
+      ('content_artifact_research_sources'::text, 'cars_insert_admin_business_buyer_only'::text)
   ) as policies(table_name, policy_name)
 ),
 


### PR DESCRIPTION
## Resumo

Cria migration corretiva pequena para substituir o nome longo/truncado da policy de INSERT em `content_artifact_research_sources` por um nome curto e estável.

## Problema

No Supabase real, a policy esperada `content_artifact_research_sources_insert_admin_business_buyer_only` foi truncada pelo Postgres para `content_artifact_research_sources_insert_admin_business_buyer_o` por limite de 63 caracteres. Isso impedia o snippet completo de validação de encontrar o nome esperado.

## Mudanças

- Adiciona migration `20260621181742_e10_7_fix_research_sources_policy_name.sql`.
- Remove de forma idempotente o nome longo, o nome truncado real e eventual policy curta existente.
- Recria a policy como `cars_insert_admin_business_buyer_only` mantendo a mesma regra: admin-only e `audience_scope = 'business_buyer'`.
- Atualiza o snippet de verificação para esperar o nome curto.
- Atualiza `docs/schema.md` para registrar `v1.0.25` e a policy estável.

## Fora de escopo

- Sem SQL manual aplicado no Supabase.
- Sem UI.
- Sem Account Dashboard.
- Sem geração IA.
- Sem LP Builder.
- Sem novas tabelas.
- Sem alteração de hierarquia de taxons.

## Validação

- `git diff --check`
- `npx --yes supabase@2.106.0 migration list --linked`
- `npx --yes supabase@2.106.0 db push --linked --dry-run`

O dry-run confirmou que apenas `20260621181742_e10_7_fix_research_sources_policy_name.sql` seria enviada.