### PR TITLE
[codex] E10.7 Fase 1B normaliza plano Lite

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -2,7 +2,7 @@
 
 0.1 Cabeçalho
 • Data da última atualização: 21/06/2026
-• Documento: LP Factory 10 — Schema (DB Contract) v1.0.25
+• Documento: LP Factory 10 — Schema (DB Contract) v1.0.26
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -70,7 +70,13 @@
 1.4.1 Chaves e campos críticos
 • PK: id uuid
 • UNIQUE: name
-• Campos críticos: name, max_lps, max_conversions
+• Campos críticos: name, max_lps, max_conversions, price_monthly, features
+• name text not null
+• max_lps integer null default 0
+• max_conversions integer null default 0
+• price_monthly numeric null default 0.00
+• features jsonb null default '{}'::jsonb
+• Fonte canônica parcial para E10.7: name, price_monthly, max_lps, max_conversions e features. Não é fonte suficiente para garantias, condições comerciais, URLs oficiais de checkout, promessas, descontos ou regras promocionais.
 1.4.2 Segurança
 • Trigger Hub: não
 • RLS: conforme uso (geralmente read-only)
@@ -786,6 +792,10 @@
 • Rollback: não remove automaticamente a extensão, pois pode ser reutilizada por outros recursos
 
 99. Changelog
+v1.0.26 (21/06/2026) — E10.7 Fase 1B: plans como fonte canônica parcial
+• Registrados `price_monthly` e `features` na tabela `plans`.
+• Registrado que `plans` é fonte canônica parcial para name, price_monthly, max_lps, max_conversions e features; demais condições comerciais permanecem fora desta fonte.
+
 v1.0.25 (21/06/2026) — E10.7 Fase 1: nome estável para policy de fontes de pesquisa
 • Substituída a policy longa/truncável de INSERT em `content_artifact_research_sources` por `cars_insert_admin_business_buyer_only`.
 • Mantida a mesma regra: is_super_admin() OU is_platform_admin(); somente `audience_scope = 'business_buyer'`.

--- a/supabase/migrations/20260621194501_e10_7_normalize_lite_plan_name.sql
+++ b/supabase/migrations/20260621194501_e10_7_normalize_lite_plan_name.sql
@@ -1,0 +1,7 @@
+begin;
+
+update public.plans
+set name = 'Lite'
+where name = 'Light';
+
+commit;


### PR DESCRIPTION
## Resumo

Normaliza a fonte canônica parcial de planos antes da E10.7 Fase 2.

## Mudanças

- Cria migration de dados `20260621194501_e10_7_normalize_lite_plan_name.sql`.
- Normaliza `public.plans.name` de `Light` para `Lite`.
- Atualiza `docs/schema.md` para registrar os campos reais de `public.plans`, incluindo `price_monthly` e `features`.
- Registra `plans` como fonte canônica parcial apenas para `name`, `price_monthly`, `max_lps`, `max_conversions` e `features`.

## Validação no Supabase real

A migration foi aplicada com `npx --yes supabase@2.106.0 db push --linked`.

SELECT read-only confirmou:

- `Light`: 0 linhas
- `Lite`: 1 linha
- `Lite` preservou `id = 062739c7-f1f3-40a3-a4e4-f9e95547d92b`
- `max_lps = 5`
- `max_conversions = 100`
- `price_monthly = 29.90`
- `features = {"analytics":"basic","custom_domain":false}`

Estrutura de `public.plans` confirmada: `id`, `name`, `created_at`, `updated_at`, `max_lps`, `max_conversions`, `price_monthly`, `features`.

## Fora de escopo

- Sem UI.
- Sem Account Dashboard.
- Sem Admin UI.
- Sem geração IA.
- Sem LP Builder.
- Sem alteração da página genérica E10.6.
- Sem alteração de ids, vínculos `accounts.plan_id`, preços, limites ou features.

## Checks

- `git diff --check`
- `npx --yes supabase@2.106.0 migration list --linked`
- SELECTs read-only de validação no Supabase real

`npm ci` e `npm run check` não se aplicam porque a mudança é apenas SQL/docs.