### PR TITLE
[codex] E10.7 Phase 1D plans service role read grant

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -2,7 +2,7 @@
 
 0.1 Cabeçalho
 • Data da última atualização: 21/06/2026
-• Documento: LP Factory 10 — Schema (DB Contract) v1.0.26
+• Documento: LP Factory 10 — Schema (DB Contract) v1.0.27
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -80,6 +80,7 @@
 1.4.2 Segurança
 • Trigger Hub: não
 • RLS: conforme uso (geralmente read-only)
+• Grants: `authenticated` com SELECT; `service_role` com SELECT para leitura server-side administrativa da E10.7.
 1.4.3 Policies (TBD: preencher nomes reais no Supabase)
 • Select: público autenticado (se aplicável) ou somente admins
 
@@ -792,6 +793,9 @@
 • Rollback: não remove automaticamente a extensão, pois pode ser reutilizada por outros recursos
 
 99. Changelog
+v1.0.27 (22/06/2026) — E10.7 Fase 1D: leitura server-side de `plans`
+• Registrado grant mínimo de SELECT em `public.plans` para `service_role`, viabilizando leitura server-side administrativa da fonte canônica parcial de planos.
+
 v1.0.26 (21/06/2026) — E10.7 Fase 1B: plans como fonte canônica parcial
 • Registrados `price_monthly` e `features` na tabela `plans`.
 • Registrado que `plans` é fonte canônica parcial para name, price_monthly, max_lps, max_conversions e features; demais condições comerciais permanecem fora desta fonte.

--- a/supabase/migrations/20260622182227_e10_7_phase_1d_plans_service_role_select.sql
+++ b/supabase/migrations/20260622182227_e10_7_phase_1d_plans_service_role_select.sql
@@ -1,0 +1,1 @@
+grant select on table public.plans to service_role;

--- a/supabase/snippets/e10_7_phase_1d_plans_service_role_select_verify.sql
+++ b/supabase/snippets/e10_7_phase_1d_plans_service_role_select_verify.sql
@@ -1,0 +1,13 @@
+-- e10_7_phase_1d_plans_service_role_select_verify.sql
+-- Objetivo: validar grant minimo de leitura server-side em public.plans.
+-- Tipo: read-only / execucao manual no Supabase SQL Editor.
+
+select
+  grantee,
+  privilege_type,
+  is_grantable
+from information_schema.role_table_grants
+where table_schema = 'public'
+  and table_name = 'plans'
+  and grantee in ('anon', 'authenticated', 'service_role')
+order by grantee, privilege_type;


### PR DESCRIPTION
## Summary

- Adds the E10.7 Phase 1D migration granting `SELECT` on `public.plans` to `service_role`.
- Adds a read-only verification snippet for the `plans` grants.
- Updates `docs/schema.md` to document schema contract v1.0.27 and the `service_role` read grant for server-side administrative plan reads.

## Validation

- `git diff --check`
- Read-only pre-validation snippet before migration application showed only `authenticated -> SELECT`; `service_role -> SELECT` was absent.
- `npx --yes supabase@2.106.0 migration list --linked` showed the new migration as local-only.

`npx --yes supabase@2.106.0 db push --linked --dry-run` was attempted but blocked locally by missing/invalid `SUPABASE_DB_PASSWORD` for Postgres auth. Per project flow, no direct SQL or `apply_migration` bypass was executed.

## Scope Boundaries

- No AI generation.
- No draft creation or `content_artifacts` writes.
- No `content_artifact_research_sources` writes.
- No publication or `published` changes.
- No data changes in `public.plans`.
- No UI, `/a/[account]`, Account Dashboard, LP Builder, Agents SDK, job, queue, or agent changes.
- No new table, view, function, policy, or data migration beyond the single grant.