### PR TITLE
docs: add AI model selection guideline to gestor-automations

### DIFF
--- a/docs/gestor-automations.md
+++ b/docs/gestor-automations.md
@@ -112,6 +112,7 @@ Exemplos: logs, tracing, métricas, alertas, auditoria, aprovação humana, roll
 
 * Começar por automação simples sempre que o fluxo for linear, previsível e com passos conhecidos.
 * Usar Responses API quando a IA precisar gerar, classificar, resumir ou estruturar resposta dentro de um fluxo controlado.
+* Modelo de IA deve ser configurável por env var e avaliado por caso de uso: fluxo linear ou administrativo começa por modelo mini/custo-benefício; agente real de dashboard, com múltiplas etapas, tools, decisões, validação e rastreabilidade, pode avaliar GPT-5.2, GPT-5.5 ou superior após teste de custo, qualidade e segurança; nenhum modelo vira padrão único do projeto sem validação prática.
 * Avaliar Agents SDK apenas quando houver decisão adaptativa real, uso coordenado de tools, lacunas, revisão, handoffs, sessões ou tracing.
 * Tratar Sandbox Agents como laboratório técnico em beta para arquivos, comandos, workspace, testes, patches e artefatos.
 * Manter aprovação humana quando houver publicação, custo relevante, alteração de dados, exclusão, envio externo ou conteúdo comercial público.


### PR DESCRIPTION
### Motivation
* Provide a short, actionable rule in “7. Como decidir” to ensure IA model choice remains configurable and evaluated per use case, prevent hardcoding a single project-wide default, and preserve existing guidance on Responses API and Agents SDK.

### Description
* Inserted one concise line in `docs/gestor-automations.md` (section “7. Como decidir”) requiring the model to be configurable via env var and evaluated by case of use, recommending mini/cost-benefit models for linear/administrative flows, allowing GPT-5.2/GPT-5.5 (or higher) to be considered for multi-step dashboard agents only after cost/quality/security tests, and explicitly prohibiting a single hardcoded project default.

### Testing
* Executed repository checks: `git status --short`, `git diff --name-only`, `git diff --check`, `git diff --stat`, `rg` to confirm mentions, and `wc -l` to verify line counts (before: 147, after: 148); all checks succeeded, and `npm ci` / `npm run check` were considered not applicable for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39943674a08329b22c9d4b57a08d1e)