### PR TITLE
docs: ABC pós-merge da E10.7 Fase 2

### DIFF
--- a/docs/automations.md
+++ b/docs/automations.md
@@ -1,6 +1,6 @@
 0.1 Cabeçalho
-Data: 12/06/2026
-Versão: v1.9
+Data: 22/06/2026
+Versão: v1.10
 Status: Alinhado ao Platform Config
 
 0.2 Função do documento
@@ -263,6 +263,38 @@ Runtime: `automations/niche-runtime-tests/`
 Casos versionados: `automations/niche-runtime-tests/cases/`
 Reuso de mailbox: `automations/validador-final/`
 Verificação opcional de banco: `automations/supabase-inspect/verify-niche-runtime.mjs`
+
+3.8 E10.7 Fase 2 — geração administrativa de draft comercial por taxon
+
+Objetivo:
+Gerar draft comercial `commercial_activation` por taxon em fluxo assistido por IA, server-side/Admin, sem publicação automática.
+
+Status:
+Implementada e validada como automação operacional administrativa.
+
+Acesso:
+Action administrativa protegida por permissão administrativa.
+
+Como funciona:
+- Usa OpenAI Responses API com Structured Outputs.
+- Gera e valida `content_json` antes da persistência.
+- Persiste somente `status = draft` em `content_artifacts`.
+- Registra fontes relacionais apenas `business_buyer`.
+- Mantém contexto `end_customer` apenas em `provenance_json`.
+- Usa CTA seguro definido server-side.
+- Em falha após criação do artifact e antes do registro completo das fontes, invalida/arquiva o draft parcial e retorna erro seguro.
+
+Limites:
+- Não publica.
+- Não altera `published`.
+- Não roda em runtime público.
+- Não é agente.
+- Não usa Agents SDK, Sandbox Agents, job, fila nem execução recorrente.
+
+Referências / dependências:
+Regra técnica: `docs/base-tecnica.md`
+Status funcional: `docs/roadmap.md`
+Configuração de modelo: `docs/platform-config.md`
 
 Nota de descontinuação:
 O experimento Agent Investigator foi descontinuado porque as capacidades necessárias passaram a ser atendidas pelos plugins oficiais do Codex App.

--- a/docs/automations.md
+++ b/docs/automations.md
@@ -295,9 +295,9 @@ Referências / dependências:
 Regra técnica: `docs/base-tecnica.md`
 Status funcional: `docs/roadmap.md`
 Configuração de modelo: `docs/platform-config.md`
-
-Nota de descontinuação:
-O experimento Agent Investigator foi descontinuado porque as capacidades necessárias passaram a ser atendidas pelos plugins oficiais do Codex App.
+Action administrativa: `app/admin/(protected)/templates/actions.ts`
+Adapter de geração: `lib/conversion-content/commercial-activation/draft-generation.ts`
+Snippet de validação: `supabase/snippets/e10_7_phase_2_draft_verify.sql`
 
 4. Aprendizados operacionais
 4.1 Princípios identificados

--- a/docs/base-tecnica.md
+++ b/docs/base-tecnica.md
@@ -2,8 +2,8 @@
 
 0.1. Cabeçalho
 • Documento: Base Técnica LP Factory 10
-• Versão: v2.0.42
-• Data: 16/06/2026
+• Versão: v2.0.43
+• Data: 22/06/2026
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -309,6 +309,21 @@
 • A validação deve ocorrer no servidor antes da renderização.
 • Casos executáveis: `npm run validate:commercial-activation`.
 
+3.15.1 Geração administrativa de draft de `commercial_activation`
+• Path canônico do adapter de geração: `lib/conversion-content/commercial-activation/draft-generation.ts`.
+• Entrada administrativa canônica: `app/admin/(protected)/templates/actions.ts`, protegida por `requirePlatformAdmin()`.
+• A geração deve ser server-side/Admin, usando `createServiceClient()` para leituras e persistência permitidas pelo contrato de banco.
+• Recurso de IA aprovado para fluxo linear de draft: OpenAI Responses API com Structured Outputs; o modelo deve ser configurado por `OPENAI_COMMERCIAL_ACTIVATION_MODEL`.
+• O fluxo não deve depender de Agents SDK, Sandbox Agents, job, fila, agente ou IA em runtime público.
+• Fontes de entrada permitidas: taxon, pesquisa ativa `business_buyer`, contexto `end_customer` apenas para proveniência, composição/variantes de `commercial_activation` e `public.plans` como fonte parcial de planos.
+• `public.plans` só é fonte canônica parcial para `name`, `price_monthly`, `max_lps`, `max_conversions` e `features`; não é fonte para garantias, condições comerciais, checkout, promessas, descontos ou promoções.
+• Antes da persistência, validar em duas camadas: envelope `CommercialActivationContentV1` e cada `section.content` contra o schema registrado para a `variant_key` permitida pela composição.
+• Persistir apenas `status = draft`; publicação e alteração de `published` pertencem a fluxo transacional próprio.
+• `content_artifact_research_sources` deve receber somente fontes relacionais `business_buyer`; contexto `end_customer` permanece apenas em `provenance_json`.
+• CTA gerado deve usar `href` interno seguro aprovado pelo servidor; sem `href` seguro, bloquear antes de persistir.
+• Se o insert das fontes relacionais falhar após criar o artifact, o draft recém-criado deve ser arquivado/invalidado e o fluxo deve retornar erro seguro, sem parecer concluído.
+• Logs devem registrar somente metadados operacionais seguros; não registrar prompt completo, pesquisa bruta, payload sensível ou resposta integral da IA.
+
 4. DB Contract - Fonte única: PATH: docs/schema.md
 • Este documento não lista mais tabelas/views/functions/triggers/policies; isso está em PATH: docs/schema.md.
 • Trigger Hub é regra do contrato de DB (governança/auditoria). Fonte única e detalhes: PATH: docs/schema.md (seções 3.5 e 4.1).
@@ -456,6 +471,8 @@ Fonte normativa da allowlist SULB para exceções de Auth. Qualquer novo arquivo
 • Tipos canônicos e adapters vNext: validar por 3.6 e 3.14.
 
 99. Changelog
+v2.0.43 — 22/06/2026 — Registrado o contrato técnico da geração administrativa de draft `commercial_activation`: fluxo server-side/Admin com Responses API e Structured Outputs, modelo por env var, validação em duas camadas, persistência somente como `draft`, fontes relacionais `business_buyer`, `end_customer` apenas em `provenance_json` e compensação segura em falha parcial.
+
 v2.0.42 — 16/06/2026 — Registrado o contrato técnico do renderer composicional de `commercial_activation`, com `content_json` v1, validação Zod estrita, registry fechado, regras de falha e conteúdo estruturado seguro.
 
 v2.0.41 — 12/06/2026 — Concluído o fluxo universal de migrations Supabase: merge na `main` aplica migrations automaticamente com gate `true`; SQL Editor excluído do fluxo normal e histórico definido como forward-only, com reversões por nova migration.

--- a/docs/gestor-automations.md
+++ b/docs/gestor-automations.md
@@ -112,6 +112,7 @@ Exemplos: logs, tracing, métricas, alertas, auditoria, aprovação humana, roll
 
 * Começar por automação simples sempre que o fluxo for linear, previsível e com passos conhecidos.
 * Usar Responses API quando a IA precisar gerar, classificar, resumir ou estruturar resposta dentro de um fluxo controlado.
+* A E10.7 Fase 2 confirma que geração administrativa linear de draft comercial deve começar por Responses API com Structured Outputs, sem Agents SDK, Sandbox Agents, job, fila ou agente enquanto não houver decisão adaptativa real.
 * Modelo de IA deve ser configurável por env var e avaliado por caso de uso: fluxo linear ou administrativo começa por modelo mini/custo-benefício; agente real de dashboard, com múltiplas etapas, tools, decisões, validação e rastreabilidade, pode avaliar GPT-5.2, GPT-5.5 ou superior após teste de custo, qualidade e segurança; nenhum modelo vira padrão único do projeto sem validação prática.
 * Avaliar Agents SDK apenas quando houver decisão adaptativa real, uso coordenado de tools, lacunas, revisão, handoffs, sessões ou tracing.
 * Tratar Sandbox Agents como laboratório técnico em beta para arquivos, comandos, workspace, testes, patches e artefatos.

--- a/docs/gestor-automations.md
+++ b/docs/gestor-automations.md
@@ -112,7 +112,6 @@ Exemplos: logs, tracing, métricas, alertas, auditoria, aprovação humana, roll
 
 * Começar por automação simples sempre que o fluxo for linear, previsível e com passos conhecidos.
 * Usar Responses API quando a IA precisar gerar, classificar, resumir ou estruturar resposta dentro de um fluxo controlado.
-* A E10.7 Fase 2 confirma que geração administrativa linear de draft comercial deve começar por Responses API com Structured Outputs, sem Agents SDK, Sandbox Agents, job, fila ou agente enquanto não houver decisão adaptativa real.
 * Modelo de IA deve ser configurável por env var e avaliado por caso de uso: fluxo linear ou administrativo começa por modelo mini/custo-benefício; agente real de dashboard, com múltiplas etapas, tools, decisões, validação e rastreabilidade, pode avaliar GPT-5.2, GPT-5.5 ou superior após teste de custo, qualidade e segurança; nenhum modelo vira padrão único do projeto sem validação prática.
 * Avaliar Agents SDK apenas quando houver decisão adaptativa real, uso coordenado de tools, lacunas, revisão, handoffs, sessões ou tracing.
 * Tratar Sandbox Agents como laboratório técnico em beta para arquivos, comandos, workspace, testes, patches e artefatos.

--- a/docs/platform-config.md
+++ b/docs/platform-config.md
@@ -260,8 +260,8 @@
 
 6.3.1 Endpoint externo atual
 • Endpoint OpenAI Responses API: `https://api.openai.com/v1/responses`
-• Consumidor: `lib/conversion-content/commercial-activation/draft-generation.ts`
 • Consumidores atuais conhecidos:
+• `lib/conversion-content/commercial-activation/draft-generation.ts`
 • `lib/onboarding/niche-resolution/adapters/openAiResolver.ts`
 • `automations/supabase-inspect/run.mjs`
 • Regra: novas APIs ou endpoints OpenAI devem ser registrados aqui quando virarem dependência operacional.

--- a/docs/platform-config.md
+++ b/docs/platform-config.md
@@ -2,8 +2,8 @@
 
 0.1 Cabeçalho
 • Documento: LP Factory 10 — Platform Config
-• Versão: v0.1.4
-• Data: 12/06/2026
+• Versão: v0.1.5
+• Data: 22/06/2026
 
 0.2 Contrato do documento
 • O QUE É: snapshot operacional e fonte única das configurações de plataformas externas do LP Factory 10, refletindo o estado conhecido/cadastrado nas plataformas conforme indicado.
@@ -144,6 +144,11 @@
 • Escopo: Production e Preview.
 • Valor atual de referência: `gpt-5.4-mini`
 • Regra: deve conter apenas o ID do modelo; nunca inserir `OPENAI_API_KEY` nessa variável.
+
+• `OPENAI_COMMERCIAL_ACTIVATION_MODEL`
+• Finalidade: modelo usado pela geração administrativa server-side de drafts `commercial_activation` da E10.7.
+• Escopo: Vercel Preview/Production, conforme necessidade do recurso.
+• Valor real: não versionar.
 
 • `LPF_MCP_SECRET`
 • Finalidade: secret Bearer usado para autenticar chamadas ao MCP Supabase Inspect.
@@ -330,6 +335,8 @@
 • Configurações de plataformas, secrets por nome, workflows, ambientes e endpoints usados por automações devem ser registrados neste documento.
 
 99. Changelog
+v0.1.5 (22/06/2026) — Registrada a variável `OPENAI_COMMERCIAL_ACTIVATION_MODEL` como configuração server-side da geração administrativa de drafts `commercial_activation`, sem versionar valor real nem modelo padrão definitivo.
+
 v0.1.4 (12/06/2026) — Apply automático de migrations Supabase liberado
 • Registrado `SUPABASE_APPLY_MIGRATIONS_ENABLED = true` como estado operacional normal.
 • Consolidado o fluxo PR, merge na `main` e apply automático.

--- a/docs/platform-config.md
+++ b/docs/platform-config.md
@@ -253,8 +253,14 @@
 • Finalidade: selecionar modelo do resolvedor IA de nicho.
 • Valor atual de referência: `gpt-5.4-mini`
 
+• `OPENAI_COMMERCIAL_ACTIVATION_MODEL`
+• Plataforma: Vercel.
+• Finalidade: selecionar o modelo usado pela geração administrativa server-side de drafts `commercial_activation`.
+• Valor real: não versionar.
+
 6.3.1 Endpoint externo atual
 • Endpoint OpenAI Responses API: `https://api.openai.com/v1/responses`
+• Consumidor: `lib/conversion-content/commercial-activation/draft-generation.ts`
 • Consumidores atuais conhecidos:
 • `lib/onboarding/niche-resolution/adapters/openAiResolver.ts`
 • `automations/supabase-inspect/run.mjs`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 0.1 Cabeçalho
 • Data: 22/06/2026
-• Versão: v1.5.79
+• Versão: v1.5.80
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -762,8 +762,8 @@ Repositório — Ajustados
 • Implementar detecção por ambiente somente se o ganho justificar a complexidade.
 
 10.7 Páginas comerciais personalizadas por nicho
-• Status: Em execução faseada — Fase 1 concluída e validada em 21/06/2026.
-• Próxima execução: Fase 2 — geração IA com `version = 1` e quatro blocos fixos.
+• Status: Em execução faseada — Fase 2 concluída e validada em 22/06/2026.
+• Próxima execução: Fase 3 — operação administrativa mínima em `/admin/templates`.
 • Objetivo: gerar, revisar, publicar e consumir páginas comerciais por taxon; a IA roda apenas em operação administrativa; `/a/[account]` consome artefato publicado e validado; ausência de conteúdo nichado não pode quebrar `/a/[account]`.
 • Dependência estrutural: a E18 define os contratos reutilizáveis mínimos; a E10.7 aplica, valida e ajusta esses contratos no caso comercial concreto.
 • A página genérica `generic-v1` da E10.6 permanece concluída e será o fallback obrigatório.
@@ -790,21 +790,16 @@ Repositório — Ajustados
   • Repositório — Criados: `supabase/migrations/20260621162400_e10_7_admin_artifact_write_publish.sql`; `supabase/migrations/20260621181742_e10_7_fix_research_sources_policy_name.sql`; `supabase/snippets/e10_7_admin_artifact_write_publish_verify.sql`
   • Repositório — Ajustados: `docs/schema.md`
 
-10.7.3 Fase 2 — Geração IA com version 1 e quatro blocos fixos
-• Escopo: gerar conteúdo da página comercial do taxon piloto usando IA server-side/Admin; sem publicação, sem consumo em `/a/[account]`, sem Account Dashboard, sem UI completa em `/admin/templates`, sem LP Builder e sem IA em runtime público.
-• Recurso de IA aprovado: fluxo server-side/Admin com Responses API ou padrão equivalente já existente, structured output e validação; não usar Agents SDK, Sandbox Agents, job, fila ou agente nesta fase.
-• Entrada obrigatória: taxon ativo; template `commercial_activation`; composição ativa `version = 1`; itens da composição; 8 pesquisas `active version 1`; itens estruturados ativos; dados comerciais oficiais da LP Factory; schema esperado do `content_json`; regras editoriais.
-• Leituras server-side via Supabase Data API/PostgREST devem seguir o padrão técnico vigente do projeto quando aplicável; `public.plans` é fonte canônica parcial para dados comerciais oficiais.
-• A IA só pode gerar JSON compatível com `CommercialActivationContentV1`; não pode gerar HTML, JSX, CSS, Tailwind, scripts, módulos livres, variantes livres ou ordem das seções.
-• A IA não pode inventar planos, preços, garantias, condições, URLs ou promessas.
-• CTAs não podem inventar checkout nem URL comercial: usar apenas `href` interno seguro já existente ou permitido pelo template/composição; sem `href` aprovado, bloquear antes de persistir.
-• Validação obrigatória em duas camadas: envelope `CommercialActivationContentV1` e `section.content` contra o schema da `variant_key` correspondente no registry, respeitando os `composition_items` permitidos.
-• A fonte canônica dos dados comerciais oficiais precisa existir antes da geração; sem fonte canônica suficiente, a geração deve omitir o item permitido pelo schema ou falhar de forma segura.
-• Persistência esperada: `audience_scope = business_buyer`, `template_version = 1`, `composition_version = 1`, `research_version = 1`, `status = draft`, `artifact_version = próxima versão disponível`, primeira geração podendo usar `artifact_version = 1`, regenerações incrementando `artifact_version`, `content_json` validado, `provenance_json` com `business_buyer` e `end_customer`, e `content_artifact_research_sources` somente com fontes `business_buyer`.
-• Consultas novas de validação devem ser versionadas como snippets read-only em `supabase/snippets/*` quando aplicável.
-• Logs seguros: registrar evento, `request_id`, `taxon_id`, `status`, `artifact_version` e erro seguro; não registrar prompt completo, pesquisas brutas, payload sensível ou resposta integral da IA.
-• Limite estrutural: sem nova tabela, view, função, grants, mudança de acesso, alteração da hierarquia de taxons ou alteração de `research_version`; se a Fase 2 exigir qualquer item estrutural, parar e devolver ao Estrategista antes de implementar.
-• Critério de passagem: draft gerado, JSON validado, `artifact_version` correto, dados comerciais não inventados, `provenance_json` completo, `end_customer` fora de `content_artifact_research_sources`, falha da IA sem alterar `published` vigente e sem consumo no Account Dashboard ainda.
+10.7.3 Fase 2 — Geração IA administrativa de draft comercial
+• Status: Concluída e validada em 22/06/2026.
+• Resultado: geração server-side/Admin de draft comercial por taxon concluída para o taxon piloto; draft real criado em `content_artifacts` com `status = draft`, sem publicação e sem consumo em `/a/[account]`.
+• Evidência validada: artifact `c95e52ea-b4b3-44af-b5a5-aedd48a1ba0f`, `artifact_version = 1`, `audience_scope = business_buyer`, `research_version = 1`, `content_json` com 8 seções e `validation_status = ready`.
+• Persistência e proveniência: `content_artifact_research_sources` recebeu somente 4 fontes `business_buyer`; `end_customer` permanece apenas em `provenance_json`; `public.plans` foi usado como fonte parcial de planos.
+• Falha segura: se o insert das fontes falhar após criar o artifact, o draft recém-criado é arquivado/invalidado e o fluxo retorna erro seguro.
+• Fora do escopo preservado: publicação, alteração em `published`, Account Dashboard, `/a/[account]`, UI completa em `/admin/templates`, LP Builder, Agents SDK, Sandbox Agents, job, fila, agente, IA em runtime público, nova tabela, view, função, grant, policy, migration, hierarquia de taxons e `research_version`.
+• Critério de passagem: cumprido; snippet `supabase/snippets/e10_7_phase_2_draft_verify.sql` retornou todas as linhas com `check_status = ok`, `published_count = 0` e nenhum draft válido sem fontes relacionais.
+• Estruturas e artefatos:
+  • Repositório — Criados: `app/admin/(protected)/templates/actions.ts`; `lib/conversion-content/commercial-activation/draft-generation.ts`; `supabase/snippets/e10_7_phase_2_draft_verify.sql`
 
 10.7.4 Fase 3 — Operação administrativa mínima
 • Escopo: implementar operação mínima em `/admin/templates`, permitindo gerar, regenerar, visualizar e publicar.
@@ -1271,6 +1266,8 @@ Repositório — Criados
 • Esta referência não cria obrigação de implementar E19 agora.
 
 99. Changelog
+v1.5.80 — 22/06/2026 — E10.7 Fase 2 concluída e validada: geração administrativa server-side de draft comercial por IA, draft real criado como `status = draft` para o taxon piloto, validação em duas camadas, fontes `business_buyer` registradas, `end_customer` apenas em `provenance_json`, falha segura por arquivamento/invalidação de draft parcial e sem publicação, `published`, Account Dashboard ou `/a/[account]`.
+
 v1.5.79 — 22/06/2026 — E12 registra o refinamento 12.3.2 em implementação: `/admin/documentacao` como leitor read-only protegido para whitelist de documentos de `docs/`, sem Supabase, migrations, GitHub API em runtime, edição ou mutações.
 v1.5.78 — 22/06/2026 — E12 registra o refinamento 12.3.1 concluído e validado: `/admin` passa a entrada pública do Admin Dashboard, subrotas internas seguem protegidas por `app/admin/(protected)/layout.tsx`.
 v1.5.77 — 21/06/2026 — E10.7 Fase 2: critérios de IA, validação e logs.


### PR DESCRIPTION
## Resumo
- Atualiza `docs/roadmap.md` para registrar a E10.7 Fase 2 como concluída e validada, com próxima execução na Fase 3.
- Atualiza `docs/base-tecnica.md` com o contrato técnico estável da geração administrativa de draft `commercial_activation`.
- Atualiza `docs/automations.md` com registro operacional enxuto da automação server-side/Admin da Fase 2 e referências aos artefatos operacionais principais.
- Atualiza `docs/platform-config.md` para registrar `OPENAI_COMMERCIAL_ACTIVATION_MODEL` sem valor real nem modelo padrão definitivo.

## ABC documental
- A — `docs/roadmap.md`: atualizado para refletir o estado final pós-merge da Fase 2.
- B — `docs/base-tecnica.md`: atualizado porque a Fase 2 consolidou regra técnica estável de runtime/persistência segura.
- B — `docs/automations.md`: atualizado porque a Fase 2 criou automação operacional administrativa assistida por IA, sem agente e sem recorrência.
- B — `docs/platform-config.md`: atualizado porque a Fase 2 introduziu env var server-side de configuração de modelo.
- B sem delta — `docs/schema.md`: sem alterações necessárias; não houve delta de banco, migration, grant, policy, função, tabela ou view na Fase 2.
- C — demais documentos, código, migrations, snippets, package files e banco: sem alterações.

## Validação
- `git diff --check main...HEAD`: ok.
- `npm ci`: N/A, alteração exclusivamente documental.
- `npm run check`: N/A, alteração exclusivamente documental.

## Escopo preservado
Sem alteração em código, banco, migrations, snippets, `.env`, `.env.local`, secrets, package files, `/a/[account]`, Account Dashboard, LP Builder, Admin UI funcional, publicação, Agents SDK, Sandbox Agents, job, fila ou agente.
