### PR TITLE
docs: atualiza roadmap e design system do leitor admin

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -134,7 +134,8 @@ Este documento consolida o estado atual do design system ao final do ciclo E6.4�
 - Header administrativo permanece fixo no topo durante rolagem.
 - Desktop usa sidebar esquerda para navegação administrativa.
 - Mobile usa menu superior/hamburger para navegação.
-- A navegação atual cobre: Contas, Resoluções de nicho, Taxonomia, Templates e Auditoria.
+- A navegação atual cobre: Contas, Resoluções de nicho, Taxonomia, Templates, Auditoria e Documentação.
+- A área Documentação usa filtro superior, select nativo em ordem alfabética e conteúdo read-only abaixo do filtro, com layout responsivo empilhado no mobile.
 - Páginas administrativas usam cabeçalho operacional com título, descrição e marcador de status/contagem quando aplicável.
 - Listagens read-only usam filtros simples, tabela e links de detalhe.
 - Páginas de detalhe read-only usam blocos funcionais para dados da entidade e relações associadas.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 0.1 Cabeçalho
 • Data: 22/06/2026
-• Versão: v1.5.80
+• Versão: v1.5.81
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -863,10 +863,12 @@ Repositório — Ajustados
 • `/admin/contas` permanece como destino pós-login do admin.
 
 12.3.2 Leitor read-only de documentação do repositório no Admin Dashboard
-• Status: Em implementação.
+• Status: Concluído e validado em testes humanos (22/06/2026).
 • `/admin/documentacao` é uma área protegida pelo gate administrativo existente.
 • A página lista uma whitelist fixa de documentos de `docs/` e permite leitura read-only do conteúdo.
 • A leitura usa filesystem server-side do repositório, com inclusão explícita dos arquivos permitidos no tracing da rota.
+• UI final: filtro superior, dropdown alfabético, conteúdo abaixo, sem lista intermediária e responsiva em desktop/mobile.
+• Markdown é exibido como texto bruto; renderer Markdown fica como oportunidade futura por exigir dependência não instalada.
 • Não usa Supabase, migrations, GitHub API em runtime, edição, salvamento, publicação ou mutações.
 
 12.4 Áreas atuais
@@ -1266,6 +1268,8 @@ Repositório — Criados
 • Esta referência não cria obrigação de implementar E19 agora.
 
 99. Changelog
+v1.5.81 — 22/06/2026 — E12.3.2 concluído e validado: `/admin/documentacao` passa a leitor read-only protegido de documentos whitelist de `docs/`, com leitura server-side por filesystem, tracing explícito dos arquivos permitidos, UI responsiva com filtro/dropdown e sem Supabase, migrations, GitHub API em runtime, edição ou mutações.
+
 v1.5.80 — 22/06/2026 — E10.7 Fase 2 concluída e validada: geração administrativa server-side de draft comercial por IA, draft real criado como `status = draft` para o taxon piloto, validação em duas camadas, fontes `business_buyer` registradas, `end_customer` apenas em `provenance_json`, falha segura por arquivamento/invalidação de draft parcial e sem publicação, `published`, Account Dashboard ou `/a/[account]`.
 
 v1.5.79 — 22/06/2026 — E12 registra o refinamento 12.3.2 em implementação: `/admin/documentacao` como leitor read-only protegido para whitelist de documentos de `docs/`, sem Supabase, migrations, GitHub API em runtime, edição ou mutações.


### PR DESCRIPTION
### Motivation
- Registrar a conclusão e validação do recurso 12.3.2 (leitor read-only em `/admin/documentacao`) e refletir essa decisão no roadmap e no design system.

### Description
- Atualiza `docs/roadmap.md` para `v1.5.81` e substitui a seção 12.3.2 com status "Concluído e validado (22/06/2026)", descrevendo UI final (filtro superior, dropdown alfabético, conteúdo abaixo), leitura server-side via filesystem, tracing explícito dos arquivos permitidos e observação de que Markdown é exibido como texto bruto; adiciona entrada correspondente no changelog.
- Atualiza `docs/design-system.md` para incluir "Documentação" na navegação administrativa e acrescentar o padrão da área (filtro superior, select nativo em ordem alfabética, conteúdo read-only com layout responsivo empilhado no mobile).
- Arquivos alterados: `docs/roadmap.md`, `docs/design-system.md`; branch utilizada: `work`; PR title: `docs: atualiza roadmap e design system do leitor admin`.

### Testing
- Executed `git diff --check` and `git diff --stat`, which completed successfully.
- `git diff main..HEAD` and `git diff main...HEAD` were not available in this clone because the `main` ref is missing in the local environment.
- `npm ci` and `npm run check` are not applicable because the change is exclusively documental.
- Publicação remota não realizada por ausência de remote/push destination configurado no clone, portanto o change remains local for review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39c0361dd883299d4d8e44cd05f353)