### PR TITLE
feat: E10.7 Fase 3 operação admin de templates

### DIFF
--- a/app/admin/(protected)/templates/actions.ts
+++ b/app/admin/(protected)/templates/actions.ts
@@ -1,6 +1,14 @@
 "use server";
 
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
 import { requirePlatformAdmin } from "@/lib/access/guards";
+import {
+  readPublishContext,
+  validatePublicationResult,
+} from "@/lib/admin/adapters/adminCommercialActivationTemplatesAdapter";
+import { createClient } from "@/lib/supabase/server";
 import { generateCommercialActivationDraftForTaxon } from "@/conversion-content/commercial-activation/draft-generation";
 
 export type GenerateCommercialActivationDraftActionState = {
@@ -32,4 +40,88 @@ export async function generatePilotCommercialActivationDraftAction(): Promise<Ge
     artifactVersion: result.artifactVersion,
     requestId: result.requestId,
   };
+}
+
+export async function generateOrRegeneratePilotCommercialActivationDraftAction() {
+  const result = await generatePilotCommercialActivationDraftAction();
+
+  revalidatePath("/admin/templates");
+
+  if (result.error) {
+    redirect(
+      `/admin/templates?event=generation_failed&reason=${encodeURIComponent(
+        result.error,
+      )}&requestId=${encodeURIComponent(result.requestId ?? "")}`,
+    );
+  }
+
+  redirect(
+    `/admin/templates?event=draft_generated&artifactId=${encodeURIComponent(
+      result.artifactId ?? "",
+    )}&artifactVersion=${encodeURIComponent(String(result.artifactVersion ?? ""))}`,
+  );
+}
+
+export async function publishCommercialActivationDraftAction(formData: FormData) {
+  const gate = await requirePlatformAdmin();
+
+  if (!gate.allowed) {
+    redirect("/admin/templates?event=publish_failed&reason=unauthorized");
+  }
+
+  const artifactId = String(formData.get("artifactId") ?? "").trim();
+  if (!isUuid(artifactId)) {
+    redirect("/admin/templates?event=publish_failed&reason=invalid_artifact");
+  }
+
+  const context = await readPublishContext(artifactId);
+  if (!context.ok) {
+    redirect(
+      `/admin/templates?event=publish_failed&reason=${encodeURIComponent(
+        context.reason,
+      )}`,
+    );
+  }
+
+  const supabase = await createClient();
+  const { error } = await supabase.rpc("publish_content_artifact_draft", {
+    p_artifact_id: artifactId,
+  });
+
+  if (error) {
+    console.error("publishCommercialActivationDraftAction failed", {
+      code: error.code,
+      message: error.message,
+    });
+    redirect("/admin/templates?event=publish_failed&reason=rpc_failed");
+  }
+
+  const validation = await validatePublicationResult({
+    targetArtifactId: artifactId,
+    previousPublishedId: context.previousPublishedId,
+  });
+
+  revalidatePath("/admin/templates");
+
+  if (!validation.ok) {
+    redirect(
+      `/admin/templates?event=publish_failed&reason=${encodeURIComponent(
+        validation.reason,
+      )}`,
+    );
+  }
+
+  redirect(
+    `/admin/templates?event=published&artifactId=${encodeURIComponent(
+      artifactId,
+    )}&publishedCount=${validation.publishedCount}&previousArchived=${String(
+      validation.previousArchived,
+    )}`,
+  );
+}
+
+function isUuid(value: string) {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    value,
+  );
 }

--- a/app/admin/(protected)/templates/page.tsx
+++ b/app/admin/(protected)/templates/page.tsx
@@ -46,7 +46,8 @@ export default async function AdminTemplatesPage({
     );
   }
 
-  const previewArtifact = state.latestDraft ?? state.published;
+  const reviewDraft = state.publishableDraft;
+  const previewArtifact = reviewDraft ?? state.published ?? state.latestDraft;
 
   return (
     <div className="space-y-6">
@@ -79,8 +80,8 @@ export default async function AdminTemplatesPage({
             </div>
 
             <div className="flex flex-wrap gap-2">
-              <AdminStatusBadge tone={state.latestDraft ? "warning" : "neutral"}>
-                {state.latestDraft ? "Em revisao" : "Sem draft"}
+              <AdminStatusBadge tone={reviewDraft ? "warning" : "neutral"}>
+                {reviewDraft ? "Em revisao" : "Sem draft em revisao"}
               </AdminStatusBadge>
               <AdminStatusBadge tone={state.published ? "success" : "neutral"}>
                 {state.published ? "Publicado" : "Sem published"}
@@ -91,7 +92,7 @@ export default async function AdminTemplatesPage({
           <div className="flex flex-col gap-2 sm:flex-row">
             <form action={generateOrRegeneratePilotCommercialActivationDraftAction}>
               <button className="inline-flex h-10 w-full items-center justify-center rounded-md bg-brand-600 px-4 text-sm font-medium text-white transition hover:bg-brand-700 sm:w-auto">
-                {state.latestDraft ? "Regenerar draft" : "Gerar draft"}
+                {reviewDraft ? "Regenerar draft" : "Gerar draft"}
               </button>
             </form>
 
@@ -99,11 +100,11 @@ export default async function AdminTemplatesPage({
               <input
                 name="artifactId"
                 type="hidden"
-                value={state.latestDraft?.id ?? ""}
+                value={reviewDraft?.id ?? ""}
               />
               <button
                 className="inline-flex h-10 w-full items-center justify-center rounded-md border border-border px-4 text-sm font-medium text-muted-foreground transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
-                disabled={!state.latestDraft}
+                disabled={!reviewDraft}
               >
                 Publicar draft
               </button>
@@ -116,14 +117,16 @@ export default async function AdminTemplatesPage({
         <StatusCard
           label="Draft atual"
           value={
-            state.latestDraft
-              ? `v${state.latestDraft.artifactVersion}`
+            reviewDraft
+              ? `v${reviewDraft.artifactVersion}`
               : "Nenhum"
           }
           detail={
-            state.latestDraft
-              ? `${state.latestDraft.sourceCount} fontes business_buyer`
-              : "Gere um draft para revisar"
+            reviewDraft
+              ? `${reviewDraft.sourceCount} fontes business_buyer`
+              : state.latestDraft
+                ? "Draft antigo mantido apenas no historico"
+                : "Gere um draft para revisar"
           }
         />
         <StatusCard

--- a/app/admin/(protected)/templates/page.tsx
+++ b/app/admin/(protected)/templates/page.tsx
@@ -1,13 +1,306 @@
-import { notFound } from 'next/navigation';
-import { AdminPlaceholderPage } from '@/components/admin/AdminPlaceholderPage';
-import { getAdminArea } from '@/components/admin/adminNavigation';
+import { notFound } from "next/navigation";
 
-export default function AdminTemplatesPage() {
-  const area = getAdminArea('/admin/templates');
+import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
+import { AdminStatusBadge } from "@/components/admin/AdminStatusBadge";
+import { getAdminArea } from "@/components/admin/adminNavigation";
+import { EmptyState } from "@/components/ui/empty-state";
+import {
+  generateOrRegeneratePilotCommercialActivationDraftAction,
+  publishCommercialActivationDraftAction,
+} from "./actions";
+import { CommercialActivationRenderer } from "@/conversion-content/commercial-activation/renderer";
+import { readAdminCommercialActivationState } from "@/lib/admin/adapters/adminCommercialActivationTemplatesAdapter";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+type AdminTemplatesPageProps = {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function AdminTemplatesPage({
+  searchParams,
+}: AdminTemplatesPageProps) {
+  const area = getAdminArea("/admin/templates");
+  const params = (await searchParams) ?? {};
+  const state = await readAdminCommercialActivationState();
+  const message = getActionMessage(params);
 
   if (!area) {
     notFound();
   }
 
-  return <AdminPlaceholderPage area={area} />;
+  if (!state.ok) {
+    return (
+      <div className="space-y-6">
+        <AdminPageHeader
+          title={area.title}
+          description="Operacao administrativa minima para drafts comerciais por taxon."
+          meta="commercial_activation"
+        />
+        <EmptyState
+          title="Template comercial indisponivel"
+          description={`Nao foi possivel carregar o estado administrativo: ${state.reason}.`}
+        />
+      </div>
+    );
+  }
+
+  const previewArtifact = state.latestDraft ?? state.published;
+
+  return (
+    <div className="space-y-6">
+      <AdminPageHeader
+        title={area.title}
+        description="Operacao minima para gerar, regenerar, visualizar e publicar drafts comerciais do taxon piloto."
+        meta="commercial_activation"
+      />
+
+      {message ? (
+        <section className={message.className}>
+          <p className="text-sm font-medium">{message.title}</p>
+          <p className="mt-1 text-sm">{message.description}</p>
+        </section>
+      ) : null}
+
+      <section className="rounded-lg border border-border bg-card p-5 shadow-card">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="space-y-3">
+            <div>
+              <p className="text-xs font-medium uppercase text-muted-foreground">
+                Taxon piloto
+              </p>
+              <h2 className="mt-1 text-lg font-semibold text-card-foreground">
+                {state.taxon.name}
+              </h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {state.taxon.slug}
+              </p>
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              <AdminStatusBadge tone={state.latestDraft ? "warning" : "neutral"}>
+                {state.latestDraft ? "Em revisao" : "Sem draft"}
+              </AdminStatusBadge>
+              <AdminStatusBadge tone={state.published ? "success" : "neutral"}>
+                {state.published ? "Publicado" : "Sem published"}
+              </AdminStatusBadge>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <form action={generateOrRegeneratePilotCommercialActivationDraftAction}>
+              <button className="inline-flex h-10 w-full items-center justify-center rounded-md bg-brand-600 px-4 text-sm font-medium text-white transition hover:bg-brand-700 sm:w-auto">
+                {state.latestDraft ? "Regenerar draft" : "Gerar draft"}
+              </button>
+            </form>
+
+            <form action={publishCommercialActivationDraftAction}>
+              <input
+                name="artifactId"
+                type="hidden"
+                value={state.latestDraft?.id ?? ""}
+              />
+              <button
+                className="inline-flex h-10 w-full items-center justify-center rounded-md border border-border px-4 text-sm font-medium text-muted-foreground transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
+                disabled={!state.latestDraft}
+              >
+                Publicar draft
+              </button>
+            </form>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-3">
+        <StatusCard
+          label="Draft atual"
+          value={
+            state.latestDraft
+              ? `v${state.latestDraft.artifactVersion}`
+              : "Nenhum"
+          }
+          detail={
+            state.latestDraft
+              ? `${state.latestDraft.sourceCount} fontes business_buyer`
+              : "Gere um draft para revisar"
+          }
+        />
+        <StatusCard
+          label="Published atual"
+          value={
+            state.published ? `v${state.published.artifactVersion}` : "Nenhum"
+          }
+          detail={
+            state.published?.publishedAt
+              ? formatDate(state.published.publishedAt)
+              : "A publicacao usa RPC transacional"
+          }
+        />
+        <StatusCard
+          label="Historico carregado"
+          value={String(state.artifacts.length)}
+          detail="draft, published e archived"
+        />
+      </section>
+
+      {previewArtifact ? (
+        <section className="space-y-3">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 className="text-lg font-semibold text-foreground">
+                Preview do {previewArtifact.status === "draft" ? "draft" : "published"}
+              </h2>
+              <p className="text-sm text-muted-foreground">
+                Artifact {previewArtifact.id} · versao{" "}
+                {previewArtifact.artifactVersion}
+              </p>
+            </div>
+            <AdminStatusBadge tone={statusTone(previewArtifact.status)}>
+              {previewArtifact.status}
+            </AdminStatusBadge>
+          </div>
+          <div className="overflow-hidden rounded-lg border border-border bg-muted/40 p-3 shadow-card">
+            <div className="max-h-[900px] overflow-auto rounded-lg">
+              <CommercialActivationRenderer
+                composition={state.composition}
+                contentJson={previewArtifact.contentJson}
+              />
+            </div>
+          </div>
+        </section>
+      ) : (
+        <EmptyState
+          title="Nenhum artefato para visualizar"
+          description="Gere o primeiro draft administrativo para habilitar o preview."
+        />
+      )}
+
+      <section className="overflow-hidden rounded-lg border border-border bg-card shadow-card">
+        <div className="border-b border-border px-4 py-3">
+          <h2 className="text-sm font-semibold text-card-foreground">
+            Historico de artefatos
+          </h2>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-border text-sm">
+            <thead className="bg-muted/60 text-left text-xs font-medium uppercase text-muted-foreground">
+              <tr>
+                <th className="px-4 py-3">Versao</th>
+                <th className="px-4 py-3">Status</th>
+                <th className="px-4 py-3">Fontes</th>
+                <th className="px-4 py-3">Criado</th>
+                <th className="px-4 py-3">Publicado</th>
+                <th className="px-4 py-3">Arquivado</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {state.artifacts.map((artifact) => (
+                <tr key={artifact.id}>
+                  <td className="px-4 py-3 font-medium text-foreground">
+                    v{artifact.artifactVersion}
+                  </td>
+                  <td className="px-4 py-3">
+                    <AdminStatusBadge tone={statusTone(artifact.status)}>
+                      {artifact.status}
+                    </AdminStatusBadge>
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">
+                    {artifact.sourceCount}
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">
+                    {formatDate(artifact.createdAt)}
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">
+                    {artifact.publishedAt ? formatDate(artifact.publishedAt) : "-"}
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">
+                    {artifact.archivedAt ? formatDate(artifact.archivedAt) : "-"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function StatusCard({
+  label,
+  value,
+  detail,
+}: {
+  label: string;
+  value: string;
+  detail: string;
+}) {
+  return (
+    <section className="rounded-lg border border-border bg-card p-4 shadow-card">
+      <p className="text-xs font-medium uppercase text-muted-foreground">
+        {label}
+      </p>
+      <p className="mt-2 text-2xl font-semibold text-card-foreground">{value}</p>
+      <p className="mt-1 text-sm text-muted-foreground">{detail}</p>
+    </section>
+  );
+}
+
+function statusTone(status: string) {
+  if (status === "published") return "success";
+  if (status === "draft") return "warning";
+  if (status === "archived") return "neutral";
+  return "neutral";
+}
+
+function getActionMessage(params: Record<string, string | string[] | undefined>) {
+  const event = getFirstParam(params.event);
+  const reason = getFirstParam(params.reason);
+  const artifactVersion = getFirstParam(params.artifactVersion);
+  const publishedCount = getFirstParam(params.publishedCount);
+  const previousArchived = getFirstParam(params.previousArchived);
+
+  if (event === "draft_generated") {
+    return {
+      title: "Draft gerado",
+      description: artifactVersion
+        ? `Artifact version ${artifactVersion} criado como draft.`
+        : "Novo draft criado para revisao.",
+      className:
+        "rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-green-800",
+    };
+  }
+
+  if (event === "published") {
+    return {
+      title: "Draft publicado",
+      description: `Validacao pos-publicacao concluida: published_count=${publishedCount ?? "1"}, previous_archived=${previousArchived ?? "null"}.`,
+      className:
+        "rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-green-800",
+    };
+  }
+
+  if (event === "generation_failed" || event === "publish_failed") {
+    return {
+      title: event === "generation_failed" ? "Geracao bloqueada" : "Publicacao bloqueada",
+      description: reason ?? "Erro seguro retornado pela operacao.",
+      className:
+        "rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-800",
+    };
+  }
+
+  return null;
+}
+
+function getFirstParam(value: string | string[] | undefined) {
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat("pt-BR", {
+    dateStyle: "short",
+    timeStyle: "short",
+  }).format(new Date(value));
 }

--- a/components/admin/adminNavigation.ts
+++ b/components/admin/adminNavigation.ts
@@ -45,12 +45,12 @@ export const adminAreas: AdminArea[] = [
   {
     title: 'Templates',
     href: '/admin/templates',
-    description: 'Área prevista para consultar templates internos.',
-    status: 'Em preparação',
+    description: 'Operação administrativa mínima de drafts comerciais.',
+    status: 'Disponível',
     scope: [
-      'Catálogo read-only de templates',
-      'Relação com nichos e taxons',
-      'Estado de preparação por template',
+      'Geração e regeneração de drafts comerciais',
+      'Preview administrativo com renderer existente',
+      'Publicação transacional via RPC',
     ],
   },
   {

--- a/lib/admin/adapters/adminCommercialActivationTemplatesAdapter.ts
+++ b/lib/admin/adapters/adminCommercialActivationTemplatesAdapter.ts
@@ -3,21 +3,20 @@ import "server-only";
 import { createServiceClient } from "@/lib/supabase/service";
 import {
   COMMERCIAL_ACTIVATION_AUDIENCE_SCOPE,
-  COMMERCIAL_ACTIVATION_TEMPLATE_FAMILY,
   type ContentArtifactStatus,
   type ContentComposition,
 } from "@/conversion-content/contracts";
-import {
-  mapContentComposition,
-  isRecord,
-} from "@/conversion-content/validation";
+import { isRecord } from "@/conversion-content/validation";
 import { COMMERCIAL_ACTIVATION_PILOT_TAXON_SLUG } from "@/conversion-content/commercial-activation/draft-generation";
-
-const TEMPLATE_COLUMNS =
-  "id,template_key,name,slug,template_family,template_scope,status,version,is_active,payload_json";
+import { resolveCommercialActivationCompositionForTaxon } from "@/conversion-content/commercial-activation/composition";
+import { resolveCommercialActivationRenderModel } from "@/conversion-content/commercial-activation/resolve";
 
 export type AdminCommercialActivationArtifact = {
   id: string;
+  templateId: string;
+  compositionId: string;
+  taxonId: string;
+  audienceScope: string;
   status: ContentArtifactStatus;
   artifactVersion: number;
   templateVersion: number;
@@ -42,6 +41,7 @@ export type AdminCommercialActivationState =
       };
       composition: ContentComposition;
       latestDraft: AdminCommercialActivationArtifact | null;
+      publishableDraft: AdminCommercialActivationArtifact | null;
       published: AdminCommercialActivationArtifact | null;
       artifacts: AdminCommercialActivationArtifact[];
     }
@@ -66,7 +66,16 @@ export type PublishContext =
       };
       previousPublishedId: string | null;
     }
-  | { ok: false; reason: "artifact_not_found" | "artifact_not_draft" | "read_failed" };
+  | {
+      ok: false;
+      reason:
+        | "artifact_not_found"
+        | "artifact_not_draft"
+        | "artifact_not_current_review"
+        | "artifact_bundle_mismatch"
+        | "artifact_content_invalid"
+        | "read_failed";
+    };
 
 export type PublishValidation =
   | {
@@ -103,7 +112,7 @@ export async function readAdminCommercialActivationState(
       return { ok: false, reason: "taxon_not_found" };
     }
 
-    const composition = await readCommercialActivationComposition({
+    const composition = await resolveCommercialActivationCompositionForTaxon({
       taxonId: taxonRow.id,
     });
 
@@ -121,6 +130,7 @@ export async function readAdminCommercialActivationState(
       artifacts.find((artifact) => artifact.status === "draft") ?? null;
     const published =
       artifacts.find((artifact) => artifact.status === "published") ?? null;
+    const publishableDraft = getPublishableDraft({ artifacts, published });
 
     return {
       ok: true,
@@ -131,6 +141,7 @@ export async function readAdminCommercialActivationState(
       },
       composition: composition.composition,
       latestDraft,
+      publishableDraft,
       published,
       artifacts,
     };
@@ -145,56 +156,56 @@ export async function readAdminCommercialActivationState(
 export async function readPublishContext(
   artifactId: string,
 ): Promise<PublishContext> {
-  const supabase = createServiceClient();
-
   try {
-    const { data: targetRow, error: targetError } = await supabase
-      .from("content_artifacts")
-      .select("id,template_id,taxon_id,audience_scope,status")
-      .eq("id", artifactId)
-      .maybeSingle();
+    const state = await readAdminCommercialActivationState();
+    if (!state.ok) return { ok: false, reason: "read_failed" };
 
-    if (targetError) throw targetError;
-    if (!isRecord(targetRow) || !isString(targetRow.id)) {
-      return { ok: false, reason: "artifact_not_found" };
+    if (!state.publishableDraft || state.publishableDraft.id !== artifactId) {
+      const requested = state.artifacts.find(
+        (artifact) => artifact.id === artifactId,
+      );
+      if (!requested) return { ok: false, reason: "artifact_not_found" };
+      if (requested.status !== "draft") {
+        return { ok: false, reason: "artifact_not_draft" };
+      }
+      return { ok: false, reason: "artifact_not_current_review" };
     }
 
-    const target = {
-      id: targetRow.id,
-      templateId: isString(targetRow.template_id) ? targetRow.template_id : "",
-      taxonId: isString(targetRow.taxon_id) ? targetRow.taxon_id : "",
-      audienceScope: isString(targetRow.audience_scope)
-        ? targetRow.audience_scope
-        : "",
-      status: targetRow.status as ContentArtifactStatus,
-    };
+    const target = state.publishableDraft;
+    const contentValidation = resolveCommercialActivationRenderModel({
+      composition: state.composition,
+      contentJson: target.contentJson,
+    });
+
+    if (contentValidation.status !== "ready") {
+      return { ok: false, reason: "artifact_content_invalid" };
+    }
 
     if (
       target.status !== "draft" ||
-      !target.templateId ||
-      !target.taxonId ||
+      target.sourceCount !== 4 ||
+      target.templateId !== state.composition.template.id ||
+      target.compositionId !== state.composition.id ||
+      target.taxonId !== state.taxon.id ||
       target.audienceScope !== COMMERCIAL_ACTIVATION_AUDIENCE_SCOPE
     ) {
-      return { ok: false, reason: "artifact_not_draft" };
+      return { ok: false, reason: "artifact_bundle_mismatch" };
     }
 
-    const { data: previousRow, error: previousError } = await supabase
-      .from("content_artifacts")
-      .select("id")
-      .eq("template_id", target.templateId)
-      .eq("taxon_id", target.taxonId)
-      .eq("audience_scope", target.audienceScope)
-      .eq("status", "published")
-      .neq("id", target.id)
-      .maybeSingle();
-
-    if (previousError) throw previousError;
+    if (!isString(target.id)) {
+      return { ok: false, reason: "artifact_not_found" };
+    }
 
     return {
       ok: true,
-      target,
-      previousPublishedId:
-        isRecord(previousRow) && isString(previousRow.id) ? previousRow.id : null,
+      target: {
+        id: target.id,
+        templateId: target.templateId,
+        taxonId: target.taxonId,
+        audienceScope: target.audienceScope,
+        status: target.status,
+      },
+      previousPublishedId: state.published?.id ?? null,
     };
   } catch (error) {
     console.error("readPublishContext failed", {
@@ -275,72 +286,6 @@ export async function validatePublicationResult(input: {
   }
 }
 
-async function readCommercialActivationComposition(input: {
-  taxonId: string;
-}): Promise<
-  | { status: "ready"; composition: ContentComposition }
-  | { status: "composition_not_found" | "composition_invalid" }
-> {
-  const supabase = createServiceClient();
-  const { data: templateLinkRow, error: templateLinkError } = await supabase
-    .from("content_template_taxons")
-    .select(
-      `id,template_id,taxon_id,is_primary,priority,created_at,template:content_templates!content_template_taxons_template_id_fkey!inner(${TEMPLATE_COLUMNS})`,
-    )
-    .eq("taxon_id", input.taxonId)
-    .eq("is_active", true)
-    .eq("template.template_family", COMMERCIAL_ACTIVATION_TEMPLATE_FAMILY)
-    .eq("template.template_scope", "page")
-    .eq("template.status", "active")
-    .eq("template.is_active", true)
-    .order("is_primary", { ascending: false })
-    .order("priority", { ascending: false })
-    .order("created_at", { ascending: true })
-    .order("id", { ascending: true })
-    .limit(1)
-    .maybeSingle();
-
-  if (templateLinkError) throw templateLinkError;
-  if (!isRecord(templateLinkRow) || !isString(templateLinkRow.template_id)) {
-    return { status: "composition_not_found" };
-  }
-
-  const { data: compositionRow, error: compositionError } = await supabase
-    .from("content_template_compositions")
-    .select("id,template_id,taxon_id,version,status")
-    .eq("template_id", templateLinkRow.template_id)
-    .eq("taxon_id", input.taxonId)
-    .eq("status", "active")
-    .maybeSingle();
-
-  if (compositionError) throw compositionError;
-  if (!compositionRow) return { status: "composition_not_found" };
-
-  const { data: itemRows, error: itemsError } = await supabase
-    .from("content_template_composition_items")
-    .select(
-      `id,composition_id,module_template_id,variant_key,sort_order,is_required,config_json,module:content_templates!content_template_composition_items_module_template_id_fkey!inner(${TEMPLATE_COLUMNS})`,
-    )
-    .eq("composition_id", (compositionRow as Record<string, unknown>).id as string)
-    .eq("module.template_family", COMMERCIAL_ACTIVATION_TEMPLATE_FAMILY)
-    .eq("module.template_scope", "section")
-    .eq("module.status", "active")
-    .eq("module.is_active", true)
-    .order("sort_order", { ascending: true });
-
-  if (itemsError) throw itemsError;
-
-  const composition = mapContentComposition({
-    composition: compositionRow,
-    template: templateLinkRow.template,
-    items: (itemRows ?? []) as unknown[],
-  });
-
-  return composition
-    ? { status: "ready", composition }
-    : { status: "composition_invalid" };
-}
-
 async function readCommercialActivationArtifacts(input: {
   templateId: string;
   compositionId: string;
@@ -351,7 +296,7 @@ async function readCommercialActivationArtifacts(input: {
   const { data: artifactRows, error: artifactsError } = await supabase
     .from("content_artifacts")
     .select(
-      "id,template_version,composition_version,research_version,artifact_version,status,content_json,provenance_json,created_at,updated_at,published_at,archived_at",
+      "id,template_id,composition_id,taxon_id,audience_scope,template_version,composition_version,research_version,artifact_version,status,content_json,provenance_json,created_at,updated_at,published_at,archived_at",
     )
     .eq("template_id", input.templateId)
     .eq("composition_id", input.compositionId)
@@ -392,6 +337,24 @@ async function readCommercialActivationArtifacts(input: {
     );
 }
 
+function getPublishableDraft(input: {
+  artifacts: AdminCommercialActivationArtifact[];
+  published: AdminCommercialActivationArtifact | null;
+}) {
+  const latestDraft =
+    input.artifacts.find((artifact) => artifact.status === "draft") ?? null;
+
+  if (!latestDraft) return null;
+  if (
+    input.published &&
+    input.published.artifactVersion >= latestDraft.artifactVersion
+  ) {
+    return null;
+  }
+
+  return latestDraft;
+}
+
 function mapAdminArtifact(
   value: unknown,
   sourceCounts: Map<string, number>,
@@ -399,6 +362,10 @@ function mapAdminArtifact(
   if (!isRecord(value)) return null;
   if (
     !isString(value.id) ||
+    !isString(value.template_id) ||
+    !isString(value.composition_id) ||
+    !isString(value.taxon_id) ||
+    !isString(value.audience_scope) ||
     !isPositiveInteger(value.template_version) ||
     !isPositiveInteger(value.composition_version) ||
     !isPositiveInteger(value.research_version) ||
@@ -414,6 +381,10 @@ function mapAdminArtifact(
 
   return {
     id: value.id,
+    templateId: value.template_id,
+    compositionId: value.composition_id,
+    taxonId: value.taxon_id,
+    audienceScope: value.audience_scope,
     status: value.status,
     artifactVersion: value.artifact_version,
     templateVersion: value.template_version,

--- a/lib/admin/adapters/adminCommercialActivationTemplatesAdapter.ts
+++ b/lib/admin/adapters/adminCommercialActivationTemplatesAdapter.ts
@@ -1,0 +1,442 @@
+import "server-only";
+
+import { createServiceClient } from "@/lib/supabase/service";
+import {
+  COMMERCIAL_ACTIVATION_AUDIENCE_SCOPE,
+  COMMERCIAL_ACTIVATION_TEMPLATE_FAMILY,
+  type ContentArtifactStatus,
+  type ContentComposition,
+} from "@/conversion-content/contracts";
+import {
+  mapContentComposition,
+  isRecord,
+} from "@/conversion-content/validation";
+import { COMMERCIAL_ACTIVATION_PILOT_TAXON_SLUG } from "@/conversion-content/commercial-activation/draft-generation";
+
+const TEMPLATE_COLUMNS =
+  "id,template_key,name,slug,template_family,template_scope,status,version,is_active,payload_json";
+
+export type AdminCommercialActivationArtifact = {
+  id: string;
+  status: ContentArtifactStatus;
+  artifactVersion: number;
+  templateVersion: number;
+  compositionVersion: number;
+  researchVersion: number;
+  contentJson: Record<string, unknown>;
+  provenanceJson: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+  publishedAt: string | null;
+  archivedAt: string | null;
+  sourceCount: number;
+};
+
+export type AdminCommercialActivationState =
+  | {
+      ok: true;
+      taxon: {
+        id: string;
+        name: string;
+        slug: string;
+      };
+      composition: ContentComposition;
+      latestDraft: AdminCommercialActivationArtifact | null;
+      published: AdminCommercialActivationArtifact | null;
+      artifacts: AdminCommercialActivationArtifact[];
+    }
+  | {
+      ok: false;
+      reason:
+        | "taxon_not_found"
+        | "composition_not_found"
+        | "composition_invalid"
+        | "artifacts_read_failed";
+    };
+
+export type PublishContext =
+  | {
+      ok: true;
+      target: {
+        id: string;
+        templateId: string;
+        taxonId: string;
+        audienceScope: string;
+        status: ContentArtifactStatus;
+      };
+      previousPublishedId: string | null;
+    }
+  | { ok: false; reason: "artifact_not_found" | "artifact_not_draft" | "read_failed" };
+
+export type PublishValidation =
+  | {
+      ok: true;
+      publishedCount: number;
+      targetPublished: boolean;
+      previousArchived: boolean | null;
+    }
+  | {
+      ok: false;
+      reason:
+        | "target_not_published"
+        | "multiple_published"
+        | "previous_not_archived"
+        | "validation_read_failed";
+      publishedCount?: number;
+    };
+
+export async function readAdminCommercialActivationState(
+  taxonSlug = COMMERCIAL_ACTIVATION_PILOT_TAXON_SLUG,
+): Promise<AdminCommercialActivationState> {
+  const supabase = createServiceClient();
+
+  try {
+    const { data: taxonRow, error: taxonError } = await supabase
+      .from("business_taxons")
+      .select("id,name,slug")
+      .eq("slug", taxonSlug)
+      .eq("is_active", true)
+      .maybeSingle();
+
+    if (taxonError) throw taxonError;
+    if (!isRecord(taxonRow) || !isString(taxonRow.id)) {
+      return { ok: false, reason: "taxon_not_found" };
+    }
+
+    const composition = await readCommercialActivationComposition({
+      taxonId: taxonRow.id,
+    });
+
+    if (composition.status !== "ready") {
+      return { ok: false, reason: composition.status };
+    }
+
+    const artifacts = await readCommercialActivationArtifacts({
+      templateId: composition.composition.template.id,
+      compositionId: composition.composition.id,
+      taxonId: taxonRow.id,
+    });
+
+    const latestDraft =
+      artifacts.find((artifact) => artifact.status === "draft") ?? null;
+    const published =
+      artifacts.find((artifact) => artifact.status === "published") ?? null;
+
+    return {
+      ok: true,
+      taxon: {
+        id: taxonRow.id,
+        name: isString(taxonRow.name) ? taxonRow.name : taxonSlug,
+        slug: isString(taxonRow.slug) ? taxonRow.slug : taxonSlug,
+      },
+      composition: composition.composition,
+      latestDraft,
+      published,
+      artifacts,
+    };
+  } catch (error) {
+    console.error("readAdminCommercialActivationState failed", {
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return { ok: false, reason: "artifacts_read_failed" };
+  }
+}
+
+export async function readPublishContext(
+  artifactId: string,
+): Promise<PublishContext> {
+  const supabase = createServiceClient();
+
+  try {
+    const { data: targetRow, error: targetError } = await supabase
+      .from("content_artifacts")
+      .select("id,template_id,taxon_id,audience_scope,status")
+      .eq("id", artifactId)
+      .maybeSingle();
+
+    if (targetError) throw targetError;
+    if (!isRecord(targetRow) || !isString(targetRow.id)) {
+      return { ok: false, reason: "artifact_not_found" };
+    }
+
+    const target = {
+      id: targetRow.id,
+      templateId: isString(targetRow.template_id) ? targetRow.template_id : "",
+      taxonId: isString(targetRow.taxon_id) ? targetRow.taxon_id : "",
+      audienceScope: isString(targetRow.audience_scope)
+        ? targetRow.audience_scope
+        : "",
+      status: targetRow.status as ContentArtifactStatus,
+    };
+
+    if (
+      target.status !== "draft" ||
+      !target.templateId ||
+      !target.taxonId ||
+      target.audienceScope !== COMMERCIAL_ACTIVATION_AUDIENCE_SCOPE
+    ) {
+      return { ok: false, reason: "artifact_not_draft" };
+    }
+
+    const { data: previousRow, error: previousError } = await supabase
+      .from("content_artifacts")
+      .select("id")
+      .eq("template_id", target.templateId)
+      .eq("taxon_id", target.taxonId)
+      .eq("audience_scope", target.audienceScope)
+      .eq("status", "published")
+      .neq("id", target.id)
+      .maybeSingle();
+
+    if (previousError) throw previousError;
+
+    return {
+      ok: true,
+      target,
+      previousPublishedId:
+        isRecord(previousRow) && isString(previousRow.id) ? previousRow.id : null,
+    };
+  } catch (error) {
+    console.error("readPublishContext failed", {
+      artifactId,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return { ok: false, reason: "read_failed" };
+  }
+}
+
+export async function validatePublicationResult(input: {
+  targetArtifactId: string;
+  previousPublishedId: string | null;
+}): Promise<PublishValidation> {
+  const supabase = createServiceClient();
+
+  try {
+    const { data: targetRow, error: targetError } = await supabase
+      .from("content_artifacts")
+      .select("id,template_id,taxon_id,audience_scope,status")
+      .eq("id", input.targetArtifactId)
+      .maybeSingle();
+
+    if (targetError) throw targetError;
+
+    if (!isRecord(targetRow) || targetRow.status !== "published") {
+      return { ok: false, reason: "target_not_published" };
+    }
+
+    const { data: publishedRows, error: publishedError } = await supabase
+      .from("content_artifacts")
+      .select("id")
+      .eq("template_id", targetRow.template_id as string)
+      .eq("taxon_id", targetRow.taxon_id as string)
+      .eq("audience_scope", targetRow.audience_scope as string)
+      .eq("status", "published");
+
+    if (publishedError) throw publishedError;
+
+    const publishedCount = Array.isArray(publishedRows)
+      ? publishedRows.length
+      : 0;
+
+    if (publishedCount > 1) {
+      return { ok: false, reason: "multiple_published", publishedCount };
+    }
+
+    if (input.previousPublishedId) {
+      const { data: previousRow, error: previousError } = await supabase
+        .from("content_artifacts")
+        .select("id,status,archived_at")
+        .eq("id", input.previousPublishedId)
+        .maybeSingle();
+
+      if (previousError) throw previousError;
+
+      if (
+        !isRecord(previousRow) ||
+        previousRow.status !== "archived" ||
+        !isString(previousRow.archived_at)
+      ) {
+        return { ok: false, reason: "previous_not_archived", publishedCount };
+      }
+    }
+
+    return {
+      ok: true,
+      publishedCount,
+      targetPublished: true,
+      previousArchived: input.previousPublishedId ? true : null,
+    };
+  } catch (error) {
+    console.error("validatePublicationResult failed", {
+      targetArtifactId: input.targetArtifactId,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return { ok: false, reason: "validation_read_failed" };
+  }
+}
+
+async function readCommercialActivationComposition(input: {
+  taxonId: string;
+}): Promise<
+  | { status: "ready"; composition: ContentComposition }
+  | { status: "composition_not_found" | "composition_invalid" }
+> {
+  const supabase = createServiceClient();
+  const { data: templateLinkRow, error: templateLinkError } = await supabase
+    .from("content_template_taxons")
+    .select(
+      `id,template_id,taxon_id,is_primary,priority,created_at,template:content_templates!content_template_taxons_template_id_fkey!inner(${TEMPLATE_COLUMNS})`,
+    )
+    .eq("taxon_id", input.taxonId)
+    .eq("is_active", true)
+    .eq("template.template_family", COMMERCIAL_ACTIVATION_TEMPLATE_FAMILY)
+    .eq("template.template_scope", "page")
+    .eq("template.status", "active")
+    .eq("template.is_active", true)
+    .order("is_primary", { ascending: false })
+    .order("priority", { ascending: false })
+    .order("created_at", { ascending: true })
+    .order("id", { ascending: true })
+    .limit(1)
+    .maybeSingle();
+
+  if (templateLinkError) throw templateLinkError;
+  if (!isRecord(templateLinkRow) || !isString(templateLinkRow.template_id)) {
+    return { status: "composition_not_found" };
+  }
+
+  const { data: compositionRow, error: compositionError } = await supabase
+    .from("content_template_compositions")
+    .select("id,template_id,taxon_id,version,status")
+    .eq("template_id", templateLinkRow.template_id)
+    .eq("taxon_id", input.taxonId)
+    .eq("status", "active")
+    .maybeSingle();
+
+  if (compositionError) throw compositionError;
+  if (!compositionRow) return { status: "composition_not_found" };
+
+  const { data: itemRows, error: itemsError } = await supabase
+    .from("content_template_composition_items")
+    .select(
+      `id,composition_id,module_template_id,variant_key,sort_order,is_required,config_json,module:content_templates!content_template_composition_items_module_template_id_fkey!inner(${TEMPLATE_COLUMNS})`,
+    )
+    .eq("composition_id", (compositionRow as Record<string, unknown>).id as string)
+    .eq("module.template_family", COMMERCIAL_ACTIVATION_TEMPLATE_FAMILY)
+    .eq("module.template_scope", "section")
+    .eq("module.status", "active")
+    .eq("module.is_active", true)
+    .order("sort_order", { ascending: true });
+
+  if (itemsError) throw itemsError;
+
+  const composition = mapContentComposition({
+    composition: compositionRow,
+    template: templateLinkRow.template,
+    items: (itemRows ?? []) as unknown[],
+  });
+
+  return composition
+    ? { status: "ready", composition }
+    : { status: "composition_invalid" };
+}
+
+async function readCommercialActivationArtifacts(input: {
+  templateId: string;
+  compositionId: string;
+  taxonId: string;
+}): Promise<AdminCommercialActivationArtifact[]> {
+  const supabase = createServiceClient();
+
+  const { data: artifactRows, error: artifactsError } = await supabase
+    .from("content_artifacts")
+    .select(
+      "id,template_version,composition_version,research_version,artifact_version,status,content_json,provenance_json,created_at,updated_at,published_at,archived_at",
+    )
+    .eq("template_id", input.templateId)
+    .eq("composition_id", input.compositionId)
+    .eq("taxon_id", input.taxonId)
+    .eq("audience_scope", COMMERCIAL_ACTIVATION_AUDIENCE_SCOPE)
+    .order("artifact_version", { ascending: false })
+    .limit(20);
+
+  if (artifactsError) throw artifactsError;
+
+  const rows = Array.isArray(artifactRows) ? artifactRows : [];
+  const artifactIds = rows
+    .map((row) => (isRecord(row) && isString(row.id) ? row.id : null))
+    .filter((id): id is string => Boolean(id));
+
+  const sourceCounts = new Map<string, number>();
+  if (artifactIds.length > 0) {
+    const { data: sourceRows, error: sourcesError } = await supabase
+      .from("content_artifact_research_sources")
+      .select("artifact_id")
+      .in("artifact_id", artifactIds);
+
+    if (sourcesError) throw sourcesError;
+
+    for (const sourceRow of sourceRows ?? []) {
+      if (!isRecord(sourceRow) || !isString(sourceRow.artifact_id)) continue;
+      sourceCounts.set(
+        sourceRow.artifact_id,
+        (sourceCounts.get(sourceRow.artifact_id) ?? 0) + 1,
+      );
+    }
+  }
+
+  return rows
+    .map((row) => mapAdminArtifact(row, sourceCounts))
+    .filter((artifact): artifact is AdminCommercialActivationArtifact =>
+      Boolean(artifact),
+    );
+}
+
+function mapAdminArtifact(
+  value: unknown,
+  sourceCounts: Map<string, number>,
+): AdminCommercialActivationArtifact | null {
+  if (!isRecord(value)) return null;
+  if (
+    !isString(value.id) ||
+    !isPositiveInteger(value.template_version) ||
+    !isPositiveInteger(value.composition_version) ||
+    !isPositiveInteger(value.research_version) ||
+    !isPositiveInteger(value.artifact_version) ||
+    !isArtifactStatus(value.status) ||
+    !isRecord(value.content_json) ||
+    !isRecord(value.provenance_json) ||
+    !isString(value.created_at) ||
+    !isString(value.updated_at)
+  ) {
+    return null;
+  }
+
+  return {
+    id: value.id,
+    status: value.status,
+    artifactVersion: value.artifact_version,
+    templateVersion: value.template_version,
+    compositionVersion: value.composition_version,
+    researchVersion: value.research_version,
+    contentJson: value.content_json,
+    provenanceJson: value.provenance_json,
+    createdAt: value.created_at,
+    updatedAt: value.updated_at,
+    publishedAt: isString(value.published_at) ? value.published_at : null,
+    archivedAt: isString(value.archived_at) ? value.archived_at : null,
+    sourceCount: sourceCounts.get(value.id) ?? 0,
+  };
+}
+
+function isArtifactStatus(value: unknown): value is ContentArtifactStatus {
+  return value === "draft" || value === "published" || value === "archived";
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
+}

--- a/lib/conversion-content/commercial-activation/composition.ts
+++ b/lib/conversion-content/commercial-activation/composition.ts
@@ -1,0 +1,87 @@
+import "server-only";
+
+import { createServiceClient } from "@/lib/supabase/service";
+import {
+  COMMERCIAL_ACTIVATION_TEMPLATE_FAMILY,
+  type ContentComposition,
+} from "../contracts";
+import { mapContentComposition, isRecord } from "../validation";
+
+const TEMPLATE_COLUMNS =
+  "id,template_key,name,slug,template_family,template_scope,status,version,is_active,payload_json";
+
+export type CommercialActivationCompositionResolution =
+  | { status: "ready"; composition: ContentComposition }
+  | { status: "composition_not_found" | "composition_invalid" };
+
+export async function resolveCommercialActivationCompositionForTaxon(input: {
+  taxonId: string;
+}): Promise<CommercialActivationCompositionResolution> {
+  const supabase = createServiceClient();
+
+  const { data: templateLinkRow, error: templateLinkError } = await supabase
+    .from("content_template_taxons")
+    .select(
+      `id,template_id,taxon_id,is_primary,priority,created_at,template:content_templates!content_template_taxons_template_id_fkey!inner(${TEMPLATE_COLUMNS})`,
+    )
+    .eq("taxon_id", input.taxonId)
+    .eq("is_active", true)
+    .eq("template.template_family", COMMERCIAL_ACTIVATION_TEMPLATE_FAMILY)
+    .eq("template.template_scope", "page")
+    .eq("template.status", "active")
+    .eq("template.is_active", true)
+    .order("is_primary", { ascending: false })
+    .order("priority", { ascending: false })
+    .order("created_at", { ascending: true })
+    .order("id", { ascending: true })
+    .limit(1)
+    .maybeSingle();
+
+  if (templateLinkError) throw new Error("template_link_read_failed");
+  if (!isRecord(templateLinkRow) || !isString(templateLinkRow.template_id)) {
+    return { status: "composition_not_found" };
+  }
+
+  const { data: compositionRow, error: compositionError } = await supabase
+    .from("content_template_compositions")
+    .select("id,template_id,taxon_id,version,status")
+    .eq("template_id", templateLinkRow.template_id)
+    .eq("taxon_id", input.taxonId)
+    .eq("status", "active")
+    .maybeSingle();
+
+  if (compositionError) throw new Error("composition_read_failed");
+  if (!compositionRow) return { status: "composition_not_found" };
+
+  const compositionData = compositionRow as Record<string, unknown>;
+  const compositionId = compositionData.id;
+  if (!isString(compositionId)) return { status: "composition_invalid" };
+
+  const { data: itemRows, error: itemsError } = await supabase
+    .from("content_template_composition_items")
+    .select(
+      `id,composition_id,module_template_id,variant_key,sort_order,is_required,config_json,module:content_templates!content_template_composition_items_module_template_id_fkey!inner(${TEMPLATE_COLUMNS})`,
+    )
+    .eq("composition_id", compositionId)
+    .eq("module.template_family", COMMERCIAL_ACTIVATION_TEMPLATE_FAMILY)
+    .eq("module.template_scope", "section")
+    .eq("module.status", "active")
+    .eq("module.is_active", true)
+    .order("sort_order", { ascending: true });
+
+  if (itemsError) throw new Error("composition_items_read_failed");
+
+  const composition = mapContentComposition({
+    composition: compositionRow,
+    template: templateLinkRow.template,
+    items: (itemRows ?? []) as unknown[],
+  });
+
+  return composition
+    ? { status: "ready", composition }
+    : { status: "composition_invalid" };
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}

--- a/lib/conversion-content/commercial-activation/draft-generation.ts
+++ b/lib/conversion-content/commercial-activation/draft-generation.ts
@@ -22,7 +22,8 @@ import {
 } from "./schemas";
 
 const OPENAI_RESPONSES_ENDPOINT = "https://api.openai.com/v1/responses";
-const PILOT_TAXON_SLUG = "corretor-de-imoveis-de-medio-padrao";
+export const COMMERCIAL_ACTIVATION_PILOT_TAXON_SLUG =
+  "corretor-de-imoveis-de-medio-padrao";
 const RESEARCH_VERSION = 1;
 const TEMPLATE_VERSION = 1;
 const COMPOSITION_VERSION = 1;
@@ -302,7 +303,8 @@ export async function generateCommercialActivationDraftForTaxon(input: {
   requestId?: string;
 } = {}): Promise<GenerateCommercialActivationDraftResult> {
   const requestId = input.requestId ?? crypto.randomUUID();
-  const taxonSlug = input.taxonSlug?.trim() || PILOT_TAXON_SLUG;
+  const taxonSlug =
+    input.taxonSlug?.trim() || COMMERCIAL_ACTIVATION_PILOT_TAXON_SLUG;
   const model = process.env[MODEL_ENV_NAME]?.trim() ?? "";
   const apiKey = process.env.OPENAI_API_KEY?.trim() ?? "";
 

--- a/lib/conversion-content/commercial-activation/draft-generation.ts
+++ b/lib/conversion-content/commercial-activation/draft-generation.ts
@@ -6,12 +6,12 @@ import { createServiceClient } from "@/lib/supabase/service";
 import {
   COMMERCIAL_ACTIVATION_AUDIENCE_SCOPE,
   COMMERCIAL_ACTIVATION_RESEARCH_BLOCKS,
-  COMMERCIAL_ACTIVATION_TEMPLATE_FAMILY,
   type CommercialActivationResearchBlock,
   type ContentComposition,
   type ContentCompositionItem,
 } from "../contracts";
-import { mapContentComposition, isRecord } from "../validation";
+import { isRecord } from "../validation";
+import { resolveCommercialActivationCompositionForTaxon } from "./composition";
 import { commercialActivationSectionRegistry } from "./registry";
 import { resolveCommercialActivationRenderModel } from "./resolve";
 import {
@@ -25,14 +25,9 @@ const OPENAI_RESPONSES_ENDPOINT = "https://api.openai.com/v1/responses";
 export const COMMERCIAL_ACTIVATION_PILOT_TAXON_SLUG =
   "corretor-de-imoveis-de-medio-padrao";
 const RESEARCH_VERSION = 1;
-const TEMPLATE_VERSION = 1;
-const COMPOSITION_VERSION = 1;
 const SAFE_CTA_HREF = "/auth/sign-up";
 const MODEL_ENV_NAME = "OPENAI_COMMERCIAL_ACTIVATION_MODEL";
 const MAX_GENERATION_ATTEMPTS = 2;
-
-const TEMPLATE_COLUMNS =
-  "id,template_key,name,slug,template_family,template_scope,status,version,is_active,payload_json";
 
 const generatedCtaSchema = z
   .object({
@@ -403,9 +398,12 @@ async function readDraftContext(input: { taxonSlug: string }): Promise<DraftCont
     throw new Error("pilot_taxon_missing");
   }
 
-  const composition = await readComposition({
+  const compositionResult = await resolveCommercialActivationCompositionForTaxon({
     taxonId: taxonRow.id,
   });
+  if (compositionResult.status !== "ready") {
+    throw new Error(compositionResult.status);
+  }
 
   const research = await readResearchSources({
     taxonId: taxonRow.id,
@@ -419,7 +417,7 @@ async function readDraftContext(input: { taxonSlug: string }): Promise<DraftCont
       name: String(taxonRow.name),
       slug: String(taxonRow.slug),
     },
-    composition,
+    composition: compositionResult.composition,
     businessBuyerResearch: research.filter(
       (source) => source.audienceScope === "business_buyer",
     ),
@@ -428,64 +426,6 @@ async function readDraftContext(input: { taxonSlug: string }): Promise<DraftCont
     ),
     plans,
   };
-}
-
-async function readComposition(input: {
-  taxonId: string;
-}): Promise<ContentComposition> {
-  const supabase = createServiceClient();
-
-  const { data: templateRow, error: templateError } = await supabase
-    .from("content_templates")
-    .select(TEMPLATE_COLUMNS)
-    .eq("template_key", "commercial_activation_page")
-    .eq("template_family", COMMERCIAL_ACTIVATION_TEMPLATE_FAMILY)
-    .eq("template_scope", "page")
-    .eq("version", TEMPLATE_VERSION)
-    .eq("status", "active")
-    .eq("is_active", true)
-    .maybeSingle();
-
-  if (templateError) throw new Error("template_read_failed");
-  if (!templateRow) throw new Error("template_missing");
-
-  const { data: compositionRow, error: compositionError } = await supabase
-    .from("content_template_compositions")
-    .select("id,template_id,taxon_id,version,status")
-    .eq("template_id", (templateRow as Record<string, unknown>).id as string)
-    .eq("taxon_id", input.taxonId)
-    .eq("version", COMPOSITION_VERSION)
-    .eq("status", "active")
-    .maybeSingle();
-
-  if (compositionError) throw new Error("composition_read_failed");
-  if (!compositionRow) throw new Error("composition_missing");
-
-  const { data: itemRows, error: itemsError } = await supabase
-    .from("content_template_composition_items")
-    .select(
-      `id,composition_id,module_template_id,variant_key,sort_order,is_required,config_json,module:content_templates!content_template_composition_items_module_template_id_fkey!inner(${TEMPLATE_COLUMNS})`,
-    )
-    .eq("composition_id", (compositionRow as Record<string, unknown>).id as string)
-    .eq("module.template_family", COMMERCIAL_ACTIVATION_TEMPLATE_FAMILY)
-    .eq("module.template_scope", "section")
-    .eq("module.status", "active")
-    .eq("module.is_active", true)
-    .order("sort_order", { ascending: true });
-
-  if (itemsError) throw new Error("composition_items_read_failed");
-
-  const composition = mapContentComposition({
-    composition: compositionRow,
-    template: templateRow,
-    items: (itemRows ?? []) as unknown[],
-  });
-
-  if (!composition || composition.items.length !== 8) {
-    throw new Error("composition_invalid");
-  }
-
-  return composition;
 }
 
 async function readResearchSources(input: {


### PR DESCRIPTION
## Resumo
- Implementa a operação mínima em `/admin/templates` para o taxon piloto `commercial_activation`.
- Reutiliza o gerador da Fase 2 para gerar/regenerar drafts, sem duplicar lógica de IA.
- Adiciona preview administrativo com o renderer existente.
- Publica draft pela RPC `publish_content_artifact_draft(uuid)` usando sessão `authenticated` de admin e valida o estado pós-publicação com service client.
- Patch estrutural: geração e leitura admin usam a mesma resolução server-side de composição via `content_template_taxons`.
- Patch estrutural: publicação só aceita o draft atual em revisão, do bundle esperado, com conteúdo resolvido pelo contrato/renderer e 4 fontes `business_buyer`.

## Arquivos alterados
- `app/admin/(protected)/templates/page.tsx`
- `app/admin/(protected)/templates/actions.ts`
- `components/admin/adminNavigation.ts`
- `lib/admin/adapters/adminCommercialActivationTemplatesAdapter.ts`
- `lib/conversion-content/commercial-activation/draft-generation.ts`
- `lib/conversion-content/commercial-activation/composition.ts`

## Validações executadas
- `npm ci`: ok; npm audit reportou 13 vulnerabilidades existentes do ambiente.
- `npm run check`: ok; manteve 24 warnings existentes de lint, 0 erros.
- `npm run validate:commercial-activation`: ok, todos os casos do contrato/renderer passaram.
- `git diff --check`: ok.
- Verificação textual: `draft-generation.ts` não contém mais seleção direta por `commercial_activation_page`/`template_key`; a seleção por `content_template_taxons` está no helper compartilhado `composition.ts`.
- Supabase read-only: RPC `publish_content_artifact_draft(p_artifact_id uuid)` confirmada como `SECURITY DEFINER` e retorno `content_artifacts`.
- Supabase read-only: grants reais da RPC confirmados para `authenticated`; por isso a action publica com client da sessão autenticada, não com service_role.
- Supabase read-only: estado do taxon piloto confirmado com 1 draft, 0 published; nenhuma publicação foi executada por este patch.
- `/a/[account]`: não alterado.

## Limitações de validação funcional
- O dev server subiu, mas `/admin/templates` retornou 500 antes da rota por ausência local de `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` no middleware. A rota/admin UI não pôde ser validada visualmente neste ambiente.
- Não executei geração/regeneração real porque o ambiente local não tem todas as envs públicas/modelo necessárias persistidas.
- Não executei publicação real porque não há sessão administrativa autenticada disponível no ambiente Codex. A publicação real permanece para validação humana via PR/preview com login admin.
- Não simulei falha real da RPC no banco para evitar mutação indevida; a validação implementada checa pós-publicação que existe no máximo um `published` e que o `published` anterior foi arquivado quando aplicável.

## Fora do escopo preservado
Sem `/a/[account]`, Account Dashboard, fallback por ancestral, segundo taxon, LP Builder, edição visual avançada, Agents SDK, Sandbox Agents, job, fila, agente, IA em runtime público, nova tabela, nova hierarquia de taxons ou alteração de `research_version`.
