### PR TITLE
docs: tighten Base Técnica residency rules in prompt-abc.md

### DIFF
--- a/docs/prompt-abc.md
+++ b/docs/prompt-abc.md
@@ -56,8 +56,11 @@ REGRAS DE LEITURA
 ALLOWLISTS POR DOC_ALVO
 
 `docs/base-tecnica.md` — CONTRATO_TÉCNICO
-* ENTRA: runtime, segurança (PII/secrets/permissão mínima), observability mínima estável, integrações com parâmetros fixos, convenções obrigatórias de repo e decisões arquiteturais estáveis.
-* NÃO ENTRA: itens pertencentes a DB/schema, roadmap/casos, design system, platform config, services ou automations.
+* ENTRA: regras técnicas permanentes do produto; padrões de implementação segura; runtime; segurança (PII/secrets/permissão mínima); SSR; adapters; imports; camadas e boundaries; validação; logs seguros; observability mínima estável; integrações com parâmetros fixos; convenções obrigatórias de repo; e decisões arquiteturais estáveis, normativas, reutilizáveis e aplicáveis a futuras implementações além do caso imediato.
+* NÃO ENTRA: status de caso E*, fase, PR, branch, merge, evidência de validação, prints, estado de artifacts, taxon piloto, contagens de registros, próximo passo, fora de escopo de fase, pendências de produto, decisões que só explicam uma entrega específica ou itens pertencentes a DB/schema, roadmap/casos, design system, platform config, services ou automations.
+* REGRA ANTI-ROADMAP: se a informação responde “o que este caso/fase entregou, validou, decidiu ou deixou para depois”, ela pertence a `docs/roadmap.md`.
+* REGRA DE PROMOÇÃO: uma decisão de caso só entra em `docs/base-tecnica.md` quando virar padrão técnico durável para implementações futuras.
+* RESIDÊNCIA: objetos/permissões de banco ficam em `docs/schema.md`; plataformas/env/secrets ficam em `docs/platform-config.md`; automações e fluxos operacionais ficam em `docs/automations.md`; status, escopo, decisões e fases de casos E* ficam em `docs/roadmap.md`.
 
 `docs/schema.md` — CONTRATO_DB
 * ENTRA: tabelas, colunas, constraints, enums, relacionamentos, views, RPCs/functions, triggers, RLS/policies, grants e notas mínimas de validação no Supabase.


### PR DESCRIPTION
### Motivation
- Evitar que `docs/base-tecnica.md` seja inflada com regras específicas de casos, fases, PRs ou evidências e garantir que apenas regras técnicas duráveis e reutilizáveis sejam promovidas à Base Técnica.

### Description
- Atualizei o bloco `CONTRATO_TÉCNICO` em `docs/prompt-abc.md` para expandir a lista `ENTRA` (destacando runtime, SSR, adapters, imports, camadas/boundaries, validação, logs seguros, observability e padrões de implementação segura) e acrescentei `NÃO ENTRA`, `REGRA ANTI-ROADMAP`, `REGRA DE PROMOÇÃO` e `RESIDÊNCIA` para direcionar conteúdo específico para `docs/schema.md`, `docs/platform-config.md`, `docs/automations.md` e `docs/roadmap.md`; somente `docs/prompt-abc.md` foi alterado.

### Testing
- Rodei `git diff --check` (sem erros) e `git status --short --branch`, confirmei a alteração localmente e ao tentar `git push` o envio falhou por ausência de destino remoto (`fatal: No configured push destination`); `npm ci` e `npm run check` não são aplicáveis por se tratar de mudança documental.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a97b59a5883298e5f500f9ca40599)