### PR TITLE
docs: record E10.7 Phase 3 completion and update platform-config (v1.5.82 / v0.1.6)

### DIFF
--- a/docs/platform-config.md
+++ b/docs/platform-config.md
@@ -2,8 +2,8 @@
 
 0.1 Cabeçalho
 • Documento: LP Factory 10 — Platform Config
-• Versão: v0.1.5
-• Data: 22/06/2026
+• Versão: v0.1.6
+• Data: 23/06/2026
 
 0.2 Contrato do documento
 • O QUE É: snapshot operacional e fonte única das configurações de plataformas externas do LP Factory 10, refletindo o estado conhecido/cadastrado nas plataformas conforme indicado.
@@ -147,8 +147,11 @@
 
 • `OPENAI_COMMERCIAL_ACTIVATION_MODEL`
 • Finalidade: modelo usado pela geração administrativa server-side de drafts `commercial_activation` da E10.7.
-• Escopo: Vercel Preview/Production, conforme necessidade do recurso.
-• Valor real: não versionar.
+• Escopo validado: Preview.
+• Valor atual de referência em Preview: `gpt-5.4-mini`
+• Production: pendente de decisão operacional antes de configurar.
+• Valor real de secret: não versionar.
+• Regra: deve conter apenas o ID do modelo; nunca inserir `OPENAI_API_KEY` nessa variável.
 
 • `LPF_MCP_SECRET`
 • Finalidade: secret Bearer usado para autenticar chamadas ao MCP Supabase Inspect.
@@ -341,6 +344,8 @@
 • Configurações de plataformas, secrets por nome, workflows, ambientes e endpoints usados por automações devem ser registrados neste documento.
 
 99. Changelog
+v0.1.6 — 23/06/2026 — Registrado o estado operacional de `OPENAI_COMMERCIAL_ACTIVATION_MODEL` para E10.7 Fase 3: configurada e validada em Vercel Preview com modelo de referência, Production pendente de decisão operacional e sem exposição de secrets.
+
 v0.1.5 (22/06/2026) — Registrada a variável `OPENAI_COMMERCIAL_ACTIVATION_MODEL` como configuração server-side da geração administrativa de drafts `commercial_activation`, sem versionar valor real nem modelo padrão definitivo.
 
 v0.1.4 (12/06/2026) — Apply automático de migrations Supabase liberado

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data: 22/06/2026
-• Versão: v1.5.81
+• Data: 23/06/2026
+• Versão: v1.5.82
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -762,8 +762,8 @@ Repositório — Ajustados
 • Implementar detecção por ambiente somente se o ganho justificar a complexidade.
 
 10.7 Páginas comerciais personalizadas por nicho
-• Status: Em execução faseada — Fase 2 concluída e validada em 22/06/2026.
-• Próxima execução: Fase 3 — operação administrativa mínima em `/admin/templates`.
+• Status: Em execução faseada — Fase 3 concluída, validada e mergeada em 23/06/2026.
+• Próxima execução: Fase 4 — consumo no Account Dashboard.
 • Objetivo: gerar, revisar, publicar e consumir páginas comerciais por taxon; a IA roda apenas em operação administrativa; `/a/[account]` consome artefato publicado e validado; ausência de conteúdo nichado não pode quebrar `/a/[account]`.
 • Dependência estrutural: a E18 define os contratos reutilizáveis mínimos; a E10.7 aplica, valida e ajusta esses contratos no caso comercial concreto.
 • A página genérica `generic-v1` da E10.6 permanece concluída e será o fallback obrigatório.
@@ -801,13 +801,35 @@ Repositório — Ajustados
 • Estruturas e artefatos:
   • Repositório — Criados: `app/admin/(protected)/templates/actions.ts`; `lib/conversion-content/commercial-activation/draft-generation.ts`; `supabase/snippets/e10_7_phase_2_draft_verify.sql`
 
-10.7.4 Fase 3 — Operação administrativa mínima
-• Escopo: implementar operação mínima em `/admin/templates`, permitindo gerar, regenerar, visualizar e publicar.
-• Estados persistidos: `draft`, `published` e `archived`.
-• Estado visual: “em revisão” = `draft` existente ainda não publicado.
-• Publicação: publicar exige operação segura; arquivar `published` anterior e publicar novo `draft` na mesma operação transacional; não pode deixar dois `published`; não pode deixar o taxon sem `published` por falha intermediária; se a transação falhar, o estado anterior deve permanecer válido; caminho preferencial é RPC/função transacional ou mecanismo equivalente no banco.
-• Critério de passagem: admin gera draft, visualiza draft e publica draft; `published` anterior vira `archived` na mesma operação; fluxo exige permissão administrativa e funciona sem sobrescrita destrutiva.
-• Pendência/melhoria futura não bloqueante: avaliar mapa editorial mínimo por seção para orientar a IA e reduzir interpretação livre na geração de drafts comerciais — hero: dor principal + transformação desejada + nicho; benefícios: dores e ganhos do `business_buyer`; serviços: necessidades operacionais do taxon; planos: `public.plans` somente; FAQ: objeções e dúvidas recorrentes; CTA: ação genérica segura, sem promessa ou checkout.
+10.7.4 Fase 3 — Operação administrativa mínima em `/admin/templates`
+• Status: Concluída, validada e mergeada em 23/06/2026.
+• Resultado: operação administrativa mínima validada no Preview para gerar, regenerar, visualizar e publicar drafts comerciais `commercial_activation`.
+• Implementado:
+• tela administrativa em `/admin/templates` com taxon piloto, estado de draft, published atual, cards de estado, preview e histórico de artefatos;
+• gerar/regenerar draft usando o gerador da Fase 2;
+• publicação via `publish_content_artifact_draft(uuid)`;
+• validação server-side de que o artifact recebido é o draft publicável do bundle esperado;
+• resolução compartilhada de composição por `content_template_taxons`;
+• preview administrativo usando renderer existente;
+• navegação Admin atualizada para disponibilizar Templates.
+• Estado real validado no Supabase:
+• `v3` published;
+• `v2` draft histórico não publicável;
+• `v1` archived.
+• Fora do escopo preservado: `/a/[account]`, Account Dashboard, consumo público da página nichada, fallback por ancestral, segundo taxon, LP Builder, edição visual avançada, Agents SDK, Sandbox Agents, job, fila, agente, IA em runtime público, nova tabela, nova migration, nova função, novo grant, nova policy, alteração de `research_version`, liberação de LPs, continuidade de contas e bloqueio de ativações.
+• Próxima fase: E10.7 Fase 4 — consumo no Account Dashboard, usando apenas artifact `published` e nunca `draft`.
+
+10.7.4.1 Estruturas e artefatos
+
+Repositório — Criados
+• `lib/admin/adapters/adminCommercialActivationTemplatesAdapter.ts`
+• `lib/conversion-content/commercial-activation/composition.ts`
+
+Repositório — Ajustados
+• `app/admin/(protected)/templates/page.tsx`
+• `app/admin/(protected)/templates/actions.ts`
+• `components/admin/adminNavigation.ts`
+• `lib/conversion-content/commercial-activation/draft-generation.ts`
 
 10.7.5 Fase 4 — Consumo no Account Dashboard
 • Escopo: renderizar página publicada sem IA em runtime; identificar taxon original da conta; consultar bundle próprio; se não houver, tentar ancestral quando existir; se não houver, usar `generic-v1`; renderizar com `CommercialActivationRenderer`; preservar `NicheResolutionCard`; preservar tracking existente.
@@ -1269,6 +1291,8 @@ Repositório — Criados
 • Esta referência não cria obrigação de implementar E19 agora.
 
 99. Changelog
+v1.5.82 — 23/06/2026 — E10.7 Fase 3 concluída com operação administrativa mínima em `/admin/templates`: geração/regeneração de draft, preview administrativo, publicação via RPC existente, validação server-side do draft publicável, resolução compartilhada por `content_template_taxons` e estado real validado com `v3` published, `v2` draft histórico e `v1` archived.
+
 v1.5.81 — 22/06/2026 — E12.3.2 concluído e validado: `/admin/documentacao` passa a leitor read-only protegido de documentos whitelist de `docs/`, com leitura server-side por filesystem, tracing explícito dos arquivos permitidos, UI responsiva com filtro/dropdown e sem Supabase, migrations, GitHub API em runtime, edição ou mutações.
 
 v1.5.80 — 22/06/2026 — E10.7 Fase 2 concluída e validada: geração administrativa server-side de draft comercial por IA, draft real criado como `status = draft` para o taxon piloto, validação em duas camadas, fontes `business_buyer` registradas, `end_customer` apenas em `provenance_json`, falha segura por arquivamento/invalidação de draft parcial e sem publicação, `published`, Account Dashboard ou `/a/[account]`.


### PR DESCRIPTION
### Motivation
- Record the completion, validation and merge of E10.7 Phase 3 (admin templates) and advance the roadmap version to reflect the new state. 
- Capture the operational status of the server-side OpenAI model used by the commercial-activation draft generator for Preview and avoid leaking secret values. 

### Description
- Updated `docs/roadmap.md` header to `v1.5.82` and date `23/06/2026`, marked E10.7 as Phase 3 completed/validated/merged, and added the detailed `10.7.4` section describing the admin `/admin/templates` surface, implemented behaviors, persisted artifact states and the list of repo artifacts created/adjusted. 
- Added `v1.5.82` entry to the `docs/roadmap.md` changelog. 
- Updated `docs/platform-config.md` header to `v0.1.6` and date `23/06/2026`, documented `OPENAI_COMMERCIAL_ACTIVATION_MODEL` as validated in Preview (reference model `gpt-5.4-mini`), noted Production decision pending, enforced rule to only store the model ID (not `OPENAI_API_KEY`), and added `v0.1.6` changelog entry. 
- Files changed: `docs/roadmap.md`, `docs/platform-config.md` on branch `docs/e10-7-phase3-abc-20260623` (commit `docs: update E10.7 phase 3 ABC`). 

### Testing
- Ran `git diff --check` which passed with no whitespace/error issues. 
- `npm ci` and `npm run check` were considered not applicable because this is a documentation-only change. 
- `git push -u origin docs/e10-7-phase3-abc-20260623` failed due to no `origin` remote configured in this environment. 
- `git diff --name-only main..HEAD` / `main...HEAD` could not be executed because the local `main` reference is not present in this clone.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ada0a62288329b34926fead6eb2a4)