### PR TITLE
E10.7 Phase 4 Account Dashboard consumption

### DIFF
--- a/app/a/[account]/_components/commercial-page/CommercialActivationTrackingScope.tsx
+++ b/app/a/[account]/_components/commercial-page/CommercialActivationTrackingScope.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useEffect, type MouseEvent, type ReactNode } from 'react';
+
+import { trackCommercialEvent } from './actions';
+
+type Props = {
+  accountSubdomain: string;
+  children: ReactNode;
+};
+
+const TRACKING_TIMEOUT_MS = 350;
+
+async function waitForTracking(promise: Promise<{ ok: boolean }>) {
+  await Promise.race([
+    promise,
+    new Promise((resolve) => window.setTimeout(resolve, TRACKING_TIMEOUT_MS)),
+  ]);
+}
+
+export function CommercialActivationTrackingScope({
+  accountSubdomain,
+  children,
+}: Props) {
+  useEffect(() => {
+    void trackCommercialEvent({
+      accountSubdomain,
+      event: 'commercial_page_view',
+      pageVariant: 'commercial_activation_published',
+    });
+  }, [accountSubdomain]);
+
+  const handleClickCapture = async (event: MouseEvent<HTMLDivElement>) => {
+    if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey) {
+      return;
+    }
+
+    const target = event.target instanceof Element ? event.target : null;
+    const anchor = target?.closest<HTMLAnchorElement>('a[data-commercial-cta]');
+    if (!anchor || !event.currentTarget.contains(anchor)) return;
+
+    const ctaLocation = anchor.dataset.commercialCta;
+    const href = anchor.href;
+    if (!href) return;
+
+    if (ctaLocation === 'hero' || ctaLocation === 'final') {
+      event.preventDefault();
+      await waitForTracking(
+        trackCommercialEvent({
+          accountSubdomain,
+          event: 'commercial_primary_cta_click',
+          ctaLocation,
+          pageVariant: 'commercial_activation_published',
+        }),
+      );
+      window.location.assign(href);
+      return;
+    }
+
+    if (ctaLocation === 'plan_card') {
+      const planKey = anchor.dataset.commercialPlanKey;
+      if (!planKey) return;
+
+      event.preventDefault();
+      await waitForTracking(
+        trackCommercialEvent({
+          accountSubdomain,
+          event: 'commercial_plan_cta_click',
+          ctaLocation: 'plan_card',
+          planKey,
+          pageVariant: 'commercial_activation_published',
+        }),
+      );
+      window.location.assign(href);
+    }
+  };
+
+  return <div onClickCapture={handleClickCapture}>{children}</div>;
+}

--- a/app/a/[account]/_components/commercial-page/PublishedCommercialActivationPage.tsx
+++ b/app/a/[account]/_components/commercial-page/PublishedCommercialActivationPage.tsx
@@ -1,0 +1,23 @@
+import type { CommercialActivationBundle } from '@/conversion-content';
+import { CommercialActivationRenderer } from '@/conversion-content/commercial-activation/renderer';
+
+import { CommercialActivationTrackingScope } from './CommercialActivationTrackingScope';
+
+type Props = {
+  accountSubdomain: string;
+  bundle: CommercialActivationBundle;
+};
+
+export function PublishedCommercialActivationPage({
+  accountSubdomain,
+  bundle,
+}: Props) {
+  return (
+    <CommercialActivationTrackingScope accountSubdomain={accountSubdomain}>
+      <CommercialActivationRenderer
+        composition={bundle.composition}
+        contentJson={bundle.artifact.content}
+      />
+    </CommercialActivationTrackingScope>
+  );
+}

--- a/app/a/[account]/_components/commercial-page/actions.ts
+++ b/app/a/[account]/_components/commercial-page/actions.ts
@@ -23,8 +23,9 @@ type CommercialCtaLocation = 'hero' | 'plan_card' | 'final';
 type TrackCommercialEventInput = {
   accountSubdomain: string;
   event: CommercialEventName;
-  planKey?: CommercialPlanKey;
+  planKey?: CommercialPlanKey | string;
   ctaLocation?: CommercialCtaLocation;
+  pageVariant?: 'generic-v1' | 'commercial_activation_published';
 };
 
 const planKeys = new Set<CommercialPlanKey>(['starter', 'lite', 'pro', 'ultra']);
@@ -54,11 +55,14 @@ export async function trackCommercialEvent(
 
   const accountId = ctx.account.id;
   const properties: Record<string, string> = {
-    page_variant: GENERIC_COMMERCIAL_PAGE_VARIANT,
+    page_variant:
+      input.pageVariant === 'commercial_activation_published'
+        ? 'commercial_activation_published'
+        : GENERIC_COMMERCIAL_PAGE_VARIANT,
   };
 
   if (input.event === 'commercial_plan_cta_click') {
-    if (!input.planKey || !planKeys.has(input.planKey)) {
+    if (!input.planKey || !planKeys.has(input.planKey as CommercialPlanKey)) {
       return { ok: false };
     }
 

--- a/app/a/[account]/page.tsx
+++ b/app/a/[account]/page.tsx
@@ -1,8 +1,11 @@
 import { getAccessContext } from "@/lib/access/getAccessContext";
+import { getCommercialActivationHierarchicalBundle } from "@/conversion-content";
 import { getActionableNicheResolutionForAccount } from "../../../lib/onboarding/niche-resolution/adapters/accountNicheResolutionUserAdapter";
+import { getActivePrimaryAccountTaxon } from "../../../lib/onboarding/niche-resolution/adapters/accountTaxonomyAdapter";
 import { PendingSetupFirstSteps } from "./_components/PendingSetupFirstSteps";
 import { NicheResolutionCard } from "./_components/NicheResolutionCard";
 import { GenericCommercialPage } from "./_components/commercial-page/GenericCommercialPage";
+import { PublishedCommercialActivationPage } from "./_components/commercial-page/PublishedCommercialActivationPage";
 
 type DashState = "auth" | "onboarding" | "public";
 
@@ -61,6 +64,23 @@ export default async function Page({ params }: PageProps) {
           accountStatus,
         })
       : null;
+    const primaryTaxon = accountId
+      ? await getActivePrimaryAccountTaxon({ accountId })
+      : null;
+    const commercialActivation = primaryTaxon
+      ? await getCommercialActivationHierarchicalBundle({
+          taxonId: primaryTaxon.taxonId,
+        })
+      : null;
+    const commercialPage =
+      commercialActivation?.status === "ready" && commercialActivation.bundle ? (
+        <PublishedCommercialActivationPage
+          accountSubdomain={accountSubdomain}
+          bundle={commercialActivation.bundle}
+        />
+      ) : (
+        <GenericCommercialPage accountSubdomain={accountSubdomain} />
+      );
 
     return (
       <main className="mx-auto max-w-7xl px-4 py-6 sm:px-6 sm:py-10">
@@ -72,7 +92,7 @@ export default async function Page({ params }: PageProps) {
             />
           ) : null}
 
-          <GenericCommercialPage accountSubdomain={accountSubdomain} />
+          {commercialPage}
         </div>
       </main>
     );

--- a/lib/conversion-content/adapters/commercialActivationAdapter.ts
+++ b/lib/conversion-content/adapters/commercialActivationAdapter.ts
@@ -13,6 +13,7 @@ import {
   mapPublishedContentArtifact,
 } from "../validation";
 import { resolveCommercialActivationHierarchicalBundle } from "../commercial-activation/hierarchical-resolve";
+import { resolveCommercialActivationRenderModel } from "../commercial-activation/resolve";
 
 const TEMPLATE_COLUMNS =
   "id,template_key,name,slug,template_family,template_scope,status,version,is_active,payload_json";
@@ -122,6 +123,24 @@ export async function getCommercialActivationBundle(input: {
       artifact.templateVersion !== composition.template.version ||
       artifact.compositionVersion !== composition.version
     ) {
+      return { status: "artifact_invalid" };
+    }
+
+    const renderModel = resolveCommercialActivationRenderModel({
+      composition,
+      contentJson: artifact.content,
+      logSafeWarning: (_message, details) => {
+        console.warn("commercial activation optional section omitted", details);
+      },
+    });
+
+    if (renderModel.status !== "ready") {
+      console.warn("commercial activation published artifact invalid", {
+        reason: renderModel.reason,
+        artifactId: artifact.id,
+        taxonId,
+      });
+
       return { status: "artifact_invalid" };
     }
 

--- a/lib/conversion-content/commercial-activation/renderer.tsx
+++ b/lib/conversion-content/commercial-activation/renderer.tsx
@@ -145,6 +145,7 @@ function HeroDefault({
         <div className="mt-8 flex flex-col gap-3 sm:flex-row">
           <a
             href={content.primary_cta.href}
+            data-commercial-cta="hero"
             className="inline-flex min-h-11 items-center justify-center rounded-md bg-white px-5 py-3 text-sm font-semibold text-brand-dark-900 shadow-sm hover:bg-brand-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-brand-dark-900"
           >
             {content.primary_cta.label}
@@ -262,6 +263,8 @@ function PlansCards({
             </ul>
             <a
               href={plan.cta.href}
+              data-commercial-cta="plan_card"
+              data-commercial-plan-key={plan.key}
               className={cn(
                 "mt-6 w-full",
                 plan.highlighted ? primaryButton : secondaryButton,
@@ -354,7 +357,11 @@ function FinalCtaSimple({
       <p className="mx-auto mt-4 max-w-2xl text-sm leading-6 text-graytech-600 sm:text-base">
         {content.description}
       </p>
-      <a href={content.cta.href} className={cn(primaryButton, "mt-7")}>
+      <a
+        href={content.cta.href}
+        data-commercial-cta="final"
+        className={cn(primaryButton, "mt-7")}
+      >
         {content.cta.label}
       </a>
     </section>

--- a/lib/conversion-content/commercial-activation/validation-cases.ts
+++ b/lib/conversion-content/commercial-activation/validation-cases.ts
@@ -355,6 +355,26 @@ const cases: Case[] = [
     },
   },
   {
+    name: "hierarchical resolver falls back when published artifact is invalid",
+    run: async () => {
+      const result = await resolveCommercialActivationHierarchicalBundle({
+        taxonId: taxonIds.original,
+        readTaxon: async (taxonId) => taxonHierarchy.get(taxonId) ?? null,
+        readBundle: async ({ taxonId }): Promise<CommercialActivationBundleResult> =>
+          taxonId === taxonIds.original
+            ? { status: "artifact_invalid" }
+            : { status: "composition_not_found" },
+      });
+
+      assert.deepEqual(result, {
+        status: "fallback_no_ready_bundle",
+        original_taxon_id: taxonIds.original,
+        resolved_content_taxon_id: null,
+        bundle: null,
+      });
+    },
+  },
+  {
     name: "hierarchical resolver returns safe fallback on read error",
     run: async () => {
       const result = await resolveCommercialActivationHierarchicalBundle({

--- a/lib/conversion-content/commercial-activation/validation-cases.ts
+++ b/lib/conversion-content/commercial-activation/validation-cases.ts
@@ -8,11 +8,17 @@ import { resolveCommercialActivationHierarchicalBundle } from "./hierarchical-re
 import { resolveCommercialActivationRenderModel } from "./resolve";
 import type { CommercialActivationContentV1 } from "./schemas";
 import type {
+  CommercialActivationResearchBlock,
   CommercialActivationBundle,
   CommercialActivationBundleResult,
   CommercialActivationContentTaxon,
   ContentComposition,
+  ContentArtifactStatus,
 } from "../contracts";
+import {
+  COMMERCIAL_ACTIVATION_RESEARCH_BLOCKS,
+} from "../contracts";
+import { mapPublishedContentArtifact } from "../validation";
 
 type Case = {
   name: string;
@@ -217,6 +223,33 @@ const cases: Case[] = [
         status: "invalid",
         reason: "section_content_invalid",
       });
+    },
+  },
+  {
+    name: "artifact mapper accepts only published artifacts",
+    run: () => {
+      const artifact = makeArtifactRow("published");
+
+      const result = mapPublishedContentArtifact({
+        artifact,
+        researchSources: makeResearchSourceRows(),
+      });
+
+      assert.ok(result);
+      assert.equal(result.id, artifact.id);
+    },
+  },
+  {
+    name: "artifact mapper rejects draft and archived artifacts",
+    run: () => {
+      for (const status of ["draft", "archived"] as const) {
+        const result = mapPublishedContentArtifact({
+          artifact: makeArtifactRow(status),
+          researchSources: makeResearchSourceRows(),
+        });
+
+        assert.equal(result, null);
+      }
     },
   },
   {
@@ -451,4 +484,34 @@ function makeBundle(taxonId: string): CommercialActivationBundle {
       publishedAt: "2026-06-16T12:00:00.000Z",
     },
   };
+}
+
+function makeArtifactRow(status: ContentArtifactStatus) {
+  return {
+    id: "77777777-7777-4777-8777-777777777777",
+    template_id: commercialActivationFixtureComposition.template.id,
+    composition_id: commercialActivationFixtureComposition.id,
+    taxon_id: taxonIds.original,
+    audience_scope: "business_buyer",
+    template_version: commercialActivationFixtureComposition.template.version,
+    composition_version: commercialActivationFixtureComposition.version,
+    research_version: 1,
+    artifact_version: 1,
+    status,
+    content_json: clone(commercialActivationFixtureContent),
+    provenance_json: {},
+    published_at: status === "published" ? "2026-06-16T12:00:00.000Z" : null,
+  };
+}
+
+function makeResearchSourceRows() {
+  return COMMERCIAL_ACTIVATION_RESEARCH_BLOCKS.map(
+    (block: CommercialActivationResearchBlock, index) => ({
+      research_id: `88888888-8888-4888-8888-88888888888${index}`,
+      research: {
+        research_block: block,
+        version: 1,
+      },
+    }),
+  );
 }


### PR DESCRIPTION
## Summary
- Consume published `commercial_activation` bundles in `/a/[account]` using the existing hierarchical adapter.
- Preserve `generic-v1` fallback, `NicheResolutionCard`, and the existing commercial tracking events.
- Add validation coverage that `draft` and `archived` artifacts are rejected by the published artifact mapper.

## Validation
- `npm ci`
- `npm run check`
- `npm run validate:commercial-activation`
- Supabase read-only: pilot taxon has `v3 published`, `v2 draft`, `v1 archived`; no duplicate `published` rows.

## Notes
- No OpenAI runtime usage, no draft generation import, no schema/migration/snippet/database mutation.
- Local visual smoke was limited by missing local `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`.