### PR TITLE
docs: ajustar lousa base E10.7

### DIFF
--- a/docs/lousa-plano-base-e10-7.md
+++ b/docs/lousa-plano-base-e10-7.md
@@ -21,7 +21,7 @@ Fontes: chat, PR #435, docs/roadmap.md, docs/base-tecnica.md, docs/schema.md, do
 * Validação de render model antes de ready implementada.
 * Relatório da Fase 4 enviado ao Gestor de Docs.
 * ABC documental da Fase 4 pendente de confirmação final.
-* Fase 5 pendente.
+* Fase 5 pendente de briefing.
 
 3. Caso de uso
 

--- a/docs/lousa-plano-base-e10-7.md
+++ b/docs/lousa-plano-base-e10-7.md
@@ -2,21 +2,19 @@
 docs/lousa-plano-base-e10-7.md
 Fontes: chat, PR #435, docs/roadmap.md, docs/base-tecnica.md, docs/schema.md, docs/platform-config.md, docs/automations.md
 
-1. Objetivo da lousa
-   docs/lousa-plano-base-e10-7.md
+1. Objetivo
 
 * Manter o plano base vivo da E10.7 sem inflar o roadmap.
-* Registrar decisões, invariantes, fases, status, ajustes e limites do caso.
+* Registrar decisões, invariantes, status, fases e ajustes do caso.
 * Servir como fonte obrigatória antes de briefing, implementação, review e merge.
 * Roadmap e docs oficiais só são atualizados após fase implementada e mergeada.
-* Não substituir docs oficiais; orientar execução e evitar drift.
+* Não substituir docs oficiais nem virar relatório histórico longo.
 
-2. Status geral da E10.7
-   docs/lousa-plano-base-e10-7.md
+2. Status atual
 
 * Fases 1 a 4 implementadas.
 * Fase 4 mergeada pela PR #435.
-* /a/[account] já consome artifact published válido.
+* /a/[account] consome artifact published válido.
 * Fallback generic-v1 preservado.
 * Tracking comercial preservado.
 * Draft e archived fora do consumo público.
@@ -26,108 +24,89 @@ Fontes: chat, PR #435, docs/roadmap.md, docs/base-tecnica.md, docs/schema.md, do
 * Fase 5 pendente.
 
 3. Caso de uso
-   docs/lousa-plano-base-e10-7.md
 
-* E10.7 — Páginas comerciais personalizadas por taxon.
+E10.7 — Páginas comerciais personalizadas por taxon
+
 * Gerar, revisar, publicar e consumir páginas comerciais por taxon a partir de pesquisa estruturada.
 * Validar primeiro com taxon piloto e depois com taxons elegíveis.
 * Evitar regra hardcoded do taxon piloto.
 * Permitir que qualquer taxon elegível apareça para o operador gerar draft quando desejar.
 
-4. Definição central
+4. Papéis conceituais
 
 4.1 Template de canal
-docs/lousa-plano-base-e10-7.md
 
 * É universal por canal.
 * O canal atual é commercial_activation.
 * Define tipo de entrega, contrato geral, família, renderer compatível, validações e capacidades aceitas.
 * Não é exclusivo de um taxon.
-* Não deve, sozinho, definir estratégia fixa de seções para todos os nichos.
-* Status: definido no E18 e usado pela E10.7.
+* Não deve ser duplicado por taxon.
+* Não define sozinho a estratégia fixa de seções para todos os nichos.
 
 4.2 Composição técnica
-docs/lousa-plano-base-e10-7.md
 
 * É o arranjo técnico resolvido para renderizar uma entrega.
-* Pode ser universal, taxon-scoped ou materialização técnica conforme schema atual.
-* No schema atual, content_template_compositions ainda possui taxon_id obrigatório.
-* Não tratar essa amarra técnica como decisão estratégica de produto.
-* Não duplicar composição por taxon apenas por cópia manual sem necessidade operacional clara.
-* Status: piloto usa composição vinculada ao taxon; Fase 5 deve reduzir dependência operacional do piloto sem migration prematura.
+* Pode estar materializada com taxon_id no schema atual.
+* Não deve ser confundida com o template universal do canal.
+* Não deve virar tarefa do operador.
+* Não deve virar critério manual de elegibilidade.
+* Se o sistema não conseguir gerar para taxon elegível por falta de composição técnica, isso é ajuste interno da E10.7.
 
 4.3 Estrutura estratégica de seções
-docs/lousa-plano-base-e10-7.md
 
 * Define quais seções entram, em que ordem e com qual função.
 * Pode variar por canal, segmento, nicho ou taxon.
 * Para LPs, deve ser orientada por LP Sections ou bloco estrutural equivalente.
-* Para commercial_activation, pode existir composição mínima inicial.
+* Para commercial_activation, pode usar composição mínima inicial.
 * A composição mínima inicial não deve virar regra universal rígida para todos os canais e nichos.
-* Status: estrutura mínima do canal comercial existe; uso flexível por taxon precisa ser validado na Fase 5.
 
 4.4 Taxon
-docs/lousa-plano-base-e10-7.md
 
 * Define pesquisa, conteúdo, página gerada, artifact e consumo final.
-* Taxon não deve exigir novo template de canal.
-* Taxon elegível deve aparecer na lista mesmo sem draft.
+* Taxon não exige novo template de canal.
+* Taxon elegível aparece na lista mesmo sem draft.
 * O operador decide se quer gerar draft para o taxon elegível.
-* Status: piloto validado; Corretor Imóveis tem pesquisa completa e deve ser candidato na Fase 5.
 
 4.5 Artifact
-docs/lousa-plano-base-e10-7.md
 
 * É sempre por taxon.
 * Draft, published e archived são por taxon.
 * content_json é específico do taxon.
 * Published só é consumido se validar o contrato do renderer.
-* Status: implementado para piloto; validação de published antes de consumo implementada na Fase 4.
 
-5. Critérios de elegibilidade
+5. Elegibilidade
 
-5.1 Regra visível para o operador
-docs/lousa-plano-base-e10-7.md
+Taxon aparece como elegível para geração quando possui:
 
-* Taxon ativo.
-* business_buyer active v1 com 4 blocos.
-* end_customer active v1 com 4 blocos.
-* Itens estruturados suficientes.
-* Sem exigir novo template por taxon.
-* Sem exigir composição manual por taxon.
-* Sem gerar draft automaticamente.
+* taxon ativo;
+* business_buyer active v1 com 4 blocos;
+* end_customer active v1 com 4 blocos;
+* itens estruturados suficientes.
 
-5.2 Blocos exigidos
-docs/lousa-plano-base-e10-7.md
+Blocos exigidos:
 
-* strategic_core.
-* lp_overview.
-* lp_sections.
+* strategic_core;
+* lp_overview;
+* lp_sections;
 * seo.
 
-5.3 Responsabilidade interna do sistema
-docs/lousa-plano-base-e10-7.md
+Regras:
 
-* Template de canal commercial_activation deve estar disponível.
-* Renderer deve validar o contrato da página.
-* Geração deve conseguir usar a infraestrutura técnica existente.
-* Composição técnica não é etapa do operador.
-* Composição técnica não deve virar critério manual de elegibilidade.
-* Se o sistema não conseguir gerar para taxon elegível por falta de composição técnica, isso é ajuste técnico interno da E10.7.
+* não exigir novo template por taxon;
+* não exigir composição manual por taxon;
+* não gerar draft automaticamente;
+* template, composição técnica, renderer e geração são responsabilidade interna do sistema.
 
-5.4 Status
-docs/lousa-plano-base-e10-7.md
+Status:
 
-* Critério de pesquisa validado no piloto.
-* Critério de pesquisa validado em Corretor Imóveis.
-* Listagem flexível por elegibilidade ainda pendente.
-* Resolver/estrutura ainda precisa evitar dependência indevida do taxon piloto.
-* A lista deve tratar taxon elegível por pesquisa como elegível para o operador.
+* critério validado no piloto;
+* critério validado em Corretor Imóveis;
+* listagem flexível por elegibilidade ainda pendente;
+* resolver/estrutura ainda precisa evitar dependência indevida do taxon piloto.
 
-6. Estados operacionais da lista admin
+6. Estados da lista admin
 
 6.1 Publicado
-docs/lousa-plano-base-e10-7.md
 
 * Taxon tem artifact published válido.
 * Pode ser consumido em /a/[account].
@@ -135,14 +114,12 @@ docs/lousa-plano-base-e10-7.md
 * Pode receber nova geração/regeneração se o operador decidir.
 
 6.2 Em revisão
-docs/lousa-plano-base-e10-7.md
 
 * Taxon tem draft criado.
 * Ainda não foi publicado.
 * Pode ser visualizado, regenerado ou publicado.
 
 6.3 Elegível para gerar
-docs/lousa-plano-base-e10-7.md
 
 * Taxon tem pesquisa estruturada completa.
 * Ainda não precisa ter draft.
@@ -151,15 +128,13 @@ docs/lousa-plano-base-e10-7.md
 * A listagem não gera draft automaticamente.
 
 6.4 Incompleto
-docs/lousa-plano-base-e10-7.md
 
-* Taxon não aparece na lista principal do MVP.
+* Não aparece na lista principal do MVP.
 * Diagnóstico de incompletos fica fora do escopo inicial, salvo pedido explícito.
 
 7. Runtime público
 
-7.1 /a/[account]
-docs/lousa-plano-base-e10-7.md
+/a/[account]
 
 * Não usa OpenAI.
 * Não usa Responses API.
@@ -176,46 +151,57 @@ docs/lousa-plano-base-e10-7.md
 * Se não houver bundle ready, cai em generic-v1.
 * Preserva NicheResolutionCard quando aplicável.
 * Preserva tracking comercial existente.
-* Status: implementado na Fase 4 e revisado na PR #435.
+
+Status:
+implementado na Fase 4 e revisado na PR #435.
 
 8. Tracking comercial
-   docs/lousa-plano-base-e10-7.md
 
-* Eventos: commercial_page_view, commercial_primary_cta_click, commercial_plan_cta_click.
-* Eventos vinculados ao account_id.
-* Sem PII.
-* Sem content_json.
-* Sem payload de pesquisa.
-* Falha de tracking não quebra página pública.
-* Status: implementado/preservado na Fase 4.
+Eventos:
+
+* commercial_page_view;
+* commercial_primary_cta_click;
+* commercial_plan_cta_click.
+
+Regras:
+
+* vinculados ao account_id;
+* sem PII;
+* sem content_json;
+* sem payload de pesquisa;
+* falha de tracking não quebra página pública.
+
+Status:
+implementado/preservado na Fase 4.
 
 9. Escopo negativo permanente
-   docs/lousa-plano-base-e10-7.md
 
-* Não fazer LP Builder.
-* Não fazer editor visual.
-* Não fazer liberação de LPs.
-* Não fazer continuidade de contas.
-* Não fazer bloqueio de ativação.
-* Não criar novo produto.
-* Não criar nova camada de automação.
-* Não usar Agents SDK.
-* Não usar Sandbox Agents.
-* Não criar filas.
-* Não criar jobs.
-* Não usar IA em runtime público.
-* Não criar migration sem blocker real.
-* Não criar tabela sem decisão explícita.
-* Não criar RPC sem decisão explícita.
-* Não criar grant sem decisão explícita.
-* Não criar policy sem decisão explícita.
-* Não fazer reestruturação ampla de taxonomia.
-* Não criar versões independentes por bloco.
-* Não gerar draft automaticamente sem ação do operador.
-* Não duplicar template de canal por taxon.
+Não fazer dentro da E10.7 sem decisão explícita:
+
+* LP Builder;
+* editor visual;
+* liberação de LPs;
+* continuidade de contas;
+* bloqueio de ativação;
+* novo produto;
+* nova camada de automação;
+* Agents SDK;
+* Sandbox Agents;
+* filas;
+* jobs;
+* IA em runtime público;
+* migration sem blocker real;
+* nova tabela sem decisão explícita;
+* nova RPC sem decisão explícita;
+* novo grant sem decisão explícita;
+* nova policy sem decisão explícita;
+* reestruturação ampla de taxonomia;
+* versões independentes por bloco;
+* geração automática de draft sem ação do operador;
+* duplicação de template de canal por taxon;
+* procedimento manual para tornar taxon elegível.
 
 10. Banco e schema
-    docs/lousa-plano-base-e10-7.md
 
 * Não alterar schema sem blocker real.
 * Se fase exigir schema, migration, policy, grant, RPC ou tabela, Executor deve parar e devolver ao Estrategista.
@@ -223,12 +209,13 @@ docs/lousa-plano-base-e10-7.md
 * Mutação de banco só por fluxo aprovado da aplicação ou migration explicitamente aprovada.
 * Schema atual ainda possui composição vinculada a taxon_id.
 * Fase 5 deve tentar resolver por código/contrato atual antes de propor migration.
-* Status: Fase 4 não alterou schema.
 
-11. Fases da E10.7
+Status:
+Fase 4 não alterou schema.
+
+11. Fases
 
 11.1 Fase 1 — Base técnica
-docs/lousa-plano-base-e10-7.md
 
 * Status implementação: implementada.
 * Status documentação: registrada nas fontes do projeto.
@@ -236,7 +223,6 @@ docs/lousa-plano-base-e10-7.md
 * Resultado: estrutura inicial validada com taxon piloto.
 
 11.2 Fase 2 — Geração administrativa de draft
-docs/lousa-plano-base-e10-7.md
 
 * Status implementação: implementada.
 * Status documentação: registrada em relatórios/docs do caso.
@@ -244,7 +230,6 @@ docs/lousa-plano-base-e10-7.md
 * Resultado: draft persistido por taxon no piloto.
 
 11.3 Fase 3 — Operação administrativa mínima
-docs/lousa-plano-base-e10-7.md
 
 * Status implementação: implementada.
 * Status documentação: relatório anterior gerado.
@@ -252,7 +237,6 @@ docs/lousa-plano-base-e10-7.md
 * Resultado: publicação arquiva published anterior; draft/archived fora do consumo público.
 
 11.4 Fase 4 — Consumo em /a/[account]
-docs/lousa-plano-base-e10-7.md
 
 * Status implementação: implementada e mergeada pela PR #435.
 * Status documentação: relatório enviado ao Gestor de Docs; ABC final pendente de confirmação.
@@ -264,7 +248,6 @@ docs/lousa-plano-base-e10-7.md
 * Implementado: sem IA em runtime público.
 
 11.5 Fase 5 — Lista flexível de taxons elegíveis e ajuste interno do canal comercial
-docs/lousa-plano-base-e10-7.md
 
 * Status implementação: pendente.
 * Status documentação: esta lousa define a base do briefing.
@@ -285,30 +268,27 @@ docs/lousa-plano-base-e10-7.md
 12. E18 e papéis dos templates
 
 12.1 E18
-docs/lousa-plano-base-e10-7.md
 
 * E18 criou/organiza os templates do canal.
 * commercial_activation é o canal/família usado pela E10.7.
 * O template de página commercial_activation_page define a entrega de página comercial.
 * Os templates de section definem módulos disponíveis do canal.
 
-12.2 Papel do template
-docs/lousa-plano-base-e10-7.md
+12.2 Template
 
 * Define canal, contrato e capacidades.
 * Não define sozinho a estratégia de conteúdo do taxon.
 * Não deve ser duplicado para cada taxon.
 
-12.3 Papel da composição técnica
-docs/lousa-plano-base-e10-7.md
+12.3 Composição técnica
 
 * Resolve arranjo técnico de módulos.
 * Pode estar materializada com taxon_id no schema atual.
-* Não deve ser confundida com o template universal do canal.
+* Não deve ser confundida com template universal do canal.
 * Pode precisar de resolver canônico ou fallback técnico na Fase 5.
+* Não é etapa do operador.
 
-12.4 Papel da estrutura de seções
-docs/lousa-plano-base-e10-7.md
+12.4 Estrutura de seções
 
 * Define estratégia de seções por canal/nicho/taxon.
 * Para LPs, deve vir de LP Sections ou bloco estrutural equivalente.
@@ -318,7 +298,7 @@ docs/lousa-plano-base-e10-7.md
 13. Taxons conhecidos
 
 13.1 Taxon piloto
-docs/lousa-plano-base-e10-7.md
+
 Corretor de imóveis de médio padrão
 corretor-de-imoveis-de-medio-padrao
 
@@ -331,7 +311,7 @@ corretor-de-imoveis-de-medio-padrao
 * Usado para validar fases 1 a 4.
 
 13.2 Taxon candidato elegível por pesquisa
-docs/lousa-plano-base-e10-7.md
+
 Corretor Imóveis
 corretor-imoveis
 
@@ -340,10 +320,10 @@ corretor-imoveis
 * Ainda sem página comercial gerada.
 * Deve aparecer como elegível após ajuste da Fase 5.
 * Não deve exigir novo template de canal.
+* Não deve exigir composição manual por taxon.
 * Draft só deve ser gerado se operador acionar geração.
 
 14. Ajuste identificado após Fase 4
-    docs/lousa-plano-base-e10-7.md
 
 * Decisão estratégica: template universal por canal comercial.
 * Implementação atual: composição técnica ainda resolvida por taxon_id.
@@ -359,7 +339,6 @@ corretor-imoveis
 * Decisão: não criar migration se houver solução simples com contrato atual.
 
 15. Regra de briefing
-    docs/lousa-plano-base-e10-7.md
 
 * Citar esta lousa.
 * Declarar fase alvo.
@@ -373,7 +352,6 @@ corretor-imoveis
 * Declarar separação entre template de canal, composição técnica, estrutura de seções e artifact.
 
 16. Regra de review
-    docs/lousa-plano-base-e10-7.md
 
 * Comparar implementação com esta lousa.
 * Verificar se decisões fixas foram preservadas.
@@ -385,11 +363,10 @@ corretor-imoveis
 * Verificar se taxons elegíveis aparecem sem novo template por taxon.
 * Verificar se taxons elegíveis aparecem sem composição manual por taxon.
 * Verificar se listagem não gera draft automaticamente.
-* Verificar se composição técnica não foi tratada como decisão estratégica universal sem cuidado com schema atual.
 * Verificar se eventual falha técnica de composição não foi transformada em tarefa do operador.
+* Verificar se composição técnica não foi tratada como decisão estratégica universal sem cuidado com schema atual.
 
 17. Regra de atualização documental
-    docs/lousa-plano-base-e10-7.md
 
 * Após fase mergeada, gerar relatório de encerramento.
 * Enviar relatório ao Gestor de Docs.

--- a/docs/lousa-plano-base-e10-7.md
+++ b/docs/lousa-plano-base-e10-7.md
@@ -86,17 +86,16 @@ docs/lousa-plano-base-e10-7.md
 
 5. Critérios de elegibilidade
 
-5.1 Regra
+5.1 Regra visível para o operador
 docs/lousa-plano-base-e10-7.md
 
 * Taxon ativo.
 * business_buyer active v1 com 4 blocos.
 * end_customer active v1 com 4 blocos.
 * Itens estruturados suficientes.
-* Template de canal commercial_activation disponível.
-* Estrutura/composição resolvível pelo contrato atual.
 * Sem exigir novo template por taxon.
-* Sem exigir geração automática de draft.
+* Sem exigir composição manual por taxon.
+* Sem gerar draft automaticamente.
 
 5.2 Blocos exigidos
 docs/lousa-plano-base-e10-7.md
@@ -106,13 +105,24 @@ docs/lousa-plano-base-e10-7.md
 * lp_sections.
 * seo.
 
-5.3 Status
+5.3 Responsabilidade interna do sistema
+docs/lousa-plano-base-e10-7.md
+
+* Template de canal commercial_activation deve estar disponível.
+* Renderer deve validar o contrato da página.
+* Geração deve conseguir usar a infraestrutura técnica existente.
+* Composição técnica não é etapa do operador.
+* Composição técnica não deve virar critério manual de elegibilidade.
+* Se o sistema não conseguir gerar para taxon elegível por falta de composição técnica, isso é ajuste técnico interno da E10.7.
+
+5.4 Status
 docs/lousa-plano-base-e10-7.md
 
 * Critério de pesquisa validado no piloto.
 * Critério de pesquisa validado em Corretor Imóveis.
 * Listagem flexível por elegibilidade ainda pendente.
 * Resolver/estrutura ainda precisa evitar dependência indevida do taxon piloto.
+* A lista deve tratar taxon elegível por pesquisa como elegível para o operador.
 
 6. Estados operacionais da lista admin
 
@@ -253,22 +263,23 @@ docs/lousa-plano-base-e10-7.md
 * Implementado: validação de render model antes de ready.
 * Implementado: sem IA em runtime público.
 
-11.5 Fase 5 — Lista flexível de taxons elegíveis e ajuste de papéis
+11.5 Fase 5 — Lista flexível de taxons elegíveis e ajuste interno do canal comercial
 docs/lousa-plano-base-e10-7.md
 
 * Status implementação: pendente.
 * Status documentação: esta lousa define a base do briefing.
-* Objetivo: separar template de canal, composição técnica e estrutura estratégica de seções.
-* Objetivo: listar taxons elegíveis por critérios de pesquisa estruturada.
-* Objetivo: permitir que qualquer taxon elegível apareça para geração de draft quando operador quiser.
+* Objetivo: listar taxons elegíveis por pesquisa estruturada completa.
+* Objetivo: permitir que qualquer taxon elegível apareça para geração de draft quando o operador quiser.
 * Objetivo: não gerar draft automaticamente durante a listagem.
+* Objetivo: resolver internamente a dependência indevida de composição do piloto.
+* Objetivo: separar template de canal, composição técnica, estrutura de seções e artifact.
 * Objetivo: validar pelo menos dois estados reais: taxon publicado e taxon elegível sem página gerada.
-* Objetivo: reduzir dependência operacional do taxon piloto.
+* Não é objetivo: criar procedimento manual para tornar taxon elegível.
 * Não é objetivo: gerar draft automaticamente para segundo taxon.
 * Não é objetivo: publicar automaticamente segundo taxon.
 * Não é objetivo: limitar solução ao taxon Corretor Imóveis.
 * Não é objetivo: duplicar template por taxon.
-* Não é objetivo: criar composição por taxon apenas por cópia manual sem necessidade clara.
+* Não é objetivo: exigir composição manual por taxon.
 * Não é objetivo: criar migration sem blocker real.
 
 12. E18 e papéis dos templates
@@ -337,9 +348,13 @@ corretor-imoveis
 * Decisão estratégica: template universal por canal comercial.
 * Implementação atual: composição técnica ainda resolvida por taxon_id.
 * Risco: confundir composição técnica com template universal.
+* Risco: transformar amarra técnica em etapa operacional do usuário.
+* Risco: criar burocracia para cada taxon novo.
 * Risco: forçar migration prematura.
 * Risco: criar cópia manual por taxon sem necessidade operacional clara.
-* Decisão: Fase 5 deve separar os papéis e validar elegibilidade flexível.
+* Decisão: elegibilidade é definida pela pesquisa estruturada completa.
+* Decisão: composição/template/renderer são responsabilidade interna do sistema.
+* Decisão: Fase 5 deve corrigir a dependência do piloto sem criar novo procedimento para o operador.
 * Decisão: geração de draft deve ser ação do operador.
 * Decisão: não criar migration se houver solução simples com contrato atual.
 
@@ -368,8 +383,10 @@ corretor-imoveis
 * Verificar fallback generic-v1.
 * Verificar se o caso não ficou hardcoded no piloto.
 * Verificar se taxons elegíveis aparecem sem novo template por taxon.
+* Verificar se taxons elegíveis aparecem sem composição manual por taxon.
 * Verificar se listagem não gera draft automaticamente.
 * Verificar se composição técnica não foi tratada como decisão estratégica universal sem cuidado com schema atual.
+* Verificar se eventual falha técnica de composição não foi transformada em tarefa do operador.
 
 17. Regra de atualização documental
     docs/lousa-plano-base-e10-7.md

--- a/docs/lousa-plano-base-e10-7.md
+++ b/docs/lousa-plano-base-e10-7.md
@@ -265,6 +265,76 @@ Fase 4 não alterou schema.
 * Não é objetivo: exigir composição manual por taxon.
 * Não é objetivo: criar migration sem blocker real.
 
+11.5.1 Updates aplicáveis à Fase 5
+
+Objetivo da Fase 5:
+
+* Listar taxons elegíveis por pesquisa estruturada completa.
+* Corrigir a dependência indevida do taxon piloto.
+* Não criar processo manual.
+* Não gerar draft automaticamente.
+* Não antecipar migration.
+* Usar os updates abaixo apenas como referência técnica, validação ou trava.
+
+supa#36 — Data API / PostgREST 14.1
+
+* Referência técnica para leituras server-side no Supabase usando Data API/PostgREST.
+* Aplicar nas leituras server-side que montam a lista de taxons elegíveis.
+* Aplicar ao buscar taxons ativos, pesquisas estruturadas completas, artifacts existentes, published/draft quando necessário para estado da lista e composição técnica relacionada ao canal commercial_activation.
+* Resolver a listagem no servidor, seguindo os contratos da Base Técnica, sem criar endpoint público novo e sem expor dados sensíveis.
+
+supa#5 — Logs seguros
+
+* Usar para falhas, fallback e diagnóstico técnico sem vazar conteúdo sensível.
+* Aplicar em erro de leitura, taxon que deveria ser elegível mas não aparece, falha ao resolver composição técnica, fallback interno ou inconsistência entre pesquisa, artifact e estado exibido.
+* Pode logar status técnico, motivo resumido da falha, request/rid quando disponível e identificador técnico permitido de account/taxon.
+* Não pode logar content_json, payload completo de pesquisa, texto gerado por IA, dados pessoais ou conteúdo bruto de blocos estruturados.
+
+supa#40 — SQL snippets locais
+
+* Aplicar somente se for necessário validar elegibilidade ou composição fora da UI.
+* Exemplos: conferir business_buyer completo, end_customer completo, 4 blocos exigidos, artifact draft/published ou composição técnica prendendo fluxo ao piloto.
+* Se houver SQL de validação, versionar em supabase/snippets.
+* Não deixar query solta no chat ou no Studio.
+
+supa#58 — GRANT explícito para novos objetos
+
+* Usar como trava de segurança se surgir necessidade de nova tabela, view, função, RPC, grant, policy ou migration.
+* Fase 5 deve tentar resolver com schema atual.
+* Se surgir mudança de banco, Executor deve parar e devolver ao Estrategista.
+* Não aplicar supa#58 como tarefa inicial; usar como trava para impedir mudança de banco sem decisão explícita.
+
+revalidatePath
+
+* Usar somente se houver mutação administrativa que altere o estado exibido na tela.
+* Exemplos: gerar draft, regenerar draft, publicar, arquivar ou atualizar estado administrativo que afete a lista.
+* Na listagem simples, sem mutação, não aplicar.
+* Não usar como arquitetura antecipada.
+
+Recursos que não cabem na Fase 5
+
+* Não usar Responses API.
+* Não usar Agents SDK.
+* Não usar Sandbox Agents.
+* Não usar plugin Supabase como dependência operacional.
+* Não usar filas.
+* Não usar jobs.
+* Não usar automação operacional.
+* Não usar IA em runtime público.
+* Não usar pgvector.
+* Não usar pg_trgm.
+* Não usar busca avançada.
+* Não criar migration sem blocker real.
+
+Conclusão:
+
+* Aplicar supa#36 nas leituras server-side.
+* Aplicar supa#5 nos logs seguros.
+* Aplicar supa#40 se houver validação SQL read-only.
+* Aplicar supa#58 como trava se surgir mudança de banco.
+* Usar revalidatePath somente se houver mutação administrativa.
+* Não aplicar agentes, IA em runtime público, filas, jobs ou nova infraestrutura.
+
 12. E18 e papéis dos templates
 
 12.1 E18


### PR DESCRIPTION
### Motivation

- Deixar a lousa E10.7 mais clara e operacional separando elegibilidade do taxon, responsabilidade técnica interna, template de canal, composição técnica e artifact por taxon.

### Description

- Atualiza `docs/lousa-plano-base-e10-7.md` ajustando a seção 5 para separar a regra visível ao operador (5.1), os blocos exigidos (5.2), a responsabilidade interna do sistema (5.3) e o status (5.4).
- Substitui a seção 11.5 para explicitar a Fase 5 como lista flexível de taxons elegíveis com objetivos/limites claros e sem geração automática de draft ou duplicação de template por taxon.
- Substitui a seção 14 para explicitar riscos e decisões sobre template universal, composição técnica e responsabilidades internas, e estende a seção 16 de review com verificações adicionais sobre composição manual e falhas técnicas.
- Arquivo alterado: `docs/lousa-plano-base-e10-7.md`; branch criada: `docs/e10-7-lousa-ajuste`; PR preparado com título `docs: ajustar lousa base E10.7` (não publicado remoto neste ambiente).

### Testing

- Rodados: `rg "Elegibilidade do taxon|composição manual|gerar draft automaticamente|Responsabilidade interna" docs/lousa-plano-base-e10-7.md`, `wc -l docs/lousa-plano-base-e10-7.md`, `git diff --check`, `git status --short --branch`, `git log -1 --oneline` e `git remote -v`; todos retornaram resultados esperados no sandbox.
- Validação textual executada e confirma presença das novas frases-chave e da estrutura solicitada; `npm ci` e `npm run check` não aplicáveis por se tratar de alteração exclusivamente documental.
- Observação: commit local realizado e PR preparado localmente, porém não foi possível `git push`/publicar porque não há remote configurado neste ambiente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c3edb64608329945ca87be69016e5)