### PR TITLE
E10.7 Fase 5: composição genérica para drafts comerciais

### DIFF
--- a/app/admin/(protected)/templates/actions.ts
+++ b/app/admin/(protected)/templates/actions.ts
@@ -18,14 +18,23 @@ export type GenerateCommercialActivationDraftActionState = {
   requestId?: string;
 };
 
-export async function generatePilotCommercialActivationDraftAction(): Promise<GenerateCommercialActivationDraftActionState> {
+export async function generateCommercialActivationDraftAction(input: {
+  taxonSlug: string;
+}): Promise<GenerateCommercialActivationDraftActionState> {
   const gate = await requirePlatformAdmin();
 
   if (!gate.allowed) {
     return { error: "Acesso administrativo nao autorizado." };
   }
 
-  const result = await generateCommercialActivationDraftForTaxon();
+  const taxonSlug = input.taxonSlug.trim();
+  if (!isSafeSlug(taxonSlug)) {
+    return { error: "invalid_taxon_slug" };
+  }
+
+  const result = await generateCommercialActivationDraftForTaxon({
+    taxonSlug,
+  });
 
   if (!result.ok) {
     return {
@@ -42,21 +51,25 @@ export async function generatePilotCommercialActivationDraftAction(): Promise<Ge
   };
 }
 
-export async function generateOrRegeneratePilotCommercialActivationDraftAction() {
-  const result = await generatePilotCommercialActivationDraftAction();
+export async function generateOrRegenerateCommercialActivationDraftAction(
+  formData: FormData,
+) {
+  const taxonSlug = String(formData.get("taxonSlug") ?? "").trim();
+  const result = await generateCommercialActivationDraftAction({ taxonSlug });
+  const taxonQuery = encodeURIComponent(taxonSlug);
 
   revalidatePath("/admin/templates");
 
   if (result.error) {
     redirect(
-      `/admin/templates?event=generation_failed&reason=${encodeURIComponent(
+      `/admin/templates?taxon=${taxonQuery}&event=generation_failed&reason=${encodeURIComponent(
         result.error,
       )}&requestId=${encodeURIComponent(result.requestId ?? "")}`,
     );
   }
 
   redirect(
-    `/admin/templates?event=draft_generated&artifactId=${encodeURIComponent(
+    `/admin/templates?taxon=${taxonQuery}&event=draft_generated&artifactId=${encodeURIComponent(
       result.artifactId ?? "",
     )}&artifactVersion=${encodeURIComponent(String(result.artifactVersion ?? ""))}`,
   );
@@ -121,7 +134,11 @@ export async function publishCommercialActivationDraftAction(formData: FormData)
 }
 
 function isUuid(value: string) {
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{12}$/i.test(
     value,
   );
+}
+
+function isSafeSlug(value: string) {
+  return /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value);
 }

--- a/app/admin/(protected)/templates/actions.ts
+++ b/app/admin/(protected)/templates/actions.ts
@@ -134,7 +134,7 @@ export async function publishCommercialActivationDraftAction(formData: FormData)
 }
 
 function isUuid(value: string) {
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{12}$/i.test(
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
     value,
   );
 }

--- a/app/admin/(protected)/templates/page.tsx
+++ b/app/admin/(protected)/templates/page.tsx
@@ -1,15 +1,19 @@
+import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
 import { AdminStatusBadge } from "@/components/admin/AdminStatusBadge";
 import { getAdminArea } from "@/components/admin/adminNavigation";
 import { EmptyState } from "@/components/ui/empty-state";
+import { CommercialActivationRenderer } from "@/conversion-content/commercial-activation/renderer";
 import {
-  generateOrRegeneratePilotCommercialActivationDraftAction,
+  readAdminCommercialActivationOverview,
+  type AdminCommercialActivationListItem,
+} from "@/lib/admin/adapters/adminCommercialActivationTemplatesAdapter";
+import {
+  generateOrRegenerateCommercialActivationDraftAction,
   publishCommercialActivationDraftAction,
 } from "./actions";
-import { CommercialActivationRenderer } from "@/conversion-content/commercial-activation/renderer";
-import { readAdminCommercialActivationState } from "@/lib/admin/adapters/adminCommercialActivationTemplatesAdapter";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -23,14 +27,17 @@ export default async function AdminTemplatesPage({
 }: AdminTemplatesPageProps) {
   const area = getAdminArea("/admin/templates");
   const params = (await searchParams) ?? {};
-  const state = await readAdminCommercialActivationState();
+  const selectedTaxonSlug = getFirstParam(params.taxon);
+  const overview = await readAdminCommercialActivationOverview({
+    selectedTaxonSlug,
+  });
   const message = getActionMessage(params);
 
   if (!area) {
     notFound();
   }
 
-  if (!state.ok) {
+  if (!overview.ok) {
     return (
       <div className="space-y-6">
         <AdminPageHeader
@@ -39,21 +46,23 @@ export default async function AdminTemplatesPage({
           meta="commercial_activation"
         />
         <EmptyState
-          title="Template comercial indisponivel"
-          description={`Nao foi possivel carregar o estado administrativo: ${state.reason}.`}
+          title="Templates comerciais indisponiveis"
+          description={`Nao foi possivel carregar a lista administrativa: ${overview.reason}.`}
         />
       </div>
     );
   }
 
-  const reviewDraft = state.publishableDraft;
-  const previewArtifact = reviewDraft ?? state.published ?? state.latestDraft;
+  const selected = overview.selected?.ok ? overview.selected : null;
+  const reviewDraft = selected?.publishableDraft ?? null;
+  const previewArtifact =
+    reviewDraft ?? selected?.published ?? selected?.latestDraft ?? null;
 
   return (
     <div className="space-y-6">
       <AdminPageHeader
         title={area.title}
-        description="Operacao minima para gerar, regenerar, visualizar e publicar drafts comerciais do taxon piloto."
+        description="Operacao minima para taxons elegiveis por pesquisa estruturada completa."
         meta="commercial_activation"
       />
 
@@ -64,90 +73,133 @@ export default async function AdminTemplatesPage({
         </section>
       ) : null}
 
-      <section className="rounded-lg border border-border bg-card p-5 shadow-card">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-          <div className="space-y-3">
-            <div>
-              <p className="text-xs font-medium uppercase text-muted-foreground">
-                Taxon piloto
-              </p>
-              <h2 className="mt-1 text-lg font-semibold text-card-foreground">
-                {state.taxon.name}
-              </h2>
-              <p className="mt-1 text-sm text-muted-foreground">
-                {state.taxon.slug}
-              </p>
-            </div>
-
-            <div className="flex flex-wrap gap-2">
-              <AdminStatusBadge tone={reviewDraft ? "warning" : "neutral"}>
-                {reviewDraft ? "Em revisao" : "Sem draft em revisao"}
-              </AdminStatusBadge>
-              <AdminStatusBadge tone={state.published ? "success" : "neutral"}>
-                {state.published ? "Publicado" : "Sem published"}
-              </AdminStatusBadge>
-            </div>
-          </div>
-
-          <div className="flex flex-col gap-2 sm:flex-row">
-            <form action={generateOrRegeneratePilotCommercialActivationDraftAction}>
-              <button className="inline-flex h-10 w-full items-center justify-center rounded-md bg-brand-600 px-4 text-sm font-medium text-white transition hover:bg-brand-700 sm:w-auto">
-                {reviewDraft ? "Regenerar draft" : "Gerar draft"}
-              </button>
-            </form>
-
-            <form action={publishCommercialActivationDraftAction}>
-              <input
-                name="artifactId"
-                type="hidden"
-                value={reviewDraft?.id ?? ""}
-              />
-              <button
-                className="inline-flex h-10 w-full items-center justify-center rounded-md border border-border px-4 text-sm font-medium text-muted-foreground transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
-                disabled={!reviewDraft}
-              >
-                Publicar draft
-              </button>
-            </form>
-          </div>
+      <section className="overflow-hidden rounded-lg border border-border bg-card shadow-card">
+        <div className="border-b border-border px-4 py-3">
+          <h2 className="text-sm font-semibold text-card-foreground">
+            Taxons elegiveis
+          </h2>
+          <p className="mt-1 text-xs text-muted-foreground">
+            A lista usa pesquisa completa; nao cria composicao nem draft.
+          </p>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-border text-sm">
+            <thead className="bg-muted/60 text-left text-xs font-medium uppercase text-muted-foreground">
+              <tr>
+                <th className="px-4 py-3">Taxon</th>
+                <th className="px-4 py-3">Estado</th>
+                <th className="px-4 py-3">Pesquisa</th>
+                <th className="px-4 py-3">Composicao</th>
+                <th className="px-4 py-3">Artefatos</th>
+                <th className="px-4 py-3">Acao</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {overview.items.map((item) => (
+                <TaxonRow
+                  key={item.taxon.id}
+                  item={item}
+                  selected={selected?.taxon.id === item.taxon.id}
+                />
+              ))}
+            </tbody>
+          </table>
         </div>
       </section>
 
-      <section className="grid gap-4 lg:grid-cols-3">
-        <StatusCard
-          label="Draft atual"
-          value={
-            reviewDraft
-              ? `v${reviewDraft.artifactVersion}`
-              : "Nenhum"
-          }
-          detail={
-            reviewDraft
-              ? `${reviewDraft.sourceCount} fontes business_buyer`
-              : state.latestDraft
-                ? "Draft antigo mantido apenas no historico"
-                : "Gere um draft para revisar"
-          }
-        />
-        <StatusCard
-          label="Published atual"
-          value={
-            state.published ? `v${state.published.artifactVersion}` : "Nenhum"
-          }
-          detail={
-            state.published?.publishedAt
-              ? formatDate(state.published.publishedAt)
-              : "A publicacao usa RPC transacional"
-          }
-        />
-        <StatusCard
-          label="Historico carregado"
-          value={String(state.artifacts.length)}
-          detail="draft, published e archived"
-        />
-      </section>
+      {selected ? (
+        <section className="rounded-lg border border-border bg-card p-5 shadow-card">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+            <div className="space-y-3">
+              <div>
+                <p className="text-xs font-medium uppercase text-muted-foreground">
+                  Taxon selecionado
+                </p>
+                <h2 className="mt-1 text-lg font-semibold text-card-foreground">
+                  {selected.taxon.name}
+                </h2>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {selected.taxon.slug}
+                </p>
+              </div>
 
-      {previewArtifact ? (
+              <div className="flex flex-wrap gap-2">
+                <AdminStatusBadge tone={reviewDraft ? "warning" : "neutral"}>
+                  {reviewDraft ? "Em revisao" : "Sem draft em revisao"}
+                </AdminStatusBadge>
+                <AdminStatusBadge tone={selected.published ? "success" : "neutral"}>
+                  {selected.published ? "Publicado" : "Sem published"}
+                </AdminStatusBadge>
+                <AdminStatusBadge tone={selected.composition ? "success" : "neutral"}>
+                  {selected.composition ? "Composicao pronta" : "Composicao sob demanda"}
+                </AdminStatusBadge>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <form action={generateOrRegenerateCommercialActivationDraftAction}>
+                <input name="taxonSlug" type="hidden" value={selected.taxon.slug} />
+                <button className="inline-flex h-10 w-full items-center justify-center rounded-md bg-brand-600 px-4 text-sm font-medium text-white transition hover:bg-brand-700 sm:w-auto">
+                  {reviewDraft ? "Regenerar draft" : "Gerar draft"}
+                </button>
+              </form>
+
+              <form action={publishCommercialActivationDraftAction}>
+                <input
+                  name="artifactId"
+                  type="hidden"
+                  value={reviewDraft?.id ?? ""}
+                />
+                <button
+                  className="inline-flex h-10 w-full items-center justify-center rounded-md border border-border px-4 text-sm font-medium text-muted-foreground transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
+                  disabled={!reviewDraft}
+                >
+                  Publicar draft
+                </button>
+              </form>
+            </div>
+          </div>
+        </section>
+      ) : (
+        <EmptyState
+          title="Nenhum taxon elegivel"
+          description="A lista sera preenchida quando houver pesquisa estruturada completa."
+        />
+      )}
+
+      {selected ? (
+        <section className="grid gap-4 lg:grid-cols-3">
+          <StatusCard
+            label="Draft atual"
+            value={reviewDraft ? `v${reviewDraft.artifactVersion}` : "Nenhum"}
+            detail={
+              reviewDraft
+                ? `${reviewDraft.sourceCount} fontes business_buyer`
+                : selected.latestDraft
+                  ? "Draft antigo mantido apenas no historico"
+                  : "Gere um draft para revisar"
+            }
+          />
+          <StatusCard
+            label="Published atual"
+            value={
+              selected.published ? `v${selected.published.artifactVersion}` : "Nenhum"
+            }
+            detail={
+              selected.published?.publishedAt
+                ? formatDate(selected.published.publishedAt)
+                : "A publicacao usa RPC transacional"
+            }
+          />
+          <StatusCard
+            label="Historico carregado"
+            value={String(selected.artifacts.length)}
+            detail="draft, published e archived"
+          />
+        </section>
+      ) : null}
+
+      {previewArtifact && selected?.composition ? (
         <section className="space-y-3">
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <div>
@@ -155,7 +207,7 @@ export default async function AdminTemplatesPage({
                 Preview do {previewArtifact.status === "draft" ? "draft" : "published"}
               </h2>
               <p className="text-sm text-muted-foreground">
-                Artifact {previewArtifact.id} · versao{" "}
+                Artifact {previewArtifact.id} - versao{" "}
                 {previewArtifact.artifactVersion}
               </p>
             </div>
@@ -166,67 +218,110 @@ export default async function AdminTemplatesPage({
           <div className="overflow-hidden rounded-lg border border-border bg-muted/40 p-3 shadow-card">
             <div className="max-h-[900px] overflow-auto rounded-lg">
               <CommercialActivationRenderer
-                composition={state.composition}
+                composition={selected.composition}
                 contentJson={previewArtifact.contentJson}
               />
             </div>
           </div>
         </section>
-      ) : (
+      ) : selected ? (
         <EmptyState
           title="Nenhum artefato para visualizar"
           description="Gere o primeiro draft administrativo para habilitar o preview."
         />
-      )}
+      ) : null}
 
-      <section className="overflow-hidden rounded-lg border border-border bg-card shadow-card">
-        <div className="border-b border-border px-4 py-3">
-          <h2 className="text-sm font-semibold text-card-foreground">
-            Historico de artefatos
-          </h2>
-        </div>
-        <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-border text-sm">
-            <thead className="bg-muted/60 text-left text-xs font-medium uppercase text-muted-foreground">
-              <tr>
-                <th className="px-4 py-3">Versao</th>
-                <th className="px-4 py-3">Status</th>
-                <th className="px-4 py-3">Fontes</th>
-                <th className="px-4 py-3">Criado</th>
-                <th className="px-4 py-3">Publicado</th>
-                <th className="px-4 py-3">Arquivado</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border">
-              {state.artifacts.map((artifact) => (
-                <tr key={artifact.id}>
-                  <td className="px-4 py-3 font-medium text-foreground">
-                    v{artifact.artifactVersion}
-                  </td>
-                  <td className="px-4 py-3">
-                    <AdminStatusBadge tone={statusTone(artifact.status)}>
-                      {artifact.status}
-                    </AdminStatusBadge>
-                  </td>
-                  <td className="px-4 py-3 text-muted-foreground">
-                    {artifact.sourceCount}
-                  </td>
-                  <td className="px-4 py-3 text-muted-foreground">
-                    {formatDate(artifact.createdAt)}
-                  </td>
-                  <td className="px-4 py-3 text-muted-foreground">
-                    {artifact.publishedAt ? formatDate(artifact.publishedAt) : "-"}
-                  </td>
-                  <td className="px-4 py-3 text-muted-foreground">
-                    {artifact.archivedAt ? formatDate(artifact.archivedAt) : "-"}
-                  </td>
+      {selected ? (
+        <section className="overflow-hidden rounded-lg border border-border bg-card shadow-card">
+          <div className="border-b border-border px-4 py-3">
+            <h2 className="text-sm font-semibold text-card-foreground">
+              Historico de artefatos
+            </h2>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-border text-sm">
+              <thead className="bg-muted/60 text-left text-xs font-medium uppercase text-muted-foreground">
+                <tr>
+                  <th className="px-4 py-3">Versao</th>
+                  <th className="px-4 py-3">Status</th>
+                  <th className="px-4 py-3">Fontes</th>
+                  <th className="px-4 py-3">Criado</th>
+                  <th className="px-4 py-3">Publicado</th>
+                  <th className="px-4 py-3">Arquivado</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </section>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {selected.artifacts.map((artifact) => (
+                  <tr key={artifact.id}>
+                    <td className="px-4 py-3 font-medium text-foreground">
+                      v{artifact.artifactVersion}
+                    </td>
+                    <td className="px-4 py-3">
+                      <AdminStatusBadge tone={statusTone(artifact.status)}>
+                        {artifact.status}
+                      </AdminStatusBadge>
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">
+                      {artifact.sourceCount}
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">
+                      {formatDate(artifact.createdAt)}
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">
+                      {artifact.publishedAt ? formatDate(artifact.publishedAt) : "-"}
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">
+                      {artifact.archivedAt ? formatDate(artifact.archivedAt) : "-"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      ) : null}
     </div>
+  );
+}
+
+function TaxonRow({
+  item,
+  selected,
+}: {
+  item: AdminCommercialActivationListItem;
+  selected: boolean;
+}) {
+  return (
+    <tr className={selected ? "bg-brand-50/60" : undefined}>
+      <td className="px-4 py-3">
+        <p className="font-medium text-foreground">{item.taxon.name}</p>
+        <p className="text-xs text-muted-foreground">{item.taxon.slug}</p>
+      </td>
+      <td className="px-4 py-3">
+        <AdminStatusBadge tone={listStateTone(item.state)}>
+          {item.stateLabel}
+        </AdminStatusBadge>
+      </td>
+      <td className="px-4 py-3 text-muted-foreground">
+        BB {item.research.businessBuyerBlocks}/4 ({item.research.businessBuyerItems}) - EC{" "}
+        {item.research.endCustomerBlocks}/4 ({item.research.endCustomerItems})
+      </td>
+      <td className="px-4 py-3 text-muted-foreground">
+        {item.hasActiveComposition ? "Pronta" : "Sob demanda"}
+      </td>
+      <td className="px-4 py-3 text-muted-foreground">
+        {item.publishedVersion ? `published v${item.publishedVersion}` : "sem published"}
+        {item.latestDraftVersion ? ` - draft v${item.latestDraftVersion}` : ""}
+      </td>
+      <td className="px-4 py-3">
+        <Link
+          href={`/admin/templates?taxon=${encodeURIComponent(item.taxon.slug)}`}
+          className="text-sm font-medium text-brand-700 hover:underline"
+        >
+          Selecionar
+        </Link>
+      </td>
+    </tr>
   );
 }
 
@@ -248,6 +343,12 @@ function StatusCard({
       <p className="mt-1 text-sm text-muted-foreground">{detail}</p>
     </section>
   );
+}
+
+function listStateTone(status: AdminCommercialActivationListItem["state"]) {
+  if (status === "published") return "success";
+  if (status === "review") return "warning";
+  return "neutral";
 }
 
 function statusTone(status: string) {

--- a/docs/lousa-plano-base-e10-7.md
+++ b/docs/lousa-plano-base-e10-7.md
@@ -335,6 +335,22 @@ Conclusão:
 * Usar revalidatePath somente se houver mutação administrativa.
 * Não aplicar agentes, IA em runtime público, filas, jobs ou nova infraestrutura.
 
+11.5.2 Blocker estrutural e decisão de desbloqueio
+
+* Blocker confirmado em 24/06/2026.
+* `content_artifacts` exige FK composta com `composition_id`, `template_id`, `taxon_id` e `composition_version`.
+* Taxon elegível sem composição ativa não consegue gerar draft válido no fluxo atual.
+* Corretor Imóveis é caso de validação, não solução pontual.
+* Decisão: criar mecanismo interno e genérico para garantir/materializar composição técnica `commercial_activation` quando operador acionar geração de draft para qualquer taxon elegível.
+* A listagem não materializa composição.
+* A listagem não gera draft.
+* O operador não prepara composição.
+* Template continua universal por canal.
+* Composição técnica pode continuar fisicamente por taxon no schema atual.
+* Materialização técnica não pode duplicar template de canal.
+* Materialização técnica não pode depender de slug ou nome de taxon.
+* Migration, grant, função ou RPC ficam limitados ao desbloqueio estrutural mínimo aprovado nesta fase.
+
 12. E18 e papéis dos templates
 
 12.1 E18

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -698,6 +698,7 @@
 • has_account_min_role (motivo: helper RLS; limites: somente leitura; sem writes)
 • ensure_first_account_for_current_user (motivo: F2 auto 1ª conta; limites: idempotente; cria 1ª conta + owner/active)
 • publish_content_artifact_draft (motivo: publicação transacional E10.7; limites: publica um draft por `id`, arquiva o published anterior do mesmo template/taxon/audience_scope e exige is_super_admin() OU is_platform_admin())
+• ensure_commercial_activation_composition (motivo: materialização técnica genérica E10.7 Fase 5; limites: somente `commercial_activation`, taxon ativo e elegível por pesquisa completa v1; cria/atualiza vínculo, composição e itens técnicos mínimos sem duplicar template de canal)
 
 3.3.4 publish_content_artifact_draft(p_artifact_id uuid) → content_artifacts
 • Segurança: SECURITY DEFINER (aprovado; escrita transacional controlada)
@@ -707,6 +708,14 @@
 • Efeito: bloqueia o draft alvo, valida `status = 'draft'`, bloqueia o `published` anterior do mesmo template/taxon/audience_scope, arquiva o anterior e publica o draft na mesma transação.
 • Garantia complementar: `content_artifacts_one_published_uidx` mantém no máximo um `published` por (`template_id`, `taxon_id`, `audience_scope`).
 • Risco residual aceito para Fase 2: geração segura da próxima `artifact_version`; a UNIQUE `(template_id, composition_id, taxon_id, audience_scope, research_version, artifact_version)` protege colisão, mas o fluxo de geração ainda deve calcular ou tentar inserir a próxima versão de forma segura.
+
+3.3.5 ensure_commercial_activation_composition(p_taxon_id uuid) → content_template_compositions
+• Segurança: SECURITY DEFINER (aprovado; materialização técnica controlada para E10.7 Fase 5)
+• search_path: public, pg_temp
+• Grants de EXECUTE: service_role
+• Sem EXECUTE para public, anon ou authenticated
+• Efeito: valida taxon ativo e pesquisa completa `active version 1` para `business_buyer` e `end_customer` nos blocos `strategic_core`, `lp_overview`, `lp_sections` e `seo`; retorna composição ativa existente ou materializa vínculo `content_template_taxons`, composição v1 ativa e oito itens técnicos `commercial_activation`.
+• Limites: não cria template, não duplica template por taxon, não gera draft, não publica, não roda na listagem e não depende de slug/nome de taxon.
 
 3.4 Convites de Conta
 • accept_account_invite(account_id uuid, ttl_days int) → boolean
@@ -793,6 +802,10 @@
 • Rollback: não remove automaticamente a extensão, pois pode ser reutilizada por outros recursos
 
 99. Changelog
+v1.0.28 (24/06/2026) — E10.7 Fase 5: composição técnica genérica
+• Registrada a RPC `ensure_commercial_activation_composition(uuid)` para materialização técnica controlada de composição `commercial_activation` por taxon elegível.
+• Registrados limites: execução apenas via `service_role`, sem acesso público/authenticated direto, sem criação de template, sem geração de draft e sem execução na listagem administrativa.
+
 v1.0.27 (22/06/2026) — E10.7 Fase 1D: leitura server-side de `plans`
 • Registrado grant mínimo de SELECT em `public.plans` para `service_role`, viabilizando leitura server-side administrativa da fonte canônica parcial de planos.
 

--- a/lib/admin/adapters/adminCommercialActivationTemplatesAdapter.ts
+++ b/lib/admin/adapters/adminCommercialActivationTemplatesAdapter.ts
@@ -6,10 +6,44 @@ import {
   type ContentArtifactStatus,
   type ContentComposition,
 } from "@/conversion-content/contracts";
-import { isRecord } from "@/conversion-content/validation";
-import { COMMERCIAL_ACTIVATION_PILOT_TAXON_SLUG } from "@/conversion-content/commercial-activation/draft-generation";
 import { resolveCommercialActivationCompositionForTaxon } from "@/conversion-content/commercial-activation/composition";
 import { resolveCommercialActivationRenderModel } from "@/conversion-content/commercial-activation/resolve";
+import { isRecord } from "@/conversion-content/validation";
+
+const RESEARCH_VERSION = 1;
+const REQUIRED_RESEARCH_BLOCKS = [
+  "strategic_core",
+  "lp_overview",
+  "lp_sections",
+  "seo",
+] as const;
+const REQUIRED_AUDIENCES = ["business_buyer", "end_customer"] as const;
+
+type RequiredAudience = (typeof REQUIRED_AUDIENCES)[number];
+type RequiredResearchBlock = (typeof REQUIRED_RESEARCH_BLOCKS)[number];
+
+type AdminCommercialActivationTaxon = {
+  id: string;
+  name: string;
+  slug: string;
+};
+
+type AdminCommercialActivationResearchSummary = {
+  businessBuyerBlocks: number;
+  businessBuyerItems: number;
+  endCustomerBlocks: number;
+  endCustomerItems: number;
+};
+
+export type AdminCommercialActivationListItem = {
+  taxon: AdminCommercialActivationTaxon;
+  state: "published" | "review" | "eligible";
+  stateLabel: "Publicado" | "Em revisao" | "Elegivel para gerar";
+  research: AdminCommercialActivationResearchSummary;
+  hasActiveComposition: boolean;
+  latestDraftVersion: number | null;
+  publishedVersion: number | null;
+};
 
 export type AdminCommercialActivationArtifact = {
   id: string;
@@ -31,15 +65,22 @@ export type AdminCommercialActivationArtifact = {
   sourceCount: number;
 };
 
+export type AdminCommercialActivationOverview =
+  | {
+      ok: true;
+      items: AdminCommercialActivationListItem[];
+      selected: AdminCommercialActivationState | null;
+    }
+  | {
+      ok: false;
+      reason: "template_not_found" | "eligible_taxons_read_failed";
+    };
+
 export type AdminCommercialActivationState =
   | {
       ok: true;
-      taxon: {
-        id: string;
-        name: string;
-        slug: string;
-      };
-      composition: ContentComposition;
+      taxon: AdminCommercialActivationTaxon;
+      composition: ContentComposition | null;
       latestDraft: AdminCommercialActivationArtifact | null;
       publishableDraft: AdminCommercialActivationArtifact | null;
       published: AdminCommercialActivationArtifact | null;
@@ -49,7 +90,6 @@ export type AdminCommercialActivationState =
       ok: false;
       reason:
         | "taxon_not_found"
-        | "composition_not_found"
         | "composition_invalid"
         | "artifacts_read_failed";
     };
@@ -94,35 +134,77 @@ export type PublishValidation =
       publishedCount?: number;
     };
 
-export async function readAdminCommercialActivationState(
-  taxonSlug = COMMERCIAL_ACTIVATION_PILOT_TAXON_SLUG,
-): Promise<AdminCommercialActivationState> {
+export async function readAdminCommercialActivationOverview(input: {
+  selectedTaxonSlug?: string;
+} = {}): Promise<AdminCommercialActivationOverview> {
+  try {
+    const templateId = await readCommercialActivationPageTemplateId();
+    if (!templateId) return { ok: false, reason: "template_not_found" };
+
+    const items = await readEligibleCommercialActivationTaxons({ templateId });
+    const selectedSlug = input.selectedTaxonSlug?.trim();
+    const selectedItem =
+      (selectedSlug
+        ? items.find((item) => item.taxon.slug === selectedSlug)
+        : null) ?? items[0] ?? null;
+    const selected = selectedItem
+      ? await readAdminCommercialActivationState({
+          taxonId: selectedItem.taxon.id,
+          templateId,
+        })
+      : null;
+
+    return { ok: true, items, selected };
+  } catch (error) {
+    console.error("readAdminCommercialActivationOverview failed", {
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return { ok: false, reason: "eligible_taxons_read_failed" };
+  }
+}
+
+export async function readAdminCommercialActivationState(input: {
+  taxonSlug?: string;
+  taxonId?: string;
+  templateId?: string;
+} = {}): Promise<AdminCommercialActivationState> {
   const supabase = createServiceClient();
 
   try {
-    const { data: taxonRow, error: taxonError } = await supabase
+    const templateId =
+      input.templateId ?? (await readCommercialActivationPageTemplateId());
+    if (!templateId) return { ok: false, reason: "artifacts_read_failed" };
+
+    let query = supabase
       .from("business_taxons")
       .select("id,name,slug")
-      .eq("slug", taxonSlug)
       .eq("is_active", true)
-      .maybeSingle();
+      .limit(1);
+
+    if (input.taxonId) {
+      query = query.eq("id", input.taxonId.trim());
+    } else if (input.taxonSlug) {
+      query = query.eq("slug", input.taxonSlug.trim());
+    } else {
+      return { ok: false, reason: "taxon_not_found" };
+    }
+
+    const { data: taxonRow, error: taxonError } = await query.maybeSingle();
 
     if (taxonError) throw taxonError;
     if (!isRecord(taxonRow) || !isString(taxonRow.id)) {
       return { ok: false, reason: "taxon_not_found" };
     }
 
-    const composition = await resolveCommercialActivationCompositionForTaxon({
+    const compositionResult = await resolveCommercialActivationCompositionForTaxon({
       taxonId: taxonRow.id,
     });
-
-    if (composition.status !== "ready") {
-      return { ok: false, reason: composition.status };
+    if (compositionResult.status === "composition_invalid") {
+      return { ok: false, reason: "composition_invalid" };
     }
 
     const artifacts = await readCommercialActivationArtifacts({
-      templateId: composition.composition.template.id,
-      compositionId: composition.composition.id,
+      templateId,
       taxonId: taxonRow.id,
     });
 
@@ -136,10 +218,13 @@ export async function readAdminCommercialActivationState(
       ok: true,
       taxon: {
         id: taxonRow.id,
-        name: isString(taxonRow.name) ? taxonRow.name : taxonSlug,
-        slug: isString(taxonRow.slug) ? taxonRow.slug : taxonSlug,
+        name: isString(taxonRow.name) ? taxonRow.name : "",
+        slug: isString(taxonRow.slug) ? taxonRow.slug : "",
       },
-      composition: composition.composition,
+      composition:
+        compositionResult.status === "ready"
+          ? compositionResult.composition
+          : null,
       latestDraft,
       publishableDraft,
       published,
@@ -156,9 +241,26 @@ export async function readAdminCommercialActivationState(
 export async function readPublishContext(
   artifactId: string,
 ): Promise<PublishContext> {
+  const supabase = createServiceClient();
+
   try {
-    const state = await readAdminCommercialActivationState();
-    if (!state.ok) return { ok: false, reason: "read_failed" };
+    const { data: targetRow, error: targetError } = await supabase
+      .from("content_artifacts")
+      .select("id,taxon_id,status")
+      .eq("id", artifactId)
+      .maybeSingle();
+
+    if (targetError) throw targetError;
+    if (!isRecord(targetRow) || !isString(targetRow.taxon_id)) {
+      return { ok: false, reason: "artifact_not_found" };
+    }
+
+    const state = await readAdminCommercialActivationState({
+      taxonId: targetRow.taxon_id,
+    });
+    if (!state.ok || !state.composition) {
+      return { ok: false, reason: "read_failed" };
+    }
 
     if (!state.publishableDraft || state.publishableDraft.id !== artifactId) {
       const requested = state.artifacts.find(
@@ -190,10 +292,6 @@ export async function readPublishContext(
       target.audienceScope !== COMMERCIAL_ACTIVATION_AUDIENCE_SCOPE
     ) {
       return { ok: false, reason: "artifact_bundle_mismatch" };
-    }
-
-    if (!isString(target.id)) {
-      return { ok: false, reason: "artifact_not_found" };
     }
 
     return {
@@ -286,9 +384,240 @@ export async function validatePublicationResult(input: {
   }
 }
 
+async function readCommercialActivationPageTemplateId() {
+  const supabase = createServiceClient();
+  const { data, error } = await supabase
+    .from("content_templates")
+    .select("id")
+    .eq("template_key", "commercial_activation_page")
+    .eq("template_family", "commercial_activation")
+    .eq("template_scope", "page")
+    .eq("version", 1)
+    .eq("status", "active")
+    .eq("is_active", true)
+    .limit(1)
+    .maybeSingle();
+
+  if (error) throw error;
+  return isRecord(data) && isString(data.id) ? data.id : null;
+}
+
+async function readEligibleCommercialActivationTaxons(input: {
+  templateId: string;
+}): Promise<AdminCommercialActivationListItem[]> {
+  const supabase = createServiceClient();
+  const { data: taxonRows, error: taxonError } = await supabase
+    .from("business_taxons")
+    .select("id,name,slug")
+    .eq("is_active", true)
+    .order("name", { ascending: true })
+    .order("slug", { ascending: true })
+    .limit(500);
+
+  if (taxonError) throw taxonError;
+
+  const taxons = (taxonRows ?? [])
+    .map(mapTaxon)
+    .filter((taxon): taxon is AdminCommercialActivationTaxon => taxon !== null);
+  if (taxons.length === 0) return [];
+
+  const taxonIds = taxons.map((taxon) => taxon.id);
+  const research = await readResearchEligibility(taxonIds);
+  const compositionTaxonIds = await readActiveCompositionTaxonIds({
+    templateId: input.templateId,
+    taxonIds,
+  });
+  const artifactsByTaxon = await readArtifactSummaries({
+    templateId: input.templateId,
+    taxonIds,
+  });
+
+  return taxons
+    .map((taxon) => {
+      const researchSummary = research.get(taxon.id);
+      if (!researchSummary) return null;
+
+      const artifactSummary = artifactsByTaxon.get(taxon.id) ?? {
+        latestDraftVersion: null,
+        publishedVersion: null,
+      };
+      const state = resolveListState(artifactSummary);
+
+      return {
+        taxon,
+        state,
+        stateLabel:
+          state === "published"
+            ? "Publicado"
+            : state === "review"
+              ? "Em revisao"
+              : "Elegivel para gerar",
+        research: researchSummary,
+        hasActiveComposition: compositionTaxonIds.has(taxon.id),
+        latestDraftVersion: artifactSummary.latestDraftVersion,
+        publishedVersion: artifactSummary.publishedVersion,
+      };
+    })
+    .filter((item): item is AdminCommercialActivationListItem => item !== null);
+}
+
+async function readResearchEligibility(taxonIds: string[]) {
+  const supabase = createServiceClient();
+  const { data: researchRows, error: researchError } = await supabase
+    .from("taxon_market_research")
+    .select("id,taxon_id,audience_scope,research_block")
+    .in("taxon_id", taxonIds)
+    .eq("version", RESEARCH_VERSION)
+    .eq("status", "active")
+    .in("audience_scope", [...REQUIRED_AUDIENCES])
+    .in("research_block", [...REQUIRED_RESEARCH_BLOCKS])
+    .order("taxon_id", { ascending: true })
+    .order("audience_scope", { ascending: true })
+    .order("research_block", { ascending: true });
+
+  if (researchError) throw researchError;
+
+  const researchIds = (researchRows ?? [])
+    .map((row) => (isRecord(row) && isString(row.id) ? row.id : null))
+    .filter((id): id is string => Boolean(id));
+  const itemCounts = new Map<string, number>();
+
+  if (researchIds.length > 0) {
+    const { data: itemRows, error: itemError } = await supabase
+      .from("taxon_market_research_items")
+      .select("research_id")
+      .in("research_id", researchIds)
+      .eq("is_active", true)
+      .order("research_id", { ascending: true });
+
+    if (itemError) throw itemError;
+
+    for (const row of itemRows ?? []) {
+      if (!isRecord(row) || !isString(row.research_id)) continue;
+      itemCounts.set(row.research_id, (itemCounts.get(row.research_id) ?? 0) + 1);
+    }
+  }
+
+  const coverage = new Map<
+    string,
+    Map<RequiredAudience, Map<RequiredResearchBlock, number>>
+  >();
+
+  for (const row of researchRows ?? []) {
+    if (!isRecord(row)) continue;
+    if (
+      !isString(row.id) ||
+      !isString(row.taxon_id) ||
+      !isRequiredAudience(row.audience_scope) ||
+      !isRequiredResearchBlock(row.research_block)
+    ) {
+      continue;
+    }
+
+    const taxonCoverage = coverage.get(row.taxon_id) ?? new Map();
+    const audienceCoverage =
+      taxonCoverage.get(row.audience_scope) ?? new Map();
+    audienceCoverage.set(row.research_block, itemCounts.get(row.id) ?? 0);
+    taxonCoverage.set(row.audience_scope, audienceCoverage);
+    coverage.set(row.taxon_id, taxonCoverage);
+  }
+
+  const eligible = new Map<string, AdminCommercialActivationResearchSummary>();
+  for (const [taxonId, taxonCoverage] of coverage.entries()) {
+    const businessBuyer = taxonCoverage.get("business_buyer") ?? new Map();
+    const endCustomer = taxonCoverage.get("end_customer") ?? new Map();
+    const businessBuyerReady = [...REQUIRED_RESEARCH_BLOCKS].every(
+      (block) => (businessBuyer.get(block) ?? 0) > 0,
+    );
+    const endCustomerReady = [...REQUIRED_RESEARCH_BLOCKS].every(
+      (block) => (endCustomer.get(block) ?? 0) > 0,
+    );
+
+    if (!businessBuyerReady || !endCustomerReady) continue;
+
+    eligible.set(taxonId, {
+      businessBuyerBlocks: businessBuyer.size,
+      businessBuyerItems: sumCounts(businessBuyer),
+      endCustomerBlocks: endCustomer.size,
+      endCustomerItems: sumCounts(endCustomer),
+    });
+  }
+
+  return eligible;
+}
+
+async function readActiveCompositionTaxonIds(input: {
+  templateId: string;
+  taxonIds: string[];
+}) {
+  const supabase = createServiceClient();
+  const { data, error } = await supabase
+    .from("content_template_compositions")
+    .select("taxon_id")
+    .eq("template_id", input.templateId)
+    .in("taxon_id", input.taxonIds)
+    .eq("status", "active")
+    .order("taxon_id", { ascending: true });
+
+  if (error) throw error;
+
+  return new Set(
+    (data ?? [])
+      .map((row) => (isRecord(row) && isString(row.taxon_id) ? row.taxon_id : null))
+      .filter((taxonId): taxonId is string => Boolean(taxonId)),
+  );
+}
+
+async function readArtifactSummaries(input: {
+  templateId: string;
+  taxonIds: string[];
+}) {
+  const supabase = createServiceClient();
+  const { data, error } = await supabase
+    .from("content_artifacts")
+    .select("taxon_id,status,artifact_version")
+    .eq("template_id", input.templateId)
+    .in("taxon_id", input.taxonIds)
+    .eq("audience_scope", COMMERCIAL_ACTIVATION_AUDIENCE_SCOPE)
+    .order("taxon_id", { ascending: true })
+    .order("artifact_version", { ascending: false });
+
+  if (error) throw error;
+
+  const summaries = new Map<
+    string,
+    { latestDraftVersion: number | null; publishedVersion: number | null }
+  >();
+
+  for (const row of data ?? []) {
+    if (!isRecord(row) || !isString(row.taxon_id)) continue;
+    const current = summaries.get(row.taxon_id) ?? {
+      latestDraftVersion: null,
+      publishedVersion: null,
+    };
+
+    if (row.status === "draft" && isPositiveInteger(row.artifact_version)) {
+      current.latestDraftVersion = Math.max(
+        current.latestDraftVersion ?? 0,
+        row.artifact_version,
+      );
+    }
+
+    if (row.status === "published" && isPositiveInteger(row.artifact_version)) {
+      current.publishedVersion = Math.max(
+        current.publishedVersion ?? 0,
+        row.artifact_version,
+      );
+    }
+
+    summaries.set(row.taxon_id, current);
+  }
+
+  return summaries;
+}
+
 async function readCommercialActivationArtifacts(input: {
   templateId: string;
-  compositionId: string;
   taxonId: string;
 }): Promise<AdminCommercialActivationArtifact[]> {
   const supabase = createServiceClient();
@@ -299,7 +628,6 @@ async function readCommercialActivationArtifacts(input: {
       "id,template_id,composition_id,taxon_id,audience_scope,template_version,composition_version,research_version,artifact_version,status,content_json,provenance_json,created_at,updated_at,published_at,archived_at",
     )
     .eq("template_id", input.templateId)
-    .eq("composition_id", input.compositionId)
     .eq("taxon_id", input.taxonId)
     .eq("audience_scope", COMMERCIAL_ACTIVATION_AUDIENCE_SCOPE)
     .order("artifact_version", { ascending: false })
@@ -317,7 +645,8 @@ async function readCommercialActivationArtifacts(input: {
     const { data: sourceRows, error: sourcesError } = await supabase
       .from("content_artifact_research_sources")
       .select("artifact_id")
-      .in("artifact_id", artifactIds);
+      .in("artifact_id", artifactIds)
+      .order("artifact_id", { ascending: true });
 
     if (sourcesError) throw sourcesError;
 
@@ -335,6 +664,21 @@ async function readCommercialActivationArtifacts(input: {
     .filter((artifact): artifact is AdminCommercialActivationArtifact =>
       Boolean(artifact),
     );
+}
+
+function resolveListState(input: {
+  latestDraftVersion: number | null;
+  publishedVersion: number | null;
+}): AdminCommercialActivationListItem["state"] {
+  if (
+    input.latestDraftVersion &&
+    (!input.publishedVersion || input.latestDraftVersion > input.publishedVersion)
+  ) {
+    return "review";
+  }
+
+  if (input.publishedVersion) return "published";
+  return "eligible";
 }
 
 function getPublishableDraft(input: {
@@ -400,8 +744,28 @@ function mapAdminArtifact(
   };
 }
 
+function mapTaxon(value: unknown): AdminCommercialActivationTaxon | null {
+  if (!isRecord(value)) return null;
+  if (!isString(value.id) || !isString(value.name) || !isString(value.slug)) {
+    return null;
+  }
+  return {
+    id: value.id,
+    name: value.name,
+    slug: value.slug,
+  };
+}
+
 function isArtifactStatus(value: unknown): value is ContentArtifactStatus {
   return value === "draft" || value === "published" || value === "archived";
+}
+
+function isRequiredAudience(value: unknown): value is RequiredAudience {
+  return value === "business_buyer" || value === "end_customer";
+}
+
+function isRequiredResearchBlock(value: unknown): value is RequiredResearchBlock {
+  return REQUIRED_RESEARCH_BLOCKS.includes(value as RequiredResearchBlock);
 }
 
 function isString(value: unknown): value is string {
@@ -410,4 +774,8 @@ function isString(value: unknown): value is string {
 
 function isPositiveInteger(value: unknown): value is number {
   return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+function sumCounts(value: Map<RequiredResearchBlock, number>) {
+  return [...value.values()].reduce((sum, count) => sum + count, 0);
 }

--- a/lib/conversion-content/commercial-activation/composition.ts
+++ b/lib/conversion-content/commercial-activation/composition.ts
@@ -14,6 +14,16 @@ export type CommercialActivationCompositionResolution =
   | { status: "ready"; composition: ContentComposition }
   | { status: "composition_not_found" | "composition_invalid" };
 
+export type CommercialActivationCompositionEnsureResult =
+  | { status: "ready"; composition: ContentComposition; createdOrExisting: true }
+  | {
+      status:
+        | "composition_not_found"
+        | "composition_invalid"
+        | "taxon_not_eligible"
+        | "materialization_failed";
+    };
+
 export async function resolveCommercialActivationCompositionForTaxon(input: {
   taxonId: string;
 }): Promise<CommercialActivationCompositionResolution> {
@@ -80,6 +90,63 @@ export async function resolveCommercialActivationCompositionForTaxon(input: {
   return composition
     ? { status: "ready", composition }
     : { status: "composition_invalid" };
+}
+
+export async function ensureCommercialActivationCompositionForTaxon(input: {
+  taxonId: string;
+}): Promise<CommercialActivationCompositionEnsureResult> {
+  const taxonId = input.taxonId.trim();
+  if (!taxonId) return { status: "composition_not_found" };
+
+  const existing = await resolveCommercialActivationCompositionForTaxon({
+    taxonId,
+  });
+  if (existing.status === "ready") {
+    return {
+      status: "ready",
+      composition: existing.composition,
+      createdOrExisting: true,
+    };
+  }
+
+  const supabase = createServiceClient();
+  const { error } = await supabase.rpc(
+    "ensure_commercial_activation_composition",
+    {
+      p_taxon_id: taxonId,
+    },
+  );
+
+  if (error) {
+    console.error("ensureCommercialActivationCompositionForTaxon failed", {
+      code: error.code ?? "rpc_failed",
+      message: error.message,
+      taxonId,
+    });
+
+    if (
+      error.message.includes("commercial_activation_taxon_not_active") ||
+      error.message.includes("commercial_activation_research_incomplete")
+    ) {
+      return { status: "taxon_not_eligible" };
+    }
+
+    return { status: "materialization_failed" };
+  }
+
+  const ensured = await resolveCommercialActivationCompositionForTaxon({
+    taxonId,
+  });
+
+  if (ensured.status !== "ready") {
+    return { status: ensured.status };
+  }
+
+  return {
+    status: "ready",
+    composition: ensured.composition,
+    createdOrExisting: true,
+  };
 }
 
 function isString(value: unknown): value is string {

--- a/lib/conversion-content/commercial-activation/draft-generation.ts
+++ b/lib/conversion-content/commercial-activation/draft-generation.ts
@@ -11,7 +11,7 @@ import {
   type ContentCompositionItem,
 } from "../contracts";
 import { isRecord } from "../validation";
-import { resolveCommercialActivationCompositionForTaxon } from "./composition";
+import { ensureCommercialActivationCompositionForTaxon } from "./composition";
 import { commercialActivationSectionRegistry } from "./registry";
 import { resolveCommercialActivationRenderModel } from "./resolve";
 import {
@@ -22,8 +22,6 @@ import {
 } from "./schemas";
 
 const OPENAI_RESPONSES_ENDPOINT = "https://api.openai.com/v1/responses";
-export const COMMERCIAL_ACTIVATION_PILOT_TAXON_SLUG =
-  "corretor-de-imoveis-de-medio-padrao";
 const RESEARCH_VERSION = 1;
 const SAFE_CTA_HREF = "/auth/sign-up";
 const MODEL_ENV_NAME = "OPENAI_COMMERCIAL_ACTIVATION_MODEL";
@@ -298,10 +296,25 @@ export async function generateCommercialActivationDraftForTaxon(input: {
   requestId?: string;
 } = {}): Promise<GenerateCommercialActivationDraftResult> {
   const requestId = input.requestId ?? crypto.randomUUID();
-  const taxonSlug =
-    input.taxonSlug?.trim() || COMMERCIAL_ACTIVATION_PILOT_TAXON_SLUG;
+  const taxonSlug = input.taxonSlug?.trim() ?? "";
   const model = process.env[MODEL_ENV_NAME]?.trim() ?? "";
   const apiKey = process.env.OPENAI_API_KEY?.trim() ?? "";
+
+  if (!taxonSlug) {
+    logDraftEvent("commercial_activation_draft_generation_blocked", {
+      requestId,
+      taxonId: null,
+      status: "blocked",
+      reason: "missing_taxon_slug",
+    });
+    return {
+      ok: false,
+      requestId,
+      status: "blocked",
+      stage: "preconditions",
+      reason: "missing_taxon_slug",
+    };
+  }
 
   if (!apiKey || !model) {
     logDraftEvent("commercial_activation_draft_generation_blocked", {
@@ -395,19 +408,19 @@ async function readDraftContext(input: { taxonSlug: string }): Promise<DraftCont
 
   if (taxonError) throw new Error("taxon_read_failed");
   if (!isRecord(taxonRow) || typeof taxonRow.id !== "string") {
-    throw new Error("pilot_taxon_missing");
-  }
-
-  const compositionResult = await resolveCommercialActivationCompositionForTaxon({
-    taxonId: taxonRow.id,
-  });
-  if (compositionResult.status !== "ready") {
-    throw new Error(compositionResult.status);
+    throw new Error("taxon_missing");
   }
 
   const research = await readResearchSources({
     taxonId: taxonRow.id,
   });
+
+  const compositionResult = await ensureCommercialActivationCompositionForTaxon({
+    taxonId: taxonRow.id,
+  });
+  if (compositionResult.status !== "ready") {
+    throw new Error(compositionResult.status);
+  }
 
   const plans = await readPlans();
 

--- a/supabase/migrations/20260624203000_e10_7_phase_5_ensure_commercial_activation_composition.sql
+++ b/supabase/migrations/20260624203000_e10_7_phase_5_ensure_commercial_activation_composition.sql
@@ -1,0 +1,244 @@
+begin;
+
+create or replace function public.ensure_commercial_activation_composition(
+  p_taxon_id uuid
+)
+returns public.content_template_compositions
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_taxon public.business_taxons%rowtype;
+  v_page_template_id uuid;
+  v_composition public.content_template_compositions%rowtype;
+  v_research_count integer;
+  v_module_count integer;
+  v_item_count integer;
+  v_variant_count integer;
+begin
+  select *
+    into v_taxon
+  from public.business_taxons
+  where id = p_taxon_id
+    and is_active = true;
+
+  if v_taxon.id is null then
+    raise exception 'commercial_activation_taxon_not_active';
+  end if;
+
+  with required_blocks(block) as (
+    values
+      ('strategic_core'::text),
+      ('lp_overview'::text),
+      ('lp_sections'::text),
+      ('seo'::text)
+  ),
+  required_audiences(audience_scope) as (
+    values
+      ('business_buyer'::text),
+      ('end_customer'::text)
+  ),
+  required_pairs as (
+    select
+      required_audiences.audience_scope,
+      required_blocks.block
+    from required_audiences
+    cross join required_blocks
+  ),
+  eligible_research as (
+    select
+      research.audience_scope,
+      research.research_block,
+      count(items.id) filter (where items.is_active = true) as active_items
+    from public.taxon_market_research research
+    left join public.taxon_market_research_items items
+      on items.research_id = research.id
+    where research.taxon_id = p_taxon_id
+      and research.status = 'active'
+      and research.version = 1
+      and research.audience_scope in ('business_buyer', 'end_customer')
+      and research.research_block in ('strategic_core', 'lp_overview', 'lp_sections', 'seo')
+    group by research.audience_scope, research.research_block
+  )
+  select count(*)
+    into v_research_count
+  from required_pairs
+  join eligible_research
+    on eligible_research.audience_scope = required_pairs.audience_scope
+   and eligible_research.research_block = required_pairs.block
+   and eligible_research.active_items > 0;
+
+  if v_research_count <> 8 then
+    raise exception 'commercial_activation_research_incomplete';
+  end if;
+
+  select id
+    into v_page_template_id
+  from public.content_templates
+  where template_key = 'commercial_activation_page'
+    and template_family = 'commercial_activation'
+    and template_scope = 'page'
+    and version = 1
+    and status = 'active'
+    and is_active = true;
+
+  if v_page_template_id is null then
+    raise exception 'commercial_activation_page_template_missing';
+  end if;
+
+  select *
+    into v_composition
+  from public.content_template_compositions
+  where template_id = v_page_template_id
+    and taxon_id = p_taxon_id
+    and status = 'active'
+  order by version desc, created_at asc, id asc
+  limit 1;
+
+  if v_composition.id is not null then
+    return v_composition;
+  end if;
+
+  with expected_modules(template_key, variant_key, sort_order) as (
+    values
+      ('hero', 'hero.default', 10),
+      ('benefits', 'benefits.cards', 20),
+      ('services', 'services.list', 30),
+      ('plans', 'plans.cards', 40),
+      ('differentials', 'differentials.cards', 50),
+      ('how_it_works', 'how_it_works.steps', 60),
+      ('faq', 'faq.accordion', 70),
+      ('final_cta', 'final_cta.simple', 80)
+  )
+  select count(*)
+    into v_module_count
+  from expected_modules
+  join public.content_templates module_template
+    on module_template.template_key = expected_modules.template_key
+   and module_template.template_family = 'commercial_activation'
+   and module_template.template_scope = 'section'
+   and module_template.version = 1
+   and module_template.status = 'active'
+   and module_template.is_active = true;
+
+  if v_module_count <> 8 then
+    raise exception 'commercial_activation_section_modules_missing';
+  end if;
+
+  update public.content_template_taxons
+  set resolution_level = v_taxon.level,
+      priority = greatest(priority, 100),
+      is_primary = true,
+      is_active = true
+  where template_id = v_page_template_id
+    and taxon_id = p_taxon_id;
+
+  if not found then
+    insert into public.content_template_taxons (
+      template_id,
+      taxon_id,
+      resolution_level,
+      priority,
+      is_primary,
+      is_active
+    )
+    values (
+      v_page_template_id,
+      p_taxon_id,
+      v_taxon.level,
+      100,
+      true,
+      true
+    );
+  end if;
+
+  insert into public.content_template_compositions (
+    template_id,
+    taxon_id,
+    version,
+    status
+  )
+  values (
+    v_page_template_id,
+    p_taxon_id,
+    1,
+    'active'
+  )
+  on conflict on constraint content_template_compositions_identity_uidx
+  do update
+  set status = excluded.status
+  returning * into v_composition;
+
+  if v_composition.id is null then
+    raise exception 'commercial_activation_composition_materialization_failed';
+  end if;
+
+  with expected_modules(template_key, variant_key, sort_order) as (
+    values
+      ('hero', 'hero.default', 10),
+      ('benefits', 'benefits.cards', 20),
+      ('services', 'services.list', 30),
+      ('plans', 'plans.cards', 40),
+      ('differentials', 'differentials.cards', 50),
+      ('how_it_works', 'how_it_works.steps', 60),
+      ('faq', 'faq.accordion', 70),
+      ('final_cta', 'final_cta.simple', 80)
+  ),
+  resolved_modules as (
+    select
+      module_template.id as module_template_id,
+      expected_modules.variant_key,
+      expected_modules.sort_order
+    from expected_modules
+    join public.content_templates module_template
+      on module_template.template_key = expected_modules.template_key
+     and module_template.template_family = 'commercial_activation'
+     and module_template.template_scope = 'section'
+     and module_template.version = 1
+     and module_template.status = 'active'
+     and module_template.is_active = true
+  )
+  insert into public.content_template_composition_items (
+    composition_id,
+    module_template_id,
+    variant_key,
+    sort_order,
+    is_required,
+    config_json
+  )
+  select
+    v_composition.id,
+    resolved_modules.module_template_id,
+    resolved_modules.variant_key,
+    resolved_modules.sort_order,
+    true,
+    '{}'::jsonb
+  from resolved_modules
+  on conflict on constraint content_template_composition_items_order_uidx
+  do update
+  set module_template_id = excluded.module_template_id,
+      variant_key = excluded.variant_key,
+      is_required = true,
+      config_json = '{}'::jsonb;
+
+  select count(*),
+         count(distinct variant_key)
+    into v_item_count, v_variant_count
+  from public.content_template_composition_items
+  where composition_id = v_composition.id;
+
+  if v_item_count <> 8 or v_variant_count <> 8 then
+    raise exception 'commercial_activation_composition_items_invalid';
+  end if;
+
+  return v_composition;
+end;
+$$;
+
+revoke all on function public.ensure_commercial_activation_composition(uuid) from public;
+revoke all on function public.ensure_commercial_activation_composition(uuid) from anon;
+revoke all on function public.ensure_commercial_activation_composition(uuid) from authenticated;
+grant execute on function public.ensure_commercial_activation_composition(uuid) to service_role;
+
+commit;

--- a/supabase/snippets/e10_7_phase_5_eligible_taxons_verify.sql
+++ b/supabase/snippets/e10_7_phase_5_eligible_taxons_verify.sql
@@ -1,0 +1,108 @@
+with required_blocks(block) as (
+  values
+    ('strategic_core'::text),
+    ('lp_overview'::text),
+    ('lp_sections'::text),
+    ('seo'::text)
+),
+eligible_research as (
+  select
+    taxon.id as taxon_id,
+    taxon.name,
+    taxon.slug,
+    research.audience_scope,
+    research.research_block,
+    count(items.id) filter (where items.is_active = true) as active_items
+  from public.business_taxons taxon
+  join public.taxon_market_research research
+    on research.taxon_id = taxon.id
+   and research.status = 'active'
+   and research.version = 1
+   and research.audience_scope in ('business_buyer', 'end_customer')
+   and research.research_block in ('strategic_core', 'lp_overview', 'lp_sections', 'seo')
+  left join public.taxon_market_research_items items
+    on items.research_id = research.id
+  where taxon.is_active = true
+  group by taxon.id, taxon.name, taxon.slug, research.audience_scope, research.research_block
+),
+eligible_taxons as (
+  select
+    taxon_id,
+    name,
+    slug,
+    count(*) filter (
+      where audience_scope = 'business_buyer'
+        and active_items > 0
+    ) as business_buyer_blocks,
+    sum(active_items) filter (
+      where audience_scope = 'business_buyer'
+    ) as business_buyer_items,
+    count(*) filter (
+      where audience_scope = 'end_customer'
+        and active_items > 0
+    ) as end_customer_blocks,
+    sum(active_items) filter (
+      where audience_scope = 'end_customer'
+    ) as end_customer_items
+  from eligible_research
+  group by taxon_id, name, slug
+  having count(*) filter (
+      where audience_scope = 'business_buyer'
+        and active_items > 0
+    ) = 4
+     and count(*) filter (
+      where audience_scope = 'end_customer'
+        and active_items > 0
+    ) = 4
+),
+page_template as (
+  select id
+  from public.content_templates
+  where template_key = 'commercial_activation_page'
+    and template_family = 'commercial_activation'
+    and template_scope = 'page'
+    and version = 1
+    and status = 'active'
+    and is_active = true
+),
+composition_summary as (
+  select
+    composition.taxon_id,
+    count(*) filter (where composition.status = 'active') as active_compositions
+  from public.content_template_compositions composition
+  join page_template on page_template.id = composition.template_id
+  group by composition.taxon_id
+),
+artifact_summary as (
+  select
+    artifact.taxon_id,
+    count(*) filter (where artifact.status = 'draft') as drafts,
+    count(*) filter (where artifact.status = 'published') as published,
+    count(*) filter (where artifact.status = 'archived') as archived
+  from public.content_artifacts artifact
+  join page_template on page_template.id = artifact.template_id
+  where artifact.audience_scope = 'business_buyer'
+  group by artifact.taxon_id
+)
+select
+  eligible_taxons.name,
+  eligible_taxons.slug,
+  eligible_taxons.business_buyer_blocks,
+  eligible_taxons.business_buyer_items,
+  eligible_taxons.end_customer_blocks,
+  eligible_taxons.end_customer_items,
+  coalesce(composition_summary.active_compositions, 0) as active_compositions,
+  coalesce(artifact_summary.drafts, 0) as drafts,
+  coalesce(artifact_summary.published, 0) as published,
+  coalesce(artifact_summary.archived, 0) as archived,
+  case
+    when coalesce(artifact_summary.published, 0) > 0 then 'published'
+    when coalesce(artifact_summary.drafts, 0) > 0 then 'review'
+    else 'eligible_to_generate'
+  end as admin_state
+from eligible_taxons
+left join composition_summary
+  on composition_summary.taxon_id = eligible_taxons.taxon_id
+left join artifact_summary
+  on artifact_summary.taxon_id = eligible_taxons.taxon_id
+order by eligible_taxons.name, eligible_taxons.slug;


### PR DESCRIPTION
## Escopo

Implementa a E10.7 Fase 5 para permitir operação administrativa genérica de geração/regeneração/publicação de drafts comerciais por taxon elegível, sem hardcode do piloto.

## Principais mudanças

- Adiciona listagem administrativa de taxons elegíveis em `/admin/templates` sem materializar composição nem gerar draft na listagem.
- Usa geração/regeneração por ação explícita do operador, reutilizando o gerador server-side da Fase 2.
- Remove fallback implícito para o taxon piloto na geração de draft: `taxonSlug` passa a ser obrigatório.
- Adiciona `ensureCommercialActivationCompositionForTaxon(taxonId)` para materializar composição técnica sob demanda.
- Cria RPC `ensure_commercial_activation_composition(p_taxon_id uuid)` via migration, genérica por taxon, com `SECURITY DEFINER` e execução limitada a `service_role`.
- Mantém publicação pela RPC existente `publish_content_artifact_draft(uuid)`.
- Corrige a validação local de UUID em `publishCommercialActivationDraftAction`, que rejeitava UUID canônico e podia retornar `invalid_artifact` antes da RPC.
- Atualiza documentação técnica e cria snippet read-only de elegibilidade.

## Validações executadas

- `npm ci`: passou, com vulnerabilidades existentes reportadas pelo npm.
- `npm run check`: passou, com warnings existentes e 0 erros.
- `npm run validate:commercial-activation`: passou.
- `git diff --check`: passou.
- Teste local da regex de UUID: passou para UUID canônico e rejeitou valor sem hífen.
- `npx --yes supabase@2.106.0 db push --linked --dry-run`: passou, indicando apenas a migration desta PR como pendente.
- Validação read-only no Supabase: confirmou taxon piloto publicado e `Corretor Imóveis` elegível sem composição/draft/published/archived.
- Validação read-only pós-patch: confirmou que as contagens não mudaram, portanto as validações/listagem não materializaram composição nem draft.
- Inspeção de `/a`: sem referência a OpenAI, `draft-generation.ts`, `content_artifacts`, draft ou archived.
- Inspeção de hardcode: sem dependência de slug/nome do piloto em `app`/`lib`.

## Limitação de validação

A RPC `ensure_commercial_activation_composition(p_taxon_id uuid)` ainda não existe no Supabase real porque a migration desta PR não foi aplicada. Por isso, a geração real para um novo taxon elegível, a materialização sob demanda e a publicação real do draft devem ser validadas após merge e aplicação da migration.

## Fora do escopo confirmado

- Sem alteração em `/a/[account]`.
- Sem OpenAI em runtime público.
- Sem Account Dashboard.
- Sem LP Builder.
- Sem Agents SDK, Sandbox Agents, job, fila ou agente.
- Sem nova tabela, nova view ou nova hierarquia de taxons.
- Sem alteração de `research_version`.