### PR TITLE
docs: update commercial activation model scope

### DIFF
--- a/docs/platform-config.md
+++ b/docs/platform-config.md
@@ -147,9 +147,8 @@
 
 • `OPENAI_COMMERCIAL_ACTIVATION_MODEL`
 • Finalidade: modelo usado pela geração administrativa server-side de drafts `commercial_activation` da E10.7.
-• Escopo validado: Preview.
+• Escopo validado em 25/06/2026: Production e Preview, sem branch customizada na Vercel.
 • Valor atual de referência em Preview: `gpt-5.4-mini`
-• Production: pendente de decisão operacional antes de configurar.
 • Valor real de secret: não versionar.
 • Regra: deve conter apenas o ID do modelo; nunca inserir `OPENAI_API_KEY` nessa variável.
 


### PR DESCRIPTION
### Motivation
- Atualizar a documentação na seção `3.5` para substituir as linhas que indicavam `Escopo validado: Preview` e `Production: pendente...` por uma única linha que registra a validação em `25/06/2026` para Production e Preview, sem branch customizada na Vercel.

### Description
- Substituída a entrada em `docs/platform-config.md` referente a `OPENAI_COMMERCIAL_ACTIVATION_MODEL` por: `• Escopo validado em 25/06/2026: Production e Preview, sem branch customizada na Vercel.`.
- Alteração aplicada em um commit na branch `work` com mensagem `docs: update commercial activation model scope` (commit `c593b88`).
- Foi gerado o corpo de PR preparado (`docs: update commercial activation model scope`) porém o push/PR não foi publicado por ausência de remote configurado.

### Testing
- `git diff --check` e verificação de diff mostraram que a alteração é documental e sem problemas de formatação.  
- Commit criado com sucesso (`c593b88`) e `git status` confirmou a mudança; `git push` falhou devido a `fatal: No configured push destination.`.  
- `npm ci` e `npm run check` foram considerados não aplicáveis por se tratar de alteração exclusivamente documental.  
- Arquivo alterado: `docs/platform-config.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d45cbb1448329b1188d8c4b028f8a)