### PR TITLE
docs: registrar E10.7 Fase 5 concluída, RPC de composição e ajuste OPENAI_COMMERCIAL_ACTIVATION_MODEL

### DIFF
--- a/docs/platform-config.md
+++ b/docs/platform-config.md
@@ -2,8 +2,8 @@
 
 0.1 Cabeçalho
 • Documento: LP Factory 10 — Platform Config
-• Versão: v0.1.6
-• Data: 23/06/2026
+• Versão: v0.1.7
+• Data: 25/06/2026
 
 0.2 Contrato do documento
 • O QUE É: snapshot operacional e fonte única das configurações de plataformas externas do LP Factory 10, refletindo o estado conhecido/cadastrado nas plataformas conforme indicado.
@@ -147,11 +147,11 @@
 
 • `OPENAI_COMMERCIAL_ACTIVATION_MODEL`
 • Finalidade: modelo usado pela geração administrativa server-side de drafts `commercial_activation` da E10.7.
-• Escopo validado: Preview.
-• Valor atual de referência em Preview: `gpt-5.4-mini`
-• Production: pendente de decisão operacional antes de configurar.
+• Escopo: Production e Preview.
+• Valor atual de referência: `gpt-5.4-mini`.
 • Valor real de secret: não versionar.
 • Regra: deve conter apenas o ID do modelo; nunca inserir `OPENAI_API_KEY` nessa variável.
+• Regra operacional: usar escopo geral Production e Preview no MVP; evitar configuração presa a branch específica salvo necessidade futura comprovada.
 
 • `LPF_MCP_SECRET`
 • Finalidade: secret Bearer usado para autenticar chamadas ao MCP Supabase Inspect.
@@ -259,7 +259,10 @@
 • `OPENAI_COMMERCIAL_ACTIVATION_MODEL`
 • Plataforma: Vercel.
 • Finalidade: selecionar o modelo usado pela geração administrativa server-side de drafts `commercial_activation`.
+• Escopo: Production e Preview.
+• Valor atual de referência: `gpt-5.4-mini`.
 • Valor real: não versionar.
+• Regra: deve conter apenas o ID do modelo; nunca inserir `OPENAI_API_KEY` nessa variável.
 
 6.3.1 Endpoint externo atual
 • Endpoint OpenAI Responses API: `https://api.openai.com/v1/responses`
@@ -344,6 +347,8 @@
 • Configurações de plataformas, secrets por nome, workflows, ambientes e endpoints usados por automações devem ser registrados neste documento.
 
 99. Changelog
+v0.1.7 — 25/06/2026 — Atualizado `OPENAI_COMMERCIAL_ACTIVATION_MODEL` para escopo Production e Preview, com referência `gpt-5.4-mini` e regra operacional de não prender configuração a branch no MVP.
+
 v0.1.6 — 23/06/2026 — Registrado o estado operacional de `OPENAI_COMMERCIAL_ACTIVATION_MODEL` para E10.7 Fase 3: configurada e validada em Vercel Preview com modelo de referência, Production pendente de decisão operacional e sem exposição de secrets.
 
 v0.1.5 (22/06/2026) — Registrada a variável `OPENAI_COMMERCIAL_ACTIVATION_MODEL` como configuração server-side da geração administrativa de drafts `commercial_activation`, sem versionar valor real nem modelo padrão definitivo.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data: 23/06/2026
-• Versão: v1.5.83
+• Data: 25/06/2026
+• Versão: v1.5.84
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -762,8 +762,8 @@ Repositório — Ajustados
 • Implementar detecção por ambiente somente se o ganho justificar a complexidade.
 
 10.7 Páginas comerciais personalizadas por nicho
-• Status: Em execução faseada — Fase 4 concluída em 23/06/2026.
-• Próxima execução: Fase 5 — validação com segundo taxon.
+• Status: Em execução faseada — Fase 5 concluída em 25/06/2026.
+• Próxima execução: Fase 6 — Admin comercial enxuto e contrato fixo da página comercial.
 • Objetivo: gerar, revisar, publicar e consumir páginas comerciais por taxon; a IA roda apenas em operação administrativa/server-side; `/a/[account]` consome somente artefato publicado e validado; ausência de conteúdo nichado não pode quebrar `/a/[account]`.
 • Dependência estrutural: a E18 define os contratos reutilizáveis mínimos; a E10.7 aplica, valida e ajusta esses contratos no caso comercial concreto.
 • A página genérica `generic-v1` da E10.6 permanece concluída e será o fallback obrigatório.
@@ -778,6 +778,12 @@ Repositório — Ajustados
 • Não implementar LP Builder, liberação de LPs, continuidade de contas, bloqueio de novas ativações nem IA em runtime da página.
 • O conteúdo da página comercial é global por taxon e reutilizado por contas que resolvam a mesma página publicada; a exibição ocorre no contexto da conta e o tracking permanece vinculado ao `account_id`.
 • O taxon piloto valida o mecanismo, mas não limita a implementação ao seu slug.
+• Taxon elegível é definido por pesquisa estruturada completa.
+• Para `commercial_activation`, o template é universal por canal e não deve ser duplicado por taxon.
+• A estrutura da página comercial é fixa no MVP: Hero, Benefícios, Serviços, Planos, Diferenciais, Como funciona, FAQ e CTA final.
+• A IA gera copy dentro da estrutura definida; não decide seções nem ordem.
+• As cores permanecem universais do template comercial no MVP.
+• A composição por taxon é materialização técnica no schema atual, não composição estratégica nem tarefa manual do operador.
 
 10.7.2 Fase 1 — Ajuste documental e patch estrutural mínimo
 • Status: Concluída e validada em 21/06/2026.
@@ -842,12 +848,45 @@ Repositório — Ajustados
 • `lib/conversion-content/commercial-activation/renderer.tsx`
 • `lib/conversion-content/commercial-activation/validation-cases.ts`
 
-10.7.6 Fase 5 — Validação com segundo taxon
-• Escopo: confirmar que a solução não depende do taxon piloto.
-• Validar: 8 pesquisas `active version 1`; composição ativa; geração IA; draft; publicação; renderização própria; fallback por ancestral quando aplicável; `generic-v1` quando necessário; ausência de regra específica por slug.
-• Critério de conclusão: segundo taxon validado, fluxo reutilizável, E10.7 operacional e sem mudança estrutural desnecessária.
+10.7.6 Fase 5 — Validação com segundo taxon e composição genérica
+• Status: Concluída em 25/06/2026.
+• Estado atual: `/admin/templates` lista taxons elegíveis por pesquisa estruturada completa e permite gerar/publicar página `commercial_activation` para qualquer taxon elegível.
+• Geração: exige `taxonSlug`; o fallback implícito para o taxon piloto foi removido.
+• Composição: `ensureCommercialActivationCompositionForTaxon(taxonId)` materializa composição técnica sob demanda quando o taxon elegível ainda não tem composição ativa.
+• Publicação: continua usando `publish_content_artifact_draft(uuid)`.
+• Consumo: `/a/[account]` permanece consumindo somente página publicada e validada.
+• Limites: não cria template por taxon, não leva IA para runtime público, não cria procedimento manual de composição por taxon e não altera a hierarquia dos taxons.
+• Pendência vigente: trocar erro técnico `missing_openai_env` por mensagem amigável quando aplicável.
+• Updates Supabase aplicados: `#Supa36`, `#Supa05`, `#Supa40` e `#Supa58`.
 
-10.7.7 Exibição, fallbacks e tracking
+10.7.6.1 Estruturas e artefatos
+
+Banco — Criados
+• `ensure_commercial_activation_composition(p_taxon_id uuid)`
+
+Repositório — Criados
+• `supabase/migrations/20260624203000_e10_7_phase_5_ensure_commercial_activation_composition.sql`
+• `supabase/snippets/e10_7_phase_5_eligible_taxons_verify.sql`
+
+Repositório — Ajustados
+• `app/admin/(protected)/templates/page.tsx`
+• `app/admin/(protected)/templates/actions.ts`
+• `lib/admin/adapters/adminCommercialActivationTemplatesAdapter.ts`
+• `lib/conversion-content/commercial-activation/draft-generation.ts`
+• `lib/conversion-content/commercial-activation/composition.ts`
+• `docs/lousa-plano-base-e10-7.md`
+• `docs/schema.md`
+• `docs/platform-config.md`
+
+10.7.7 Fase 6 — Admin comercial enxuto e contrato fixo da página comercial
+• Status: Planejada.
+• Escopo: transformar `/admin/templates` em lista limpa e mover operação detalhada para página própria por taxon.
+• Rota prevista: `/admin/templates/commercial-activation/[taxonSlug]`.
+• Incluir na página específica: status do taxon, gerar/regenerar draft, publicar draft, preview, histórico e diagnóstico técnico secundário.
+• Aplicar loading/disable nos botões no local definitivo.
+• Pendências futuras: edição manual simples do draft e avaliação de uso do latest published como base para novas regenerações.
+
+10.7.8 Exibição, fallbacks e tracking
 • Fluxo em `/a/[account]`: conta `active` → resolver `account_id` → resolver taxon primário ativo → procurar bundle `commercial_activation` publicado → renderizar página nichada somente quando o bundle estiver `ready` → usar `generic-v1` quando não houver bundle consumível.
 • Preservar `NicheResolutionCard` acima da página quando aplicável.
 • Conta sem taxon, taxon inativo ou inválido, pesquisa incompleta, composição ausente ou inválida, página não publicada, artifact inválido, erro de leitura ou render model não `ready` usam a página genérica E10.6 como fallback seguro.
@@ -1299,6 +1338,8 @@ Repositório — Criados
 • Esta referência não cria obrigação de implementar E19 agora.
 
 99. Changelog
+v1.5.84 — 25/06/2026 — E10.7 Fase 5 concluída com taxons elegíveis por pesquisa estruturada completa, composição técnica genérica sob demanda, geração/publicação `commercial_activation` por `taxonSlug` e próxima Fase 6 planejada para Admin comercial enxuto.
+
 v1.5.83 — 23/06/2026 — E10.7 Fase 4 concluída com consumo no Account Dashboard: `/a/[account]` renderiza bundle `commercial_activation` publicado e `ready`, mantém fallback `generic-v1`, preserva `NicheResolutionCard` e tracking comercial, rejeita draft/archived/artifact inválido e mantém IA fora do runtime público.
 
 v1.5.82 — 23/06/2026 — E10.7 Fase 3 concluída com operação administrativa mínima em `/admin/templates`: geração/regeneração de draft, preview administrativo, publicação via RPC existente, validação server-side do draft publicável, resolução compartilhada por `content_template_taxons` e estado real validado com `v3` published, `v2` draft histórico e `v1` archived.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data da última atualização: 21/06/2026
-• Documento: LP Factory 10 — Schema (DB Contract) v1.0.27
+• Data da última atualização: 25/06/2026
+• Documento: LP Factory 10 — Schema (DB Contract) v1.0.29
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -709,13 +709,20 @@
 • Garantia complementar: `content_artifacts_one_published_uidx` mantém no máximo um `published` por (`template_id`, `taxon_id`, `audience_scope`).
 • Risco residual aceito para Fase 2: geração segura da próxima `artifact_version`; a UNIQUE `(template_id, composition_id, taxon_id, audience_scope, research_version, artifact_version)` protege colisão, mas o fluxo de geração ainda deve calcular ou tentar inserir a próxima versão de forma segura.
 
-3.3.5 ensure_commercial_activation_composition(p_taxon_id uuid) → content_template_compositions
-• Segurança: SECURITY DEFINER (aprovado; materialização técnica controlada para E10.7 Fase 5)
-• search_path: public, pg_temp
-• Grants de EXECUTE: service_role
-• Sem EXECUTE para public, anon ou authenticated
-• Efeito: valida taxon ativo e pesquisa completa `active version 1` para `business_buyer` e `end_customer` nos blocos `strategic_core`, `lp_overview`, `lp_sections` e `seo`; retorna composição ativa existente ou materializa vínculo `content_template_taxons`, composição v1 ativa e oito itens técnicos `commercial_activation`.
-• Limites: não cria template, não duplica template por taxon, não gera draft, não publica, não roda na listagem e não depende de slug/nome de taxon.
+3.3.5 public.ensure_commercial_activation_composition(p_taxon_id uuid) → content_template_compositions
+• Finalidade: garantir composição técnica `commercial_activation` para taxon elegível.
+• Entrada: `p_taxon_id uuid`.
+• Comportamento: retorna composição existente quando houver composição ativa; materializa composição técnica quando o taxon elegível ainda não tiver composição ativa.
+• Valida taxon ativo.
+• Valida pesquisa estruturada completa.
+• Usa template existente `commercial_activation_page`.
+• Não cria novo template por taxon.
+• Não depende de slug, nome de taxon ou taxon piloto.
+• Segurança: SECURITY DEFINER.
+• search_path: public, pg_temp.
+• EXECUTE: somente `service_role`.
+• `public`, `anon` e `authenticated`: sem `EXECUTE`.
+• Migration relacionada: `supabase/migrations/20260624203000_e10_7_phase_5_ensure_commercial_activation_composition.sql`.
 
 3.4 Convites de Conta
 • accept_account_invite(account_id uuid, ttl_days int) → boolean
@@ -802,6 +809,9 @@
 • Rollback: não remove automaticamente a extensão, pois pode ser reutilizada por outros recursos
 
 99. Changelog
+v1.0.29 (25/06/2026) — E10.7 Fase 5: contrato consolidado da RPC de composição técnica genérica
+• Atualizado o contrato da RPC `public.ensure_commercial_activation_composition(p_taxon_id uuid)` com finalidade, entrada, comportamento, validações, grants e migration relacionada.
+
 v1.0.28 (24/06/2026) — E10.7 Fase 5: composição técnica genérica
 • Registrada a RPC `ensure_commercial_activation_composition(uuid)` para materialização técnica controlada de composição `commercial_activation` por taxon elegível.
 • Registrados limites: execução apenas via `service_role`, sem acesso público/authenticated direto, sem criação de template, sem geração de draft e sem execução na listagem administrativa.


### PR DESCRIPTION
### Motivation
- Aplicar o relatório da E10.7 Fase 5 ao conjunto canônico de documentos do projeto para registrar o estado final da fase e contratos técnicos decorrentes.
- Consolidar o contrato DB da nova RPC de materialização técnica e atualizar a configuração operacional do modelo OpenAI usada pela geração administrativa.

### Description
- Atualizei `docs/roadmap.md` para registrar E10.7 Fase 5 como concluída em `25/06/2026`, incluir decisões vigentes da Fase 5, inserir a seção `10.7.6` com estado concluído, adicionar `10.7.6.1 Estruturas e artefatos`, planejar a Fase 6 e renumerar a seção de exibição/fallbacks para `10.7.8`.
- Atualizei `docs/schema.md` (versão/data) e consolidei o contrato da RPC `public.ensure_commercial_activation_composition(p_taxon_id uuid)` com finalidade, entrada, comportamento, validações, segurança (`SECURITY DEFINER`), `search_path`, grants (`EXECUTE` somente para `service_role`) e referência à migration relacionada.
- Atualizei `docs/platform-config.md` (versão/data) para ajustar `OPENAI_COMMERCIAL_ACTIVATION_MODEL` ao escopo Production e Preview, definir valor de referência `gpt-5.4-mini`, reforçar regra de nunca versionar o secret e adicionar regra operacional para evitar atar a configuração a branchs.
- Arquivos alterados: `docs/roadmap.md`, `docs/schema.md`, `docs/platform-config.md`; branch usada: `codex/abc-e10-7-fase-5`; PR não publicado porque o push falhou localmente por falta de remote `origin` configurado.

### Testing
- Executado `git diff --check` e não foram encontrados problemas de whitespace ou erros de diff.
- Executado `git status --short --branch` e `git diff --stat` para revisar o diff antes do commit; resultado mostrou 3 arquivos modificados e mudanças esperadas.
- `npm ci` e `npm run check` foram considerados não aplicáveis por se tratar de alteração exclusivamente documental.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d6693de78832995e27bdfc86fa55b)