### PR TITLE
docs: fechar Fase 5 da lousa E10.7 e criar Fase 6

### DIFF
--- a/docs/lousa-plano-base-e10-7.md
+++ b/docs/lousa-plano-base-e10-7.md
@@ -1,141 +1,115 @@
 23/06/2026 — Lousa base flexível E10.7
 docs/lousa-plano-base-e10-7.md
-Fontes: chat, PR #435, docs/roadmap.md, docs/base-tecnica.md, docs/schema.md, docs/platform-config.md, docs/automations.md
+Fontes: chat, PR #435, PR #440, docs/roadmap.md, docs/base-tecnica.md, docs/schema.md, docs/platform-config.md, docs/automations.md, docs/supa-up.md
 
 1. Objetivo
-
-* Manter o plano base vivo da E10.7 sem inflar o roadmap.
+* Manter o plano vivo da E10.7 sem inflar o roadmap.
 * Registrar decisões, invariantes, status, fases e ajustes do caso.
 * Servir como fonte obrigatória antes de briefing, implementação, review e merge.
 * Roadmap e docs oficiais só são atualizados após fase implementada e mergeada.
 * Não substituir docs oficiais nem virar relatório histórico longo.
 
 2. Status atual
-
-* Fases 1 a 4 implementadas.
+* Fases 1 a 5 implementadas.
 * Fase 4 mergeada pela PR #435.
+* Fase 5 mergeada pela PR #440.
+* Fase 5 validada em Production.
+* Fluxo mínimo E10.7 validado: elegível → draft → published → consumo público.
 * /a/[account] consome artifact published válido.
+* Draft e archived fora do consumo público.
+* IA fora do runtime público.
 * Fallback generic-v1 preservado.
 * Tracking comercial preservado.
-* Draft e archived fora do consumo público.
-* Validação de render model antes de ready implementada.
-* Relatório da Fase 4 enviado ao Gestor de Docs.
-* ABC documental da Fase 4 pendente de confirmação final.
-* Fase 5 pendente de briefing.
+* Próximo trabalho: Fase 6.
 
 3. Caso de uso
-
 E10.7 — Páginas comerciais personalizadas por taxon
-
 * Gerar, revisar, publicar e consumir páginas comerciais por taxon a partir de pesquisa estruturada.
 * Validar primeiro com taxon piloto e depois com taxons elegíveis.
 * Evitar regra hardcoded do taxon piloto.
 * Permitir que qualquer taxon elegível apareça para o operador gerar draft quando desejar.
 
-4. Papéis conceituais
-
+4. Papéis e decisões fixas
 4.1 Template de canal
+* commercial_activation usa template universal por canal.
+* Página comercial tem estrutura fixa no MVP.
+* IA gera copy dentro da estrutura.
+* IA não escolhe seções nem ordem.
+* Cores são universais do template comercial no MVP.
+* IA não escolhe cores livres.
+* Template não é exclusivo de um taxon.
+* Template não deve ser duplicado por taxon.
 
-* É universal por canal.
-* O canal atual é commercial_activation.
-* Define tipo de entrega, contrato geral, família, renderer compatível, validações e capacidades aceitas.
-* Não é exclusivo de um taxon.
-* Não deve ser duplicado por taxon.
-* Não define sozinho a estratégia fixa de seções para todos os nichos.
+4.2 Estrutura fixa da página comercial
+* Hero.
+* Benefícios.
+* Serviços.
+* Planos.
+* Diferenciais.
+* Como funciona.
+* FAQ.
+* CTA final.
 
-4.2 Composição técnica
-
-* É o arranjo técnico resolvido para renderizar uma entrega.
+4.3 Composição técnica
+* É arranjo técnico resolvido para renderizar a entrega.
 * Pode estar materializada com taxon_id no schema atual.
-* Não deve ser confundida com o template universal do canal.
+* Composição física por taxon é materialização técnica do schema atual.
+* Composição física por taxon não é composição estratégica.
+* Não deve ser confundida com template universal do canal.
 * Não deve virar tarefa do operador.
-* Não deve virar critério manual de elegibilidade.
-* Se o sistema não conseguir gerar para taxon elegível por falta de composição técnica, isso é ajuste interno da E10.7.
+* Operador não prepara composição.
 
-4.3 Estrutura estratégica de seções
-
-* Define quais seções entram, em que ordem e com qual função.
-* Pode variar por canal, segmento, nicho ou taxon.
-* Para LPs, deve ser orientada por LP Sections ou bloco estrutural equivalente.
-* Para commercial_activation, pode usar composição mínima inicial.
-* A composição mínima inicial não deve virar regra universal rígida para todos os canais e nichos.
-
-4.4 Taxon
-
-* Define pesquisa, conteúdo, página gerada, artifact e consumo final.
-* Taxon não exige novo template de canal.
+4.4 Taxon e artifact
+* Taxon define pesquisa, conteúdo, página gerada, artifact e consumo final.
 * Taxon elegível aparece na lista mesmo sem draft.
-* O operador decide se quer gerar draft para o taxon elegível.
-
-4.5 Artifact
-
-* É sempre por taxon.
+* Operador decide gerar draft para taxon elegível.
+* Artifact é sempre por taxon.
 * Draft, published e archived são por taxon.
-* content_json é específico do taxon.
 * Published só é consumido se validar o contrato do renderer.
 
 5. Elegibilidade
-
 Taxon aparece como elegível para geração quando possui:
-
 * taxon ativo;
 * business_buyer active v1 com 4 blocos;
 * end_customer active v1 com 4 blocos;
 * itens estruturados suficientes.
-
 Blocos exigidos:
-
 * strategic_core;
 * lp_overview;
 * lp_sections;
 * seo.
-
 Regras:
-
 * não exigir novo template por taxon;
 * não exigir composição manual por taxon;
 * não gerar draft automaticamente;
 * template, composição técnica, renderer e geração são responsabilidade interna do sistema.
-
 Status:
-
 * critério validado no piloto;
 * critério validado em Corretor Imóveis;
-* listagem flexível por elegibilidade ainda pendente;
-* resolver/estrutura ainda precisa evitar dependência indevida do taxon piloto.
+* listagem flexível implementada na Fase 5;
+* dependência indevida do taxon piloto removida.
 
 6. Estados da lista admin
-
 6.1 Publicado
-
 * Taxon tem artifact published válido.
 * Pode ser consumido em /a/[account].
-* Pode ser visualizado no admin.
-* Pode receber nova geração/regeneração se o operador decidir.
-
+* Pode receber nova geração/regeneração se operador decidir.
 6.2 Em revisão
-
 * Taxon tem draft criado.
 * Ainda não foi publicado.
 * Pode ser visualizado, regenerado ou publicado.
-
 6.3 Elegível para gerar
-
 * Taxon tem pesquisa estruturada completa.
 * Ainda não precisa ter draft.
 * Ainda não precisa ter published.
-* Aparece na lista para o operador iniciar geração quando quiser.
+* Aparece para o operador iniciar geração.
 * A listagem não gera draft automaticamente.
-
 6.4 Incompleto
-
 * Não aparece na lista principal do MVP.
 * Diagnóstico de incompletos fica fora do escopo inicial, salvo pedido explícito.
 
 7. Runtime público
-
 /a/[account]
-
 * Não usa OpenAI.
 * Não usa Responses API.
 * Não usa OPENAI_API_KEY.
@@ -151,33 +125,23 @@ Status:
 * Se não houver bundle ready, cai em generic-v1.
 * Preserva NicheResolutionCard quando aplicável.
 * Preserva tracking comercial existente.
-
-Status:
-implementado na Fase 4 e revisado na PR #435.
+Status: implementado na Fase 4 e preservado na Fase 5.
 
 8. Tracking comercial
-
 Eventos:
-
 * commercial_page_view;
 * commercial_primary_cta_click;
 * commercial_plan_cta_click.
-
 Regras:
-
 * vinculados ao account_id;
 * sem PII;
 * sem content_json;
 * sem payload de pesquisa;
 * falha de tracking não quebra página pública.
-
-Status:
-implementado/preservado na Fase 4.
+Status: implementado/preservado desde a Fase 4.
 
 9. Escopo negativo permanente
-
 Não fazer dentro da E10.7 sem decisão explícita:
-
 * LP Builder;
 * editor visual;
 * liberação de LPs;
@@ -202,42 +166,34 @@ Não fazer dentro da E10.7 sem decisão explícita:
 * procedimento manual para tornar taxon elegível.
 
 10. Banco e schema
-
 * Não alterar schema sem blocker real.
 * Se fase exigir schema, migration, policy, grant, RPC ou tabela, Executor deve parar e devolver ao Estrategista.
 * Supabase pode ser usado em leitura server-side e tracking existente.
 * Mutação de banco só por fluxo aprovado da aplicação ou migration explicitamente aprovada.
 * Schema atual ainda possui composição vinculada a taxon_id.
-* Fase 5 deve tentar resolver por código/contrato atual antes de propor migration.
-
-Status:
-Fase 4 não alterou schema.
+* Fase 5 teve blocker real e aprovou RPC/migration mínima.
+* Fase 6 não deve alterar schema sem novo blocker.
 
 11. Fases
-
 11.1 Fase 1 — Base técnica
-
 * Status implementação: implementada.
 * Status documentação: registrada nas fontes do projeto.
 * Objetivo: preparar base de templates, composições, artifacts e contratos mínimos.
 * Resultado: estrutura inicial validada com taxon piloto.
 
 11.2 Fase 2 — Geração administrativa de draft
-
 * Status implementação: implementada.
 * Status documentação: registrada em relatórios/docs do caso.
 * Objetivo: gerar draft commercial_activation com IA apenas no admin/server-side.
 * Resultado: draft persistido por taxon no piloto.
 
 11.3 Fase 3 — Operação administrativa mínima
-
 * Status implementação: implementada.
 * Status documentação: relatório anterior gerado.
 * Objetivo: gerar, regenerar, visualizar e publicar.
 * Resultado: publicação arquiva published anterior; draft/archived fora do consumo público.
 
 11.4 Fase 4 — Consumo em /a/[account]
-
 * Status implementação: implementada e mergeada pela PR #435.
 * Status documentação: relatório enviado ao Gestor de Docs; ABC final pendente de confirmação.
 * Implementado: published válido em /a/[account].
@@ -248,184 +204,160 @@ Fase 4 não alterou schema.
 * Implementado: sem IA em runtime público.
 
 11.5 Fase 5 — Lista flexível de taxons elegíveis e ajuste interno do canal comercial
+* Status implementação: concluída.
+* Status validação: validada em Production.
+* PR: #440.
+* Resultado: fluxo mínimo validado.
+* Confirmou lista de taxons elegíveis por pesquisa estruturada completa.
+* Confirmou Corretor Imóveis como caso de validação, não solução pontual.
+* Confirmou materialização técnica genérica de composição commercial_activation.
+* Confirmou geração de draft por ação do operador.
+* Confirmou publicação do draft.
+* Confirmou versionamento publicado.
+* Confirmou consumo de published em /a/[account].
+* Confirmou runtime público sem IA, sem draft e sem archived.
 
-* Status implementação: pendente.
-* Status documentação: esta lousa define a base do briefing.
-* Objetivo: listar taxons elegíveis por pesquisa estruturada completa.
-* Objetivo: permitir que qualquer taxon elegível apareça para geração de draft quando o operador quiser.
-* Objetivo: não gerar draft automaticamente durante a listagem.
-* Objetivo: resolver internamente a dependência indevida de composição do piloto.
-* Objetivo: separar template de canal, composição técnica, estrutura de seções e artifact.
-* Objetivo: validar pelo menos dois estados reais: taxon publicado e taxon elegível sem página gerada.
-* Não é objetivo: criar procedimento manual para tornar taxon elegível.
-* Não é objetivo: gerar draft automaticamente para segundo taxon.
-* Não é objetivo: publicar automaticamente segundo taxon.
-* Não é objetivo: limitar solução ao taxon Corretor Imóveis.
-* Não é objetivo: duplicar template por taxon.
-* Não é objetivo: exigir composição manual por taxon.
-* Não é objetivo: criar migration sem blocker real.
+11.5.1 Implementação da Fase 5
+* /admin/templates lista taxons elegíveis.
+* A lista não cria composição.
+* A lista não gera draft.
+* Geração exige ação do operador.
+* taxonSlug passou a ser obrigatório.
+* Removido fallback implícito para taxon piloto.
+* Criado ensureCommercialActivationCompositionForTaxon.
+* Criada RPC ensure_commercial_activation_composition(p_taxon_id uuid).
+* RPC valida taxon ativo e pesquisa completa.
+* RPC materializa composição técnica quando necessário.
+* RPC retorna composição existente quando já houver.
+* RPC não depende de slug, nome do taxon, Corretor Imóveis ou piloto.
+* Publicação continua via publish_content_artifact_draft.
+* Corrigido isUuid para UUID canônico 8-4-4-12.
 
-11.5.1 Updates aplicáveis à Fase 5
+11.5.2 Validação em Production
+* OPENAI_API_KEY validada em Production and Preview.
+* OPENAI_COMMERCIAL_ACTIVATION_MODEL validada em Production and Preview.
+* Redeploy Production executado.
+* Migration 20260624203000 aplicada.
+* RPC ensure_commercial_activation_composition existente no Supabase real.
+* service_role pode executar a RPC.
+* anon e authenticated não executam.
+* Corretor Imóveis: Elegível para gerar → Em revisão → Publicado.
+* Corretor de imóveis de médio padrão: nova versão gerada e publicada; published atual v5.
+* /a/acc-f855e6ef abriu LP publicada corretamente.
+* Fluxo mínimo da E10.7 validado em Production.
 
-Objetivo da Fase 5:
+11.5.3 Updates aplicados na Fase 5
+#Supa36 — Data API / PostgREST 14.1
+* Aplicado nas leituras server-side da listagem admin.
+* Usado para taxons, pesquisas, compositions e artifacts.
+* Mantidas colunas explícitas, ordenação determinística e sem endpoint público novo.
+#Supa05 — Logs seguros
+* Aplicado em falhas de geração, materialização e leitura admin.
+* Não logar content_json, payload completo, texto gerado por IA, PII ou blocos brutos.
+* Pendente UX: trocar missing_openai_env por mensagem amigável quando aplicável.
+#Supa40 — SQL snippets locais
+* Aplicado com snippet read-only.
+* Arquivo: supabase/snippets/e10_7_phase_5_eligible_taxons_verify.sql.
+* Usado para validar elegibilidade, composição e artifacts.
+#Supa58 — GRANT explícito para novos objetos
+* Aplicado como trava e checklist de governança.
+* Blocker real justificou migration/RPC.
+* RPC criada com SECURITY DEFINER.
+* EXECUTE apenas para service_role.
+* EXECUTE revogado de public, anon e authenticated.
+* Sem nova tabela, sem nova view e sem refatoração ampla de schema.
 
-* Listar taxons elegíveis por pesquisa estruturada completa.
-* Corrigir a dependência indevida do taxon piloto.
-* Não criar processo manual.
-* Não gerar draft automaticamente.
-* Não antecipar migration.
-* Usar os updates abaixo apenas como referência técnica, validação ou trava.
+11.6 Fase 6 — Admin comercial enxuto e contrato fixo da página comercial
+* Status implementação: planejada.
+* Objetivo: transformar /admin/templates em lista limpa.
+* Objetivo: criar página operacional específica por taxon.
+* Objetivo: mover gerar, regenerar, publicar, preview e histórico para a página específica.
+* Objetivo: aplicar loading/disable nos botões no local definitivo.
+* Objetivo: consolidar contrato fixo da página commercial_activation.
+* Objetivo: registrar edição manual de draft como pendência futura.
+* Rota sugerida: app/admin/(protected)/templates/commercial-activation/[taxonSlug].
+* Rota equivalente pode ser usada se a estrutura real do Next.js indicar path melhor.
+Regras:
+* /admin/templates deve ficar apenas como lista limpa.
+* Selecionar deve navegar para a página operacional do taxon.
+* Lista não deve mostrar preview.
+* Lista não deve mostrar histórico.
+* Lista não deve publicar.
+* Lista não deve materializar composição.
+* Lista não deve gerar draft.
+* Página do taxon deve conter status, gerar/regenerar, publicar, preview, histórico e diagnóstico técnico mínimo.
+* Botão Gerar draft deve usar loading/disable com Gerando...
+* Botão Regenerar draft deve usar loading/disable com Regenerando...
+* Botão Publicar draft deve usar loading/disable com Publicando...
+* Não incluir edição manual de draft nesta fase.
+* Não incluir IA assistida para edição.
+* Não incluir regeneração baseada em latest published nesta fase.
+* Não alterar runtime público.
+* Não alterar schema sem novo blocker.
 
-supa#36 — Data API / PostgREST 14.1
+12. Lacuna confirmada — próximos drafts
+* Confirmado em 25/06/2026: novo draft não usa a página publicada mais recente como base editorial.
+* Geração atual usa taxon ativo, pesquisa estruturada v1, composição técnica e planos.
+* Prompt atual não inclui published, content_json anterior, artifact_id publicado ou texto da página publicada.
+* artifact_version apenas incrementa versão; não serve como base editorial.
+* Diagnóstico: nova versão é gerada a partir das fontes estruturadas atuais.
+* Decisão MVP: manter modo atual funcionando.
+* Pendência futura: edição manual simples do draft antes de publicar.
+* Pendência posterior: regenerar draft usando latest published como referência.
+Modos possíveis para futuro:
+* Gerar do zero: fontes estruturadas.
+* Editar manualmente: humano ajusta draft antes de publicar.
+* Regenerar com base: usar latest published como referência editorial.
 
-* Referência técnica para leituras server-side no Supabase usando Data API/PostgREST.
-* Aplicar nas leituras server-side que montam a lista de taxons elegíveis.
-* Aplicar ao buscar taxons ativos, pesquisas estruturadas completas, artifacts existentes, published/draft quando necessário para estado da lista e composição técnica relacionada ao canal commercial_activation.
-* Resolver a listagem no servidor, seguindo os contratos da Base Técnica, sem criar endpoint público novo e sem expor dados sensíveis.
-
-supa#5 — Logs seguros
-
-* Usar para falhas, fallback e diagnóstico técnico sem vazar conteúdo sensível.
-* Aplicar em erro de leitura, taxon que deveria ser elegível mas não aparece, falha ao resolver composição técnica, fallback interno ou inconsistência entre pesquisa, artifact e estado exibido.
-* Pode logar status técnico, motivo resumido da falha, request/rid quando disponível e identificador técnico permitido de account/taxon.
-* Não pode logar content_json, payload completo de pesquisa, texto gerado por IA, dados pessoais ou conteúdo bruto de blocos estruturados.
-
-supa#40 — SQL snippets locais
-
-* Aplicar somente se for necessário validar elegibilidade ou composição fora da UI.
-* Exemplos: conferir business_buyer completo, end_customer completo, 4 blocos exigidos, artifact draft/published ou composição técnica prendendo fluxo ao piloto.
-* Se houver SQL de validação, versionar em supabase/snippets.
-* Não deixar query solta no chat ou no Studio.
-
-supa#58 — GRANT explícito para novos objetos
-
-* Usar como trava de segurança se surgir necessidade de nova tabela, view, função, RPC, grant, policy ou migration.
-* Fase 5 deve tentar resolver com schema atual.
-* Se surgir mudança de banco, Executor deve parar e devolver ao Estrategista.
-* Não aplicar supa#58 como tarefa inicial; usar como trava para impedir mudança de banco sem decisão explícita.
-
-revalidatePath
-
-* Usar somente se houver mutação administrativa que altere o estado exibido na tela.
-* Exemplos: gerar draft, regenerar draft, publicar, arquivar ou atualizar estado administrativo que afete a lista.
-* Na listagem simples, sem mutação, não aplicar.
-* Não usar como arquitetura antecipada.
-
-Recursos que não cabem na Fase 5
-
-* Não usar Responses API.
-* Não usar Agents SDK.
-* Não usar Sandbox Agents.
-* Não usar plugin Supabase como dependência operacional.
-* Não usar filas.
-* Não usar jobs.
-* Não usar automação operacional.
-* Não usar IA em runtime público.
-* Não usar pgvector.
-* Não usar pg_trgm.
-* Não usar busca avançada.
-* Não criar migration sem blocker real.
-
-Conclusão:
-
-* Aplicar supa#36 nas leituras server-side.
-* Aplicar supa#5 nos logs seguros.
-* Aplicar supa#40 se houver validação SQL read-only.
-* Aplicar supa#58 como trava se surgir mudança de banco.
-* Usar revalidatePath somente se houver mutação administrativa.
-* Não aplicar agentes, IA em runtime público, filas, jobs ou nova infraestrutura.
-
-11.5.2 Blocker estrutural e decisão de desbloqueio
-
-* Blocker confirmado em 24/06/2026.
-* `content_artifacts` exige FK composta com `composition_id`, `template_id`, `taxon_id` e `composition_version`.
-* Taxon elegível sem composição ativa não consegue gerar draft válido no fluxo atual.
-* Corretor Imóveis é caso de validação, não solução pontual.
-* Decisão: criar mecanismo interno e genérico para garantir/materializar composição técnica `commercial_activation` quando operador acionar geração de draft para qualquer taxon elegível.
-* A listagem não materializa composição.
-* A listagem não gera draft.
-* O operador não prepara composição.
-* Template continua universal por canal.
-* Composição técnica pode continuar fisicamente por taxon no schema atual.
-* Materialização técnica não pode duplicar template de canal.
-* Materialização técnica não pode depender de slug ou nome de taxon.
-* Migration, grant, função ou RPC ficam limitados ao desbloqueio estrutural mínimo aprovado nesta fase.
-
-12. E18 e papéis dos templates
-
-12.1 E18
-
+13. E18 e papéis dos templates
+13.1 E18
 * E18 criou/organiza os templates do canal.
 * commercial_activation é o canal/família usado pela E10.7.
 * O template de página commercial_activation_page define a entrega de página comercial.
 * Os templates de section definem módulos disponíveis do canal.
-
-12.2 Template
-
+13.2 Template
 * Define canal, contrato e capacidades.
 * Não define sozinho a estratégia de conteúdo do taxon.
 * Não deve ser duplicado para cada taxon.
-
-12.3 Composição técnica
-
+13.3 Composição técnica
 * Resolve arranjo técnico de módulos.
 * Pode estar materializada com taxon_id no schema atual.
 * Não deve ser confundida com template universal do canal.
-* Pode precisar de resolver canônico ou fallback técnico na Fase 5.
 * Não é etapa do operador.
+13.4 Estrutura de seções
+* Define contrato fixo da página comercial no MVP.
+* Pode evoluir depois sem transformar IA em dona da ordem das seções.
 
-12.4 Estrutura de seções
-
-* Define estratégia de seções por canal/nicho/taxon.
-* Para LPs, deve vir de LP Sections ou bloco estrutural equivalente.
-* Para commercial_activation, pode usar composição mínima inicial.
-* Pode evoluir sem transformar template de canal em estrutura rígida para todos os casos.
-
-13. Taxons conhecidos
-
-13.1 Taxon piloto
-
+14. Taxons conhecidos
+14.1 Taxon piloto
 Corretor de imóveis de médio padrão
 corretor-de-imoveis-de-medio-padrao
-
 * Pesquisa completa.
 * Draft criado.
-* Published v3 validado.
-* Archived v1.
-* Draft v2.
+* Published v3 validado na Fase 4.
+* Nova versão gerada e publicada na Fase 5.
+* Published atual v5 em Production.
 * Consumo em /a/[account] implementado.
-* Usado para validar fases 1 a 4.
-
-13.2 Taxon candidato elegível por pesquisa
-
+* Usado para validar fases 1 a 5.
+14.2 Taxon elegível validado
 Corretor Imóveis
 corretor-imoveis
-
 * business_buyer completo.
 * end_customer completo.
-* Ainda sem página comercial gerada.
-* Deve aparecer como elegível após ajuste da Fase 5.
-* Não deve exigir novo template de canal.
-* Não deve exigir composição manual por taxon.
-* Draft só deve ser gerado se operador acionar geração.
+* Validado na Fase 5 como elegível sem solução pontual.
+* Passou por Elegível para gerar → Em revisão → Publicado.
+* Não exigiu novo template de canal.
+* Não exigiu composição manual por taxon.
+* Draft só foi gerado por ação do operador.
 
-14. Ajuste identificado após Fase 4
+15. Pendências futuras
+* Edição manual simples do draft antes de publicar.
+* Regeneração usando latest published como referência editorial.
+* Mensagem amigável para missing_openai_env.
+* IA assistida para edição somente depois.
+* Temas visuais avançados somente depois, se necessário.
 
-* Decisão estratégica: template universal por canal comercial.
-* Implementação atual: composição técnica ainda resolvida por taxon_id.
-* Risco: confundir composição técnica com template universal.
-* Risco: transformar amarra técnica em etapa operacional do usuário.
-* Risco: criar burocracia para cada taxon novo.
-* Risco: forçar migration prematura.
-* Risco: criar cópia manual por taxon sem necessidade operacional clara.
-* Decisão: elegibilidade é definida pela pesquisa estruturada completa.
-* Decisão: composição/template/renderer são responsabilidade interna do sistema.
-* Decisão: Fase 5 deve corrigir a dependência do piloto sem criar novo procedimento para o operador.
-* Decisão: geração de draft deve ser ação do operador.
-* Decisão: não criar migration se houver solução simples com contrato atual.
-
-15. Regra de briefing
-
+16. Regra de briefing
 * Citar esta lousa.
 * Declarar fase alvo.
 * Declarar escopo positivo.
@@ -437,8 +369,7 @@ corretor-imoveis
 * Declarar que draft só é gerado por ação do operador.
 * Declarar separação entre template de canal, composição técnica, estrutura de seções e artifact.
 
-16. Regra de review
-
+17. Regra de review
 * Comparar implementação com esta lousa.
 * Verificar se decisões fixas foram preservadas.
 * Verificar se não houve expansão indevida.
@@ -452,8 +383,7 @@ corretor-imoveis
 * Verificar se eventual falha técnica de composição não foi transformada em tarefa do operador.
 * Verificar se composição técnica não foi tratada como decisão estratégica universal sem cuidado com schema atual.
 
-17. Regra de atualização documental
-
+18. Regra de atualização documental
 * Após fase mergeada, gerar relatório de encerramento.
 * Enviar relatório ao Gestor de Docs.
 * Aplicar prompt-abc.

--- a/docs/lousa-plano-base-e10-7.md
+++ b/docs/lousa-plano-base-e10-7.md
@@ -20,7 +20,8 @@ Fontes: chat, PR #435, PR #440, docs/roadmap.md, docs/base-tecnica.md, docs/sche
 * IA fora do runtime público.
 * Fallback generic-v1 preservado.
 * Tracking comercial preservado.
-* Próximo trabalho: Fase 6.
+* Próximo trabalho imediato: Fase 6.
+* Próximo incremento funcional planejado: Fase 7.
 
 3. Caso de uso
 E10.7 — Páginas comerciais personalizadas por taxon
@@ -94,16 +95,19 @@ Status:
 * Taxon tem artifact published válido.
 * Pode ser consumido em /a/[account].
 * Pode receber nova geração/regeneração se operador decidir.
+
 6.2 Em revisão
 * Taxon tem draft criado.
 * Ainda não foi publicado.
 * Pode ser visualizado, regenerado ou publicado.
+
 6.3 Elegível para gerar
 * Taxon tem pesquisa estruturada completa.
 * Ainda não precisa ter draft.
 * Ainda não precisa ter published.
 * Aparece para o operador iniciar geração.
 * A listagem não gera draft automaticamente.
+
 6.4 Incompleto
 * Não aparece na lista principal do MVP.
 * Diagnóstico de incompletos fica fora do escopo inicial, salvo pedido explícito.
@@ -173,6 +177,7 @@ Não fazer dentro da E10.7 sem decisão explícita:
 * Schema atual ainda possui composição vinculada a taxon_id.
 * Fase 5 teve blocker real e aprovou RPC/migration mínima.
 * Fase 6 não deve alterar schema sem novo blocker.
+* Fase 7 deve evitar schema novo; se published oficial exigir RPC atômica, tratar como blocker específico.
 
 11. Fases
 11.1 Fase 1 — Base técnica
@@ -274,7 +279,7 @@ Não fazer dentro da E10.7 sem decisão explícita:
 * Objetivo: mover gerar, regenerar, publicar, preview e histórico para a página específica.
 * Objetivo: aplicar loading/disable nos botões no local definitivo.
 * Objetivo: consolidar contrato fixo da página commercial_activation.
-* Objetivo: registrar edição manual de draft como pendência futura.
+* Objetivo: registrar edição manual de draft como escopo da Fase 7.
 * Rota sugerida: app/admin/(protected)/templates/commercial-activation/[taxonSlug].
 * Rota equivalente pode ser usada se a estrutura real do Next.js indicar path melhor.
 Regras:
@@ -295,19 +300,67 @@ Regras:
 * Não alterar runtime público.
 * Não alterar schema sem novo blocker.
 
-12. Lacuna confirmada — próximos drafts
+11.7 Fase 7 — Edição manual de copy e gestão simples de versões
+* Status implementação: planejada.
+* Objetivo: permitir ajuste humano do conteúdo antes da publicação.
+* Objetivo: permitir troca da versão publicada oficial sem duplicar versões.
+* Objetivo: preservar estrutura fixa, cores universais e contrato do renderer.
+* Objetivo: manter geração por fontes estruturadas como padrão do MVP.
+Escopo:
+* editar copy de draft por taxon;
+* salvar draft editado;
+* revalidar render model antes de publicar;
+* publicar draft editado pelo fluxo existente;
+* listar versões do histórico com status claro;
+* permitir tornar uma versão existente a publicada oficial;
+* manter apenas uma versão published oficial por taxon/contexto;
+* arquivar as demais versões do mesmo contexto na troca oficial;
+* não duplicar versão antiga para restaurar;
+* não criar nova artifact_version quando apenas trocar a published oficial.
+Regras de edição:
+* edição humana deve ser apenas de conteúdo/copy;
+* pode editar títulos, subtítulos, descrições, bullets, benefícios, serviços, FAQ, textos de CTA e microcopy;
+* não editar ordem de seções;
+* não editar tipo de seção;
+* não editar layout;
+* não editar cores;
+* não editar componentes;
+* não editar CTA técnico sem decisão específica;
+* não editar estrutura do render model fora do formulário permitido.
+Regras de versão oficial:
+* Published direto não deve ser editado em produção.
+* Published pode virar referência visual/histórica para revisão humana.
+* Ação sugerida: Tornar publicada.
+* A ação deve valer para versão existente válida do mesmo taxon/contexto.
+* A troca deve ser atômica: versão escolhida vira published e demais viram archived.
+* Draft continua sendo publicado pelo botão Publicar draft.
+* Não permitir múltiplos published oficiais simultâneos.
+* Não criar ponteiro paralelo sem blocker real.
+* Não criar nova tabela apenas para official_artifact_id sem decisão explícita.
+Fora do escopo:
+* IA assistida para edição;
+* regenerar usando latest published como base editorial;
+* editor visual;
+* edição por bloco independente;
+* múltiplas versões published ativas;
+* duplicação de conteúdo para restaurar versão antiga;
+* alteração do runtime público;
+* alteração de template, composição, layout ou cores.
+
+12. Próximos drafts e base editorial
 * Confirmado em 25/06/2026: novo draft não usa a página publicada mais recente como base editorial.
 * Geração atual usa taxon ativo, pesquisa estruturada v1, composição técnica e planos.
 * Prompt atual não inclui published, content_json anterior, artifact_id publicado ou texto da página publicada.
 * artifact_version apenas incrementa versão; não serve como base editorial.
 * Diagnóstico: nova versão é gerada a partir das fontes estruturadas atuais.
 * Decisão MVP: manter modo atual funcionando.
-* Pendência futura: edição manual simples do draft antes de publicar.
-* Pendência posterior: regenerar draft usando latest published como referência.
-Modos possíveis para futuro:
+* Fase 7 prioriza edição manual de copy e gestão simples de versões.
+* Regenerar com base em latest published fica para depois, se houver caso real.
+Modos possíveis:
 * Gerar do zero: fontes estruturadas.
 * Editar manualmente: humano ajusta draft antes de publicar.
-* Regenerar com base: usar latest published como referência editorial.
+* Tornar publicada: versão existente válida vira a published oficial.
+* Regenerar com base: usar latest published como referência editorial apenas em fase futura.
 
 13. E18 e papéis dos templates
 13.1 E18
@@ -351,10 +404,9 @@ corretor-imoveis
 * Draft só foi gerado por ação do operador.
 
 15. Pendências futuras
-* Edição manual simples do draft antes de publicar.
-* Regeneração usando latest published como referência editorial.
 * Mensagem amigável para missing_openai_env.
 * IA assistida para edição somente depois.
+* Regeneração usando latest published como referência editorial somente depois.
 * Temas visuais avançados somente depois, se necessário.
 
 16. Regra de briefing
@@ -382,6 +434,8 @@ corretor-imoveis
 * Verificar se listagem não gera draft automaticamente.
 * Verificar se eventual falha técnica de composição não foi transformada em tarefa do operador.
 * Verificar se composição técnica não foi tratada como decisão estratégica universal sem cuidado com schema atual.
+* Verificar se Fase 7 não duplica versões ao trocar published oficial.
+* Verificar se Fase 7 mantém apenas uma published oficial por taxon/contexto.
 
 18. Regra de atualização documental
 * Após fase mergeada, gerar relatório de encerramento.


### PR DESCRIPTION
### Motivation
* Registrar encerramento da Fase 5 após validação em Production e consolidar decisões operacionais e técnicas para o canal commercial_activation.
* Garantir que a lousa reflita updates aplicados (#Supa36/#Supa05/#Supa40/#Supa58), a correção estrutural mínima e a lacuna confirmada sobre geração de novos drafts.
* Criar uma nova etapa (Fase 6) com escopo claro para a interface admin comercial e contrato fixo da página comercial.

### Description
* Atualizado o arquivo `docs/lousa-plano-base-e10-7.md` para marcar a Fase 5 como concluída e validada em Production, adicionar PR #440 às fontes e compactar redundâncias; mudanças principais documentam fluxo mínimo validado (elegível → draft → published → consumo público).
* Documentei a implementação técnica da Fase 5 incluindo `/admin/templates` como lista de taxons elegíveis, obrigatoriedade de taxonSlug, remoção de fallback para piloto, criação de ensureCommercialActivationCompositionForTaxon e da RPC `ensure_commercial_activation_composition(p_taxon_id uuid)`, publicação via publish_content_artifact_draft e correção de isUuid para UUID canônico.
* Consolidei a validação em Production (envs OPENAI_*, redeploy, migration 20260624203000, RPC existente e permissões service_role), os updates rotulados exatamente como `#Supa36`, `#Supa05`, `#Supa40`, `#Supa58`, e registrei a lacuna confirmada sobre novos drafts e modos futuros possíveis.
* Adicionei a seção `11.6 Fase 6` com objetivo, regras, rota sugerida `app/admin/(protected)/templates/commercial-activation/[taxonSlug]` e escopo claro (lista limpa em /admin/templates, página operacional por taxon, botões com loading/disable, sem edição manual/IA/regeneração baseada em latest published nesta fase).
* Branch usada: `codex/docs-e10-7-fechar-fase-5-criar-fase-6` and file changed: `docs/lousa-plano-base-e10-7.md`.

### Testing
* Executado `git diff --check` e não houve problemas de whitespace ou conflitos no diff.
* Verificações automáticas de formato com `grep -n '^#' docs/lousa-plano-base-e10-7.md` confirmaram que apenas os rótulos obrigatórios `#SupaXX` permanecem onde necessários.
* Verificação automática de acentos/quotes com `grep -n '\`' docs/lousa-plano-base-e10-7.md` confirmou ausência de crases em paths e nomes técnicos.
* `npm ci` e `npm run check` considerados não aplicáveis por se tratar de alteração exclusivamente documental.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d681949dc8329823ddd34da274287)