### PR TITLE
E10.7 Fase 6: separar lista e operação admin commercial_activation

### DIFF
--- a/app/admin/(protected)/templates/_components/PendingSubmitButton.tsx
+++ b/app/admin/(protected)/templates/_components/PendingSubmitButton.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useFormStatus } from "react-dom";
+
+import { cn } from "@/lib/utils";
+
+type PendingSubmitButtonProps = {
+  children: string;
+  pendingLabel: string;
+  disabled?: boolean;
+  variant?: "primary" | "secondary";
+};
+
+export function PendingSubmitButton({
+  children,
+  pendingLabel,
+  disabled = false,
+  variant = "primary",
+}: PendingSubmitButtonProps) {
+  const { pending } = useFormStatus();
+  const isDisabled = disabled || pending;
+
+  return (
+    <button
+      className={cn(
+        "inline-flex h-10 w-full items-center justify-center rounded-md px-4 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto",
+        variant === "primary"
+          ? "bg-brand-600 text-white hover:bg-brand-700"
+          : "border border-border text-muted-foreground hover:bg-muted",
+      )}
+      disabled={isDisabled}
+      type="submit"
+    >
+      {pending ? pendingLabel : children}
+    </button>
+  );
+}

--- a/app/admin/(protected)/templates/actions.ts
+++ b/app/admin/(protected)/templates/actions.ts
@@ -56,20 +56,23 @@ export async function generateOrRegenerateCommercialActivationDraftAction(
 ) {
   const taxonSlug = String(formData.get("taxonSlug") ?? "").trim();
   const result = await generateCommercialActivationDraftAction({ taxonSlug });
-  const taxonQuery = encodeURIComponent(taxonSlug);
+  const taxonPath = isSafeSlug(taxonSlug)
+    ? getOperationalTaxonPath(taxonSlug)
+    : "/admin/templates";
 
   revalidatePath("/admin/templates");
+  revalidatePath(taxonPath);
 
   if (result.error) {
     redirect(
-      `/admin/templates?taxon=${taxonQuery}&event=generation_failed&reason=${encodeURIComponent(
+      `${taxonPath}?event=generation_failed&reason=${encodeURIComponent(
         result.error,
       )}&requestId=${encodeURIComponent(result.requestId ?? "")}`,
     );
   }
 
   redirect(
-    `/admin/templates?taxon=${taxonQuery}&event=draft_generated&artifactId=${encodeURIComponent(
+    `${taxonPath}?event=draft_generated&artifactId=${encodeURIComponent(
       result.artifactId ?? "",
     )}&artifactVersion=${encodeURIComponent(String(result.artifactVersion ?? ""))}`,
   );
@@ -83,14 +86,18 @@ export async function publishCommercialActivationDraftAction(formData: FormData)
   }
 
   const artifactId = String(formData.get("artifactId") ?? "").trim();
+  const taxonSlug = String(formData.get("taxonSlug") ?? "").trim();
+  const failurePath = isSafeSlug(taxonSlug)
+    ? getOperationalTaxonPath(taxonSlug)
+    : "/admin/templates";
   if (!isUuid(artifactId)) {
-    redirect("/admin/templates?event=publish_failed&reason=invalid_artifact");
+    redirect(`${failurePath}?event=publish_failed&reason=invalid_artifact`);
   }
 
   const context = await readPublishContext(artifactId);
   if (!context.ok) {
     redirect(
-      `/admin/templates?event=publish_failed&reason=${encodeURIComponent(
+      `${failurePath}?event=publish_failed&reason=${encodeURIComponent(
         context.reason,
       )}`,
     );
@@ -106,7 +113,7 @@ export async function publishCommercialActivationDraftAction(formData: FormData)
       code: error.code,
       message: error.message,
     });
-    redirect("/admin/templates?event=publish_failed&reason=rpc_failed");
+    redirect(`${failurePath}?event=publish_failed&reason=rpc_failed`);
   }
 
   const validation = await validatePublicationResult({
@@ -115,17 +122,18 @@ export async function publishCommercialActivationDraftAction(formData: FormData)
   });
 
   revalidatePath("/admin/templates");
+  revalidatePath(failurePath);
 
   if (!validation.ok) {
     redirect(
-      `/admin/templates?event=publish_failed&reason=${encodeURIComponent(
+      `${failurePath}?event=publish_failed&reason=${encodeURIComponent(
         validation.reason,
       )}`,
     );
   }
 
   redirect(
-    `/admin/templates?event=published&artifactId=${encodeURIComponent(
+    `${failurePath}?event=published&artifactId=${encodeURIComponent(
       artifactId,
     )}&publishedCount=${validation.publishedCount}&previousArchived=${String(
       validation.previousArchived,
@@ -141,4 +149,8 @@ function isUuid(value: string) {
 
 function isSafeSlug(value: string) {
   return /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value);
+}
+
+function getOperationalTaxonPath(taxonSlug: string) {
+  return `/admin/templates/commercial-activation/${encodeURIComponent(taxonSlug)}`;
 }

--- a/app/admin/(protected)/templates/commercial-activation/[taxonSlug]/page.tsx
+++ b/app/admin/(protected)/templates/commercial-activation/[taxonSlug]/page.tsx
@@ -1,0 +1,395 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
+import { AdminStatusBadge } from "@/components/admin/AdminStatusBadge";
+import { EmptyState } from "@/components/ui/empty-state";
+import { CommercialActivationRenderer } from "@/conversion-content/commercial-activation/renderer";
+import {
+  readAdminCommercialActivationState,
+  type AdminCommercialActivationArtifact,
+} from "@/lib/admin/adapters/adminCommercialActivationTemplatesAdapter";
+import {
+  generateOrRegenerateCommercialActivationDraftAction,
+  publishCommercialActivationDraftAction,
+} from "../../actions";
+import { PendingSubmitButton } from "../../_components/PendingSubmitButton";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+type AdminCommercialActivationTaxonPageProps = {
+  params: Promise<{ taxonSlug: string }>;
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function AdminCommercialActivationTaxonPage({
+  params,
+  searchParams,
+}: AdminCommercialActivationTaxonPageProps) {
+  const { taxonSlug } = await params;
+  const query = (await searchParams) ?? {};
+  const state = await readAdminCommercialActivationState({ taxonSlug });
+  const message = getActionMessage(query);
+
+  if (!state.ok) {
+    if (state.reason === "taxon_not_found") {
+      notFound();
+    }
+
+    return (
+      <div className="space-y-6">
+        <BackLink />
+        <AdminPageHeader
+          title="Operacao commercial_activation"
+          description="Nao foi possivel carregar o taxon selecionado."
+          meta="commercial_activation"
+        />
+        <EmptyState
+          title="Operacao indisponivel"
+          description={`Falha segura na leitura administrativa: ${state.reason}.`}
+        />
+      </div>
+    );
+  }
+
+  const reviewDraft = state.publishableDraft;
+  const previewArtifact = reviewDraft ?? state.published ?? state.latestDraft;
+  const primaryAction = reviewDraft
+    ? "Publicar draft"
+    : state.published
+      ? "Regenerar draft"
+      : "Gerar draft";
+
+  return (
+    <div className="space-y-6">
+      <BackLink />
+
+      <AdminPageHeader
+        title={state.taxon.name}
+        description="Operacao administrativa por taxon: draft, publicacao, preview, historico e diagnostico tecnico minimo."
+        meta={state.taxon.slug}
+      />
+
+      {message ? (
+        <section className={message.className}>
+          <p className="text-sm font-medium">{message.title}</p>
+          <p className="mt-1 text-sm">{message.description}</p>
+        </section>
+      ) : null}
+
+      <section className="rounded-lg border border-border bg-card p-5 shadow-card">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="space-y-3">
+            <div>
+              <p className="text-xs font-medium uppercase text-muted-foreground">
+                Taxon operacional
+              </p>
+              <h2 className="mt-1 text-lg font-semibold text-card-foreground">
+                {state.taxon.name}
+              </h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {state.taxon.slug}
+              </p>
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              <AdminStatusBadge tone={reviewDraft ? "warning" : "neutral"}>
+                {reviewDraft ? "Em revisao" : "Sem draft em revisao"}
+              </AdminStatusBadge>
+              <AdminStatusBadge tone={state.published ? "success" : "neutral"}>
+                {state.published ? "Publicado" : "Sem published"}
+              </AdminStatusBadge>
+              <AdminStatusBadge tone={state.composition ? "success" : "neutral"}>
+                {state.composition ? "Composicao pronta" : "Composicao sob demanda"}
+              </AdminStatusBadge>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <form action={generateOrRegenerateCommercialActivationDraftAction}>
+              <input name="taxonSlug" type="hidden" value={state.taxon.slug} />
+              <PendingSubmitButton
+                pendingLabel={reviewDraft ? "Regenerando..." : "Gerando..."}
+              >
+                {reviewDraft ? "Regenerar draft" : "Gerar draft"}
+              </PendingSubmitButton>
+            </form>
+
+            <form action={publishCommercialActivationDraftAction}>
+              <input name="taxonSlug" type="hidden" value={state.taxon.slug} />
+              <input
+                name="artifactId"
+                type="hidden"
+                value={reviewDraft?.id ?? ""}
+              />
+              <PendingSubmitButton
+                disabled={!reviewDraft}
+                pendingLabel="Publicando..."
+                variant="secondary"
+              >
+                Publicar draft
+              </PendingSubmitButton>
+            </form>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-4">
+        <StatusCard
+          label="Estado atual"
+          value={stateLabel({ reviewDraft, published: state.published })}
+          detail={`Proximo passo: ${primaryAction}`}
+        />
+        <StatusCard
+          label="Draft atual"
+          value={reviewDraft ? `v${reviewDraft.artifactVersion}` : "Nenhum"}
+          detail={
+            reviewDraft
+              ? `${reviewDraft.sourceCount} fontes business_buyer`
+              : state.latestDraft
+                ? "Draft antigo mantido apenas no historico"
+                : "Gere um draft para revisar"
+          }
+        />
+        <StatusCard
+          label="Published atual"
+          value={state.published ? `v${state.published.artifactVersion}` : "Nenhum"}
+          detail={
+            state.published?.publishedAt
+              ? formatDate(state.published.publishedAt)
+              : "A publicacao usa RPC transacional"
+          }
+        />
+        <StatusCard
+          label="Historico"
+          value={String(state.artifacts.length)}
+          detail="draft, published e archived"
+        />
+      </section>
+
+      <section className="rounded-lg border border-border bg-card p-5 shadow-card">
+        <h2 className="text-sm font-semibold text-card-foreground">
+          Diagnostico tecnico minimo
+        </h2>
+        <dl className="mt-4 grid gap-3 text-sm sm:grid-cols-2 lg:grid-cols-4">
+          <DiagnosticItem
+            label="Composicao"
+            value={state.composition ? "ready" : "sob demanda"}
+          />
+          <DiagnosticItem
+            label="Draft publicavel"
+            value={reviewDraft ? `v${reviewDraft.artifactVersion}` : "nao"}
+          />
+          <DiagnosticItem
+            label="Published valido"
+            value={state.published ? `v${state.published.artifactVersion}` : "nao"}
+          />
+          <DiagnosticItem
+            label="Fontes do draft"
+            value={reviewDraft ? String(reviewDraft.sourceCount) : "-"}
+          />
+        </dl>
+      </section>
+
+      {previewArtifact && state.composition ? (
+        <section className="space-y-3">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 className="text-lg font-semibold text-foreground">
+                Preview do{" "}
+                {previewArtifact.status === "draft" ? "draft" : "published"}
+              </h2>
+              <p className="text-sm text-muted-foreground">
+                Artifact {previewArtifact.id} - versao{" "}
+                {previewArtifact.artifactVersion}
+              </p>
+            </div>
+            <AdminStatusBadge tone={statusTone(previewArtifact.status)}>
+              {previewArtifact.status}
+            </AdminStatusBadge>
+          </div>
+          <div className="overflow-hidden rounded-lg border border-border bg-muted/40 p-3 shadow-card">
+            <div className="max-h-[900px] overflow-auto rounded-lg">
+              <CommercialActivationRenderer
+                composition={state.composition}
+                contentJson={previewArtifact.contentJson}
+              />
+            </div>
+          </div>
+        </section>
+      ) : (
+        <EmptyState
+          title="Nenhum artefato para visualizar"
+          description="Gere o primeiro draft administrativo para habilitar o preview."
+        />
+      )}
+
+      <section className="overflow-hidden rounded-lg border border-border bg-card shadow-card">
+        <div className="border-b border-border px-4 py-3">
+          <h2 className="text-sm font-semibold text-card-foreground">
+            Historico de artefatos
+          </h2>
+        </div>
+        {state.artifacts.length > 0 ? (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-border text-sm">
+              <thead className="bg-muted/60 text-left text-xs font-medium uppercase text-muted-foreground">
+                <tr>
+                  <th className="px-4 py-3">Versao</th>
+                  <th className="px-4 py-3">Status</th>
+                  <th className="px-4 py-3">Fontes</th>
+                  <th className="px-4 py-3">Criado</th>
+                  <th className="px-4 py-3">Publicado</th>
+                  <th className="px-4 py-3">Arquivado</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {state.artifacts.map((artifact) => (
+                  <tr key={artifact.id}>
+                    <td className="px-4 py-3 font-medium text-foreground">
+                      v{artifact.artifactVersion}
+                    </td>
+                    <td className="px-4 py-3">
+                      <AdminStatusBadge tone={statusTone(artifact.status)}>
+                        {artifact.status}
+                      </AdminStatusBadge>
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">
+                      {artifact.sourceCount}
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">
+                      {formatDate(artifact.createdAt)}
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">
+                      {artifact.publishedAt ? formatDate(artifact.publishedAt) : "-"}
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">
+                      {artifact.archivedAt ? formatDate(artifact.archivedAt) : "-"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div className="p-4">
+            <EmptyState
+              title="Sem historico"
+              description="Os artefatos aparecerao aqui apos a primeira geracao."
+            />
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function BackLink() {
+  return (
+    <Link
+      className="text-sm font-medium text-brand-700 hover:underline"
+      href="/admin/templates"
+    >
+      Voltar para templates
+    </Link>
+  );
+}
+
+function StatusCard({
+  label,
+  value,
+  detail,
+}: {
+  label: string;
+  value: string;
+  detail: string;
+}) {
+  return (
+    <section className="rounded-lg border border-border bg-card p-4 shadow-card">
+      <p className="text-xs font-medium uppercase text-muted-foreground">
+        {label}
+      </p>
+      <p className="mt-2 text-xl font-semibold text-card-foreground">{value}</p>
+      <p className="mt-1 text-sm text-muted-foreground">{detail}</p>
+    </section>
+  );
+}
+
+function DiagnosticItem({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-xs font-medium uppercase text-muted-foreground">
+        {label}
+      </dt>
+      <dd className="mt-1 font-medium text-foreground">{value}</dd>
+    </div>
+  );
+}
+
+function stateLabel(input: {
+  reviewDraft: AdminCommercialActivationArtifact | null;
+  published: AdminCommercialActivationArtifact | null;
+}) {
+  if (input.reviewDraft) return "Em revisao";
+  if (input.published) return "Publicado";
+  return "Elegivel para gerar";
+}
+
+function statusTone(status: string) {
+  if (status === "published") return "success";
+  if (status === "draft") return "warning";
+  if (status === "archived") return "neutral";
+  return "neutral";
+}
+
+function getActionMessage(params: Record<string, string | string[] | undefined>) {
+  const event = getFirstParam(params.event);
+  const reason = getFirstParam(params.reason);
+  const artifactVersion = getFirstParam(params.artifactVersion);
+  const publishedCount = getFirstParam(params.publishedCount);
+  const previousArchived = getFirstParam(params.previousArchived);
+
+  if (event === "draft_generated") {
+    return {
+      title: "Draft gerado",
+      description: artifactVersion
+        ? `Artifact version ${artifactVersion} criado como draft.`
+        : "Novo draft criado para revisao.",
+      className:
+        "rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-green-800",
+    };
+  }
+
+  if (event === "published") {
+    return {
+      title: "Draft publicado",
+      description: `Validacao pos-publicacao concluida: published_count=${publishedCount ?? "1"}, previous_archived=${previousArchived ?? "null"}.`,
+      className:
+        "rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-green-800",
+    };
+  }
+
+  if (event === "generation_failed" || event === "publish_failed") {
+    return {
+      title: event === "generation_failed" ? "Geracao bloqueada" : "Publicacao bloqueada",
+      description: reason ?? "Erro seguro retornado pela operacao.",
+      className:
+        "rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-800",
+    };
+  }
+
+  return null;
+}
+
+function getFirstParam(value: string | string[] | undefined) {
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat("pt-BR", {
+    dateStyle: "short",
+    timeStyle: "short",
+  }).format(new Date(value));
+}

--- a/app/admin/(protected)/templates/commercial-activation/[taxonSlug]/page.tsx
+++ b/app/admin/(protected)/templates/commercial-activation/[taxonSlug]/page.tsx
@@ -55,11 +55,12 @@ export default async function AdminCommercialActivationTaxonPage({
 
   const reviewDraft = state.publishableDraft;
   const previewArtifact = reviewDraft ?? state.published ?? state.latestDraft;
-  const primaryAction = reviewDraft
-    ? "Publicar draft"
-    : state.published
-      ? "Regenerar draft"
-      : "Gerar draft";
+  const shouldRegenerate = Boolean(reviewDraft || state.published);
+  const generationLabel = shouldRegenerate ? "Regenerar draft" : "Gerar draft";
+  const generationPendingLabel = shouldRegenerate
+    ? "Regenerando..."
+    : "Gerando...";
+  const primaryAction = reviewDraft ? "Publicar draft" : generationLabel;
 
   return (
     <div className="space-y-6">
@@ -109,10 +110,8 @@ export default async function AdminCommercialActivationTaxonPage({
           <div className="flex flex-col gap-2 sm:flex-row">
             <form action={generateOrRegenerateCommercialActivationDraftAction}>
               <input name="taxonSlug" type="hidden" value={state.taxon.slug} />
-              <PendingSubmitButton
-                pendingLabel={reviewDraft ? "Regenerando..." : "Gerando..."}
-              >
-                {reviewDraft ? "Regenerar draft" : "Gerar draft"}
+              <PendingSubmitButton pendingLabel={generationPendingLabel}>
+                {generationLabel}
               </PendingSubmitButton>
             </form>
 
@@ -364,7 +363,10 @@ function getActionMessage(params: Record<string, string | string[] | undefined>)
   if (event === "published") {
     return {
       title: "Draft publicado",
-      description: `Validacao pos-publicacao concluida: published_count=${publishedCount ?? "1"}, previous_archived=${previousArchived ?? "null"}.`,
+      description:
+        previousArchived === "true"
+          ? "Draft publicado com sucesso. A versao anterior publicada foi arquivada."
+          : `Draft publicado com sucesso. Published ativo: ${publishedCount ?? "1"}.`,
       className:
         "rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-green-800",
     };

--- a/app/admin/(protected)/templates/page.tsx
+++ b/app/admin/(protected)/templates/page.tsx
@@ -5,33 +5,17 @@ import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
 import { AdminStatusBadge } from "@/components/admin/AdminStatusBadge";
 import { getAdminArea } from "@/components/admin/adminNavigation";
 import { EmptyState } from "@/components/ui/empty-state";
-import { CommercialActivationRenderer } from "@/conversion-content/commercial-activation/renderer";
 import {
   readAdminCommercialActivationOverview,
   type AdminCommercialActivationListItem,
 } from "@/lib/admin/adapters/adminCommercialActivationTemplatesAdapter";
-import {
-  generateOrRegenerateCommercialActivationDraftAction,
-  publishCommercialActivationDraftAction,
-} from "./actions";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
-type AdminTemplatesPageProps = {
-  searchParams?: Promise<Record<string, string | string[] | undefined>>;
-};
-
-export default async function AdminTemplatesPage({
-  searchParams,
-}: AdminTemplatesPageProps) {
+export default async function AdminTemplatesPage() {
   const area = getAdminArea("/admin/templates");
-  const params = (await searchParams) ?? {};
-  const selectedTaxonSlug = getFirstParam(params.taxon);
-  const overview = await readAdminCommercialActivationOverview({
-    selectedTaxonSlug,
-  });
-  const message = getActionMessage(params);
+  const overview = await readAdminCommercialActivationOverview();
 
   if (!area) {
     notFound();
@@ -42,7 +26,7 @@ export default async function AdminTemplatesPage({
       <div className="space-y-6">
         <AdminPageHeader
           title={area.title}
-          description="Operacao administrativa minima para drafts comerciais por taxon."
+          description="Lista administrativa de taxons comerciais elegiveis."
           meta="commercial_activation"
         />
         <EmptyState
@@ -53,246 +37,60 @@ export default async function AdminTemplatesPage({
     );
   }
 
-  const selected = overview.selected?.ok ? overview.selected : null;
-  const reviewDraft = selected?.publishableDraft ?? null;
-  const previewArtifact =
-    reviewDraft ?? selected?.published ?? selected?.latestDraft ?? null;
-
   return (
     <div className="space-y-6">
       <AdminPageHeader
         title={area.title}
-        description="Operacao minima para taxons elegiveis por pesquisa estruturada completa."
+        description="Lista limpa de taxons comerciais. Selecione um taxon para operar draft, preview, publicacao e historico."
         meta="commercial_activation"
       />
-
-      {message ? (
-        <section className={message.className}>
-          <p className="text-sm font-medium">{message.title}</p>
-          <p className="mt-1 text-sm">{message.description}</p>
-        </section>
-      ) : null}
 
       <section className="overflow-hidden rounded-lg border border-border bg-card shadow-card">
         <div className="border-b border-border px-4 py-3">
           <h2 className="text-sm font-semibold text-card-foreground">
-            Taxons elegiveis
+            Taxons comerciais
           </h2>
           <p className="mt-1 text-xs text-muted-foreground">
-            A lista usa pesquisa completa; nao cria composicao nem draft.
+            Esta lista e somente leitura: nao gera draft, nao materializa
+            composicao, nao publica e nao chama IA.
           </p>
         </div>
-        <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-border text-sm">
-            <thead className="bg-muted/60 text-left text-xs font-medium uppercase text-muted-foreground">
-              <tr>
-                <th className="px-4 py-3">Taxon</th>
-                <th className="px-4 py-3">Estado</th>
-                <th className="px-4 py-3">Pesquisa</th>
-                <th className="px-4 py-3">Composicao</th>
-                <th className="px-4 py-3">Artefatos</th>
-                <th className="px-4 py-3">Acao</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border">
-              {overview.items.map((item) => (
-                <TaxonRow
-                  key={item.taxon.id}
-                  item={item}
-                  selected={selected?.taxon.id === item.taxon.id}
-                />
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </section>
-
-      {selected ? (
-        <section className="rounded-lg border border-border bg-card p-5 shadow-card">
-          <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-            <div className="space-y-3">
-              <div>
-                <p className="text-xs font-medium uppercase text-muted-foreground">
-                  Taxon selecionado
-                </p>
-                <h2 className="mt-1 text-lg font-semibold text-card-foreground">
-                  {selected.taxon.name}
-                </h2>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  {selected.taxon.slug}
-                </p>
-              </div>
-
-              <div className="flex flex-wrap gap-2">
-                <AdminStatusBadge tone={reviewDraft ? "warning" : "neutral"}>
-                  {reviewDraft ? "Em revisao" : "Sem draft em revisao"}
-                </AdminStatusBadge>
-                <AdminStatusBadge tone={selected.published ? "success" : "neutral"}>
-                  {selected.published ? "Publicado" : "Sem published"}
-                </AdminStatusBadge>
-                <AdminStatusBadge tone={selected.composition ? "success" : "neutral"}>
-                  {selected.composition ? "Composicao pronta" : "Composicao sob demanda"}
-                </AdminStatusBadge>
-              </div>
-            </div>
-
-            <div className="flex flex-col gap-2 sm:flex-row">
-              <form action={generateOrRegenerateCommercialActivationDraftAction}>
-                <input name="taxonSlug" type="hidden" value={selected.taxon.slug} />
-                <button className="inline-flex h-10 w-full items-center justify-center rounded-md bg-brand-600 px-4 text-sm font-medium text-white transition hover:bg-brand-700 sm:w-auto">
-                  {reviewDraft ? "Regenerar draft" : "Gerar draft"}
-                </button>
-              </form>
-
-              <form action={publishCommercialActivationDraftAction}>
-                <input
-                  name="artifactId"
-                  type="hidden"
-                  value={reviewDraft?.id ?? ""}
-                />
-                <button
-                  className="inline-flex h-10 w-full items-center justify-center rounded-md border border-border px-4 text-sm font-medium text-muted-foreground transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
-                  disabled={!reviewDraft}
-                >
-                  Publicar draft
-                </button>
-              </form>
-            </div>
-          </div>
-        </section>
-      ) : (
-        <EmptyState
-          title="Nenhum taxon elegivel"
-          description="A lista sera preenchida quando houver pesquisa estruturada completa."
-        />
-      )}
-
-      {selected ? (
-        <section className="grid gap-4 lg:grid-cols-3">
-          <StatusCard
-            label="Draft atual"
-            value={reviewDraft ? `v${reviewDraft.artifactVersion}` : "Nenhum"}
-            detail={
-              reviewDraft
-                ? `${reviewDraft.sourceCount} fontes business_buyer`
-                : selected.latestDraft
-                  ? "Draft antigo mantido apenas no historico"
-                  : "Gere um draft para revisar"
-            }
-          />
-          <StatusCard
-            label="Published atual"
-            value={
-              selected.published ? `v${selected.published.artifactVersion}` : "Nenhum"
-            }
-            detail={
-              selected.published?.publishedAt
-                ? formatDate(selected.published.publishedAt)
-                : "A publicacao usa RPC transacional"
-            }
-          />
-          <StatusCard
-            label="Historico carregado"
-            value={String(selected.artifacts.length)}
-            detail="draft, published e archived"
-          />
-        </section>
-      ) : null}
-
-      {previewArtifact && selected?.composition ? (
-        <section className="space-y-3">
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <h2 className="text-lg font-semibold text-foreground">
-                Preview do {previewArtifact.status === "draft" ? "draft" : "published"}
-              </h2>
-              <p className="text-sm text-muted-foreground">
-                Artifact {previewArtifact.id} - versao{" "}
-                {previewArtifact.artifactVersion}
-              </p>
-            </div>
-            <AdminStatusBadge tone={statusTone(previewArtifact.status)}>
-              {previewArtifact.status}
-            </AdminStatusBadge>
-          </div>
-          <div className="overflow-hidden rounded-lg border border-border bg-muted/40 p-3 shadow-card">
-            <div className="max-h-[900px] overflow-auto rounded-lg">
-              <CommercialActivationRenderer
-                composition={selected.composition}
-                contentJson={previewArtifact.contentJson}
-              />
-            </div>
-          </div>
-        </section>
-      ) : selected ? (
-        <EmptyState
-          title="Nenhum artefato para visualizar"
-          description="Gere o primeiro draft administrativo para habilitar o preview."
-        />
-      ) : null}
-
-      {selected ? (
-        <section className="overflow-hidden rounded-lg border border-border bg-card shadow-card">
-          <div className="border-b border-border px-4 py-3">
-            <h2 className="text-sm font-semibold text-card-foreground">
-              Historico de artefatos
-            </h2>
-          </div>
+        {overview.items.length > 0 ? (
           <div className="overflow-x-auto">
             <table className="min-w-full divide-y divide-border text-sm">
               <thead className="bg-muted/60 text-left text-xs font-medium uppercase text-muted-foreground">
                 <tr>
-                  <th className="px-4 py-3">Versao</th>
-                  <th className="px-4 py-3">Status</th>
-                  <th className="px-4 py-3">Fontes</th>
-                  <th className="px-4 py-3">Criado</th>
-                  <th className="px-4 py-3">Publicado</th>
-                  <th className="px-4 py-3">Arquivado</th>
+                  <th className="px-4 py-3">Taxon</th>
+                  <th className="px-4 py-3">Estado</th>
+                  <th className="px-4 py-3">Pesquisa</th>
+                  <th className="px-4 py-3">Composicao</th>
+                  <th className="px-4 py-3">Artefatos</th>
+                  <th className="px-4 py-3">Acao</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-border">
-                {selected.artifacts.map((artifact) => (
-                  <tr key={artifact.id}>
-                    <td className="px-4 py-3 font-medium text-foreground">
-                      v{artifact.artifactVersion}
-                    </td>
-                    <td className="px-4 py-3">
-                      <AdminStatusBadge tone={statusTone(artifact.status)}>
-                        {artifact.status}
-                      </AdminStatusBadge>
-                    </td>
-                    <td className="px-4 py-3 text-muted-foreground">
-                      {artifact.sourceCount}
-                    </td>
-                    <td className="px-4 py-3 text-muted-foreground">
-                      {formatDate(artifact.createdAt)}
-                    </td>
-                    <td className="px-4 py-3 text-muted-foreground">
-                      {artifact.publishedAt ? formatDate(artifact.publishedAt) : "-"}
-                    </td>
-                    <td className="px-4 py-3 text-muted-foreground">
-                      {artifact.archivedAt ? formatDate(artifact.archivedAt) : "-"}
-                    </td>
-                  </tr>
+                {overview.items.map((item) => (
+                  <TaxonRow key={item.taxon.id} item={item} />
                 ))}
               </tbody>
             </table>
           </div>
-        </section>
-      ) : null}
+        ) : (
+          <div className="p-4">
+            <EmptyState
+              title="Nenhum taxon elegivel"
+              description="A lista sera preenchida quando houver pesquisa estruturada completa."
+            />
+          </div>
+        )}
+      </section>
     </div>
   );
 }
 
-function TaxonRow({
-  item,
-  selected,
-}: {
-  item: AdminCommercialActivationListItem;
-  selected: boolean;
-}) {
+function TaxonRow({ item }: { item: AdminCommercialActivationListItem }) {
   return (
-    <tr className={selected ? "bg-brand-50/60" : undefined}>
+    <tr>
       <td className="px-4 py-3">
         <p className="font-medium text-foreground">{item.taxon.name}</p>
         <p className="text-xs text-muted-foreground">{item.taxon.slug}</p>
@@ -303,19 +101,33 @@ function TaxonRow({
         </AdminStatusBadge>
       </td>
       <td className="px-4 py-3 text-muted-foreground">
-        BB {item.research.businessBuyerBlocks}/4 ({item.research.businessBuyerItems}) - EC{" "}
-        {item.research.endCustomerBlocks}/4 ({item.research.endCustomerItems})
+        <span className="whitespace-nowrap">
+          BB {item.research.businessBuyerBlocks}/4 (
+          {item.research.businessBuyerItems})
+        </span>
+        <span className="ml-0 block whitespace-nowrap sm:ml-2 sm:inline">
+          EC {item.research.endCustomerBlocks}/4 (
+          {item.research.endCustomerItems})
+        </span>
       </td>
       <td className="px-4 py-3 text-muted-foreground">
         {item.hasActiveComposition ? "Pronta" : "Sob demanda"}
       </td>
       <td className="px-4 py-3 text-muted-foreground">
-        {item.publishedVersion ? `published v${item.publishedVersion}` : "sem published"}
-        {item.latestDraftVersion ? ` - draft v${item.latestDraftVersion}` : ""}
+        <span className="whitespace-nowrap">
+          {item.publishedVersion
+            ? `published v${item.publishedVersion}`
+            : "sem published"}
+        </span>
+        <span className="ml-0 block whitespace-nowrap sm:ml-2 sm:inline">
+          {item.latestDraftVersion ? `draft v${item.latestDraftVersion}` : "sem draft"}
+        </span>
       </td>
       <td className="px-4 py-3">
         <Link
-          href={`/admin/templates?taxon=${encodeURIComponent(item.taxon.slug)}`}
+          href={`/admin/templates/commercial-activation/${encodeURIComponent(
+            item.taxon.slug,
+          )}`}
           className="text-sm font-medium text-brand-700 hover:underline"
         >
           Selecionar
@@ -325,86 +137,8 @@ function TaxonRow({
   );
 }
 
-function StatusCard({
-  label,
-  value,
-  detail,
-}: {
-  label: string;
-  value: string;
-  detail: string;
-}) {
-  return (
-    <section className="rounded-lg border border-border bg-card p-4 shadow-card">
-      <p className="text-xs font-medium uppercase text-muted-foreground">
-        {label}
-      </p>
-      <p className="mt-2 text-2xl font-semibold text-card-foreground">{value}</p>
-      <p className="mt-1 text-sm text-muted-foreground">{detail}</p>
-    </section>
-  );
-}
-
 function listStateTone(status: AdminCommercialActivationListItem["state"]) {
   if (status === "published") return "success";
   if (status === "review") return "warning";
   return "neutral";
-}
-
-function statusTone(status: string) {
-  if (status === "published") return "success";
-  if (status === "draft") return "warning";
-  if (status === "archived") return "neutral";
-  return "neutral";
-}
-
-function getActionMessage(params: Record<string, string | string[] | undefined>) {
-  const event = getFirstParam(params.event);
-  const reason = getFirstParam(params.reason);
-  const artifactVersion = getFirstParam(params.artifactVersion);
-  const publishedCount = getFirstParam(params.publishedCount);
-  const previousArchived = getFirstParam(params.previousArchived);
-
-  if (event === "draft_generated") {
-    return {
-      title: "Draft gerado",
-      description: artifactVersion
-        ? `Artifact version ${artifactVersion} criado como draft.`
-        : "Novo draft criado para revisao.",
-      className:
-        "rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-green-800",
-    };
-  }
-
-  if (event === "published") {
-    return {
-      title: "Draft publicado",
-      description: `Validacao pos-publicacao concluida: published_count=${publishedCount ?? "1"}, previous_archived=${previousArchived ?? "null"}.`,
-      className:
-        "rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-green-800",
-    };
-  }
-
-  if (event === "generation_failed" || event === "publish_failed") {
-    return {
-      title: event === "generation_failed" ? "Geracao bloqueada" : "Publicacao bloqueada",
-      description: reason ?? "Erro seguro retornado pela operacao.",
-      className:
-        "rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-800",
-    };
-  }
-
-  return null;
-}
-
-function getFirstParam(value: string | string[] | undefined) {
-  if (Array.isArray(value)) return value[0];
-  return value;
-}
-
-function formatDate(value: string) {
-  return new Intl.DateTimeFormat("pt-BR", {
-    dateStyle: "short",
-    timeStyle: "short",
-  }).format(new Date(value));
 }

--- a/lib/admin/adapters/adminCommercialActivationTemplatesAdapter.ts
+++ b/lib/admin/adapters/adminCommercialActivationTemplatesAdapter.ts
@@ -143,10 +143,9 @@ export async function readAdminCommercialActivationOverview(input: {
 
     const items = await readEligibleCommercialActivationTaxons({ templateId });
     const selectedSlug = input.selectedTaxonSlug?.trim();
-    const selectedItem =
-      (selectedSlug
-        ? items.find((item) => item.taxon.slug === selectedSlug)
-        : null) ?? items[0] ?? null;
+    const selectedItem = selectedSlug
+      ? items.find((item) => item.taxon.slug === selectedSlug)
+      : null;
     const selected = selectedItem
       ? await readAdminCommercialActivationState({
           taxonId: selectedItem.taxon.id,


### PR DESCRIPTION
## Escopo

Implementa a E10.7 Fase 6 para separar a tela administrativa atual em:

- `/admin/templates`: lista limpa de taxons comerciais elegíveis;
- `/admin/templates/commercial-activation/[taxonSlug]`: página operacional específica por taxon.

## O que ficou em `/admin/templates`

- Nome e slug do taxon.
- Estado principal: Publicado, Em revisão ou Elegível para gerar.
- Status de pesquisa.
- Status de composição.
- Resumo de artifacts.
- Ação `Selecionar`, apontando para a página operacional do taxon.

A lista não mostra preview, histórico completo, card operacional detalhado, gerar draft, regenerar draft ou publicar draft.

## Nova rota operacional

Criada:

`app/admin/(protected)/templates/commercial-activation/[taxonSlug]/page.tsx`

A página concentra:

- identificação do taxon;
- status atual;
- diagnóstico técnico mínimo;
- gerar/regenerar draft;
- publicar draft;
- preview;
- histórico de artifacts.

## Patch pós-review

Corrigida a inconsistência entre o card de próximo passo e o botão de geração.

Regra atual:

- se existe draft em revisão: `Regenerar draft` / `Regenerando...`;
- se existe published e não existe draft em revisão: `Regenerar draft` / `Regenerando...`;
- se não existe published nem draft em revisão: `Gerar draft` / `Gerando...`.

Também foi suavizada a mensagem principal de publicação para texto operacional, mantendo o detalhe técnico fora da mensagem principal.

## Loading/disable

Criado componente route-local pequeno:

`app/admin/(protected)/templates/_components/PendingSubmitButton.tsx`

Ele usa `useFormStatus()` para:

- `Gerar draft` -> `Gerando...`;
- `Regenerar draft` -> `Regenerando...`;
- `Publicar draft` -> `Publicando...`;
- desabilitar o botão enquanto a ação está pendente;
- reduzir risco de duplo clique.

## prod#14

Aplicado por separação de reconhecimento:

- lista limpa para leitura rápida dos estados;
- ação principal `Selecionar` por taxon;
- página operacional agrupando ação, status, preview, histórico e diagnóstico;
- próximo passo visível no card `Estado atual`;
- label do botão alinhado ao estado real: gerar somente quando não há published/draft, regenerar quando já há published ou draft.

## prod#16 / QA

Validações executadas localmente após o patch pós-review:

- `npm ci`: passou, com 13 vulnerabilidades já reportadas pelo npm.
- `npm run check`: passou, com 24 warnings existentes e 0 erros.
- `npm run validate:commercial-activation`: passou.
- `git diff --check`: passou.
- Inspeção de `/a`: sem OpenAI, `draft-generation.ts`, `content_artifacts`, draft ou archived.

Smoke de Preview Vercel:

- Deployment READY: `lp-factory-10-94vav5fhl-alcino-afonsos-projects.vercel.app`.
- `/admin/templates`: respondeu 200 e redirecionou/renderizou `/auth/login` por proteção de sessão.
- `/admin/templates/commercial-activation/corretor-imoveis`: respondeu 200 e redirecionou/renderizou `/auth/login` por proteção de sessão.
- `/admin/templates/commercial-activation/corretor-de-imoveis-de-medio-padrao`: respondeu 200 e redirecionou/renderizou `/auth/login` por proteção de sessão.

Limitação: não foi possível validar visual/UX autenticado via fetch sem sessão admin. A validação visual em Preview ainda precisa ser feita em sessão administrativa real antes do merge final.

Checklist pendente para sessão admin no Preview:

- `/admin/templates` como lista limpa;
- ausência de preview/histórico/botões operacionais na lista;
- `Selecionar` navegando para a página operacional;
- página operacional de `corretor-imoveis`;
- página operacional de `corretor-de-imoveis-de-medio-padrao`;
- botão `Regenerar draft` quando houver published ou draft;
- botão `Gerar draft` quando não houver published nem draft;
- loading/disable dos botões;
- responsividade básica;
- foco e navegação;
- ausência de layout shift relevante.

## Vercel updates

Não registrei vercel#15, vercel#16, vercel#17, vercel#18 ou vercel#19 como usados, porque não foram usados de fato no QA desta PR.

Confirmado que não foram aplicados:

- vercel#20 Flags / Flags SDK / Flags Explorer;
- vercel#8 APIs de Cache refinadas;
- vercel#11 Server-side Tracking API;
- prod#12 Navegação multi-contas e LPs.

## Fora do escopo confirmado

- Sem alteração de `/a/[account]`.
- Sem runtime público novo.
- Sem IA em runtime público.
- Sem schema, migration, tabela, RPC, grant ou policy.
- Sem Fase 7.
- Sem editor visual.
- Sem LP Builder.
- Sem flags, A/B test, cache novo, `revalidateTag`/`updateTag` ou tracking novo.
- Sem hardcode de Corretor Imóveis ou do taxon piloto.