### PR TITLE
Ajusta precisão da lousa base E10.7

### DIFF
--- a/docs/lousa-plano-base-e10-7.md
+++ b/docs/lousa-plano-base-e10-7.md
@@ -30,8 +30,8 @@ Fontes: chat, PR #435, PR #440, docs/roadmap.md, docs/base-tecnica.md, docs/sche
 * Auditoria deve verificar template, composição, prompt, content_json, renderer, preview/admin e /a/[account].
 * Objetivo da auditoria: garantir que todos obedecem à mesma estrutura fixa.
 * Redução das 8 seções da página comercial exige decisão estratégica própria.
-* Não decidir redução de seções nesta PR.
-* Não alterar template, prompt, renderer, schema ou runtime público nesta PR.
+* Não decidir redução de seções na Fase 7 sem decisão explícita.
+* Não alterar template, prompt, renderer, schema ou runtime público na Fase 7 sem decisão explícita.
 
 3. Fases e próxima ação
 3.1 Fase 1 — Base técnica
@@ -66,4 +66,4 @@ Fontes: chat, PR #435, PR #440, docs/roadmap.md, docs/base-tecnica.md, docs/sche
 * Parar se a próxima fase exigir schema, RPC, mudança no runtime público ou alteração de contrato fora da auditoria.
 * Parar se template, composição, prompt, content_json, renderer, preview/admin ou /a/[account] divergirem entre si.
 * Parar se a redução de seções da página comercial exigir decisão estratégica.
-* Review deve confirmar: 4 seções principais, sem histórico longo, Fase 7 como auditoria do contrato e Fase 8 como edição manual.
+* Review deve confirmar: lousa compacta com 4 seções principais, sem histórico longo, Fase 7 como auditoria do contrato e Fase 8 como edição manual.


### PR DESCRIPTION
### Motivation

- Corrigir duas imprecisões textuais na lousa E10.7 para evitar referências temporais ambíguas e clarificar que as “4 seções principais” se referem à lousa compacta, sem alterar estrutura, fases ou escopo técnico.

### Description

- Atualiza `docs/lousa-plano-base-e10-7.md` substituindo ocorrências temporais de "nesta PR" por regra permanente ligada à Fase 7 (`na Fase 7 sem decisão explícita`) e ajustando o item de review para mencionar explicitamente a "lousa compacta com 4 seções principais".
- Nenhuma outra seção, ordem, fase, escopo técnico, código, migration ou schema foi alterado.

### Testing

- Executados checks de conteúdo com `rg` para validar cabeçalhos e referências (`rg -n '^[1-4]\. ' docs/lousa-plano-base-e10-7.md` e `rg -n 'Fase 7|Fase 8|nesta PR|lousa compacta|8 seções' docs/lousa-plano-base-e10-7.md`) e todos retornaram os trechos esperados.
- Executado `git diff --check` e verificado `git diff --name-only` para garantir que apenas `docs/lousa-plano-base-e10-7.md` foi modificado e que não há problemas de formatação; ambos OK.
- `npm ci` e `npm run check` não aplicáveis por se tratar de alteração exclusivamente documental.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e957769dc832990488fdc0467747f)