### PR TITLE
docs: simplificar E9 — Billing, trial e entitlements

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -298,115 +298,41 @@
 • Bloqueios por status da conta seguem UX dedicada (ver E16)
 • Redirect seguro e anti-loop (ver E4.2
 
-9. E9 — Billing Engine & Stripe Sync
+9. E9 — Billing, trial e entitlements
 
 9.1 Status
-• Em desenvolvimento
+• Parcialmente concluído em definições de produto/runtime.
+• Sem Billing Engine completo implementado nesta fase.
 
-9.2 Objetivo
-• Unificar cobrança (manual, híbrida e automatizada) e controle de recursos (grants)
-• Permitir modelo único de billing com snapshot por conta
+9.2 Objetivo atual
+• Separar condição comercial da conta do lifecycle da conta.
+• Definir que trial, plano e assinatura controlam permissões, não accounts.status.
+• Preparar a base para decisões futuras de contratação, trial e liberação de recursos produtivos.
 
-9.3 Escopo geral
-• Definir modelo técnico de planos, recursos e billing snapshot
-• Implementar motor de grants (model_grants + get_feature())
-• Integrar Stripe como modalidade opcional (billing_mode = stripe)
-• Garantir compatibilidade com Conta Consultiva (E7)
+9.3 Decisões consolidadas
 
-9.4 Grants e Features
-9.4.1 Status
-• Em evolução
-9.4.2 Escopo
-• Criar tabela model_grants para controlar recursos e limites por conta
-• Implementar get_feature(account_id, feature_key, lp_id?, section_id?) com fallback section > lp > account > plan > default
-• Adicionar colunas origin_plan_id, origin_plan_version, locked e limit_json
-9.4.3 Critérios de Aceite
-• Cada conta tem grants independente do plano
-• Mudanças em planos não alteram contas existentes automaticamente (snapshot)
-• Sincronização com plano atual apenas via ação explícita
-9.4.4 Integrações
-• Conta Consultiva Update (E7.5)
-• Admin Dashboard (E12)
-
-9.5 Billing Snapshot e Ciclos
-9.5.1 Status
-• Em planejamento
-9.5.2 Escopo
-• Adicionar billing_mode (stripe, manual, hybrid)
-• Adicionar plan_price_snapshot e billing_recurring_snapshot
-• Adicionar billing_cycle_start, billing_cycle_end e next_adjustment_at
-• Aplicar grandfathering (contas antigas mantêm preço e recursos)
-• Snapshot de preço e recursos no momento da criação da conta
-9.5.3 Critérios de Aceite
-• Contas consultivas e SaaS usam a mesma estrutura
-• Snapshots sempre específicos por conta
-• Histórico auditável de alterações de preço e ciclo
-9.5.4 Integrações
-• Conta Consultiva (E7)
-• Admin Dashboard (E12)
-
-9.6 Stripe Sync (Automação SaaS)
-9.6.1 Status
-• Planejado
-9.6.2 Escopo
-• Webhooks checkout.session.completed e subscription.updated
-• Sincronizar billing_status, subscription_id e subscription_current_period_end
-• Atualizar plan_price_map com planos e valores atuais
-• Suportar upgrade/downgrade automático para planos SaaS
-9.6.3 Pós-venda
+9.3.1 Trial como entitlement
 • Status: Concluído (definição)
-• Escopo: eventos/estados de pós-venda e billing (ex.: trial iniciado, trial expirado, assinatura ativa, cancelamento, inadimplência).
-• Importante: “status” aqui se refere a billing/subscription, e não a accounts.status.
-• Regra: billing/subscription controla entitlements/permissões; accounts.status permanece como lifecycle do setup (ver E10.4.6/E10.4.2).
+• Trial/plano controla permissões e limites de uso.
+• Trial/plano não define accounts.status.
+• Conta com setup concluído permanece accounts.status='active', mesmo sem plano ou após expiração de trial nesta fase.
+• Expiração de trial/plano deve afetar permissões, não o lifecycle da conta.
 
-9.7 Auditoria e Drift
-9.7.1 Status
-• Planejado
-9.7.2 Escopo
-• Relatório comparativo entre grants/preços da conta e plano original
-• Detectar divergências (drift) e registrar em audit_logs
-• Expor métricas de billing e recursos (limites, upgrades, consumo)
-9.7.3 Critérios de Aceite
-• Logs automáticos para toda atualização de plano/grant/ciclo
-• Painel de auditoria integrado ao Admin Dashboard
-• Exportação CSV/JSON
+9.3.2 Lifecycle da conta separado de billing
+• Status: Concluído (definição)
+• accounts.status representa lifecycle da conta/setup.
+• Billing, trial, plano e assinatura representam condição comercial.
+• inactive/suspended não são disparados automaticamente por expiração de trial/plano nesta fase.
 
-9.8 Compatibilidade
-• Billing Engine é o núcleo técnico que garante coerência entre Conta Consultiva (E7), Admin (E12) e Account Dashboard (E10)
-9.8.1 Trial como entitlement (trial não é status)
-• Status: Concluído (definição)
-• Regra (fonte de verdade): trial/plano controla apenas entitlements/permissões (ex.: “pode criar LPs”).
-• Importante: trial/plano não define accounts.status.
-• Pré-condição (pós-setup): conta já passou por setup concluído (ver E10.4.6/E10.4.2: setup concluído = accounts.status='active').
-• Pós-expiração do trial (sem plano):
-• Manter accounts.status='active' (nesta fase).
-• Remover/zerar entitlements do trial (feature gating).
-• UX esperada: “active persuasiva sem plano/trial” (ver E10.5).
-• Nota (lifecycle futuro): transições para inactive/suspended ficam para um ciclo posterior, quando houver regra de churn/inadimplência/banimento formalizada.
-• Dependência operacional: se exigir rotina/job para expiração, registrar em E12.x (sem implementar aqui)
-9.8.2 Motivos de inactive (definição; não aplicado no runtime ainda)
-• Status: Concluído (definição)
-• Objetivo: catalogar motivos de “inactive” para futura ativação do lifecycle (ex.: churn, inadimplência, fraude, banimento, etc.).
-• Estado atual (desde E10.4.6): inactive/suspended não são disparados por expiração de trial/plano nesta fase.
-• Regra atual: expiração de trial/plano afeta entitlements, não accounts.status.
-• Nota: quando o lifecycle for ativado, esta seção passará a ter enforcement no runtime (fora do escopo atual).
-9.8.3 Exec: Remover drift trial do runtime + docs
+9.3.3 Remoção de trial como status no runtime
 • Status: Concluído (04/02/2026)
-• Objetivo: remover trial como status (drift) do runtime e alinhar docs; trial permanece apenas como commercial.kind='trial' (E9.8.1).
-• Implementado (runtime): removido trial de tipos/allowlists/condicionais/UI onde aparecia como status.
-9.8.4 Persistência/consulta de commercial.inactive_reason (CRM/relatórios)
-• Status: Pendente
-• Objetivo: decidir se/como o motivo precisa ser persistido/consultável (BD/pipeline/CRM) e impactos (migrations/rollback se aplicável).
-• Dependências: E9.8.2, E9.8.1
-9.8.5 Persistência do sinal comercial (trial/entitlements) — expires_at
-• Status: Briefing
-• Objetivo: decidir onde persiste o sinal comercial (trial/plano), em especial commercial.expires_at, e definir o destino de accounts.trial_ends_at.
-• Decisão esperada (fechada):
-• Opção A: reaproveitar accounts.trial_ends_at como commercial.expires_at (formalizar contrato e evitar drift).
-• Opção B: criar outra persistência para o comercial e então deprecar/remover accounts.trial_ends_at com migration + rollback.
-• Regra de agora (legado): manter accounts.trial_ends_at como legado por enquanto (não mexer neste momento).
-• Dependências: E9.8.1 (contrato do sinal comercial); E9.8.3 (remoção do drift trial no runtime/docs).
-• Fora de escopo: billing/checkout; alterar accounts.status; mexer em accounts.trial_ends_at neste momento.
+• Trial foi removido de tipos, allowlists, condicionais e UI onde aparecia como status.
+• Trial permanece apenas como sinal comercial/permissão.
+
+9.4 Pendências vigentes
+• Definir onde registrar o sinal comercial de trial/plano.
+• Decidir o uso futuro de accounts.trial_ends_at.
+• Definir o recorte mínimo para contratação manual, concessão de trial e elegibilidade futura para criação de LP.
 
 10. E10 — Account Dashboard (UX)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -379,7 +379,7 @@
 • Status: Concluído (exec) (13/02/2026)
 • Escopo final: entregar o fluxo ponta a ponta de “Primeiros passos” em `/a/[account]` quando `accounts.status=pending_setup`, com formulário inline, validação, persistência do perfil v1, promoção `pending_setup → active` e redirecionamento para o pós-setup.
 • Estado atual: onboarding v1 inline em `pending_setup`, com `name` obrigatório, `niche` obrigatório, `preferred_channel` opcional com default `email`, `whatsapp` obrigatório somente quando `preferred_channel=whatsapp` e `site_url` opcional com normalização para URL válida.
-• Dependências: E9.8.1.
+• Dependências: E9.3.1.
 • Nota: `setup_completed_at/account_setup_completed_at` não devem ser usados no runtime, no gating, no fluxo nem nos logs; ficam mantidos no DB apenas por segurança.
 
 10.4.1 Marcador legado de setup (deprecated)
@@ -454,7 +454,7 @@
 • Escopo atual: separar o estado `active` do fluxo `pending_setup` e preparar a camada pós-setup do dashboard da conta.
 • Estado atual do runtime: `app/a/[account]/page.tsx` renderiza “Primeiros passos” somente para `accounts.status=pending_setup`; para conta autenticada fora desse estado, a rota ainda não entrega UX específica do E10.5.
 • Base já implementada no repo: estrutura de taxonomia/templates/guides no BD e pipeline operacional de resolução de nicho no pós-save do onboarding.
-• Dependências: E9.8.1, E10.4.6, E10.5.1, E10.5.2, E10.5.6.
+• Dependências: E9.3.1, E10.4.6, E10.5.1, E10.5.2, E10.5.6.
 • Nota: `setup_completed_at/account_setup_completed_at` não devem ser usados no runtime, no gating, no fluxo nem nos logs; ficam mantidos no DB apenas por segurança.
 
 10.5.1 Matriz “preparação vs produtivo” + enforcement (SSR + actions)
@@ -464,7 +464,7 @@
 • fechar status/entitlements mínimos por rota/ação
 • declarar o sinal canônico de entitlement/limite efetivo
 • definir mensagens e CTAs de bloqueio coerentes com o E10.5
-• Dependências: E9.8.1, E10.5.
+• Dependências: E9.3.1, E10.5.
 • Fora de escopo: implementação da UX principal do E10.5 nesta etapa.
 
 10.5.2 Base do BD do E10.5
@@ -1430,9 +1430,9 @@ v1.5.12 (01/02/2026)
 • Atualizado 10.4 para focar em UX/CTAs do subestado “setup incompleto” e registrar a transição para 10.5 ao setar setup_completed_at (sem mudar accounts.status).
 • Registrados 10.4.1 e 10.4.2 como Concluídos (infra do marcador + regra v0 executável de setup concluído), com dependências e pendência explícita de dados mínimos v1.
 • Mantidos como Briefing: 10.4.3 (política do marcador), 10.4.4 (dados mínimos v1: nicho/WhatsApp/outros) e criado 10.5.1 (matriz “preparação vs produtivo” + enforcement servidor).
-• Ajustadas dependências de 10.4 e 10.5 para incluir E9.8.1 apenas como referência de CTA/roteamento (sem implementar entitlements aqui).
+• Ajustadas dependências de 10.4 e 10.5 para incluir E9.3.1 apenas como referência de CTA/roteamento (sem implementar entitlements aqui).
 v1.5.11 (31/01/2026)
-• Atualizado 9.8.1 com definição do trial como entitlement (início pós-setup; expiração `active → inactive`) e contrato mínimo do sinal comercial consumido por SSR/gate/UX.
+• Atualizado 9.3.1 com definição do trial como entitlement (início pós-setup; expiração `active → inactive`) e contrato mínimo do sinal comercial consumido por SSR/gate/UX.
 • Adicionado 9.8.2 (Briefing) para motivos de `inactive` (trial_expired vs churn) para segmentação de marketing.
 • Adicionado 9.8.3 (Briefing) para execução: remoção do drift `trial` no runtime + alinhamento de docs ao estado final.
 v1.5.10 (31/01/2026)
@@ -1442,8 +1442,8 @@ v1.5.10 (31/01/2026)
 • Adicionado E10.4.5 (Briefing) para dados mínimos v1 (nicho/WhatsApp/outros) com contrato de armazenamento/validações.
 v1.5.9 (30/01/2026)
 • Adicionado E10.4.1 (infra do marcador setup_completed_at) como pré-requisito para diferenciar subestados de pending_setup.
-• Ajustado 9.8.1 para manter foco em entitlements; remoção do hardcode/allowlist de trial no Access Context foi concluída em E10.4.1.
-• Adicionado placeholder do E10.4 (Briefing) com dependências (E10.4.1, E9.8.1).
+• Ajustado 9.3.1 para manter foco em entitlements; remoção do hardcode/allowlist de trial no Access Context foi concluída em E10.4.1.
+• Adicionado placeholder do E10.4 (Briefing) com dependências (E10.4.1, E9.3.1).
 v1.5.8 (27/01/2026)
 • Adicionado E16 (Accounts) para consolidar lifecycle de accounts.status (definições, transições e UX/CTAs), com referências para docs/base-tecnica.md e docs/schema.md (anti-drift).
 • Ajustado E4.2 para remover redundâncias e focar no fluxo/UX do gateway e roteamentos, adicionando subitem de referências numerado.


### PR DESCRIPTION
### Motivation
- Limpar e alinhar a seção E9 do roadmap para refletir apenas decisões, status e pendências reais conforme a regra de `docs/prompt-abc.md` sobre registrar o estado final dos casos E*.
- Remover conteúdo operacional extensivo (Billing Engine/Stripe Sync detalhado) que não está implementado nesta fase e manter apenas o que foi decidido ou permanece pendente.

### Description
- Substituí a seção antiga `9. E9 — Billing Engine & Stripe Sync` por `9. E9 — Billing, trial e entitlements` em `docs/roadmap.md` reduzindo o texto e preservando decisões e pendências relevantes.
- Mantive e consolidizei as decisões aprovadas sobre `trial` como entitlement, a separação entre `accounts.status` (lifecycle) e condição comercial (billing/plano/entitlements), e a remoção do `trial` como status no runtime.
- Removi detalhes de escopo técnico e integrações (ex.: model_grants, billing snapshot, Stripe Sync, auditoria) conforme regra de não inventariar trabalho não implementado; deixei apenas as pendências reais sobre persistência do sinal comercial e `accounts.trial_ends_at`.
- Alteração feita na branch `docs/e9-billing-trial-entitlements` no arquivo modificado `docs/roadmap.md` e preparada para PR de documentação (não houve alteração em `docs/schema.md`, `docs/base-tecnica.md` ou E10.7 conforme instruído).

### Testing
- Executado `git diff --check` para validação do diff e passou sem erros.
- Verificações de conteúdo por busca (`rg`) para confirmar que a seção antiga foi substituída e que as referências essenciais a trial/entitlements permanecem corretas, e essas verificações passaram.
- `npm ci`: não aplicável (alteração exclusivamente documental).
- `npm run check`: não aplicável (alteração exclusivamente documental).
- Observação operacional: tentativa de `git push` para publicar a branch falhou neste ambiente porque o remote `origin` não está configurado como repositório válido.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ec5489e3883299a60e6e5301d5bef)