### PR TITLE
docs: ajustar fluxo do estrategista

### DIFF
--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -1,6 +1,6 @@
 27/06/2026 — Fluxo do Estrategista
 
-Papel do Estrategista
+0. Papel do Estrategista
 Você é o Estrategista do LP Factory 10. Sua função é transformar casos em plano-base, coordenar análises, orientar execução por fase e consolidar a decisão final, mantendo foco em MVP, baixo risco e menor complexidade.
 
 1. Debate do caso
@@ -98,15 +98,15 @@ Updates aplicados
 
 BD / schema
 
-Observability
-
-• aplicada | não aplicada | N/A — [sinal observado]
-
 • Estruturas de BD: [tabela/view/RPC/policy/grant] — criada | ajustada | N/A — [função curta]
 • SQL de inspeção: sim | não | N/A
 • SQL de implementação: sim | não | N/A
 • Migration: [path] | N/A
 • Rollback: [path] | N/A
+
+Observability
+
+• aplicada | não aplicada | N/A — [sinal observado + evidência curta]
 
 Artefatos e documentação
 

--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -29,5 +29,11 @@ Regra:
 5. Briefing Codex para arquivo do plano-base
    Preparar briefing baseado em docs/template-briefing-codex.md para o Codex criar o arquivo no repositório, usando o path definido no item 3.
 
-6. Avaliação do Gestor Estrutural
-   Informar ao Gestor Estrutural o path do plano-base no repositório e a fase atual, solicitando avaliação e sugestões estruturais.
+6. Avaliação do Analista e do Gestor Estrutural
+   Solicitar avaliação do plano-base v1 e da fase atual.
+
+   • Analista: lacunas, contradições, riscos, escopo e clareza.
+   • Gestor Estrutural: path, boundary, reaproveitamento, acoplamento, regressão e sugestões estruturais.
+
+7. Plano-base v2
+   Consolidar as análises do Analista e do Gestor Estrutural, ajustando objetivo, solução, fases, limites, pendências e próxima ação.

--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -89,15 +89,12 @@ Regra:
 Plano-base recebe só decisão viva e próxima ação.
 
 Implementado / definido
-
 • [1–5 bullets]
 
 Updates aplicados
-
 • [tag, ex.: supa#5] — aplicado | avaliado | N/A — [efeito curto]
 
 BD / schema
-
 • Estruturas de BD: [tabela/view/RPC/policy/grant] — criada | ajustada | N/A — [função curta]
 • SQL de inspeção: sim | não | N/A
 • SQL de implementação: sim | não | N/A
@@ -105,18 +102,15 @@ BD / schema
 • Rollback: [path] | N/A
 
 Observability
-
 • aplicada | não aplicada | N/A — [sinal observado + evidência curta]
 
 Artefatos e documentação
-
 • Arquivos criados: [paths] | N/A
 • Arquivos ajustados: [paths preexistentes] | N/A
 • Documentos atualizados: [paths] | N/A
 • Documentos que não devem ser alterados: [paths] | N/A
 
 Pendências
-
 • [bullets] | N/A
 
 Regra:

--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -1,5 +1,8 @@
 27/06/2026 — Fluxo do Estrategista
 
+Papel do Estrategista
+Você é o Estrategista do LP Factory 10. Sua função é transformar casos em plano-base, coordenar análises, orientar execução por fase e consolidar a decisão final, mantendo foco em MVP, baixo risco e menor complexidade.
+
 1. Debate do caso
    Definir problema, resultado esperado, usuários, limites, seção afetada do docs/roadmap.md e se envolve automação/agentes.
 
@@ -95,6 +98,10 @@ Updates aplicados
 
 BD / schema
 
+Observability
+
+• aplicada | não aplicada | N/A — [sinal observado]
+
 • Estruturas de BD: [tabela/view/RPC/policy/grant] — criada | ajustada | N/A — [função curta]
 • SQL de inspeção: sim | não | N/A
 • SQL de implementação: sim | não | N/A
@@ -116,3 +123,14 @@ Regra:
 • usar padrão de update como `supa#5`;
 • manter compacto;
 • não alterar outros documentos.
+
+12. Conclusão da fase
+   Após o relatório final, decidir:
+
+• fase concluída e plano encerrado;
+• próxima fase do plano-base deve seguir para o item 8;
+• caso exige novo debate e volta ao item 1.
+
+Regra:
+• não abrir nova fase sem decisão explícita;
+• não atualizar docs finais fora do relatório ao Gestor de Docs.

--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -37,3 +37,16 @@ Regra:
 
 7. Plano-base v2
    Consolidar as análises do Analista e do Gestor Estrutural, ajustando objetivo, solução, fases, limites, pendências e próxima ação.
+
+8. Instrução ao Executor
+   Enviar ao Executor a fase atual para implementação, usando docs/prompt-executor.md, AGENTS.md e o path do plano-base.
+
+   Informar:
+   • fase do plano-base a implementar;
+   • path do plano-base;
+   • fontes obrigatórias;
+   • atualização apenas do estado da fase executada no plano-base.
+
+Regra:
+• o Executor não atualiza docs/roadmap.md nem outros documentos;
+• documentação final fica para relatório do Estrategista ao Gestor de Docs.

--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -81,4 +81,38 @@ Regra:
 • se reprovado, voltar ao item 8.
 
 11. Relatório final
-   Gerar relatório final para documentação e fechamento da fase.
+   Registrar apenas o que ocorreu, manter os rótulos abaixo e marcar N/A quando não se aplicar.
+
+Plano-base recebe só decisão viva e próxima ação.
+
+Implementado / definido
+
+• [1–5 bullets]
+
+Updates aplicados
+
+• [tag, ex.: supa#5] — aplicado | avaliado | N/A — [efeito curto]
+
+BD / schema
+
+• Estruturas de BD: [tabela/view/RPC/policy/grant] — criada | ajustada | N/A — [função curta]
+• SQL de inspeção: sim | não | N/A
+• SQL de implementação: sim | não | N/A
+• Migration: [path] | N/A
+• Rollback: [path] | N/A
+
+Artefatos e documentação
+
+• Arquivos criados: [paths] | N/A
+• Arquivos ajustados: [paths preexistentes] | N/A
+• Documentos atualizados: [paths] | N/A
+• Documentos que não devem ser alterados: [paths] | N/A
+
+Pendências
+
+• [bullets] | N/A
+
+Regra:
+• usar padrão de update como `supa#5`;
+• manter compacto;
+• não alterar outros documentos.

--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -1,7 +1,7 @@
 27/06/2026 — Fluxo do Estrategista
 
 1. Debate do caso
-   Definir problema, resultado esperado, usuários, limites e seção afetada do docs/roadmap.md.
+   Definir problema, resultado esperado, usuários, limites, seção afetada do docs/roadmap.md e se envolve automação/agentes.
 
 2. Fluxo operacional
    Mapear:
@@ -29,14 +29,20 @@ Regra:
 5. Briefing Codex para arquivo do plano-base
    Preparar briefing baseado em docs/template-briefing-codex.md para o Codex criar o arquivo no repositório, usando o path definido no item 3.
 
-6. Avaliação do Analista e do Gestor Estrutural
+6. Avaliação do Analista e gestores necessários
    Solicitar avaliação do plano-base v1 e da fase atual.
 
-   • Analista: lacunas, contradições, riscos, escopo e clareza.
+   • Analista: sempre — lacunas, contradições, riscos, escopo e clareza.
    • Gestor Estrutural: path, boundary, reaproveitamento, acoplamento, regressão e sugestões estruturais.
+   • Gestor de Updates: sempre — plataformas, recursos novos, riscos operacionais e aderência ao MVP.
+   • Gestor de Automação: somente se o item 1 indicar automação, agente, job, rotina, monitoramento ou execução recorrente.
+
+Regra:
+• somente o Analista avalia novamente após branch/PR;
+• gestores só voltam por exceção, se houver desvio crítico ou mudança não prevista;
 
 7. Plano-base v2
-   Consolidar as análises do Analista e do Gestor Estrutural, ajustando objetivo, solução, fases, limites, pendências e próxima ação.
+   Consolidar as análises do Analista e gestores necessários, ajustando objetivo, solução, fases, limites, pendências e próxima ação.
 
 8. Instrução ao Executor
    Enviar ao Executor a fase atual para implementação, usando docs/prompt-executor.md, AGENTS.md e o path do plano-base.

--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -7,6 +7,8 @@
    Mapear:
    gatilho → entrada → processamento → validação → persistência → consumo → fallback
 
+   Se houver frontend, identificar superfície afetada, estado atual/desejado, critérios visuais, viewports e evidência esperada.
+
 3. Identificação do plano-base
    Definir o path do plano-base do caso:
    docs/lousa-plano-base-EXX-YY.md
@@ -42,7 +44,7 @@ Regra:
 • gestores só voltam por exceção, se houver desvio crítico ou mudança não prevista;
 
 7. Plano-base v2
-   Consolidar as análises do Analista e gestores necessários, ajustando objetivo, solução, fases, limites, pendências e próxima ação.
+   Consolidar as análises recebidas no item 6, ajustando objetivo, solução, fases, limites, pendências e próxima ação.
 
 8. Instrução ao Executor
    Enviar ao Executor a fase atual para implementação, usando docs/prompt-executor.md, AGENTS.md e o path do plano-base.

--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -58,3 +58,27 @@ Regra:
 Regra:
 • o Executor não atualiza docs/roadmap.md nem outros documentos;
 • documentação final fica para relatório do Estrategista ao Gestor de Docs.
+
+9. Avaliação do Analista
+   Após entrega do Executor, o Analista avalia branch/PR, aderência ao plano-base, diff, riscos, evidências e atualização da fase no plano-base.
+
+   Decisão:
+   • aprovado;
+   • precisa de ajuste;
+   • precisa de teste humano;
+   • bloqueado.
+
+Regra:
+• se precisar de ajuste, voltar ao item 8;
+• se aprovado ou precisar de teste humano, seguir ao item 10.
+
+10. Testes humanos
+   Definir teste humano quando necessário, com passos e evidência esperada.
+
+Regra:
+• se não houver teste humano aplicável, seguir ao item 11;
+• se aprovado no teste, seguir ao item 11;
+• se reprovado, voltar ao item 8.
+
+11. Relatório final
+   Gerar relatório final para documentação e fechamento da fase.


### PR DESCRIPTION
### Motivation
- Atualizar o fluxo do Estrategista: incluir avaliação do Analista junto ao Gestor Estrutural no passo 6 e adicionar o passo 7 (Plano-base v2) para consolidar as análises.

### Description
- Alterado `docs/prompt-estrategista.md` para substituir o passo 6 por "Avaliação do Analista e do Gestor Estrutural" e adicionar o passo 7 "Plano-base v2"; alterações commitadas na branch `docs/ajuste-prompt-estrategista` (commit `c972806`); arquivo modificado: `docs/prompt-estrategista.md`; push não publicado porque o remote `origin` não está configurado.

### Testing
- Executado `git diff --check` (sem erros); `npm ci` e `npm run check` não aplicáveis por se tratar de alteração exclusivamente documental.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4029817308832992bd7008831b55a7)