### PR TITLE
docs: clarify registered phase handling

### DIFF
--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -41,7 +41,7 @@ Regra:
    Preparar briefing baseado em docs/template-briefing-codex.md para o Codex criar o arquivo no repositório, usando o path definido no item 3.
 
 6. Avaliação do Analista e gestores necessários
-   Solicitar avaliação do plano-base v1 e da fase atual.
+   Solicitar avaliação do plano-base v1 quando for plano novo, ou da fase alvo quando o plano-base já existir.
 
    • Analista: sempre — lacunas, contradições, riscos, escopo e clareza.
    • Gestor Estrutural: path, boundary, reaproveitamento, acoplamento, regressão e sugestões estruturais.
@@ -52,8 +52,8 @@ Regra:
 • somente o Analista avalia novamente após branch/PR;
 • gestores só voltam por exceção, se houver desvio crítico ou mudança não prevista;
 
-7. Plano-base v2
-   Consolidar as análises recebidas no item 6, ajustando objetivo, solução, fases, limites, pendências e próxima ação.
+7. Consolidação
+   Consolidar as análises recebidas no item 6, ajustando plano-base ou fase alvo conforme o caso, com objetivo, solução, fases, limites, pendências e próxima ação.
 
 8. Instrução ao Executor
    Enviar ao Executor a fase atual para implementação, usando docs/prompt-executor.md, AGENTS.md e o path do plano-base.

--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -16,6 +16,12 @@ Você é o Estrategista do LP Factory 10. Sua função é transformar casos em p
    Definir o path do plano-base do caso:
    docs/lousa-plano-base-EXX-YY.md
 
+Regra:
+• se o plano-base já existir e a fase estiver registrada, tratar a fase alvo como recorte operacional do plano-base para debate, análise e execução;
+• não recriar plano-base v1/v2 do caso inteiro;
+• ajustar apenas a fase alvo, se necessário;
+• seguir para o item 6 com avaliação focada na fase.
+
 4. Plano-base v1
    Criar plano-base compacto com 4 blocos:
 


### PR DESCRIPTION
### Motivation
- Clarify ambiguity when a plano-base already exists so that a registered target phase is handled as an operational slice for debate, analysis and execution without creating a new full-case plano-base or parallel flow.

### Description
- Inserted a compact rule after item 3 in `docs/prompt-estrategista.md` that instructs treating an already-registered target phase as a focused recorte operacional, avoiding recreation of plano-base v1/v2 and limiting adjustments to the target phase; file changed: `docs/prompt-estrategista.md`, branch: `work`.

### Testing
- Automated checks: `git diff --check` passed; `npm ci` not applicable (documentation-only change); `npm run check` not applicable; publishing to remote was not completed due to no configured push destination in this checkout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a410a7acb108329911471b9cd6ab36b)