### PR TITLE
docs: clarify Gestor Estrutural short instruction handling

### DIFF
--- a/docs/gestor-estrutural.md
+++ b/docs/gestor-estrutural.md
@@ -21,6 +21,7 @@ Lousa (índice estrutural) — Gestor Estrutural VS9
 * em caso de conflito, prevalece a fonte competente por assunto, e não uma hierarquia linear única
 * antes de orientar mudança estrutural, confirmar no repositório real a localização atual dos artefatos
 * ao criar briefing para o Codex no repositório, usar obrigatoriamente docs/template-briefing-codex.md
+* ao receber instrução curta do Estrategista, como “Avalie a fase XX do plano-base Y segundo suas diretrizes documentadas”, aplicar este documento como critério de avaliação dentro do escopo do Gestor Estrutural.
 * na dúvida, pedir investigação antes de orientar mudança estrutural
 * classificar o resultado como: aprovado; aprovado com condicionantes; requer investigação; requer patch estrutural; ou rejeitado por conflito com fonte competente
 1.5 Regra de evolução da lousa


### PR DESCRIPTION
### Motivation

- Tornar explícito que o Gestor Estrutural pode ser acionado por instrução curta do Estrategista e que, nesses casos, deve aplicar as diretrizes documentadas neste documento como critério de avaliação.

### Description

- Adicionado um bullet em `1.4 Regra de consulta e validação estrutural` do arquivo `docs/gestor-estrutural.md` que especifica que, ao receber instrução curta do Estrategista (por exemplo: “Avalie a fase XX do plano-base Y segundo suas diretrizes documentadas”), o Gestor Estrutural deve aplicar este documento como critério de avaliação dentro do seu escopo.

### Testing

- Validações documentais realizadas: conferida a presença do bullet em `1.4` com `rg -n 'ao receber instrução curta do Estrategista' docs/gestor-estrutural.md`; confirmado que `docs/gestor-estrutural.md` permanece compacto (64 linhas); executado `git diff --check` sem erros; arquivo alterado: `docs/gestor-estrutural.md`; branch usada: `docs/gestor-instrucao-curta`; commit: `9bde3eb`; tentativa de `git push -u origin docs/gestor-instrucao-curta` falhou por ausência do remoto `origin`; `npm ci` e `npm run check` não aplicáveis por ser alteração exclusivamente documental.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4119492d388329a77edf0ead756d79)