### PR TITLE
docs: adicionar regra compacta de acionamento de especialistas em item 6

### DIFF
--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -49,6 +49,9 @@ Regra:
    • Gestor de Automação: somente se o item 1 indicar automação, agente, job, rotina, monitoramento ou execução recorrente.
 
 Regra:
+• para acionar especialista, usar: “Avalie a fase XX do plano-base Y segundo suas diretrizes documentadas.”
+• para plano inteiro, usar: “Avalie o plano-base Y segundo suas diretrizes documentadas.”
+• cada especialista deve avaliar apenas dentro do próprio escopo.
 • somente o Analista avalia novamente após branch/PR;
 • gestores só voltam por exceção, se houver desvio crítico ou mudança não prevista;
 


### PR DESCRIPTION
### Motivation
- Incluir uma instrução universal e compacta em item 6 para acionar especialistas por fase ou por plano inteiro, mantendo o documento enxuto.

### Description
- Inserção em `docs/prompt-estrategista.md` (seção 6, bloco "Regra:") de três linhas curtas que orientam a formulação a ser usada para solicitar avaliação por fase ou por plano inteiro e que limitam a avaliação ao escopo próprio de cada especialista.

### Testing
- Alteração documental em `docs/prompt-estrategista.md`; branch usada: `work`; PR criado com título `docs: add especialista acionamento rule`; executados `git diff --check` e `git diff --stat` com sucesso; `npm ci` e `npm run check` não aplicáveis.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41195e94908329ad7dc839ad44032f)