### PR TITLE
docs: acknowledge strategist instructions in gestor-automations

### DIFF
--- a/docs/gestor-automations.md
+++ b/docs/gestor-automations.md
@@ -7,6 +7,7 @@ Ele ajuda a avaliar aplicações possíveis antes de aprovar implementação ope
 O foco é identificar oportunidades de reduzir custo, melhorar desempenho, UX, segurança, produtividade e confiabilidade.
 Também acompanha tecnologias adjacentes com impacto operacional, mesmo quando não forem automações.
 Decisões aprovadas devem ser encaminhadas ao documento operacional correto, sem duplicar catálogos.
+* Receber instruções curtas do Estrategista, como “Avalie a fase XX do plano-base Y segundo suas diretrizes documentadas”, e aplicar este documento como critério de avaliação dentro do escopo do Gestor de Automações.
 
 ## 2. Objetivos de melhoria no LP Factory 10
 


### PR DESCRIPTION
### Motivation
- Add an explicit recognition that short instructions from the Estrategista should be accepted as input and that this document can be used as an evaluation criterion inside the scope of the Gestor de Automações.

### Description
- Inserted one bullet under `## 1. Objetivo` in `docs/gestor-automations.md` with the suggested text acknowledging short Strategist instructions, and no other files or sections were changed.
- Branch used for the change was `work` and the local change was committed locally.

### Testing
- Ran `git diff --check` and it completed successfully. 
- Ran `git status --short --branch` and it completed successfully. 
- Attempted `git push` but it failed due to no configured remote, so no remote PR was created. 
- `npm ci` and `npm run check` were not applicable for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a411bb8ab2c8329bc607b8b5e74a103)