### PR TITLE
docs: patch corretivo do plano-base E9

### DIFF
--- a/docs/lousa-plano-base-e9.md
+++ b/docs/lousa-plano-base-e9.md
@@ -27,6 +27,21 @@ Fontes: chat, docs/roadmap.md, docs/prompt-estrategista.md
 3. Fases e próxima ação
 
 * Fase 1 — Contrato interno de elegibilidade: definir origem comercial, status, consumo pelo Account Dashboard e necessidade estrutural mínima de persistência.
+
+3.1 Detalhamento da Fase 1 — Contrato interno de elegibilidade
+
+* Objetivo: definir o contrato mínimo que decide quando uma conta pode acessar o gate comercial de criação de LPs.
+* Resultado esperado: contrato conceitual aprovado, sem checkout, sem webhook, sem migration e sem alteração de runtime.
+* Investigar: lógica atual de conta ativa, membership, Account Dashboard, plans, trial, permissões e bloqueios existentes.
+* Definir: origens comerciais válidas, status conceituais, bloqueios independentes, consumo pelo Account Dashboard e dados mínimos necessários para fases futuras.
+* Regra central: conta precisa estar em estado operacional permitido, membership precisa permitir acesso e entitlement comercial precisa estar válido.
+* Origem inicial: plano pago confirmado.
+* Origens futuras: trial, liberação manual, provedor de checkout e webhook.
+* Status conceituais esperados: sem_entitlement, pendente_confirmacao, ativo, expirado, cancelado e bloqueado_operacionalmente.
+* Os nomes são conceituais; antes da implementação, verificar se já existe nomenclatura canônica no projeto.
+* Não implementar checkout, provedor, webhook, migration, tabela, RPC, policy, grant, constraint, Account Dashboard, cards, LP Builder ou tela admin.
+* Parar se a investigação exigir mudança de banco, runtime, arquitetura, cards da E10.7 ou mutação administrativa da E12 antes de nova decisão estratégica.
+* Entrega esperada da Fase 1: investigação resumida, arquivos consultados, contrato interno proposto, riscos, lacunas e validação documental.
 * E9.xx futuro — Provedor de checkout: escolher e integrar primeiro provedor para cards pagos.
 * E9.xx futuro — Webhook e persistência: validar confirmação, idempotência e registro de entitlement comercial.
 * E9.xx futuro — Consumo da elegibilidade: liberar gate comercial para criação de LPs após persistência validada.

--- a/docs/lousa-plano-base-e9.md
+++ b/docs/lousa-plano-base-e9.md
@@ -42,6 +42,9 @@ Fontes: chat, docs/roadmap.md, docs/prompt-estrategista.md
 * Não implementar checkout, provedor, webhook, migration, tabela, RPC, policy, grant, constraint, Account Dashboard, cards, LP Builder ou tela admin.
 * Parar se a investigação exigir mudança de banco, runtime, arquitetura, cards da E10.7 ou mutação administrativa da E12 antes de nova decisão estratégica.
 * Entrega esperada da Fase 1: investigação resumida, arquivos consultados, contrato interno proposto, riscos, lacunas e validação documental.
+
+3.2 Fases futuras e próxima ação
+
 * E9.xx futuro — Provedor de checkout: escolher e integrar primeiro provedor para cards pagos.
 * E9.xx futuro — Webhook e persistência: validar confirmação, idempotência e registro de entitlement comercial.
 * E9.xx futuro — Consumo da elegibilidade: liberar gate comercial para criação de LPs após persistência validada.

--- a/docs/lousa-plano-base-e9.md
+++ b/docs/lousa-plano-base-e9.md
@@ -4,9 +4,12 @@ Fontes: chat, docs/roadmap.md, docs/prompt-estrategista.md
 1. Estado e decisões fixas
 
 * E9 define elegibilidade comercial para criar LPs.
+* E9 libera apenas o gate/elegibilidade comercial; não implementa LP Builder nem fluxo visual de criação de LPs.
 * Conta active não fica elegível apenas por estar ativa.
+* Entitlement comercial não substitui bloqueios de conta, membership ou status operacional.
 * Elegibilidade nasce de origem comercial válida: plano pago confirmado ou, futuramente, trial concedido.
 * Recorte inicial: cards pagos Start, Lite, Pro e Ultra + checkout confirmado.
+* Usar a nomenclatura canônica dos planos vigente no projeto; se houver diferença entre Start e Starter, resolver antes da implementação do checkout.
 * Provedor de checkout entra como subseção futura E9.xx.
 * Trial automático/manual entra como subseção futura E9.xx.
 * Ajuste de valores pertence a E12.xx, por ser operação administrativa no Admin Dashboard.
@@ -23,13 +26,17 @@ Fontes: chat, docs/roadmap.md, docs/prompt-estrategista.md
 
 3. Fases e próxima ação
 
-* Fase 1 — Contrato interno de elegibilidade: definir origem comercial, status e consumo pelo Account Dashboard.
-* Fase 2 — Provedor de checkout: escolher e integrar primeiro provedor para cards pagos.
-* Fase 3 — Webhook e persistência: validar confirmação e registrar entitlement.
-* Fase 4 — Consumo da elegibilidade: liberar criação de LPs para conta elegível.
-* Fase futura — Trial E9.xx: trial automático/manual como outra origem de entitlement.
-* Fase futura — Valores E12.xx: ajuste administrativo de valores, planos ativos e vínculo com provedor.
-* Próxima ação: solicitar avaliação do plano-base por Analista, Gestor Estrutural, Gestor de Updates e Gestor de Automação.
+* Fase 1 — Contrato interno de elegibilidade: definir origem comercial, status, consumo pelo Account Dashboard e necessidade estrutural mínima de persistência.
+* E9.xx futuro — Provedor de checkout: escolher e integrar primeiro provedor para cards pagos.
+* E9.xx futuro — Webhook e persistência: validar confirmação, idempotência e registro de entitlement comercial.
+* E9.xx futuro — Consumo da elegibilidade: liberar gate comercial para criação de LPs após persistência validada.
+* E9.xx futuro — Trial: trial automático/manual como outra origem de entitlement.
+* E9.xx futuro — Liberação manual: contratação manual ou concessão administrativa como origem comercial válida, sem comprovante informal por WhatsApp.
+* E12.xx futuro — Valores: ajuste administrativo de valores, planos ativos e vínculo com provedor.
+* Próxima ação: seguir para consolidação do Estrategista e só depois abrir recorte de execução aprovado.
+* Estrutura de persistência será definida em fase própria antes da implementação.
+* Webhook de confirmação, quando implementado, deve ser catalogado em docs/automations.md como automação operacional, com recurso utilizado, categoria e classificação.
+* Updates aplicáveis: supa#5 para logs seguros, supa#36 para leituras server-side, supa#40 para validação SQL read-only, supa#58 como trava de schema/grants/policies e prod#13 apenas como referência futura, sem bundles/grants no recorte inicial.
 
 4. Escopo negativo e critérios de parada
 
@@ -40,4 +47,7 @@ Fontes: chat, docs/roadmap.md, docs/prompt-estrategista.md
 * Não criar tela administrativa de valores dentro do E9.
 * Não transformar E9 em Billing Engine completo.
 * Não usar agente de IA.
+* Não implementar LP Builder nem fluxo visual de criação de LPs no E9; E9 libera apenas o gate/elegibilidade comercial.
+* Parar se a fase exigir tabela, RPC, policy, grant ou migration antes de definir contrato de entitlement, idempotência e consumo no Account Dashboard.
+* Não assumir public.plans como fonte suficiente para checkout, descontos, garantias, regras promocionais ou URLs oficiais sem decisão específica.
 * Parar se o recorte exigir mudança visual da E10.7, mutação administrativa ampla da E12, ou definição de trial antes do checkout pago mínimo.


### PR DESCRIPTION
### Motivation

* Corrigir o plano-base E9 após merge acidental para explicitar limites, fases futuras e travas de persistência antes da execução técnica.

### Description

* Atualiza apenas `docs/lousa-plano-base-e9.md` para explicitar que E9 libera somente o gate/elegibilidade comercial e não implementa LP Builder nem o fluxo visual de criação de LPs.
* Acrescenta que o entitlement comercial não substitui bloqueios de conta, membership ou status operacional e exige nomenclatura canônica de planos (Start vs Starter) antes do checkout.
* Reordena e marca fases como futuras (`E9.xx` / `E12.xx`) para provedor de checkout, webhook/persistência, consumo da elegibilidade, trial e liberação manual, e adiciona nota de que a estrutura de persistência será definida em fase própria.
* Adiciona guardrails operacionais incluindo catalogação do webhook em `docs/automations.md`, referência a updates aplicáveis (`supa#5`, `supa#36`, `supa#40`, `supa#58`, `prod#13`) e bloqueio de schema/RPC/policy/grant/migration antes do contrato de entitlement e idempotência.

### Testing

* Alteração verificada por `git diff --name-only` — somente `docs/lousa-plano-base-e9.md` foi modificada; verificação de diff mostrou 17 inserções e 7 deleções.
* Verificações locais: `git diff --check` sem erros de whitespace e `git status` em branch limpa; branch usada: `fix/e9-plano-base-patch-documental`.
* Publicação remota não concluída porque o remote `origin` não está configurado neste ambiente, portanto o push/PR não foi criado automaticamente.
* `npm ci` e `npm run check` não foram executados por serem não aplicáveis em alteração exclusivamente documental.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a413020af908329b19b601db7fdaac6)