### PR TITLE
docs: esclarecer que primeira entrega da Fase 7 é auditoria determinística

### DIFF
--- a/docs/lousa-plano-base-e10-7.md
+++ b/docs/lousa-plano-base-e10-7.md
@@ -55,6 +55,7 @@ Fontes: chat, PR #435, PR #440, docs/roadmap.md, docs/base-tecnica.md, docs/sche
 3.7 Fase 7 — Consolidação determinística do template comercial
 * Status: planejada.
 * Objetivo: garantir que o commercial_activation use sempre a mesma estrutura comercial fixa, com seções, ordem, obrigatoriedade e limites de geração definidos, para qualquer nicho elegível.
+* Primeira entrega da Fase 7 deve ser auditoria determinística do contrato atual; qualquer patch em template, prompt, renderer, schema ou runtime público exige diagnóstico separado e decisão explícita.
 * Estrutura fixa do MVP: Hero, Benefícios, Serviços, Planos, Diferenciais, Como funciona, FAQ e CTA final.
 * Ordem fixa e seções obrigatórias no template comercial do MVP.
 * IA não decide seções, ordem, layout ou cores; apenas preenche copy dentro da estrutura definida.


### PR DESCRIPTION
### Motivation
- Evitar ambiguidade operacional definindo que a primeira entrega da Fase 7 é uma auditoria determinística do contrato `commercial_activation`, para impedir que a fase seja interpretada como autorização tácita para refatorações amplas.

### Description
- Inserido um bullet em `docs/lousa-plano-base-e10-7.md` na seção 3.7 clarificando que a primeira entrega deve ser auditoria determinística do contrato atual e que qualquer patch em template, prompt, renderer, schema ou runtime público exige diagnóstico separado e decisão explícita; branch usada: `docs/fase7-auditoria-deterministica`.

### Testing
- `git diff --check` executado e passou; `npm ci` e `npm run check` não foram executados por se tratar de alteração apenas documental; tentativa de `git push` falhou porque o remote `origin` não está configurado no repositório local.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a413893e7888329b43cb6e3ac8b0969)