### PR TITLE
docs: ajustar regra do executor no prompt estrategista

### DIFF
--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -1,6 +1,6 @@
 27/06/2026 — Fluxo do Estrategista
 
-Versão: v2
+Versão: v3
 
 0. Papel do Estrategista
 Você é o Estrategista do LP Factory 10. Sua função é transformar casos em plano-base, coordenar análises, orientar execução por fase e consolidar a decisão final, mantendo foco em MVP, baixo risco e menor complexidade.
@@ -68,8 +68,8 @@ Regra:
    • atualização apenas do estado da fase executada no plano-base.
 
 Regra:
-• o Executor não atualiza docs/roadmap.md nem outros documentos;
-• documentação final fica para relatório do Estrategista ao Gestor de Docs.
+• o único documento que o Executor pode ajustar é o plano-base do caso: docs/lousa-plano-base-EXX-YY.md;
+• docs/roadmap.md, docs/base-tecnica.md, docs/schema.md e demais documentos finais ficam para o Gestor de Docs, com base no relatório final do Estrategista.
 
 9. Avaliação do Analista
    Após entrega do Executor, o Analista avalia branch/PR, aderência ao plano-base, diff, riscos, evidências e atualização da fase no plano-base.


### PR DESCRIPTION
### Motivation
- Corrigir a regra documental do item 8 para limitar o que o Executor pode alterar e garantir que documentos finais sejam responsabilidade do Gestor de Docs. 
- Atualizar a versão do documento para `v3`.

### Description
- Atualizei a linha no topo de `docs/prompt-estrategista.md` de `Versão: v2` para `Versão: v3`.
- Substituí o bloco de regra do item 8 em `docs/prompt-estrategista.md` para definir que o Executor só pode ajustar o plano-base do caso em `docs/lousa-plano-base-EXX-YY.md` e que `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/schema.md` e demais documentos finais ficam para o Gestor de Docs.
- Não foram criados novos itens, fluxos, ou alterada a numeração; nenhuma outra documentação foi modificada.

### Testing
- Executei `git diff --check` com sucesso para validar o diff.
- `npm ci`: não aplicável para alteração exclusivamente documental.
- `npm run check`: não aplicável para alteração exclusivamente documental.
- Branch usada: `codex/ajustar-item-6-no-documento-de-estrategias`; o commit foi criado localmente, porém o `git push` não foi concluído porque o remote `origin` não está configurado no repositório (`fatal: 'origin' does not appear to be a git repository`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a417aab5bc08329b12a987084f6e02a)