### PR TITLE
docs: ajustar recorte da E19 no roadmap

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1347,12 +1347,14 @@ Repositório — Criados
 • O E19 só deve avançar para implementação quando houver recorte funcional real do LP Builder, evitando antecipação estrutural sem massa de código.
 
 19.5 Dependências / referências
+• E9 — Billing, trial e entitlements
 • E10 — Account Dashboard
 • E12 — Admin Dashboard
 • E13 — Partner Dashboard
+• E18 — Base transversal de templates, módulos, composições e artefatos
 
 19.6 Próximo passo
-• Definir o primeiro recorte funcional do LP Builder no roadmap
+• Definir o primeiro recorte funcional do LP Builder no roadmap, incluindo o ponto server-side de criação produtiva de LP por conta, a persistência mínima da LP e a aplicação do gate comercial da E9 nesse ponto real.
 
 19.7 Referência futura a páginas comerciais por taxon
 • E19 poderá futuramente consumir a existência de página comercial publicada por taxon.


### PR DESCRIPTION
### Motivation
- Tornar explícito, de forma mínima e sem inflar o roadmap, que o primeiro recorte funcional da E19 deve cobrir o ponto server-side real de criação produtiva de LP por conta e referenciar as dependências comerciais/transversais necessárias (E9, E18). 

### Description
- Alterei apenas `docs/roadmap.md`, atualizando `19.5 Dependências / referências` para incluir `E9` e `E18` e substituindo `19.6 Próximo passo` para explicitar: ponto server-side de criação produtiva de LP por conta, persistência mínima da LP e aplicação do gate comercial da `E9`; mudança realizada na branch `docs/e19-lp-builder-recorte` com commit `d846ec5` and nenhum outro arquivo foi modificado. 

### Testing
- Executei `git diff --check` e inspeção manual do diff, que confirmaram sucesso e que somente `docs/roadmap.md` foi alterado enquanto cabeçalho/versão/changelog permaneceram inalterados; `npm ci` e `npm run check` foram considerados não aplicáveis; tentativa de `git push` falhou por falta de remote `origin` configurado no ambiente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42786044ec8329b7e79b3c8a4b500a)