### PR TITLE
docs: registrar Stripe Plugin em docs/gestor-codex.md

### DIFF
--- a/docs/gestor-codex.md
+++ b/docs/gestor-codex.md
@@ -61,7 +61,7 @@ Plugins aproximam serviços externos das tarefas de investigação e execução.
 
 **Aptidão:** apoio consultivo/read-only para boas práticas de billing, trial e entitlements da futura E9.
 **Estado:** em teste.
-**Conta Stripe:** LP Factory; e-mail da conta: `[INFORMAR_EMAIL_DA_CONTA_STRIPE]`.
+**Conta Stripe:** LP Factory; e-mail não informado neste ajuste.
 **Ambiente:** modo teste / área restrita.
 **Chave restrita criada:** `codex-test-lpfactory`; tipo agente; permissões selecionadas somente leitura.
 **Recursos com leitura selecionada:** Customers, Products, Prices, Subscriptions, Invoices e Checkout Sessions.

--- a/docs/gestor-codex.md
+++ b/docs/gestor-codex.md
@@ -57,6 +57,18 @@ Plugins aproximam serviços externos das tarefas de investigação e execução.
 **Valor:** acelera diagnóstico de deploys, previews, build logs, runtime, endpoints e configurações Vercel.
 **Limite:** escrita, deploy manual, variáveis de ambiente, domínios, settings e ações em produção não testados nem aprovados.
 
+### Stripe Plugin
+
+**Aptidão:** apoio consultivo/read-only para boas práticas de billing, trial e entitlements da futura E9.
+**Estado:** em teste.
+**Conta Stripe:** LP Factory; e-mail da conta: `[INFORMAR_EMAIL_DA_CONTA_STRIPE]`.
+**Ambiente:** modo teste / área restrita.
+**Chave restrita criada:** `codex-test-lpfactory`; tipo agente; permissões selecionadas somente leitura.
+**Recursos com leitura selecionada:** Customers, Products, Prices, Subscriptions, Invoices e Checkout Sessions.
+**Valor:** agregou valor como consultor de boas práticas para E9; a avaliação conceitual confirmou que billing/assinatura devem ficar fora de `accounts.status`; Stripe deve alimentar/confirmar o entitlement, mas a decisão local deve continuar server-side e fail-closed; checkout de assinatura deve usar Stripe Billing/Checkout Session em modo `subscription`; webhooks, assinatura do evento e idempotência são obrigatórios antes de liberar entitlement.
+**Limite:** uso aprovado por enquanto somente consultivo/read-only; escrita/gravação não aprovada; produção não ativada; conta de produção não criada/ativada nesta etapa; não usar para criar, alterar ou excluir dados; não usar em produção; não registrar chaves Stripe no repositório; não depender do plugin como bloqueador da E9; se o plugin pedir permissões adicionais, registrar a necessidade antes de ampliar o acesso.
+**Pendência:** leitura operacional da conta Stripe ainda não validada no Codex App local; a leitura/listagem operacional de dados Stripe não funcionou na sessão testada, pois nenhuma ferramenta MCP de listagem foi exposta ao Codex App local.
+
 **Disponíveis não adotados:** Slack.
 
 ## 5. Skills


### PR DESCRIPTION
### Motivation

- Registrar o uso experimental do Stripe Plugin no documento central de gestão do Codex para apoiar rastreabilidade da futura E9 (Billing, trial e entitlements).
- Comunicar limites, permissões e pendências operacionais para evitar uso indevido do plugin em produção ou com escrita. 

### Description

- Adicionada a seção "Stripe Plugin" em `docs/gestor-codex.md` com campos de aptidão, estado, conta, ambiente e nome da chave restrita (`codex-test-lpfactory`).
- Documentadas as permissões aprovadas (somente leitura), recursos com leitura habilitada (Customers, Products, Prices, Subscriptions, Invoices, Checkout Sessions) e que escrita/gravação e produção não estão aprovadas.
- Registrados aprendizados e recomendações conceituais (entitlement server-side fail-closed, cobrança via Billing/Checkout Session em `subscription`, webhooks e idempotência obrigatórios). 
- Especificada a pendência operacional de validação da leitura/listagem na sessão do Codex App local e limites de uso (não criar/alterar/excluir dados, não registrar chaves no repositório). 

### Testing

- Executado `git diff --check` e não retornou problemas (sucesso). 
- Executada busca por padrões de tokens Stripe usando regex e não foram encontrados segredos ou fragmentos de chaves no arquivo alterado (sucesso). 
- Revisado o diff de `docs/gestor-codex.md` para confirmar o conteúdo inserido e conformidade com os limites solicitados (sucesso). 
- `npm ci` e `npm run check` não aplicáveis por se tratar de alteração exclusivamente documental.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4297adbbc083299eac932e13b99341)