### PR TITLE
docs: atualizar Fase 6 do E9 para recomendar Stripe Checkout (subscription)

### DIFF
--- a/docs/lousa-plano-base-e9.md
+++ b/docs/lousa-plano-base-e9.md
@@ -380,10 +380,16 @@ Governança da Fase 4:
 3.7 Fase 6 — Provedor de checkout mínimo
 
 * Objetivo: escolher 1 provedor inicial de checkout para confirmação comercial mínima.
+* Provedor inicial recomendado: Stripe, usando Stripe Checkout em modo `subscription`, no ambiente de teste, com recorrência mensal/anual conforme contrato comercial aprovado.
+* Reserva operacional: Asaas fica como provedor reserva para avaliação posterior, sem implementação no recorte inicial.
+* Adiado: Mercado Pago fica explicitamente adiado, sem adapter, SDK, webhook, configuração ou dependência nesta fase.
 * Boundary obrigatório: implementar a integração dentro de `lib/billing-checkout/`, com contrato neutro para o app e adapter mínimo/substituível do provedor escolhido.
+* Recorte técnico do checkout: criação de sessão do Stripe Checkout em modo `subscription`, ambiente teste, referência de conta/plano e retorno de identificadores externos necessários para fase posterior de persistência.
 * Resultado esperado: plano pago gera referência externa para posterior persistência do entitlement, sem acoplar o app ao SDK, API, nomenclatura ou eventos internos do provedor.
+* Referência operacional do plugin: manter qualquer orientação operacional específica de plugin apenas em `docs/gestor-codex.md`; este plano-base deve registrar somente o recorte estratégico/técnico da fase.
 * Limite: não criar múltiplos provedores, roteamento multi-provider, Billing Engine completo ou abstração prematura além do boundary neutro necessário.
 * Limite de acoplamento: não espalhar SDK/API do provedor por páginas, actions, Account Dashboard, domínio de entitlement ou outros módulos fora do adapter.
+* Pendências obrigatórias antes de qualquer implementação: fechar contrato interno plano/assinatura; definir mapeamento Stripe Product/Price → `plan_key`; decidir tratamento do `PlanId` legado; desenhar fluxo de checkout em ambiente teste; definir contrato de webhook normalizado → `account_commercial_entitlements`.
 
 3.8 Fase 7 — Webhook e persistência do entitlement
 


### PR DESCRIPTION
### Motivation

* Escolher um provedor inicial de checkout claro para o recorte E9 e evitar ambiguidade entre múltiplos provedores. 
* Definir o recorte técnico mínimo do checkout e manter o boundary neutro para futura implementação sem acoplamento ao SDK/API do provedor.

### Description

* Atualiza `docs/lousa-plano-base-e9.md` na Fase 6 para recomendar Stripe como provedor inicial usando Stripe Checkout em modo `subscription` (ambiente de teste, recorrência mensal/anual). 
* Registra `Asaas` como provedor reserva e marca `Mercado Pago` como adiado, sem implementação nem dependência nesta fase. 
* Especifica o boundary neutro `lib/billing-checkout/`, o recorte técnico de criação de sessão Stripe Checkout e que a orientação operacional do plugin deve ficar apenas em `docs/gestor-codex.md`. 
* Adiciona pendências obrigatórias antes de implementação: contrato interno plano/assinatura; mapeamento Stripe Product/Price → `plan_key`; decisão sobre `PlanId` legado; fluxo de checkout em ambiente teste; e contrato de webhook normalizado → `account_commercial_entitlements`.

### Testing

* Executado `git diff --check` e sem problemas detectados. 
* `npm ci` não aplicável por ser alteração exclusivamente documental. 
* `npm run check` não aplicável por ser alteração exclusivamente documental.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42a0f18cec83298466f7d2a2a34cfd)