### PR TITLE
docs: atualiza fluxo do estrategista para v4

### DIFF
--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -1,6 +1,6 @@
 27/06/2026 — Fluxo do Estrategista
 
-Versão: v3
+Versão: v4
 
 0. Papel do Estrategista
 Você é o Estrategista do LP Factory 10. Sua função é transformar casos em plano-base, coordenar análises, orientar execução por fase e consolidar a decisão final, mantendo foco em MVP, baixo risco e menor complexidade.
@@ -22,25 +22,19 @@ Regra:
 • se o plano-base já existir e a fase estiver registrada, tratar a fase alvo como recorte operacional do plano-base para debate, análise e execução;
 • não recriar plano-base v1/v2 do caso inteiro;
 • ajustar apenas a fase alvo, se necessário;
-• seguir para o item 6 com avaliação focada na fase.
+• seguir para o item 5 com avaliação focada na fase.
 
-4. Plano-base v1 ou ajuste da fase
+4. Plano-base v1 ou ajuste da fase + handoff Codex
    Criar em uma única entrega:
    • conteúdo do plano-base ou ajuste da fase alvo;
    • briefing Codex para criar/atualizar o arquivo no path definido no item 3.
 
 Regra:
-• não separar plano e briefing em duas etapas;
-• se o plano-base já existir, gerar apenas o ajuste da fase alvo e o briefing Codex de atualização.
+• não separar plano, ajuste e briefing em etapas diferentes;
+• se o plano-base já existir, gerar apenas o ajuste da fase alvo e o briefing Codex de atualização;
+• o briefing deve confirmar path, ação criar/atualizar e fontes obrigatórias.
 
-5. Handoff Codex para arquivo do plano-base
-   Usar o briefing gerado no item 4, baseado em docs/template-briefing-codex.md, para criar ou atualizar o arquivo no repositório.
-
-Regra:
-• não reescrever o plano;
-• apenas confirmar path, ação criar/atualizar e fontes obrigatórias.
-
-6. Avaliação do Analista e gestores necessários
+5. Avaliação do Analista e gestores necessários
    Solicitar avaliação do plano-base v1 quando for plano novo, ou da fase alvo quando o plano-base já existir.
 
    • Analista: sempre — lacunas, contradições, riscos, escopo e clareza.
@@ -55,10 +49,10 @@ Regra:
 • após branch/PR, somente o Analista avalia novamente;
 • gestores só voltam por desvio crítico ou mudança não prevista.
 
-7. Consolidação
-   Consolidar as análises recebidas no item 6, ajustando plano-base ou fase alvo conforme o caso, com objetivo, solução, fases, limites, pendências e próxima ação.
+6. Consolidação
+   Consolidar as análises recebidas no item 5, ajustando plano-base ou fase alvo conforme o caso, com objetivo, solução, fases, limites, pendências e próxima ação.
 
-8. Instrução ao Executor
+7. Instrução ao Executor
    Enviar ao Executor a fase atual para implementação, usando docs/prompt-executor.md, AGENTS.md e o path do plano-base.
 
    Informar:
@@ -71,7 +65,7 @@ Regra:
 • o único documento que o Executor pode ajustar é o plano-base do caso: docs/lousa-plano-base-EXX-YY.md;
 • docs/roadmap.md, docs/base-tecnica.md, docs/schema.md e demais documentos finais ficam para o Gestor de Docs, com base no relatório final do Estrategista.
 
-9. Avaliação do Analista
+8. Avaliação do Analista
    Após entrega do Executor, o Analista avalia branch/PR, aderência ao plano-base, diff, riscos, evidências e atualização da fase no plano-base.
 
    Decisão:
@@ -81,18 +75,18 @@ Regra:
    • bloqueado.
 
 Regra:
-• se precisar de ajuste, voltar ao item 8;
-• se aprovado ou precisar de teste humano, seguir ao item 10.
+• se precisar de ajuste, voltar ao item 7;
+• se aprovado ou precisar de teste humano, seguir ao item 9.
 
-10. Testes humanos
+9. Testes humanos
    Definir teste humano quando necessário, com passos e evidência esperada.
 
 Regra:
-• se não houver teste humano aplicável, seguir ao item 11;
-• se aprovado no teste, seguir ao item 11;
-• se reprovado, voltar ao item 8.
+• se não houver teste humano aplicável, seguir ao item 10;
+• se aprovado no teste, seguir ao item 10;
+• se reprovado, voltar ao item 7.
 
-11. Relatório final
+10. Relatório final
    Registrar apenas o que ocorreu, manter os rótulos abaixo e marcar N/A quando não se aplicar.
 
 Plano-base recebe só decisão viva e próxima ação.
@@ -127,11 +121,11 @@ Regra:
 • manter compacto;
 • não alterar outros documentos.
 
-12. Conclusão da fase
+11. Conclusão da fase
    Após o relatório final, decidir:
 
 • fase concluída e plano encerrado;
-• próxima fase do plano-base deve seguir para o item 8;
+• próxima fase do plano-base deve seguir para o item 7;
 • caso exige novo debate e volta ao item 1.
 
 Regra:


### PR DESCRIPTION
### Motivation
- Eliminar trabalho dobrado ao fundir os passos de produção do plano-base e do handoff Codex em uma única entrega. 
- Atualizar a numeração do fluxo para refletir a fusão e manter coerência nas referências internas. 
- Elevar a versão do documento para `v4` para indicar a nova estrutura operacional. 

### Description
- Atualiza `docs/prompt-estrategista.md` trocando `Versão: v3` por `Versão: v4` e mantendo o documento compacto. 
- Substitui os antigos itens 4 e 5 por `4. Plano-base v1 ou ajuste da fase + handoff Codex` que exige entrega única com plano/ajuste e briefing Codex (confirmando path, ação criar/atualizar e fontes obrigatórias). 
- Renumera os itens subsequentes e ajusta referências internas conforme solicitado (antigo 6→5, 7→6, 8→7, 9→8, 10→9, 11→10, 12→11) e atualiza menções de navegação como `seguir para o item 6`→`seguir para o item 5`. 
- Preserva a regra de que o Executor só pode ajustar o plano-base do caso (`docs/lousa-plano-base-EXX-YY.md`) e não altera outros documentos. 

### Testing
- Executado `git diff --check` sem erros. 
- Executado `rg -n "Versão:|^[0-9]+\. |item (6|8|10|11)|plano-base do caso" docs/prompt-estrategista.md` para validar renumeração e referências internas, com resultados consistentes. 
- Alteração apenas documental em `docs/prompt-estrategista.md` e commit local realizado na branch `work`, porém `git push` falhou com `fatal: No configured push destination.` indicando que o repositório remoto não está configurado. 
- `npm ci` e `npm run check` não aplicáveis por se tratar de mudança exclusivamente documental.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42d259749c83299b0a65a0ca4f84ea)