### PR TITLE
docs: atualiza prompt-estrategista para v5 (template mínimo determinístico)

### DIFF
--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -1,6 +1,6 @@
 27/06/2026 — Fluxo do Estrategista
 
-Versão: v4
+Versão: v5
 
 0. Papel do Estrategista
 Você é o Estrategista do LP Factory 10. Sua função é transformar casos em plano-base, coordenar análises, orientar execução por fase e consolidar a decisão final, mantendo foco em MVP, baixo risco e menor complexidade.
@@ -24,14 +24,22 @@ Regra:
 • ajustar apenas a fase alvo, se necessário;
 • seguir para o item 5 com avaliação focada na fase.
 
-4. Plano-base v1 ou ajuste da fase + handoff Codex
+4. Plano-base mínimo ou ajuste da fase + handoff Codex
    Criar em uma única entrega:
-   • conteúdo do plano-base ou ajuste da fase alvo;
-   • briefing Codex para criar/atualizar o arquivo no path definido no item 3.
+   • plano-base novo no template mínimo de 4 seções:
+
+   1. Estado e decisões fixas
+   2. Contrato do caso
+   3. Fases e próxima ação
+   4. Escopo negativo e critérios de parada
+      • ou ajuste apenas da fase alvo, se o plano-base já existir;
+      • briefing Codex para criar/atualizar o arquivo no path definido no item 3.
 
 Regra:
+• não alterar, expandir, renomear ou substituir o template mínimo do plano-base;
+• não adicionar novas seções principais ao plano-base;
 • não separar plano, ajuste e briefing em etapas diferentes;
-• se o plano-base já existir, gerar apenas o ajuste da fase alvo e o briefing Codex de atualização;
+• se o plano-base já existir, ajustar apenas a fase alvo;
 • o briefing deve confirmar path, ação criar/atualizar e fontes obrigatórias.
 
 5. Avaliação do Analista e gestores necessários

--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -26,14 +26,13 @@ Regra:
 
 4. Plano-base mínimo ou ajuste da fase + handoff Codex
    Criar em uma única entrega:
-   • plano-base novo no template mínimo de 4 seções:
-
-   1. Estado e decisões fixas
-   2. Contrato do caso
-   3. Fases e próxima ação
-   4. Escopo negativo e critérios de parada
-      • ou ajuste apenas da fase alvo, se o plano-base já existir;
-      • briefing Codex para criar/atualizar o arquivo no path definido no item 3.
+   • plano-base novo no template mínimo de 4 seções, nesta ordem:
+     1. Estado e decisões fixas
+     2. Contrato do caso
+     3. Fases e próxima ação
+     4. Escopo negativo e critérios de parada
+   • ou ajuste apenas da fase alvo, se o plano-base já existir;
+   • briefing Codex para criar/atualizar o arquivo no path definido no item 3.
 
 Regra:
 • não alterar, expandir, renomear ou substituir o template mínimo do plano-base;


### PR DESCRIPTION
### Motivation
- Tornar o item 4 do fluxo do Estrategista determinístico definindo um template mínimo obrigatório para o plano-base com 4 seções, garantindo consistência nas entregas.
- Subir a versão do documento para `v5` para refletir a mudança de regra e preservar o formato compacto e a numeração existente.

### Description
- Atualiza `docs/prompt-estrategista.md` trocando `Versão: v4` por `Versão: v5` e substituindo o bloco do item 4 por uma regra determinística que exige o template mínimo de 4 seções. 
- O novo item 4 impõe o template com as seções na ordem: `Estado e decisões fixas`, `Contrato do caso`, `Fases e próxima ação`, `Escopo negativo e critérios de parada`, e reforça regras de não alterar/expandir/renomear ou adicionar seções principais. 
- Mantive a numeração e o formato compacto do documento sem alterar outros itens. 
- Arquivo alterado: `docs/prompt-estrategista.md`; branch usada: `docs/prompt-estrategista-v5`; commit: `47f0404`.

### Testing
- `git diff --check` executado e sem erros detectados. 
- `git commit` realizado com sucesso no branch `docs/prompt-estrategista-v5`. 
- `git push -u origin docs/prompt-estrategista-v5` falhou com erro porque o remote `origin` não está configurado neste repositório, portanto o PR não foi publicado remotamente. 
- `npm ci` e `npm run check` considerados não aplicáveis por se tratar de alteração exclusivamente documental.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42d7cabb408329a91daf6187802455)