### PR TITLE
docs: adicionar 3.7.1 Fase 6.1 — Contrato interno de planos e PlanId legado

### DIFF
--- a/docs/lousa-plano-base-e9.md
+++ b/docs/lousa-plano-base-e9.md
@@ -395,6 +395,17 @@ Governança da Fase 4:
 * Limite de acoplamento: não espalhar SDK/API do provedor por páginas, actions, Account Dashboard, domínio de entitlement ou outros módulos fora do adapter futuro.
 * Pendências obrigatórias antes de qualquer implementação: resolver ou aposentar o `PlanId` legado; fechar contrato interno plano/assinatura/checkout; definir mapeamento Stripe Product/Price → `plan_key`; desenhar fluxo de checkout em ambiente teste; definir contrato de webhook normalizado → `account_commercial_entitlements`.
 
+3.7.1 Fase 6.1 — Contrato interno de planos e PlanId legado
+
+* Status: recorte obrigatório de decisão e contrato, sem implementação técnica.
+* Objetivo: destravar a Fase 6 antes de qualquer checkout, resolvendo a divergência entre o `PlanId` legado e o contrato oficial de planos.
+* Decisão pendente: definir o destino do `PlanId` legado `free`/`light`/`pro`/`ultra`, escolhendo entre aposentadoria, camada temporária de compatibilidade ou mapeamento explícito antes de qualquer uso em checkout.
+* Contrato oficial: confirmar `plan_key` como `starter`, `lite`, `pro` e `ultra` para persistência, entitlement, checkout e consumo interno.
+* Regra de segurança comercial: `free` não vira plano pago Stripe, Product, Price, assinatura ou entitlement comercial pago sem decisão explícita registrada em fase própria.
+* Normalização obrigatória: alinhar a divergência `light` vs `lite`; `light` não deve escapar para contrato novo, Product/Price, entitlement ou UI operacional sem mapeamento deliberado.
+* Preparação Stripe: produzir o mapeamento Stripe Product/Price → `plan_key` antes da criação de sessão de checkout, preservando o provedor como detalhe externo e mantendo `plan_key` como chave canônica interna.
+* Limite: não criar código, schema, migration, rota, action, checkout, webhook, admin, Billing Engine, multi-provider engine ou alteração fora desta lousa.
+
 3.8 Fase 7 — Webhook e persistência do entitlement
 
 * Objetivo: persistir ou atualizar `account_commercial_entitlements` após confirmação comercial.


### PR DESCRIPTION
### Motivation

* Resolver a divergência entre o `PlanId` legado e as chaves canônicas de plano antes de permitir qualquer checkout, documentando decisões e limites operacionais necessários para destravar a Fase 6.

### Description

* Inserido o recorte `3.7.1 Fase 6.1 — Contrato interno de planos e PlanId legado` imediatamente após a Fase 6 no arquivo `docs/lousa-plano-base-e9.md` sem reordenar seções. 
* A nova seção registra a necessidade de decidir o destino do `PlanId` legado (`free`/`light`/`pro`/`ultra`), confirmar o `plan_key` oficial (`starter`/`lite`/`pro`/`ultra`), garantir que `free` não vire plano pago sem decisão explícita, alinhar `light` vs `lite` e preparar o mapeamento Stripe Product/Price → `plan_key` antes de criar sessões de checkout. 
* Mantido explicitamente o limite de não criar código, schema, migration, rota, action, checkout, webhook, admin, Billing Engine ou multi-provider engine neste recorte. 
* Arquivo alterado: `docs/lousa-plano-base-e9.md`; branch usada: `work`; commit: `6533ce7 docs: add fase 6.1 plan contract`.

### Testing

* Executados: `git diff --check` passou sem problemas e o arquivo modificado aparece com 11 inserções. 
* `git commit` foi realizado com sucesso no branch `work` (commit `6533ce7`).
* `git push` falhou por configuração de ambiente com a mensagem de erro `fatal: No configured push destination.` e portanto não há URL de PR remoto criado. 
* `npm ci` e `npm run check` foram considerados não aplicáveis por serem alterações exclusivamente documentais.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42da2d0dfc83298b4431974956bffa)