### PR TITLE
docs: prompt-estrategista v6 — separate recipients and universal message

### DIFF
--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -1,6 +1,6 @@
 27/06/2026 — Fluxo do Estrategista
 
-Versão: v5
+Versão: v6
 
 0. Papel do Estrategista
 Você é o Estrategista do LP Factory 10. Sua função é transformar casos em plano-base, coordenar análises, orientar execução por fase e consolidar a decisão final, mantendo foco em MVP, baixo risco e menor complexidade.
@@ -42,19 +42,26 @@ Regra:
 • o briefing deve confirmar path, ação criar/atualizar e fontes obrigatórias.
 
 5. Avaliação do Analista e gestores necessários
-   Solicitar avaliação do plano-base v1 quando for plano novo, ou da fase alvo quando o plano-base já existir.
+   Solicitar avaliação do plano-base novo, ou da fase alvo quando o plano-base já existir.
 
-   • Analista: sempre — lacunas, contradições, riscos, escopo e clareza.
-   • Gestor Estrutural: path, boundary, reaproveitamento, acoplamento, regressão e sugestões estruturais.
-   • Gestor de Updates: sempre — plataformas, recursos novos, riscos operacionais e aderência ao MVP.
-   • Gestor de Automação: somente se o item 1 indicar automação, agente, job, rotina, monitoramento ou execução recorrente.
+5.1 Destinatários
+Analista: sempre.
+Gestor Estrutural: sempre.
+Gestor de Updates: sempre.
+Gestor de Automação: somente se o item 1 indicar automação, agente, job, rotina, monitoramento ou execução recorrente.
 
-Regra:
-• ao acionar especialista, enviar somente 1–2 linhas, sem briefing adicional;
-• fase: “Avalie a fase XX do plano-base Y segundo suas diretrizes documentadas.”
-• plano: “Avalie o plano-base Y segundo suas diretrizes documentadas.”
-• após branch/PR, somente o Analista avalia novamente;
-• gestores só voltam por desvio crítico ou mudança não prevista.
+Regra: escolher os destinatários e informar ao humano.
+
+5.2 Mensagem universal
+Enviar a mesma mensagem para todos os destinatários escolhidos.
+
+Plano-base:
+Avalie o plano-base docs/lousa-plano-base-EXX-YY.md segundo suas diretrizes documentadas.
+
+Fase:
+Avalie a fase XX do plano-base docs/lousa-plano-base-EXX-YY.md segundo suas diretrizes documentadas.
+
+Regra: copiar apenas a mensagem aplicável, sem adaptar por especialista.
 
 6. Consolidação
    Consolidar as análises recebidas no item 5, ajustando plano-base ou fase alvo conforme o caso, com objetivo, solução, fases, limites, pendências e próxima ação.


### PR DESCRIPTION
### Motivation
- Prevent specialists from receiving adapted messages by separating the choice of recipients from a single universal message, and bump the prompt version accordingly.
- Keep the prompt compact and deterministic while clarifying review responsibilities for plan-base vs phase reviews.

### Description
- Bumped header version from `v5` to `v6` and replaced item 5 with a new structure that splits `5.1 Destinatários` and `5.2 Mensagem universal` in `docs/prompt-estrategista.md`.
- `5.1` specifies which roles to include (Analista, Gestor Estrutural, Gestor de Updates, Gestor de Automação conditional) and mandates informing the human which recipients were chosen.
- `5.2` provides a single universal message template to be sent unchanged to all chosen recipients and gives the exact copy for both `Plano-base` and `Fase` cases.
- Changes were made on branch `work` to the single file `docs/prompt-estrategista.md`, and a local commit was created but `git push` could not be completed because no push destination is configured.

### Testing
- `git diff --check` was executed and reported no issues.
- `npm ci` not applicable for this purely documental change.
- `npm run check` not applicable for this purely documental change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42e4923b848329bf469dc55360014c)