### PR TITLE
docs: ajustar nome da Fase 1 do plano-base E19

### DIFF
--- a/docs/lousa-plano-base-E19.md
+++ b/docs/lousa-plano-base-E19.md
@@ -32,7 +32,7 @@ E19 — LP Builder MVP
 
 3. Fases e próxima ação
 
-* Fase 1 — Criação produtiva mínima de LP por conta
+* Fase 1 — Definição da criação produtiva mínima de LP por conta
   * Status: em definição.
   * Objetivo: validar recorte, persistência mínima, boundary, relação com E9, E18 e E10.7.
   * Próxima ação: solicitar avaliação do Analista, Gestor Estrutural e Gestor de Updates.


### PR DESCRIPTION
### Motivation
- Tornar explícito no plano-base E19 que a Fase 1 é de definição e não de implementação, evitando ambiguidade no fluxo de validação.

### Description
- Na branch `docs/e19-ajuste-fase-1-definicao` alterei apenas uma linha em `docs/lousa-plano-base-E19.md`, substituindo `* Fase 1 — Criação produtiva mínima de LP por conta` por `* Fase 1 — Definição da criação produtiva mínima de LP por conta`.

### Testing
- Validações automáticas executadas: `git diff --name-only` confirmou alteração só em `docs/lousa-plano-base-E19.md`, `git diff --numstat` mostrou `1` inserção e `1` remoção, `rg` confirmou o novo heading e que as 4 seções principais (`1.`, `2.`, `3.`, `4.`) permanecem; `git diff --check` não mostrou problemas; commit foi criado com sucesso; `npm ci` e `npm run check` foram dispensados por serem alterações apenas documentais; tentativa de `git push` falhou porque o repositório local não possui o remote `origin`, portanto o PR ainda precisa ser publicado no remoto (push da branch `docs/e19-ajuste-fase-1-definicao` e abertura do PR pelo usuário).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43c35c0aa08329b22d059e1bdece97)