### PR TITLE
docs: registrar Fase 2 no plano-base E19

### DIFF
--- a/docs/lousa-plano-base-E19.md
+++ b/docs/lousa-plano-base-E19.md
@@ -33,21 +33,31 @@ E19 — LP Builder MVP
 3. Fases e próxima ação
 
 * Fase 1 — Definição da criação produtiva mínima de LP por conta
-  * Status: em definição.
+
+  * Status: consolidada.
   * Objetivo: validar recorte, persistência mínima, boundary, relação com E9, E18 e E10.7.
-  * Próxima ação: solicitar avaliação do Analista, Gestor Estrutural e Gestor de Updates.
-* Fase 2 — Desenho técnico mínimo
-  * Status: futura.
-  * Objetivo: definir estrutura de persistência, contrato de criação, path canônico e ponto exato de aplicação do gate E9.
-  * Condição de entrada: Fase 1 aprovada e consolidada.
+  * Resultado: aprovado com condicionantes por Analista, Gestor Estrutural e Gestor de Updates.
+* Fase 2 — Desenho técnico mínimo da criação produtiva de LP por conta
+
+  * Status: proposta para consolidação.
+  * Objetivo: definir estrutura mínima para criação produtiva de LP por conta, sem implementação, fechando persistência, contrato, boundary, path canônico e ponto de aplicação do gate E9.
+  * Hipótese principal: avaliar tabela própria mínima para LP por conta, com account_id, name, slug, status, created_by, created_at e updated_at.
+  * Status inicial sugerido: draft.
+  * Gate obrigatório: bloquear server-side antes da persistência quando não houver conta active, membership active e entitlement comercial válido.
+  * Boundary técnico esperado: lib/lp-builder/.
+  * Superfície de entrada: ainda a definir; app/a/[account] pode ser entrada contextual futura, mas não path canônico da mutação E19 sem nova decisão.
+  * E18: referência futura para templates, módulos, composições e artefatos; não usar content_artifacts diretamente como LP produtiva por conta neste primeiro recorte sem nova validação.
+  * Próxima ação: consolidar schema mínimo, path real da mutação e contrato de criação antes de qualquer Executor.
 * Fase 3 — Implementação do primeiro recorte
+
   * Status: futura.
   * Objetivo: implementar criação produtiva mínima de LP por conta.
   * Condição de entrada: Fase 2 aprovada e instrução ao Executor emitida.
-* Avaliações necessárias após criar o plano:
-  * Analista: avaliar lacunas, contradições, riscos, escopo e clareza.
-  * Gestor Estrutural: avaliar path, boundary, reaproveitamento, acoplamento e regressão.
-  * Gestor de Updates: avaliar plataformas, recursos novos, riscos operacionais e aderência ao MVP.
+* Avaliações necessárias:
+
+  * Analista: avaliar Fase 2 após registro.
+  * Gestor Estrutural: já avaliou a proposta prévia; retorna se houver mudança estrutural.
+  * Gestor de Updates: avaliar Fase 2 após registro.
   * Gestor de Automação: N/A.
 
 4. Escopo negativo e critérios de parada


### PR DESCRIPTION
### Motivation

* Registrar a Fase 2 do plano-base E19 como desenho técnico mínimo da criação produtiva de LP por conta sem autorizar implementação;
* Deixar explícitos hipóteses, boundary e restrições operacionais para avaliação por Analista e Gestores;
* Preservar o escopo negativo e as demais seções principais do documento para evitar alterações de implementação acidentais.

### Description

* Atualizei apenas a seção `3. Fases e próxima ação` no arquivo `docs/lousa-plano-base-E19.md` para registrar a Fase 2 como desenho técnico mínimo e consolidar o status da Fase 1.;
* A Fase 2 agora declara `status: proposta para consolidação`, `status inicial sugerido: draft`, hipótese de tabela mínima (`account_id, name, slug, status, created_by, created_at, updated_at`), gate obrigatório server-side antes da persistência, boundary técnico esperado `lib/lp-builder/` e que `app/a/[account]` é apenas possível entrada contextual futura, não path canônico.;
* Mantive a Fase 3 como futura e preservei as quatro seções principais do plano-base sem tocar em roadmap, base técnica, schema, código, migrations, versão ou changelog.;
* Branch criada: `docs/e19-registrar-fase-2-desenho-tecnico` e commit local efetuado com a mensagem `docs: registrar Fase 2 no plano-base E19`.

### Testing

* Validado automaticamente que apenas `docs/lousa-plano-base-E19.md` foi alterado e que as quatro seções principais existem via `git diff`, `git diff --stat` e checagens em Python, e essas validações tiveram sucesso.;
* Commit local criado com sucesso (`fcfcaf4`) e a alteração confirmada no histórico local.;
* Tentativa de publicar com `git push -u origin docs/e19-registrar-fase-2-desenho-tecnico` falhou porque o remoto `origin` não está configurado neste checkout, portanto não há PR remoto criado neste ambiente.;
* `npm ci` e `npm run check` não foram executados por não serem aplicáveis a esta alteração exclusivamente documental.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43cdf9feec8329967f92a8c5f52e1f)