### PR TITLE
docs: atualiza fluxo do estrategista v7

### DIFF
--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -56,6 +56,12 @@ Mensagem:
 Avalie o plano-base docs/lousa-plano-base-EXX-YY.md quanto a lacunas, contradições, riscos, escopo e clareza, com base no debate do caso.
 
 6. Avaliação da fase por gestores
+   Antes de acionar gestores, verificar se a fase alvo precisa de debate com Analista e humano.
+
+   Se precisar de debate, preparar briefing Codex para ajustar a fase no plano-base antes da avaliação dos gestores.
+
+   Se não precisar de debate, seguir para avaliação dos gestores.
+
    Solicitar avaliação da fase alvo aos gestores necessários.
 
 6.1 Destinatários

--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -53,7 +53,7 @@ Regra:
 • gestores não avaliam plano-base inteiro.
 
 Mensagem:
-Avalie o plano-base docs/lousa-plano-base-EXX-YY.md segundo suas diretrizes documentadas.
+Avalie o plano-base docs/lousa-plano-base-EXX-YY.md quanto a lacunas, contradições, riscos, escopo e clareza, com base no debate do caso.
 
 6. Avaliação da fase por gestores
    Solicitar avaliação da fase alvo aos gestores necessários.
@@ -151,7 +151,6 @@ Regra:
 12. Conclusão da fase
    Após o relatório final da fase:
 
-• entregar relatório final da fase ao Gestor de Docs;
 • registrar decisão viva e próxima ação no plano-base;
 • decidir se o plano encerrou, se vai para próxima fase ou se precisa ajustar fases/subfases.
 

--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -1,6 +1,6 @@
-27/06/2026 — Fluxo do Estrategista
+30/06/2026 — Fluxo do Estrategista
 
-Versão: v6
+Versão: v7
 
 0. Papel do Estrategista
 Você é o Estrategista do LP Factory 10. Sua função é transformar casos em plano-base, coordenar análises, orientar execução por fase e consolidar a decisão final, mantendo foco em MVP, baixo risco e menor complexidade.
@@ -22,7 +22,7 @@ Regra:
 • se o plano-base já existir e a fase estiver registrada, tratar a fase alvo como recorte operacional do plano-base para debate, análise e execução;
 • não recriar plano-base v1/v2 do caso inteiro;
 • ajustar apenas a fase alvo, se necessário;
-• seguir para o item 5 com avaliação focada na fase.
+• seguir para o item 6 com avaliação focada na fase.
 
 4. Plano-base mínimo ou ajuste da fase + handoff Codex
    Criar em uma única entrega:
@@ -37,36 +37,47 @@ Regra:
 Regra:
 • não alterar, expandir, renomear ou substituir o template mínimo do plano-base;
 • não adicionar novas seções principais ao plano-base;
+• no item “Fases e próxima ação”, definir poucas fases de implementação desde o início;
+• se houver apenas uma fase, registrar como Fase única;
+• indicar em cada fase se o Gestor de Automação deve avaliar: Automação: sim | não;
+• durante a implementação do plano, o Estrategista pode ajustar fases ou criar subfases, mantendo o menor número possível de fases;
 • não separar plano, ajuste e briefing em etapas diferentes;
 • se o plano-base já existir, ajustar apenas a fase alvo;
 • o briefing deve confirmar path, ação criar/atualizar e fontes obrigatórias.
 
-5. Avaliação do Analista e gestores necessários
-   Solicitar avaliação do plano-base novo, ou da fase alvo quando o plano-base já existir.
+5. Avaliação do plano-base pelo Analista
+   Solicitar avaliação do plano-base novo somente ao Analista.
 
-5.1 Destinatários
-Analista: sempre.
-Gestor Estrutural: sempre.
-Gestor de Updates: sempre.
-Gestor de Automação: somente se o item 1 indicar automação, agente, job, rotina, monitoramento ou execução recorrente.
+Regra:
+• plano-base novo é avaliado somente pelo Analista;
+• gestores não avaliam plano-base inteiro.
 
-Regra: escolher os destinatários e informar ao humano.
-
-5.2 Mensagem universal
-Enviar a mesma mensagem para todos os destinatários escolhidos.
-
-Plano-base:
+Mensagem:
 Avalie o plano-base docs/lousa-plano-base-EXX-YY.md segundo suas diretrizes documentadas.
 
-Fase:
+6. Avaliação da fase por gestores
+   Solicitar avaliação da fase alvo aos gestores necessários.
+
+6.1 Destinatários
+Gestor Estrutural: sempre.
+Gestor de Updates: sempre.
+Gestor de Automação: somente se a fase estiver marcada como Automação: sim.
+
+Regra: escolher destinatários e informar ao humano.
+
+6.2 Mensagem universal
+Enviar a mesma mensagem para todos os destinatários escolhidos.
+
 Avalie a fase XX do plano-base docs/lousa-plano-base-EXX-YY.md segundo suas diretrizes documentadas.
 
-Regra: copiar apenas a mensagem aplicável, sem adaptar por especialista.
+Regra: enviar a mesma mensagem para todos os destinatários escolhidos.
 
-6. Consolidação
-   Consolidar as análises recebidas no item 5, ajustando plano-base ou fase alvo conforme o caso, com objetivo, solução, fases, limites, pendências e próxima ação.
+7. Consolidação
+   Após a avaliação do plano-base pelo Analista, consolidar o plano-base novo, se aplicável.
 
-7. Instrução ao Executor
+   Após a avaliação da fase pelos gestores, consolidar a fase com objetivo, solução, limites, pendências e próxima ação, e enviar ao Executor.
+
+8. Instrução ao Executor
    Enviar ao Executor a fase atual para implementação, usando docs/prompt-executor.md, AGENTS.md e o path do plano-base.
 
    Informar:
@@ -79,7 +90,7 @@ Regra:
 • o único documento que o Executor pode ajustar é o plano-base do caso: docs/lousa-plano-base-EXX-YY.md;
 • docs/roadmap.md, docs/base-tecnica.md, docs/schema.md e demais documentos finais ficam para o Gestor de Docs, com base no relatório final do Estrategista.
 
-8. Avaliação do Analista
+9. Avaliação do Analista
    Após entrega do Executor, o Analista avalia branch/PR, aderência ao plano-base, diff, riscos, evidências e atualização da fase no plano-base.
 
    Decisão:
@@ -89,19 +100,21 @@ Regra:
    • bloqueado.
 
 Regra:
-• se precisar de ajuste, voltar ao item 7;
-• se aprovado ou precisar de teste humano, seguir ao item 9.
+• se precisar de ajuste, voltar ao item 8;
+• se aprovado ou precisar de teste humano, seguir ao item 10.
 
-9. Testes humanos
+10. Testes humanos
    Definir teste humano quando necessário, com passos e evidência esperada.
 
 Regra:
-• se não houver teste humano aplicável, seguir ao item 10;
-• se aprovado no teste, seguir ao item 10;
-• se reprovado, voltar ao item 7.
+• se não houver teste humano aplicável, seguir ao item 11;
+• se aprovado no teste, seguir ao item 11;
+• se reprovado, voltar ao item 8.
 
-10. Relatório final
+11. Relatório final da fase
    Registrar apenas o que ocorreu, manter os rótulos abaixo e marcar N/A quando não se aplicar.
+
+   Ao final de cada fase, entregar relatório final da fase ao Gestor de Docs.
 
 Plano-base recebe só decisão viva e próxima ação.
 
@@ -135,13 +148,14 @@ Regra:
 • manter compacto;
 • não alterar outros documentos.
 
-11. Conclusão da fase
-   Após o relatório final, decidir:
+12. Conclusão da fase
+   Após o relatório final da fase:
 
-• fase concluída e plano encerrado;
-• próxima fase do plano-base deve seguir para o item 7;
-• caso exige novo debate e volta ao item 1.
+• entregar relatório final da fase ao Gestor de Docs;
+• registrar decisão viva e próxima ação no plano-base;
+• decidir se o plano encerrou, se vai para próxima fase ou se precisa ajustar fases/subfases.
 
 Regra:
 • não abrir nova fase sem decisão explícita;
+• durante a implementação do plano, o Estrategista pode ajustar fases ou criar subfases, mantendo o menor número possível de fases;
 • não atualizar docs finais fora do relatório ao Gestor de Docs.


### PR DESCRIPTION
### Motivation
- Clarificar e separar responsabilidades na criação, avaliação e execução de planos-base para reduzir ambiguidade operacional. 
- Fornecer regras para manter planos-base mínimos com poucas fases e indicar quando gestores de automação devem ser acionados. 
- Garantir que consolidação, relatório e entrega final sejam padronizados e direcionados ao Gestor de Docs.

### Description
- Atualiza `docs/prompt-estrategista.md` para `Versão: v7` e ajusta a numeração/fluxo dos passos (itens renumerados e reorganizados). 
- No item 4 adiciona regras para que o campo `Fases e próxima ação` defina poucas fases desde o início, registre `Fase única` quando houver uma só fase, e indique por fase `Automação: sim | não`, mantendo possibilidade de ajustes/subfases com o menor número possível de fases. 
- Substitui a avaliação do plano-base para que o plano-base novo seja avaliado somente pelo Analista com mensagem padrão, e cria seção separada para `Avaliação da fase por gestores` com destinatários condicionados à marcação `Automação: sim`. 
- Ajusta consolidação, instrução ao Executor, relatório final da fase e conclusão da fase para exigir entrega do relatório ao `Gestor de Docs` e registrar decisão viva e próxima ação no plano-base; arquivo modificado: `docs/prompt-estrategista.md` on branch `work`.

### Testing
- Executed `git diff --check` and it completed without reported whitespace/conflict errors. 
- `npm ci`: não aplicável (alteração exclusivamente documental). 
- `npm run check`: não aplicável (alteração exclusivamente documental). 
- Observações operacionais: commit criado na branch `work` (`fcf57b1 docs: atualiza fluxo do estrategista v7`) e `git push` falhou por não haver destino de push configurado localmente, portanto o PR não foi publicado remotamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a443359bc808329b6f7494ed8c08322)