### PR TITLE
docs: register E9 Phase 6 checkout boundary (Stripe test checkout)

### DIFF
--- a/docs/base-tecnica.md
+++ b/docs/base-tecnica.md
@@ -99,6 +99,23 @@
 • Componentes específicos de rota que dependem de Server Action, estado ou boundary da própria rota devem nascer como route-local em `app/.../_components`; não promover para `components/features` sem boundary compartilhada real.
 • Partner Dashboard não ganha boundary antecipada. LP Builder é seção própria, fora do Account Dashboard.
 
+3.3.3 Billing checkout
+• Path canônico: `lib/billing-checkout/`.
+• Uso: domínio server-side para criação de Checkout Session de provedor externo.
+• Provedor inicial: Stripe.
+• Ambiente inicial: teste.
+• Modo: `subscription`.
+• Contrato de planos pagos: `starter`, `lite`, `pro` e `ultra`.
+• Recorrências permitidas: `monthly` e `annual`.
+• `free`, `light` e `PlanId` legado não são contrato de negócio do checkout novo.
+• Adapter inicial: `createStripeTestCheckoutSession`.
+• Mapeamento Stripe teste: Product/Price por env, sem valores versionados.
+• Integração Stripe: chamada server-side via `fetch`, sem SDK Stripe no MVP.
+• Regra: UI/client não acessa `STRIPE_SECRET_KEY` nem cria sessão diretamente.
+• Regra: redirect de sucesso/cancelamento não confirma pagamento e não libera entitlement.
+• Regra: Stripe não substitui `public.account_commercial_entitlements`.
+• Webhook, assinatura, idempotência e persistência de entitlement pertencem à fase seguinte.
+
 3.4 CI/Lint (Bloqueios)
 • Validação por PR + preview de deploy (Vercel)
 • PATH: .github/workflows/security.yml

--- a/docs/platform-config.md
+++ b/docs/platform-config.md
@@ -19,6 +19,7 @@
 • Supabase: backend, Auth, Storage, Redirect URLs, SMTP Auth e infraestrutura.
 • Resend: envio transacional via SMTP.
 • OpenAI Platform: Projects, Service Accounts, API e modelo do resolvedor IA.
+• Stripe: provedor inicial de checkout em modo teste para assinatura.
 • Registro.com: domínio e DNS.
 • Zoho Mail: e-mail humano/corporativo quando aplicável.
 
@@ -279,9 +280,61 @@
 • Regra: não tratar como camada final robusta de orquestração.
 • Dependência: MCP Supabase Inspect em `https://lpf-10-services.vercel.app/api/mcp`.
 
-7. Domínios e DNS
+7. Stripe
 
-7.1 Domínios conhecidos
+7.1 Uso
+• Finalidade: provedor inicial de checkout do E9.
+• Ambiente atual validado: teste.
+• Modo: `subscription`.
+• O app cria Checkout Session server-side.
+• Stripe Dashboard/Plugin pode apoiar criação, validação e consulta de Product/Price e Checkout Sessions.
+• Stripe Plugin não substitui o fluxo server-side do LP Factory.
+• Webhook e persistência de entitlement ficam para fase própria.
+
+7.2 Endpoint usado pelo app
+• Checkout Sessions API: `https://api.stripe.com/v1/checkout/sessions`
+• Regra: chamada somente server-side.
+• Regra: não expor secret Stripe no client.
+
+7.3 Vercel — secrets e variáveis Stripe
+• `STRIPE_SECRET_KEY`
+• Finalidade: secret server-side Stripe para criar Checkout Sessions.
+• Plataforma: Vercel.
+• Escopo conhecido: Production validado; Preview quando necessário para testes.
+• Valor real: não versionar.
+
+Products/Prices de teste
+• `STRIPE_TEST_STARTER_MONTHLY_PRODUCT_ID`
+• `STRIPE_TEST_STARTER_MONTHLY_PRICE_ID`
+• `STRIPE_TEST_STARTER_ANNUAL_PRODUCT_ID`
+• `STRIPE_TEST_STARTER_ANNUAL_PRICE_ID`
+• `STRIPE_TEST_LITE_MONTHLY_PRODUCT_ID`
+• `STRIPE_TEST_LITE_MONTHLY_PRICE_ID`
+• `STRIPE_TEST_LITE_ANNUAL_PRODUCT_ID`
+• `STRIPE_TEST_LITE_ANNUAL_PRICE_ID`
+• `STRIPE_TEST_PRO_MONTHLY_PRODUCT_ID`
+• `STRIPE_TEST_PRO_MONTHLY_PRICE_ID`
+• `STRIPE_TEST_PRO_ANNUAL_PRODUCT_ID`
+• `STRIPE_TEST_PRO_ANNUAL_PRICE_ID`
+• `STRIPE_TEST_ULTRA_MONTHLY_PRODUCT_ID`
+• `STRIPE_TEST_ULTRA_MONTHLY_PRICE_ID`
+• `STRIPE_TEST_ULTRA_ANNUAL_PRODUCT_ID`
+• `STRIPE_TEST_ULTRA_ANNUAL_PRICE_ID`
+
+Regra:
+• Registrar apenas nomes e finalidade das envs.
+• Nunca versionar Product IDs, Price IDs, secret key, session ID, customer ID ou subscription ID reais.
+• Alteração de env Stripe na Vercel exige redeploy do deployment alvo.
+
+7.4 Redirects de checkout
+• Success URL: gerada server-side a partir do origin da requisição.
+• Cancel URL: gerada server-side a partir do origin da requisição.
+• Redirect de sucesso não confirma pagamento e não libera entitlement.
+• Confirmação de pagamento/assinatura deve ocorrer por webhook em fase própria.
+
+8. Domínios e DNS
+
+8.1 Domínios conhecidos
 • `lpfactory.com.br`
 • Uso: domínio da marca/projeto LP Factory.
 • Status conhecido: registrado e publicado.
@@ -289,60 +342,60 @@
 • `unicodigital.com.br`
 • Uso: domínio relacionado à Unico Digital e e-mail corporativo existente.
 
-7.2 Registro.com
+8.2 Registro.com
 • Uso: registrar e gerenciar DNS/domínios quando aplicável.
 • Regra: alterações DNS devem ser feitas com cuidado, preservando e-mail humano/corporativo e entregabilidade transacional.
 
-7.3 E-mail humano/corporativo
+8.3 E-mail humano/corporativo
 • Provedor conhecido: Zoho Mail para `unicodigital.com.br`.
 • Direção operacional: e-mails humanos da LP Factory devem usar provedor humano/corporativo, como Zoho/M365/Workspace, não Resend.
 • Resend deve permanecer como transacional.
 
-8. Regras operacionais de mudança
+9. Regras operacionais de mudança
 
-8.1 Alteração de env na Vercel
+9.1 Alteração de env na Vercel
 • Alterar variável no ambiente correto: Preview, Production ou ambos.
 • Executar redeploy após alteração.
 • Validar primeiro em Preview quando for alteração de feature ou risco operacional.
 • Só promover para Production após validação mínima.
 
-8.2 Alteração de SMTP/Auth
+9.2 Alteração de SMTP/Auth
 • Validar signup confirm.
 • Validar forgot password.
 • Confirmar que links funcionam.
 • Confirmar que não houve erro de envio.
 • Não expor senha SMTP em prints, logs ou chat.
 
-8.3 Alteração de DNS
+9.3 Alteração de DNS
 • Identificar o registro atual antes de alterar.
 • Avaliar impacto em site, e-mail humano e e-mail transacional.
 • Não substituir SPF/DKIM/DMARC sem mapear dependências.
 • Registrar mudança em relatório operacional quando houver impacto.
 
-8.4 Alteração de GitHub Actions secrets
+9.4 Alteração de GitHub Actions secrets
 • Não registrar valor real.
 • Confirmar qual workflow consome o secret.
 • Confirmar ambiente/escopo.
 • Reexecutar workflow necessário após alteração.
 
-9. Relação com outros documentos
+10. Relação com outros documentos
 
-9.1 Base Técnica
+10.1 Base Técnica
 • `docs/base-tecnica.md` deve manter regras de implementação, runtime, segurança, adapters e observability.
 • Configurações de plataforma devem morar neste documento.
 • Quando a Base Técnica depender de uma configuração, deve referenciar este documento de forma curta.
 
-9.2 Schema
+10.2 Schema
 • `docs/schema.md` permanece como fonte única para objetos de banco, RLS, policies, RPCs, triggers, constraints, grants e permissões de DB.
 
-9.3 Roadmap
+10.3 Roadmap
 • `docs/roadmap.md` permanece como fonte única para estado final dos casos E*, escopo, artefatos, status e pendências.
 
-9.4 Design System
+10.4 Design System
 • `docs/design-system.md` permanece como fonte única para padrões visuais, componentes UI e regras de uso visual.
 
 
-9.5 Automations
+10.5 Automations
 • `docs/automations.md` permanece como fonte para catálogo, uso, status, dependências e aprendizados das automações.
 • Configurações de plataformas, secrets por nome, workflows, ambientes e endpoints usados por automações devem ser registrados neste documento.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -301,11 +301,13 @@
 9. E9 — Billing, trial e entitlements
 
 9.1 Status
-• Em execução faseada — Fase 4 concluída em 28/06/2026.
+• Em execução faseada — Fase 6 concluída em 30/06/2026.
 • Schema mínimo de entitlement comercial versionado.
 • Consumo server-side mínimo da elegibilidade comercial disponível.
+• Stripe Checkout em teste disponível no app.
+• Assinatura teste criada sem entitlement local automático.
 • Sem Billing Engine completo implementado nesta fase.
-• Próxima execução recomendada: E9 Fase 5 — Gate produtivo de criação de LP.
+• Próxima execução recomendada: E9 Fase 7.1 — contrato do webhook Stripe e persistência de entitlement.
 
 9.2 Objetivo atual
 • Separar condição comercial da conta do lifecycle operacional da conta.
@@ -359,15 +361,34 @@
 • Account Dashboard carrega o sinal server-side, mas ainda não aplica bloqueio produtivo.
 • Checkout, webhook, provedor, admin, trial operacional, liberação manual operacional, LP Builder e Billing Engine completo permanecem fora do recorte.
 
-9.3.7 Updates avaliados
+9.3.7 Provedor de checkout mínimo
+• Status: Fase 6 concluída em 30/06/2026.
+• Provedor inicial: Stripe.
+• Ambiente inicial: teste.
+• Modo de Checkout: `subscription`.
+• Boundary criado: `lib/billing-checkout/`.
+• App cria Checkout Session server-side.
+• Stripe não substitui o entitlement local.
+• Redirect de sucesso não confirma pagamento nem libera entitlement.
+• `free` não vira plano pago.
+• `light` não entra no contrato novo.
+• `PlanId` legado não é contrato de negócio.
+• Webhook, assinatura do webhook, idempotência e persistência em `account_commercial_entitlements` ficam para a Fase 7.
+
+9.3.8 Updates avaliados
 • `supa#5`, `supa#36`, `supa#40`, `supa#58`.
 
 9.4 Pendências vigentes
-• Implementar E9 Fase 5 — Gate produtivo de criação de LP.
-• Aplicar server-side a regra: conta `active` + membership ativo + entitlement comercial válido.
-• Decidir onde o gate produtivo bloqueia criação de LP sem entitlement válido.
-• Revisar ou aposentar o legado `PlanId = "free" | "light" | "pro" | "ultra"` antes de qualquer checkout.
-• Definir provider/checkout e webhook apenas depois do gate produtivo validado.
+• Implementar E9 Fase 7.1 — contrato do webhook Stripe e persistência de entitlement.
+• Definir contrato do webhook Stripe.
+• Validar assinatura do webhook.
+• Definir evento normalizado.
+• Definir idempotência.
+• Mapear status Stripe para status comercial interno.
+• Persistir ou atualizar `public.account_commercial_entitlements`.
+• Garantir que redirect de sucesso continue sem liberar entitlement.
+• Auditar logs detalhados quando a ferramenta permitir.
+• Não persistir payload bruto, cartão, secret ou PII sensível em logs ou banco.
 
 9.5 Estruturas e artefatos
 
@@ -381,23 +402,29 @@ Repositório — Criados
 • `lib/commercial-entitlements/contracts.ts`
 • `lib/commercial-entitlements/adapters/commercialEntitlementAdapter.ts`
 • `lib/commercial-entitlements/index.ts`
+• `lib/billing-checkout/contracts.ts`
+• `lib/billing-checkout/adapters/stripePriceMap.ts`
+• `lib/billing-checkout/adapters/stripeCheckoutAdapter.ts`
+• `lib/billing-checkout/index.ts`
+• `app/a/[account]/_components/commercial-page/checkout-actions.ts`
 
 Repositório — Ajustados
 • `app/a/[account]/page.tsx`
+• `app/a/[account]/_components/commercial-page/GenericCommercialPage.tsx`
 • `docs/schema.md`
 • `docs/lousa-plano-base-e9.md`
 
-9.6 Fora do escopo da Fase 4
-• Bloqueio produtivo de criação de LP.
-• Checkout.
-• Webhook.
-• Provedor de pagamento.
+9.6 Fora do escopo da Fase 6
+• Webhook Stripe.
+• Validação de assinatura do webhook.
+• Persistência de entitlement local.
+• Billing Engine completo.
 • Admin comercial.
 • Trial operacional.
 • Liberação manual operacional.
-• Billing Engine completo.
+• LP Builder.
 • Alteração de layout, copy ou cards da E10.7.
-• Logs sensíveis, eventos, job, rotina, monitoramento ou automação.
+• Logs sensíveis, eventos persistidos, job, rotina, monitoramento ou automação.
 
 10. E10 — Account Dashboard (UX)
 


### PR DESCRIPTION
### Motivation
- Record E9 Phase 6 completion and decisions about the minimal Stripe checkout provider in the roadmap. 
- Establish a durable server-side boundary for billing checkout at `lib/billing-checkout/` in the Base Técnica to guide implementation and security rules. 
- Register Stripe as the platform used for test Checkout Sessions, list env names and endpoint in Platform Config while avoiding any real secrets or IDs. 
- Keep webhook, idempotency and entitlement persistence out of this phase and point the next execution to E9 Phase 7.1 for those responsibilities.

### Description
- Updated `docs/roadmap.md` to mark "Fase 6" complete (30/06/2026), add section `9.3.7 Provedor de checkout mínimo` describing Stripe test checkout semantics, adjust updates/pending items and list created/adjusted artifacts. 
- Added `3.3.3 Billing checkout` to `docs/base-tecnica.md`, documenting the canonical path `lib/billing-checkout/`, server-side `fetch` integration, plan/recurrence contract, and security rules (no client access to `STRIPE_SECRET_KEY`, redirects do not grant entitlement). 
- Updated `docs/platform-config.md` to include Stripe in the platforms overview and inserted a `7. Stripe` section listing usage, `https://api.stripe.com/v1/checkout/sessions` endpoint, Vercel env names (e.g. `STRIPE_SECRET_KEY` and `STRIPE_TEST_*` placeholders), redirect rules and redeploy guidance. 
- Files changed: `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/platform-config.md`; branch used: `docs/e9-phase-6-abc`; local commit message: `docs: register E9 phase 6 checkout boundary`.

### Testing
- Ran `git diff --check` and it completed with no whitespace errors. 
- Confirmed changed files are exactly `docs/roadmap.md`, `docs/base-tecnica.md`, and `docs/platform-config.md` using `git diff --name-only`, which succeeded. 
- `npm ci` was considered not applicable for this documentation-only change. 
- `npm run check` was not executed as it is optional for documentation changes per validation rules. 
- Attempted `git push -u origin docs/e9-phase-6-abc` but push failed because remote `origin` is not configured in this checkout, so the branch and commit remain local and a PR was prepared but not published.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a443b0bcef883299d497cd36897ac06)