### PR TITLE
docs: adiciona recorte 3.8.1 sobre contrato do webhook Stripe e persistência de entitlement

### DIFF
--- a/docs/lousa-plano-base-e9.md
+++ b/docs/lousa-plano-base-e9.md
@@ -634,6 +634,24 @@ Limite registrado:
 * Limite de acoplamento: eventos, status e nomenclaturas do provedor não devem virar regra canônica do produto; o produto consome o contrato interno e a tabela de entitlement.
 * Observação: esta fase aciona Gestor de Automação, porque webhook é automação operacional.
 
+3.8.1 Fase 7.1 — Contrato do webhook Stripe e persistência de entitlement
+
+docs/lousa-plano-base-e9.md
+
+* Status: recorte de decisão técnica, sem implementação.
+* Objetivo: definir contrato normalizado do webhook Stripe antes de persistir entitlement.
+* Evento de ativação recomendado: `invoice.paid`, validado com assinatura Stripe, assinatura `active`, metadata coerente e Product/Price compatíveis com `plan_key`.
+* Evento auxiliar: `checkout.session.completed`, sem liberar entitlement.
+* Eventos futuros/controlados: `customer.subscription.deleted` e `invoice.payment_failed`.
+* Idempotência: usar Stripe `event.id` como chave inicial; avaliar se `account_commercial_entitlements.idempotency_key` basta ou se será necessária tabela mínima de eventos webhook.
+* Persistência: gravar ou atualizar `account_commercial_entitlements` com `origin = plano_pago_confirmado`, `status = ativo`, `external_provider = stripe`, referência externa da assinatura e metadata mínima.
+* Limite: redirect de sucesso não confirma pagamento nem libera entitlement.
+* Limite: não criar webhook real, schema, migration, Billing Engine, multi-provider, admin ou liberação por redirect nesta fase.
+* Segurança: não salvar payload bruto, cartão, secret, e-mail como idempotência ou PII desnecessária.
+* Avaliação obrigatória antes do Executor: Analista, Gestor Estrutural, Gestor de Segurança e Gestor de Automação.
+* Avaliação condicional: Gestor de Updates para validar documentação Stripe atual, se houver dúvida técnica sobre eventos ou webhook.
+* Próximo passo: especialistas avaliam se a implementação da Fase 7.2 precisa de migration, tabela de eventos webhook ou pode usar apenas `account_commercial_entitlements`.
+
 4. Escopo negativo e critérios de parada
 
 * Não criar fluxo manual de pagamento, comprovante por WhatsApp ou liberação sem confirmação comercial.

--- a/docs/lousa-plano-base-e9.md
+++ b/docs/lousa-plano-base-e9.md
@@ -640,6 +640,7 @@ docs/lousa-plano-base-e9.md
 
 * Status: recorte de decisão técnica, sem implementação.
 * Objetivo: definir contrato normalizado do webhook Stripe antes de persistir entitlement.
+* Automação: sim.
 * Evento de ativação recomendado: `invoice.paid`, validado com assinatura Stripe, assinatura `active`, metadata coerente e Product/Price compatíveis com `plan_key`.
 * Evento auxiliar: `checkout.session.completed`, sem liberar entitlement.
 * Eventos futuros/controlados: `customer.subscription.deleted` e `invoice.payment_failed`.
@@ -648,8 +649,7 @@ docs/lousa-plano-base-e9.md
 * Limite: redirect de sucesso não confirma pagamento nem libera entitlement.
 * Limite: não criar webhook real, schema, migration, Billing Engine, multi-provider, admin ou liberação por redirect nesta fase.
 * Segurança: não salvar payload bruto, cartão, secret, e-mail como idempotência ou PII desnecessária.
-* Avaliação obrigatória antes do Executor: Analista, Gestor Estrutural, Gestor de Segurança e Gestor de Automação.
-* Avaliação condicional: Gestor de Updates para validar documentação Stripe atual, se houver dúvida técnica sobre eventos ou webhook.
+* Avaliação antes do Executor: Gestor Estrutural, Gestor de Updates e Gestor de Automação.
 * Próximo passo: especialistas avaliam se a implementação da Fase 7.2 precisa de migration, tabela de eventos webhook ou pode usar apenas `account_commercial_entitlements`.
 
 4. Escopo negativo e critérios de parada


### PR DESCRIPTION
### Motivation

* Registrar a decisão técnica sobre contrato normalizado do webhook Stripe antes de persistir `account_commercial_entitlements` para evitar ambiguidade de eventos e acoplamento com o provedor.

### Description

* Inserida a seção compacta `3.8.1 Fase 7.1 — Contrato do webhook Stripe e persistência de entitlement` em `docs/lousa-plano-base-e9.md` imediatamente após `3.8 Fase 7 — Webhook e persistência do entitlement` sem reordenar seções. 
* O recorte documenta status, objetivo, evento de ativação recomendado (`invoice.paid`), evento auxiliar (`checkout.session.completed`), eventos futuros controlados, idempotência, regras de persistência, limites e requisitos de segurança e avaliações. 
* Escopo restrito a documentação, sem criação de código, schema, migration, webhook real, rota, admin, Billing Engine ou alterações fora do arquivo indicado. 
* Arquivo alterado: `docs/lousa-plano-base-e9.md`, branch usada: `work`, commit: `docs: registra recorte fase 7.1 stripe entitlement`.

### Testing

* Executado `git diff --check` com resultado sem erros de estilo no diff. 
* `npm ci` não aplicável para alteração documental. 
* `npm run check` não aplicável para alteração documental. 
* Tentativa de `git push` falhou por configuração do ambiente com o erro: `fatal: No configured push destination.`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44410b058483299afcb511309f61c3)