### PR TITLE
docs: document E19 Phase 3 (LP Builder) in roadmap, schema and base-tecnica

### DIFF
--- a/docs/base-tecnica.md
+++ b/docs/base-tecnica.md
@@ -2,8 +2,8 @@
 
 0.1. Cabeçalho
 • Documento: Base Técnica LP Factory 10
-• Versão: v2.0.43
-• Data: 22/06/2026
+• Versão: v2.0.44
+• Data: 30/06/2026
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.

--- a/docs/base-tecnica.md
+++ b/docs/base-tecnica.md
@@ -286,6 +286,19 @@ Commercial entitlements
 • Regra de segurança: fail-closed; erro, exceção, `accountId` vazio ou ausência de linha retornam não elegível.
 • Limite: UI/client não acessa Supabase para entitlement comercial; consumo deve passar pelo boundary server-side.
 
+LP Builder
+• Path canônico: `lib/lp-builder/`.
+• Uso: boundary server-side da E19 para criação e evolução de landing pages por conta.
+• Action canônica inicial: `app/lp-builder/actions.ts`.
+• Adapter inicial: `createAccountLandingPage`.
+• Persistência inicial: `public.account_landing_pages`.
+• Status inicial permitido: `draft`.
+• Regra de gate antes do insert: conta `active` + membership `active` com role `owner` ou `admin` + entitlement comercial válido.
+• Entitlement comercial deve ser lido pelo boundary E9 existente, não duplicado no LP Builder.
+• Escrita deve ocorrer server-side com permissão adequada; UI/client não acessa Supabase diretamente para criar LP.
+• Logs server-side devem registrar falhas operacionais de forma segura, sem payload bruto, secrets, dados de cartão ou PII sensível.
+• Escopo negativo técnico: sem editor visual, publicação, render público, domínio customizado, analytics, A/B, IA runtime, automação, agente ou job nesta fase.
+
 3.14.1 Matching de taxonomia via adapter server-side
 • Provider/API do resolvedor IA: OpenAI Responses API com Structured Outputs, sempre server-side.
 • Configuração operacional do modelo IA, envs e redeploy: ver `docs/platform-config.md`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1351,45 +1351,78 @@ Repositório — Criados
 19. E19 — LP Builder
 
 19.1 Status
-• Planejado
+• Em execução faseada — Fase 3 concluída em 30/06/2026.
+• Criação produtiva mínima de LP por conta implementada.
+• Persistência mínima em `public.account_landing_pages` criada.
+• Boundary próprio do LP Builder criado em `lib/lp-builder/`.
+• Gate E9 aplicado antes da persistência.
+• Editor visual, publicação, render público, domínio customizado, analytics, A/B, IA runtime e automações permanecem fora do recorte.
 
-19.2 Objetivo
-• Consolidar a seção do Core responsável pela criação, edição e organização de landing pages, seções de LP e templates reutilizáveis.
+19.2 Objetivo atual
+• Consolidar a seção do Core responsável pela criação, edição e organização de landing pages.
+• No recorte atual, limitar E19 à criação mínima de LP por conta com status inicial `draft`.
 
-19.3 Escopo
-• Criação de landing pages
-• Criação de seções de LP
-• Templates de landing pages
-• Templates de seções
-• Organização estrutural do builder dentro do Core
+19.3 Decisões consolidadas
 
-19.4 Regra estrutural
-• E19 pertence à camada Core
-• E19 é uma seção própria, separada de Account Dashboard, Admin Dashboard e Partner Dashboard
-• Boundaries físicas internas devem nascer conforme houver massa real de código
+19.3.1 Boundary do LP Builder
+• E19 pertence à camada Core.
+• E19 é seção própria, separada de Account Dashboard, Admin Dashboard e Partner Dashboard.
+• Boundary criado: `lib/lp-builder/`.
+• Action server-side canônica criada: `app/lp-builder/actions.ts`.
 
-19.4.1 Fronteira com E10 / E12 / E18
-• E19 não inclui, nesta fase, a camada persuasiva pós-setup do Account Dashboard (E10.5 e E10.6).
-• A primeira LP será um caso real próprio do E19 e ajudará a avaliar, junto com a nova E10.6, se existe necessidade de estrutura compartilhada futura.
-• O E19 só deve avançar para implementação quando houver recorte funcional real do LP Builder, evitando antecipação estrutural sem massa de código.
+19.3.2 Criação produtiva mínima
+• LP nasce com status inicial `draft`.
+• Persistência mínima ocorre em `public.account_landing_pages`.
+• Slug é único por conta.
+• Nome não pode ser vazio.
+• Slug deve seguir formato seguro.
 
-19.5 Dependências / referências
-• E9 — Billing, trial e entitlements
-• E10 — Account Dashboard
-• E12 — Admin Dashboard
-• E13 — Partner Dashboard
-• E18 — Base transversal de templates, módulos, composições e artefatos
+19.3.3 Gate comercial e operacional
+• Criação de LP exige conta `active`.
+• Criação de LP exige membership `active` com role `owner` ou `admin`.
+• Criação de LP exige entitlement comercial válido via E9.
+• Gate é aplicado server-side antes do insert.
 
-19.6 Próximo passo
-• Definir o primeiro recorte funcional do LP Builder no roadmap, incluindo o ponto server-side de criação produtiva de LP por conta, a persistência mínima da LP e a aplicação do gate comercial da E9 nesse ponto real.
+19.3.4 Updates avaliados
+• `github#499`, `supa#20260630210213`, `e9#gate`, `automation#E19`.
 
-19.7 Referência futura a páginas comerciais por taxon
-• E19 poderá futuramente consumir a existência de página comercial publicada por taxon.
-• E10.7 não implementa LP Builder.
-• E10.7 não implementa regra de liberação para criação de LPs.
-• E10.7 não implementa continuidade de contas.
-• E10.7 não implementa bloqueio de novas ativações.
-• Esta referência não cria obrigação de implementar E19 agora.
+19.4 Estruturas e artefatos
+
+Banco — Criados
+• `public.account_landing_pages`
+• `account_landing_pages_select_member_or_platform`
+• `account_landing_pages_set_updated_at`
+
+Repositório — Criados
+• `app/lp-builder/actions.ts`
+• `lib/lp-builder/contracts.ts`
+• `lib/lp-builder/adapters/landingPagesAdapter.ts`
+• `lib/lp-builder/index.ts`
+• `supabase/migrations/20260630210213_e19_account_landing_pages.sql`
+• `supabase/snippets/e19_account_landing_pages_verify.sql`
+
+Repositório — Ajustados
+• `docs/lousa-plano-base-E19.md`
+
+19.5 Fora do escopo da Fase 3
+• Editor visual.
+• Publicação.
+• Render público.
+• Domínio customizado.
+• Analytics.
+• Teste A/B.
+• IA runtime.
+• Automações.
+• Agentes.
+• Jobs.
+• Rotinas recorrentes.
+
+19.6 Dependências / referências
+• E9 — Billing, trial e entitlements.
+• E10 — Account Dashboard.
+• E12 — Admin Dashboard.
+• E13 — Partner Dashboard.
+• E18 — Base transversal de templates, módulos, composições e artefatos.
 
 99. Changelog
 v1.5.85 — 26/06/2026 — E10.7 Fase 6 concluída; próxima fase: Fase 7 — edição manual de copy e gestão simples de versões.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data: 26/06/2026
-• Versão: v1.5.85
+• Data: 30/06/2026
+• Versão: v1.5.86
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -1401,8 +1401,6 @@ Repositório — Criados
 • `supabase/migrations/20260630210213_e19_account_landing_pages.sql`
 • `supabase/snippets/e19_account_landing_pages_verify.sql`
 
-Repositório — Ajustados
-• `docs/lousa-plano-base-E19.md`
 
 19.5 Fora do escopo da Fase 3
 • Editor visual.
@@ -1425,6 +1423,8 @@ Repositório — Ajustados
 • E18 — Base transversal de templates, módulos, composições e artefatos.
 
 99. Changelog
+v1.5.86 — 30/06/2026 — E19 Fase 3 concluída com criação produtiva mínima de LP por conta, persistência em public.account_landing_pages, boundary lib/lp-builder/ e gate E9 antes do insert.
+
 v1.5.85 — 26/06/2026 — E10.7 Fase 6 concluída; próxima fase: Fase 7 — edição manual de copy e gestão simples de versões.
 
 v1.5.84 — 25/06/2026 — E10.7 Fase 5 concluída com taxons elegíveis por pesquisa estruturada completa, composição técnica genérica sob demanda, geração/publicação `commercial_activation` por `taxonSlug` e próxima Fase 6 planejada para Admin comercial enxuto.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data da última atualização: 28/06/2026
-• Documento: LP Factory 10 — Schema (DB Contract) v1.0.30
+• Data da última atualização: 30/06/2026
+• Documento: LP Factory 10 — Schema (DB Contract) v1.0.31
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -169,60 +169,73 @@
 • account_profiles_insert_owner_admin_or_platform (INSERT to public): is_platform_admin() OU owner/admin ativo do tenant (account_users.role IN ('owner','admin'); status='active')
 • account_profiles_update_owner_admin_or_platform (UPDATE to public): is_platform_admin() OU owner/admin ativo do tenant (USING + WITH CHECK)
 
-1.9 ai_readonly (role)
-1.9.1 Segurança (parâmetros)
+1.9 account_landing_pages
+1.9.1 Função
+• Persistência mínima de landing pages produtivas por conta na E19.
+• Criação inicial limitada a status `draft`.
+
+1.9.2 Colunas
+• id uuid primary key default gen_random_uuid()
+• account_id uuid not null
+• name text not null
+• slug text not null
+• status text not null default 'draft'
+• created_by uuid not null
+• created_at timestamptz not null default now()
+• updated_at timestamptz not null default now()
+
+1.9.3 Relacionamentos
+• account_id referencia public.accounts(id) com ON UPDATE CASCADE e ON DELETE CASCADE.
+• created_by referencia auth.users(id) com ON UPDATE CASCADE e ON DELETE RESTRICT.
+
+1.9.4 Constraints
+• account_landing_pages_status_chk: status in ('draft').
+• account_landing_pages_slug_chk: slug no padrão seguro `^[a-z0-9]+(-[a-z0-9]+)*$`.
+• account_landing_pages_name_chk: nome não vazio após trim.
+• account_landing_pages_account_slug_uidx: UNIQUE (account_id, slug).
+
+1.9.5 Índices
+• account_landing_pages_account_id_idx em account_id.
+• account_landing_pages_created_by_idx em created_by.
+• account_landing_pages_status_idx em status.
+
+1.9.6 Trigger
+• account_landing_pages_set_updated_at: executa public.tg_set_updated_at() antes de update.
+
+1.9.7 RLS / policies / grants
+• RLS habilitado.
+• Policy account_landing_pages_select_member_or_platform: permite SELECT para platform admin ou membro ativo da conta.
+• authenticated: SELECT.
+• service_role: SELECT, INSERT, UPDATE, DELETE.
+• public e anon: sem grants.
+
+1.9.8 Observações de escopo
+• Escrita deve ocorrer por fluxo server-side autorizado.
+• Criação inicial é apenas `draft`.
+• Publicação, render público, domínio customizado, analytics, A/B e IA runtime não fazem parte deste schema inicial.
+
+1.10 ai_readonly (role)
+1.10.1 Segurança (parâmetros)
 • LOGIN: sim
 • statement_timeout: 5s
-1.9.2 Escopo e grants (schema public)
+1.10.2 Escopo e grants (schema public)
 • Schema: public (USAGE)
 • Tabelas existentes em public: GRANT SELECT
 • Novas tabelas em public: default privileges com GRANT SELECT
 
-1.10 business_taxons
+1.11 business_taxons
 
-1.10.1 Chaves, constraints e relacionamentos
+1.11.1 Chaves, constraints e relacionamentos
 • PK: id uuid
 • UNIQUE: slug
 • CHECK: business_taxons_level_chk (level IN ('segment', 'niche', 'ultra_niche'))
 • FK: parent_id → business_taxons(id) ON UPDATE CASCADE ON DELETE SET NULL
 
-1.10.2 Campos
+1.11.2 Campos
 • parent_id uuid null
 • level text not null
 • name text not null
 • slug text not null
-• is_active boolean not null default true
-
-1.10.3 Segurança
-• Trigger Hub: não
-• RLS: ativo (enable row level security)
-• service_role: SELECT
-
-1.10.4 Policies
-• business_taxons_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
-• business_taxons_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
-• business_taxons_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
-• business_taxons_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
-
-1.10.5 Índices
-• business_taxons_name_normalized_idx (btree em normalize_taxon_match_text(name))
-• business_taxons_slug_normalized_idx (btree em normalize_taxon_match_text(replace(slug, '-', ' ')))
-• business_taxons_name_slug_fts_gin_idx (GIN em to_tsvector('portuguese', normalize_taxon_match_text(name) + slug normalizado))
-• business_taxons_name_normalized_trgm_gin_idx (GIN trigram em normalize_taxon_match_text(name))
-• business_taxons_slug_normalized_trgm_gin_idx (GIN trigram em slug normalizado)
-
-1.11 business_taxon_aliases
-
-1.11.1 Chaves, constraints e relacionamentos
-• PK: id uuid
-• UNIQUE: (taxon_id, alias_text_normalized)
-• FK: taxon_id → business_taxons(id) ON UPDATE CASCADE ON DELETE RESTRICT
-• Generated column: alias_text_normalized (normalização derivada de alias_text)
-
-1.11.2 Campos
-• taxon_id uuid not null
-• alias_text text not null
-• alias_text_normalized text generated always as stored
 • is_active boolean not null default true
 
 1.11.3 Segurança
@@ -231,19 +244,51 @@
 • service_role: SELECT
 
 1.11.4 Policies
+• business_taxons_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
+• business_taxons_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
+• business_taxons_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
+• business_taxons_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
+
+1.11.5 Índices
+• business_taxons_name_normalized_idx (btree em normalize_taxon_match_text(name))
+• business_taxons_slug_normalized_idx (btree em normalize_taxon_match_text(replace(slug, '-', ' ')))
+• business_taxons_name_slug_fts_gin_idx (GIN em to_tsvector('portuguese', normalize_taxon_match_text(name) + slug normalizado))
+• business_taxons_name_normalized_trgm_gin_idx (GIN trigram em normalize_taxon_match_text(name))
+• business_taxons_slug_normalized_trgm_gin_idx (GIN trigram em slug normalizado)
+
+1.12 business_taxon_aliases
+
+1.12.1 Chaves, constraints e relacionamentos
+• PK: id uuid
+• UNIQUE: (taxon_id, alias_text_normalized)
+• FK: taxon_id → business_taxons(id) ON UPDATE CASCADE ON DELETE RESTRICT
+• Generated column: alias_text_normalized (normalização derivada de alias_text)
+
+1.12.2 Campos
+• taxon_id uuid not null
+• alias_text text not null
+• alias_text_normalized text generated always as stored
+• is_active boolean not null default true
+
+1.12.3 Segurança
+• Trigger Hub: não
+• RLS: ativo (enable row level security)
+• service_role: SELECT
+
+1.12.4 Policies
 • business_taxon_aliases_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
 • business_taxon_aliases_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
 • business_taxon_aliases_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
 • business_taxon_aliases_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
 
-1.11.5 Índices
+1.12.5 Índices
 • business_taxon_aliases_alias_text_normalized_idx (btree em alias_text_normalized)
 • business_taxon_aliases_alias_text_normalized_fts_gin_idx (GIN em to_tsvector('portuguese', alias_text_normalized))
 • business_taxon_aliases_alias_text_normalized_trgm_gin_idx (GIN trigram em alias_text_normalized)
 
-1.12 account_taxonomy
+1.13 account_taxonomy
 
-1.12.1 Chaves, constraints e relacionamentos
+1.13.1 Chaves, constraints e relacionamentos
 • PK: id uuid
 • UNIQUE: (account_id, taxon_id)
 • CHECK: account_taxonomy_status_chk (status IN ('active', 'inactive'))
@@ -252,7 +297,7 @@
 • FK: taxon_id → business_taxons(id) ON UPDATE CASCADE ON DELETE RESTRICT
 • Nota: não há constraint/índice garantindo apenas um `is_primary = true` por conta nesta etapa.
 
-1.12.2 Campos
+1.13.2 Campos
 • account_id uuid not null
 • taxon_id uuid not null
 • is_primary boolean not null default false
@@ -261,21 +306,21 @@
 • created_at timestamptz not null default now()
 • updated_at timestamptz not null default now()
 
-1.12.3 Segurança
+1.13.3 Segurança
 • Trigger Hub: não
 • RLS: ativo (enable row level security)
 • service_role: SELECT, INSERT, UPDATE
 • anon/authenticated/public: sem acesso direto
 
-1.12.4 Policies
+1.13.4 Policies
 • account_taxonomy_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
 • account_taxonomy_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
 • account_taxonomy_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
 • account_taxonomy_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
 
-1.13 content_templates
+1.14 content_templates
 
-1.13.1 Chaves, constraints e relacionamentos
+1.14.1 Chaves, constraints e relacionamentos
 • PK: id uuid
 • UNIQUE: (template_key, version)
 • UNIQUE: (slug, version)
@@ -285,7 +330,7 @@
 • CHECK: content_templates_template_scope_chk (template_scope IN ('page', 'section'))
 • CHECK: content_templates_status_chk (status IN ('draft', 'active', 'archived'))
 
-1.13.2 Campos
+1.14.2 Campos
 • template_key text not null
 • name text not null
 • slug text not null
@@ -299,18 +344,18 @@
 • created_at timestamptz not null default now()
 • updated_at timestamptz not null default now()
 
-1.13.3 Segurança
+1.14.3 Segurança
 • Trigger Hub: não
 • RLS: ativo (enable row level security)
 • service_role: SELECT
 
-1.13.4 Policies
+1.14.4 Policies
 • content_templates_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
 • content_templates_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
 • content_templates_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
 • content_templates_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
 
-1.13.5 Registros-base de `commercial_activation`
+1.14.5 Registros-base de `commercial_activation`
 • Template de página: `commercial_activation_page`, slug `commercial-activation-page`, escopo `page`.
 • Módulos de seção: `hero`, `benefits`, `services`, `plans`, `differentials`, `how_it_works`, `faq` e `final_cta`.
 • Slugs especiais: `how-it-works` e `final-cta`; os demais coincidem com `template_key`.
@@ -320,15 +365,15 @@
 • Migration: `supabase/migrations/20260616142000_e18_commercial_activation_base_records.sql`.
 • Verificação: `supabase/snippets/e18_commercial_activation_base_records_verify.sql`.
 
-1.14 content_template_taxons
+1.15 content_template_taxons
 
-1.14.1 Chaves, constraints e relacionamentos
+1.15.1 Chaves, constraints e relacionamentos
 • PK: id uuid
 • CHECK: content_template_taxons_resolution_level_chk (resolution_level IN ('generic', 'segment', 'niche', 'ultra_niche'))
 • FK: template_id → content_templates(id) ON UPDATE CASCADE ON DELETE CASCADE
 • FK: taxon_id → business_taxons(id) ON UPDATE CASCADE ON DELETE RESTRICT
 
-1.14.2 Campos
+1.15.2 Campos
 • template_id uuid not null
 • taxon_id uuid not null
 • resolution_level text not null
@@ -338,20 +383,20 @@
 • created_at timestamptz not null default now()
 • updated_at timestamptz not null default now()
 
-1.14.3 Segurança
+1.15.3 Segurança
 • Trigger Hub: não
 • RLS: ativo (enable row level security)
 • service_role: SELECT
 
-1.14.4 Policies
+1.15.4 Policies
 • content_template_taxons_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
 • content_template_taxons_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
 • content_template_taxons_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
 • content_template_taxons_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
 
-1.15 taxon_market_research
+1.16 taxon_market_research
 
-1.15.1 Chaves, constraints e relacionamentos
+1.16.1 Chaves, constraints e relacionamentos
 • PK: id uuid
 • UNIQUE: (taxon_id, research_block, audience_scope, version)
 • UNIQUE auxiliar: (id, taxon_id, audience_scope, version)
@@ -359,7 +404,7 @@
 • CHECK: taxon_market_research_audience_scope_chk (audience_scope IN ('end_customer', 'business_buyer'))
 • FK: taxon_id → business_taxons(id) ON UPDATE CASCADE ON DELETE RESTRICT
 
-1.15.2 Campos
+1.16.2 Campos
 • taxon_id uuid not null
 • research_block text not null
 • Regra: texto governado por processo operacional; sem CHECK fechado nesta etapa
@@ -370,29 +415,29 @@
 • created_at timestamptz not null default now()
 • updated_at timestamptz not null default now()
 
-1.15.3 Índices
+1.16.3 Índices
 • taxon_market_research_taxon_block_audience_version_uidx (UNIQUE em taxon_id, research_block, audience_scope, version)
 • taxon_market_research_one_active_per_block_audience_uidx (UNIQUE parcial em taxon_id, research_block, audience_scope WHERE status = 'active')
 
-1.15.4 Segurança
+1.16.4 Segurança
 • Trigger Hub: não
 • RLS: ativo (enable row level security)
 • service_role: SELECT
 
-1.15.5 Policies
+1.16.5 Policies
 • taxon_market_research_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
 • taxon_market_research_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
 • taxon_market_research_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
 • taxon_market_research_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
 
-1.16 taxon_market_research_items
+1.17 taxon_market_research_items
 
-1.16.1 Chaves, constraints e relacionamentos
+1.17.1 Chaves, constraints e relacionamentos
 • PK: id uuid
 • FK: research_id → taxon_market_research(id) ON UPDATE CASCADE ON DELETE CASCADE
 • UNIQUE adicional: nenhuma nesta etapa
 
-1.16.2 Campos
+1.17.2 Campos
 • research_id uuid not null
 • item_key text not null
 • item_text text not null
@@ -403,25 +448,25 @@
 • created_at timestamptz not null default now()
 • updated_at timestamptz not null default now()
 
-1.16.3 Segurança
+1.17.3 Segurança
 • Trigger Hub: não
 • RLS: ativo (enable row level security)
 • service_role: SELECT
 
-1.16.4 Policies
+1.17.4 Policies
 • taxon_market_research_items_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
 • taxon_market_research_items_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
 • taxon_market_research_items_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
 • taxon_market_research_items_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
 
-1.17 taxon_message_guides
+1.18 taxon_message_guides
 
-1.17.1 Chaves, constraints e relacionamentos
+1.18.1 Chaves, constraints e relacionamentos
 • PK: id uuid
 • CHECK: taxon_message_guides_context_type_chk (context_type IN ('e10_5', 'landing_page', 'email', 'whatsapp'))
 • FK: research_id → taxon_market_research(id) ON UPDATE CASCADE ON DELETE CASCADE
 
-1.17.2 Campos
+1.18.2 Campos
 • research_id uuid not null
 • context_type text not null
 • guide_payload_json jsonb not null
@@ -430,19 +475,19 @@
 • created_at timestamptz not null default now()
 • updated_at timestamptz not null default now()
 
-1.17.3 Segurança
+1.18.3 Segurança
 • Trigger Hub: não
 • RLS: ativo (enable row level security)
 
-1.17.4 Policies
+1.18.4 Policies
 • taxon_message_guides_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
 • taxon_message_guides_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
 • taxon_message_guides_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
 • taxon_message_guides_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
 
-1.18 account_niche_resolutions
+1.19 account_niche_resolutions
 
-1.18.1 Chaves, constraints e relacionamentos
+1.19.1 Chaves, constraints e relacionamentos
 • CHECK: account_niche_resolutions_ai_status_chk
 • CHECK: account_niche_resolutions_ai_result_json_chk
 • CHECK: account_niche_resolutions_ai_ux_mode_chk
@@ -460,7 +505,7 @@
 • CHECK: resolution_status
 • CHECK: score entre 0 e 1 ou NULL
 
-1.18.2 Campos
+1.19.2 Campos
 • ai_status text null
 • ai_error_code text null
 • ai_model text null
@@ -494,19 +539,19 @@
 • created_at timestamptz not null default now()
 • updated_at timestamptz not null default now()
 
-1.18.3 Segurança
+1.19.3 Segurança
 • Trigger Hub: não
 • RLS: ativo
 • Policies: admin-only
 • Acesso direto removido de public, anon e authenticated
 • service_role: SELECT, INSERT e UPDATE
 
-1.18.4 Índices
+1.19.4 Índices
 • account_niche_resolutions_ai_suggested_taxon_id_idx
 
-1.19 content_template_compositions
+1.20 content_template_compositions
 
-1.19.1 Chaves, constraints e relacionamentos
+1.20.1 Chaves, constraints e relacionamentos
 • PK: id uuid
 • UNIQUE: (template_id, taxon_id, version)
 • UNIQUE auxiliar: (id, template_id, taxon_id, version)
@@ -516,45 +561,11 @@
 • FK: template_id → content_templates(id) ON UPDATE CASCADE ON DELETE RESTRICT
 • FK: taxon_id → business_taxons(id) ON UPDATE CASCADE ON DELETE RESTRICT
 
-1.19.2 Campos
+1.20.2 Campos
 • template_id uuid not null
 • taxon_id uuid not null
 • version integer not null default 1
 • status text not null default 'draft'
-• created_at timestamptz not null default now()
-• updated_at timestamptz not null default now()
-
-1.19.3 Segurança
-• Trigger Hub: não
-• RLS: ativo
-• anon/authenticated/public: sem acesso
-• service_role: SELECT
-
-1.19.4 Índices
-• `content_template_compositions_one_active_uidx`: UNIQUE parcial em (`template_id`, `taxon_id`) para `status = 'active'`.
-• `content_template_compositions_taxon_id_idx`: btree em `taxon_id`.
-
-1.19.5 Triggers
-• `content_template_compositions_set_updated_at`: executa `public.tg_set_updated_at()` antes de UPDATE.
-
-1.20 content_template_composition_items
-
-1.20.1 Chaves, constraints e relacionamentos
-• PK: id uuid
-• UNIQUE: (composition_id, sort_order)
-• CHECK: variant_key descritivo no formato `modulo.variante`
-• CHECK: sort_order >= 0
-• CHECK: config_json é objeto JSON
-• FK: composition_id → content_template_compositions(id) ON UPDATE CASCADE ON DELETE CASCADE
-• FK: module_template_id → content_templates(id) ON UPDATE CASCADE ON DELETE RESTRICT
-
-1.20.2 Campos
-• composition_id uuid not null
-• module_template_id uuid not null
-• variant_key text not null
-• sort_order integer not null
-• is_required boolean not null default true
-• config_json jsonb not null default '{}'
 • created_at timestamptz not null default now()
 • updated_at timestamptz not null default now()
 
@@ -565,14 +576,48 @@
 • service_role: SELECT
 
 1.20.4 Índices
-• `content_template_composition_items_module_template_id_idx`: btree em `module_template_id`.
+• `content_template_compositions_one_active_uidx`: UNIQUE parcial em (`template_id`, `taxon_id`) para `status = 'active'`.
+• `content_template_compositions_taxon_id_idx`: btree em `taxon_id`.
 
 1.20.5 Triggers
-• `content_template_composition_items_set_updated_at`: executa `public.tg_set_updated_at()` antes de UPDATE.
+• `content_template_compositions_set_updated_at`: executa `public.tg_set_updated_at()` antes de UPDATE.
 
-1.21 content_artifacts
+1.21 content_template_composition_items
 
 1.21.1 Chaves, constraints e relacionamentos
+• PK: id uuid
+• UNIQUE: (composition_id, sort_order)
+• CHECK: variant_key descritivo no formato `modulo.variante`
+• CHECK: sort_order >= 0
+• CHECK: config_json é objeto JSON
+• FK: composition_id → content_template_compositions(id) ON UPDATE CASCADE ON DELETE CASCADE
+• FK: module_template_id → content_templates(id) ON UPDATE CASCADE ON DELETE RESTRICT
+
+1.21.2 Campos
+• composition_id uuid not null
+• module_template_id uuid not null
+• variant_key text not null
+• sort_order integer not null
+• is_required boolean not null default true
+• config_json jsonb not null default '{}'
+• created_at timestamptz not null default now()
+• updated_at timestamptz not null default now()
+
+1.21.3 Segurança
+• Trigger Hub: não
+• RLS: ativo
+• anon/authenticated/public: sem acesso
+• service_role: SELECT
+
+1.21.4 Índices
+• `content_template_composition_items_module_template_id_idx`: btree em `module_template_id`.
+
+1.21.5 Triggers
+• `content_template_composition_items_set_updated_at`: executa `public.tg_set_updated_at()` antes de UPDATE.
+
+1.22 content_artifacts
+
+1.22.1 Chaves, constraints e relacionamentos
 • PK: id uuid
 • UNIQUE: (template_id, composition_id, taxon_id, audience_scope, research_version, artifact_version)
 • UNIQUE parcial: no máximo um artefato `published` por (template_id, taxon_id, audience_scope)
@@ -585,7 +630,7 @@
 • FK composta: (composition_id, template_id, taxon_id, composition_version) → content_template_compositions(id, template_id, taxon_id, version)
 • FK: taxon_id → business_taxons(id) ON UPDATE CASCADE ON DELETE RESTRICT
 
-1.21.2 Campos
+1.22.2 Campos
 • template_id uuid not null
 • composition_id uuid not null
 • taxon_id uuid not null
@@ -602,7 +647,7 @@
 • published_at timestamptz null
 • archived_at timestamptz null
 
-1.21.3 Segurança
+1.22.3 Segurança
 • Trigger Hub: não
 • RLS: ativo
 • public/anon: sem acesso
@@ -613,22 +658,22 @@
   • content_artifacts_insert_admin_draft_only (INSERT to authenticated): is_super_admin() OU is_platform_admin(); somente `status = 'draft'`, `published_at IS NULL` e `archived_at IS NULL`
   • content_artifacts_update_admin_draft_content_only (UPDATE to authenticated): is_super_admin() OU is_platform_admin(); somente `status = 'draft'`, `published_at IS NULL` e `archived_at IS NULL` (USING + WITH CHECK)
 
-1.21.4 Índices
+1.22.4 Índices
 • `content_artifacts_one_published_uidx`: UNIQUE parcial em (`template_id`, `taxon_id`, `audience_scope`) para `status = 'published'`.
 • `content_artifacts_composition_id_idx`: btree em `composition_id`.
 • `content_artifacts_taxon_id_idx`: btree em `taxon_id`.
 
-1.21.5 Triggers
+1.22.5 Triggers
 • `content_artifacts_set_updated_at`: executa `public.tg_set_updated_at()` antes de UPDATE.
 
-1.22 content_artifact_research_sources
+1.23 content_artifact_research_sources
 
-1.22.1 Chaves, constraints e relacionamentos
+1.23.1 Chaves, constraints e relacionamentos
 • PK: (artifact_id, research_id)
 • FK composta: (artifact_id, taxon_id, audience_scope, research_version) → content_artifacts(id, taxon_id, audience_scope, research_version)
 • FK composta: (research_id, taxon_id, audience_scope, research_version) → taxon_market_research(id, taxon_id, audience_scope, version)
 
-1.22.2 Campos
+1.23.2 Campos
 • artifact_id uuid not null
 • research_id uuid not null
 • taxon_id uuid not null
@@ -636,7 +681,7 @@
 • research_version integer not null
 • created_at timestamptz not null default now()
 
-1.22.3 Segurança
+1.23.3 Segurança
 • Trigger Hub: não
 • RLS: ativo
 • public/anon: sem acesso
@@ -646,7 +691,7 @@
   • content_artifact_research_sources_select_admin_only (SELECT to authenticated): is_super_admin() OU is_platform_admin()
   • cars_insert_admin_business_buyer_only (INSERT to authenticated): is_super_admin() OU is_platform_admin(); somente `audience_scope = 'business_buyer'`
 
-1.22.4 Índices
+1.23.4 Índices
 • `content_artifact_research_sources_research_id_idx`: btree em `research_id`.
 
 2. Views


### PR DESCRIPTION
### Motivation
- Record the conclusion of E19 Phase 3 and surface the decisions and boundaries required to operate a minimal, productive LP creation flow by account.
- Ensure the DB contract and the technical boundary for the LP Builder are documented so future code or migrations can follow the agreed constraints and gate rules.

### Description
- Updated `docs/roadmap.md` to mark E19 Phase 3 as completed (30/06/2026) and to register the Phase 3 scope, decisions, artifacts created and out-of-scope items.
- Added `public.account_landing_pages` documentation to `docs/schema.md` with function, columns, relationships, constraints, indexes, trigger, RLS/policies/grants and scope notes.
- Added LP Builder boundary notes to `docs/base-tecnica.md` describing the canonical path (`lib/lp-builder/`), server-side action (`app/lp-builder/actions.ts`), adapter (`createAccountLandingPage`), persistence target and gate rule (account active + active owner/admin membership + E9 entitlement).
- Files changed: `docs/roadmap.md`, `docs/schema.md`, `docs/base-tecnica.md`, and branch used: `work`.

### Testing
- Ran `git diff --check` and the check passed with no whitespace or patch errors.
- Performed a textual scan for secrets or sensitive patterns with `rg` against the modified docs and found no added secrets, PII, raw payloads or private keys.
- `npm ci` is not applicable for documentation-only changes and was not executed by policy for this update.
- `npm run check` was not executed as it is optional for documentation-only changes, and publishing could not complete because `git push` failed due to no configured push destination for the local branch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4461d61eec83298723e57422a61f52)