### PR TITLE
docs: otimiza lousa do gestor estrutural

### DIFF
--- a/docs/gestor-estrutural.md
+++ b/docs/gestor-estrutural.md
@@ -1,4 +1,4 @@
-Lousa (índice estrutural) — Gestor Estrutural VS9
+Lousa (índice estrutural) — Gestor Estrutural VS10
 1. Objetivo
 1.1 Papel da lousa
 * Índice estrutural focado apenas nas funções do Gestor Estrutural.
@@ -24,37 +24,15 @@ Lousa (índice estrutural) — Gestor Estrutural VS9
 * ao receber instrução curta do Estrategista, como “Avalie a fase XX do plano-base Y segundo suas diretrizes documentadas”, aplicar este documento como critério de avaliação dentro do escopo do Gestor Estrutural.
 * na dúvida, pedir investigação antes de orientar mudança estrutural
 * classificar o resultado como: aprovado; aprovado com condicionantes; requer investigação; requer patch estrutural; ou rejeitado por conflito com fonte competente
-1.5 Regra de evolução da lousa
-* esta lousa deve apenas evoluir, preservando histórico e decisões vigentes
-* manter foco apenas nas funções do Gestor Estrutural
 2. Fontes que o Gestor Estrutural deve consultar
 2.1 Fontes primárias por assunto
 * docs/base-tecnica.md = runtime, convenções, segurança e estrutura do app
 * docs/schema.md = contrato do BD
 * docs/roadmap.md = E-cases, escopo final, dependências e artefatos/paths quando fizerem parte do estado final do caso
 * repositório real = estado atual de arquivos, paths e localização dos artefatos
+* ferramentas operacionais, como GitHub e Vercel, servem para confirmar estado real quando necessário, sem substituir as fontes competentes
 * updates vigentes relevantes = complemento contextual, sem substituir fonte canônica
 * esta lousa = índice estrutural, não fonte primária
-2.2 Docs de apoio e watchlist
-* docs/supa-up.md
-* docs/vercel-up.md
-* docs/automations.md = automações operacionais e componentes consumidores
-* docs/services.md = services implantáveis, MCPs, endpoints e infraestrutura reutilizável com identidade própria
-* docs/platform-config.md
-* docs/template-briefing-codex.md
-* docs/prompt-executor.md
-2.3 Fontes operacionais validadas
-2.3.1 Repositório GitHub
-* acesso confirmado ao repositório AlcinoAfonso/LP-Factory-10
-* nível validado: leitura e inspeção do repositório real
-* inclui: buscar arquivos, abrir arquivos, ler conteúdo, confirmar paths e artefatos versionados
-* não assumir capacidade mutável sem teste explícito no caso
-2.3.2 Vercel
-* acesso confirmado ao workspace e aos projetos da Vercel do LP Factory 10
-* projetos já validados: lp-factory-10 e lpf-10-services
-* nível validado: inspeção operacional
-* inclui: listar team, listar projetos, ler metadados de projeto, listar deploys, ler deployment por ID e ler build logs
-* não assumir capacidade de alterar settings, variáveis, domínios ou disparar deploy sem teste explícito no caso
 3. Notas permanentes para avaliação estrutural
 * chamar de OpenAI Project
 * compatibilidades oficiais não substituem a confirmação do repositório real nem as fontes canônicas do projeto


### PR DESCRIPTION
### Motivation
- Tornar `docs/gestor-estrutural.md` mais operacional e menos redundante sem alterar o papel do Gestor Estrutural.
- Remover seções que dispersavam o foco e consolidar referências operacionais essenciais em um único índice conciso.

### Description
- Atualizei o título para `Lousa (índice estrutural) — Gestor Estrutural VS10` e editei `docs/gestor-estrutural.md` para refletir a nova versão.
- Removi integralmente a seção `1.5 Regra de evolução da lousa` e a seção `2.2 Docs de apoio e watchlist` conforme solicitado.
- Removi a seção `2.3` como bloco separado e incorporei apenas a regra resumida sobre ferramentas operacionais (ex.: GitHub e Vercel) dentro de `2.1 Fontes primárias por assunto`, enfatizando que elas confirmam estado real sem se tornarem fontes primárias.
- Mantive intactas as regras centrais de `1.4 Regra de consulta e validação estrutural` e não alterei outros documentos referenciados (`docs/base-tecnica.md`, `docs/schema.md`, `docs/roadmap.md`).

### Testing
- Verifiquei a presença e numeração das seções com uma busca por padrões e confirmei que `1.5`, `2.2` e `2.3` não existem mais, e que as seções finais são `1. Objetivo`, `2. Fontes...` e `3. Notas permanentes` (succeeded).
- Confirmei a redução do arquivo de 64 para 42 linhas com contagem de linhas (`wc`) e inspeção do diff, e verifiquei o `git diff --stat` mostrando 24 deletions (succeeded).
- Criei um commit com a mensagem `docs: otimiza lousa do gestor estrutural` na branch `work` (commit `85e790f`) (succeeded).
- `npm ci` e `npm run check` foram considerados N/A por serem alterações exclusivamente documentais, e `git push` falhou por ausência de push remoto configurado (`fatal: No configured push destination.`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a452844a3dc8329bd1cbc505176d146)