### PR TITLE
docs: encerra Fase 3 do plano E19 e preserva fronteiras no roadmap

### DIFF
--- a/docs/lousa-plano-base-E19.md
+++ b/docs/lousa-plano-base-E19.md
@@ -57,7 +57,7 @@ E19 — LP Builder MVP
   * Próxima ação: instruir o Executor para implementar a Fase 3 — Implementação do primeiro recorte.
 * Fase 3 — Implementação do primeiro recorte
 
-  * Status: implementada em PR; depende validação humana de Supabase linked/dry-run no ambiente vinculado.
+  * Status: concluída.
   * Objetivo: implementar criação produtiva mínima de LP por conta.
   * Condição de entrada: Fase 2 consolidada e instrução ao Executor emitida.
   * Arquivos criados:
@@ -69,18 +69,17 @@ E19 — LP Builder MVP
     * `app/lp-builder/actions.ts`
   * Recorte implementado: tabela mínima `public.account_landing_pages`, RLS, grants explícitos, snippet read-only, boundary E19, action server-side canônica fora de `app/a/[account]` e gate E9 antes da persistência via `lib/commercial-entitlements/`.
   * Ajuste PR 499: removido INSERT direto de `authenticated`; criação restrita ao fluxo server-side; insert executado com `service_role` após gate E9; bypass de `platform_admin` removido da criação, exigindo membership ativa owner/admin também neste recorte.
-  * Validação do ajuste PR 499: `npm ci` e `npm run check` reexecutados; Supabase linked/dry-run permanece pendente por ausência de project ref na worktree.
-  * Validações executadas:
-    * `npm ci`: executado.
-    * `npm run check`: executado com sucesso; lint sem erros e typecheck concluído.
-    * `supabase migration list --linked`: não executado com sucesso; bloqueado por worktree sem project ref.
-    * `supabase db push --linked --dry-run`: não executado com sucesso; bloqueado por worktree sem project ref.
-  * Pendência: executar validação Supabase linked/dry-run em ambiente vinculado antes do merge/aplicação.
+  * Registro final:
+    * PR 499 mergeado.
+    * Migration `20260630210213_e19_account_landing_pages` aplicada no Supabase.
+    * Verificação pós-merge confirmou tabela, colunas, constraints, índices, RLS, policies, grants e trigger com status ok.
+    * Pendência: N/A para a Fase 3.
+    * Próxima ação: plano E19 encerrado no recorte da Fase 3; não abrir nova fase sem decisão explícita.
 * Avaliações necessárias:
 
-  * Analista: avaliar Fase 3 / PR 499.
-  * Gestor Estrutural: já avaliou a proposta prévia; retorna se houver mudança estrutural.
-  * Gestor de Updates: avaliar Fase 2 após registro.
+  * Analista: Fase 3 encerrada no recorte atual.
+  * Gestor Estrutural: Fase 3 encerrada no recorte atual.
+  * Gestor de Updates: Fase 3 encerrada no recorte atual.
   * Gestor de Automação: N/A.
 
 4. Escopo negativo e critérios de parada

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1422,6 +1422,14 @@ Repositório — Criados
 • E13 — Partner Dashboard.
 • E18 — Base transversal de templates, módulos, composições e artefatos.
 
+19.7 Fronteiras futuras preservadas
+• E19 pode futuramente consumir página comercial publicada por taxon.
+• E10.7 não implementa LP Builder.
+• E10.7 não implementa regra de liberação para criação de LPs.
+• E10.7 não implementa continuidade de contas.
+• E10.7 não implementa bloqueio de novas ativações.
+• Esta referência não cria obrigação de nova implementação agora.
+
 99. Changelog
 v1.5.86 — 30/06/2026 — E19 Fase 3 concluída com criação produtiva mínima de LP por conta, persistência em public.account_landing_pages, boundary lib/lp-builder/ e gate E9 antes do insert.
 


### PR DESCRIPTION
### Motivation
- Registrar formalmente o encerramento da Fase 3 do plano-base E19 após as mudanças recentes e remover a pendência de validação manual indicada anteriormente.
- Garantir que o roadmap preserve as fronteiras futuras entre E19 e E10.7 sem criar obrigação de implementação imediata.
- Manter histórico documental claro sobre o status de PR 499 e a migration associada.

### Description
- Atualizei `docs/lousa-plano-base-E19.md` para marcar a Fase 3 como `Status: concluída` e substituir a pendência de Supabase linked/dry-run por um `Registro final` que menciona PR 499 mergeado, migration `20260630210213_e19_account_landing_pages` aplicada, verificação pós-merge OK, pendência N/A e encerramento do plano no recorte da Fase 3.
- Adicionei em `docs/roadmap.md` a seção compacta `19.7 Fronteiras futuras preservadas` com itens que deixam explícito que E10.7 não implementa LP Builder nem regras de liberação/continuidade/bloqueio hoje e que não há obrigação de nova implementação.
- Alterações limitadas apenas aos arquivos `docs/lousa-plano-base-E19.md` e `docs/roadmap.md`, sem tocar código, migrations, snippets SQL, `docs/schema.md` ou `docs/base-tecnica.md`.

### Testing
- `git diff --check` foi executado e passou sem problemas.
- `npm ci` e `npm run check` são N/A por se tratar de alteração exclusivamente documental.
- Push remoto não foi concluído no ambiente atual devido à falta de remote `origin`, portanto a branch `codex/e19-conclusao-plano-pos-pr504` e o commit local foram criados, mas a publicação remota não pôde ser finalizada aqui.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4537cb29748329b5651df8a2266c7f)