### PR TITLE
docs: add briefing origin guard to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,9 @@ Antes de executar, confirmar objetivo, fontes, limites e validação esperada.
 
 Não completar lacunas críticas por suposição; se faltar informação necessária para executar com segurança, parar e pedir exatamente o que falta.
 
+Antes de executar briefing recebido por chat, confirmar se ele pertence ao caso, fase, branch e arquivos-alvo da tarefa atual.
+Se houver divergência ou dúvida, parar e reportar a incompatibilidade; não adaptar briefing de outro caso por inferência.
+
 ## Regras operacionais
 
 Não editar nem commitar na `main`; usar branch dedicada por tarefa ou etapa. Ao usar a `main` local como base, atualizar com `git pull --ff-only`. O merge final deve ocorrer somente pelo GitHub Web. Se o ambiente não estiver claro, perguntar antes de publicar.


### PR DESCRIPTION
### Motivation
- Evitar execução insegura de briefings recebidos por chat que pertençam a outro caso, reduzindo risco de aplicar instruções fora do escopo.

### Description
- Adicionei duas linhas em `AGENTS.md` imediatamente após a frase "Não completar lacunas críticas por suposição; se faltar informação necessária para executar com segurança, parar e pedir exatamente o que falta." que exigem confirmar se o briefing recebido por chat pertence ao caso, fase, branch e arquivos-alvo da tarefa atual e instruem a parar e reportar em caso de divergência; alteração limitada a `AGENTS.md` na branch `docs/gate-briefing-executor`.

### Testing
- Rodei verificações Git (`git status --short --branch`, `git diff --check`, `git diff --name-only`) e o commit foi criado com sucesso; `npm ci` e `npm run check` são não aplicáveis por se tratar de mudança exclusivamente documental.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a466715fc808329b5de02e5b600831e)