### PR TITLE
docs: registrar webhook Stripe mínimo (E9 Fase 7.2)

### DIFF
--- a/docs/base-tecnica.md
+++ b/docs/base-tecnica.md
@@ -2,8 +2,8 @@
 
 0.1. Cabeçalho
 • Documento: Base Técnica LP Factory 10
-• Versão: v2.0.44
-• Data: 30/06/2026
+• Versão: v2.0.45
+• Data: 02/07/2026
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -286,6 +286,20 @@ Commercial entitlements
 • Regra de segurança: fail-closed; erro, exceção, `accountId` vazio ou ausência de linha retornam não elegível.
 • Limite: UI/client não acessa Supabase para entitlement comercial; consumo deve passar pelo boundary server-side.
 
+Stripe webhook
+• Endpoint canônico: `app/api/stripe/webhook/route.ts`.
+• Runtime: Node.js, dinâmico, server-side.
+• Boundary: `lib/billing-checkout/`.
+• Adapter: `lib/billing-checkout/adapters/stripeWebhookAdapter.ts`.
+• Secret obrigatório: `STRIPE_WEBHOOK_SECRET`.
+• Assinatura Stripe deve ser validada antes de qualquer persistência.
+• Evento que ativa/renova entitlement: `invoice.paid`.
+• Eventos aceitos mas sem liberar entitlement neste recorte: `checkout.session.completed`, `customer.subscription.deleted`, `invoice.payment_failed`.
+• Idempotência: `public.stripe_webhook_events.event_id`.
+• Persistência de entitlement: upsert server-side em `public.account_commercial_entitlements`.
+• Retry permitido para evento `failed` e `processing` antigo.
+• Logs e metadata devem ser mínimos e seguros, sem payload bruto, secrets, cartão ou PII sensível.
+
 LP Builder
 • Path canônico: `lib/lp-builder/`.
 • Uso: boundary server-side da E19 para criação e evolução de landing pages por conta.
@@ -510,6 +524,7 @@ Fonte normativa da allowlist SULB para exceções de Auth. Qualquer novo arquivo
 • Tipos canônicos e adapters vNext: validar por 3.6 e 3.14.
 
 99. Changelog
+v2.0.45 (02/07/2026) — Registrado webhook Stripe mínimo do E9, com endpoint canônico, boundary, assinatura obrigatória, evento `invoice.paid`, idempotência e persistência segura de entitlement.
 v2.0.43 — 22/06/2026 — Registrado o contrato técnico da geração administrativa de draft `commercial_activation`: fluxo server-side/Admin com Responses API e Structured Outputs, modelo por env var, validação em duas camadas, persistência somente como `draft`, fontes relacionais `business_buyer`, `end_customer` apenas em `provenance_json` e compensação segura em falha parcial.
 
 v2.0.42 — 16/06/2026 — Registrado o contrato técnico do renderer composicional de `commercial_activation`, com `content_json` v1, validação Zod estrita, registry fechado, regras de falha e conteúdo estruturado seguro.

--- a/docs/platform-config.md
+++ b/docs/platform-config.md
@@ -2,8 +2,8 @@
 
 0.1 Cabeçalho
 • Documento: LP Factory 10 — Platform Config
-• Versão: v0.1.7
-• Data: 25/06/2026
+• Versão: v0.1.8
+• Data: 02/07/2026
 
 0.2 Contrato do documento
 • O QUE É: snapshot operacional e fonte única das configurações de plataformas externas do LP Factory 10, refletindo o estado conhecido/cadastrado nas plataformas conforme indicado.
@@ -283,24 +283,34 @@
 7. Stripe
 
 7.1 Uso
-• Finalidade: provedor inicial de checkout do E9.
+• Finalidade: provedor inicial de checkout e webhook do E9.
 • Ambiente atual validado: teste.
 • Modo: `subscription`.
 • O app cria Checkout Session server-side.
-• Stripe Dashboard/Plugin pode apoiar criação, validação e consulta de Product/Price e Checkout Sessions.
-• Stripe Plugin não substitui o fluxo server-side do LP Factory.
-• Webhook e persistência de entitlement ficam para fase própria.
+• Webhook mínimo produtivo validado em `POST /api/stripe/webhook`.
+• `invoice.paid` ativa/renova entitlement local.
+• Redirect de sucesso não confirma pagamento e não libera entitlement.
 
 7.2 Endpoint usado pelo app
 • Checkout Sessions API: `https://api.stripe.com/v1/checkout/sessions`
 • Regra: chamada somente server-side.
 • Regra: não expor secret Stripe no client.
+• Webhook Stripe: `POST /api/stripe/webhook`
+• Endpoint externo usado para subscription lookup: `https://api.stripe.com/v1/subscriptions`
+• Regra: webhook exige assinatura Stripe válida.
+• Regra: payload bruto Stripe não deve ser persistido.
 
 7.3 Vercel — secrets e variáveis Stripe
 • `STRIPE_SECRET_KEY`
 • Finalidade: secret server-side Stripe para criar Checkout Sessions.
 • Plataforma: Vercel.
 • Escopo conhecido: Production validado; Preview quando necessário para testes.
+• Valor real: não versionar.
+
+• `STRIPE_WEBHOOK_SECRET`
+• Finalidade: secret server-side para validação da assinatura do webhook Stripe.
+• Plataforma: Vercel.
+• Escopo conhecido: Production validado.
 • Valor real: não versionar.
 
 Products/Prices de teste
@@ -400,6 +410,8 @@ Regra:
 • Configurações de plataformas, secrets por nome, workflows, ambientes e endpoints usados por automações devem ser registrados neste documento.
 
 99. Changelog
+v0.1.8 — 02/07/2026 — Configuração Stripe atualizada com uso de webhook produtivo, endpoint `/api/stripe/webhook`, lookup de subscriptions e secret `STRIPE_WEBHOOK_SECRET`.
+
 v0.1.7 — 25/06/2026 — Atualizado `OPENAI_COMMERCIAL_ACTIVATION_MODEL` para escopo Production e Preview, com referência `gpt-5.4-mini` e regra operacional de não prender configuração a branch no MVP.
 
 v0.1.6 — 23/06/2026 — Registrado o estado operacional de `OPENAI_COMMERCIAL_ACTIVATION_MODEL` para E10.7 Fase 3: configurada e validada em Vercel Preview com modelo de referência, Production pendente de decisão operacional e sem exposição de secrets.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data: 30/06/2026
-• Versão: v1.5.86
+• Data: 02/07/2026
+• Versão: v1.5.87
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -375,56 +375,62 @@
 • `PlanId` legado não é contrato de negócio.
 • Webhook, assinatura do webhook, idempotência e persistência em `account_commercial_entitlements` ficam para a Fase 7.
 
-9.3.8 Updates avaliados
+9.3.8 Webhook Stripe mínimo
+• Status: Fase 7.2 concluída em 02/07/2026.
+• Endpoint produtivo: `POST /api/stripe/webhook`.
+• Evento que ativa/renova entitlement: `invoice.paid`.
+• `checkout.session.completed` é evento auxiliar/ignorado e não libera entitlement.
+• `customer.subscription.deleted` e `invoice.payment_failed` ficam registrados como controlados/ignorados neste recorte.
+• Idempotência operacional: `stripe_webhook_events.event_id`.
+• Retry validado para evento `failed` e para `processing` antigo com `retry_reason = stale_processing`.
+• Persistência local validada em `public.account_commercial_entitlements`.
+• Redirect de sucesso continua sem liberar entitlement.
+• Payload bruto, secret, cartão e PII sensível não são persistidos.
+
+9.3.9 Updates avaliados
 • `supa#5`, `supa#36`, `supa#40`, `supa#58`.
+• Stripe webhook, Vercel Production, Stripe test mode e Supabase/Postgres aplicados na Fase 7.2.
 
 9.4 Pendências vigentes
-• Implementar E9 Fase 7.1 — contrato do webhook Stripe e persistência de entitlement.
-• Definir contrato do webhook Stripe.
-• Validar assinatura do webhook.
-• Definir evento normalizado.
-• Definir idempotência.
-• Mapear status Stripe para status comercial interno.
-• Persistir ou atualizar `public.account_commercial_entitlements`.
-• Garantir que redirect de sucesso continue sem liberar entitlement.
-• Auditar logs detalhados quando a ferramenta permitir.
-• Não persistir payload bruto, cartão, secret ou PII sensível em logs ou banco.
+• N/A para o recorte concluído da Fase 7.2.
 
 9.5 Estruturas e artefatos
 
 Banco — Criados
 • `public.account_commercial_entitlements`
 • `public.v_account_commercial_entitlement_effective`
+• `public.stripe_webhook_events`
 
 Repositório — Criados
 • `supabase/migrations/20260628184945_e9_commercial_entitlements.sql`
 • `supabase/snippets/e9_phase_3_entitlements_verify.sql`
+• `supabase/migrations/20260701202632_e9_stripe_webhook_events.sql`
+• `supabase/snippets/e9_phase_7_2_stripe_webhook_verify.sql`
 • `lib/commercial-entitlements/contracts.ts`
 • `lib/commercial-entitlements/adapters/commercialEntitlementAdapter.ts`
 • `lib/commercial-entitlements/index.ts`
 • `lib/billing-checkout/contracts.ts`
 • `lib/billing-checkout/adapters/stripePriceMap.ts`
 • `lib/billing-checkout/adapters/stripeCheckoutAdapter.ts`
+• `lib/billing-checkout/adapters/stripeWebhookAdapter.ts`
 • `lib/billing-checkout/index.ts`
 • `app/a/[account]/_components/commercial-page/checkout-actions.ts`
+• `app/api/stripe/webhook/route.ts`
 
 Repositório — Ajustados
 • `app/a/[account]/page.tsx`
 • `app/a/[account]/_components/commercial-page/GenericCommercialPage.tsx`
-• `docs/schema.md`
-• `docs/lousa-plano-base-e9.md`
+• `lib/billing-checkout/index.ts`
 
-9.6 Fora do escopo da Fase 6
-• Webhook Stripe.
-• Validação de assinatura do webhook.
-• Persistência de entitlement local.
+9.6 Fora do escopo da Fase 7.2
 • Billing Engine completo.
 • Admin comercial.
 • Trial operacional.
 • Liberação manual operacional.
 • LP Builder.
 • Alteração de layout, copy ou cards da E10.7.
-• Logs sensíveis, eventos persistidos, job, rotina, monitoramento ou automação.
+• Processamento de cancelamento e falha de pagamento fora do registro controlado/ignorado.
+• Job, rotina, monitoramento ou automação.
 
 10. E10 — Account Dashboard (UX)
 
@@ -1431,6 +1437,8 @@ Repositório — Criados
 • Esta referência não cria obrigação de nova implementação agora.
 
 99. Changelog
+v1.5.87 — 02/07/2026 — E9 Fase 7.2 concluída com webhook Stripe mínimo em produção, `invoice.paid` ativando entitlement local, idempotência em `stripe_webhook_events`, retry operacional e persistência validada em `account_commercial_entitlements`.
+
 v1.5.86 — 30/06/2026 — E19 Fase 3 concluída com criação produtiva mínima de LP por conta, persistência em public.account_landing_pages, boundary lib/lp-builder/ e gate E9 antes do insert.
 
 v1.5.85 — 26/06/2026 — E10.7 Fase 6 concluída; próxima fase: Fase 7 — edição manual de copy e gestão simples de versões.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -131,12 +131,12 @@
 • `public.plans` continua fonte parcial de metadados de plano e não prova entitlement comercial.
 • Account Dashboard consumirá a leitura efetiva apenas em fase futura; esta etapa não altera runtime.
 
-1.6 stripe_webhook_events
-1.6.1 Função
+1.5.7 stripe_webhook_events
+1.5.7.1 Função
 • Idempotência e auditoria operacional mínima de eventos Stripe.
 • Não armazena payload bruto, secrets, dados de cartão ou PII.
 
-1.6.2 Colunas
+1.5.7.2 Colunas
 • id uuid primary key default gen_random_uuid()
 • event_id text not null
 • event_type text not null
@@ -152,7 +152,7 @@
 • created_at timestamptz not null default now()
 • updated_at timestamptz not null default now()
 
-1.6.3 Constraints e relacionamentos
+1.5.7.3 Constraints e relacionamentos
 • UNIQUE: event_id
 • CHECK: provider = 'stripe'
 • CHECK: processing_status IN ('processing', 'processed', 'ignored', 'failed')
@@ -164,62 +164,62 @@
 • FK: account_id → accounts(id) ON UPDATE CASCADE ON DELETE SET NULL
 • FK: entitlement_id → account_commercial_entitlements(id) ON UPDATE CASCADE ON DELETE SET NULL
 
-1.6.4 Índices
+1.5.7.4 Índices
 • stripe_webhook_events_event_type_idx
 • stripe_webhook_events_processing_status_idx
 • stripe_webhook_events_account_id_idx
 • stripe_webhook_events_external_reference_idx parcial quando external_reference IS NOT NULL
 
-1.6.5 Segurança
+1.5.7.5 Segurança
 • Trigger: stripe_webhook_events_set_updated_at usa public.tg_set_updated_at()
 • RLS: ativo
 • Grants: service_role com SELECT, INSERT e UPDATE
 • public, anon e authenticated sem grants
 
-1.7 partners
+1.6 partners
 • PK: id uuid
 • Campos: name, type (agency | reseller | affiliate), status (active | inactive | suspended)
 • Trigger Hub: não
 • RLS: conforme uso
 • Policies (TBD)
 
-1.8 partner_accounts
-1.8.1 Chaves e relacionamentos
+1.7 partner_accounts
+1.7.1 Chaves e relacionamentos
 • PK composto: (partner_id, account_id)
 • FK: partner_id → partners; account_id → accounts
-1.8.2 Segurança
+1.7.2 Segurança
 • Trigger Hub: sim
 • RLS: obrigatório
-1.8.3 Policies (TBD: preencher nomes reais no Supabase)
+1.7.3 Policies (TBD: preencher nomes reais no Supabase)
 • Select: platform_admin/partner autorizado
 • Insert/Update/Delete: governado via hub/regras administrativas
 
-1.9 account_profiles
-1.9.1 Chaves, constraints e relacionamentos
+1.8 account_profiles
+1.8.1 Chaves, constraints e relacionamentos
 • PK: account_id uuid (constraint account_profiles_pkey)
 • FK: account_id → accounts(id) ON DELETE CASCADE (constraint account_profiles_account_id_fkey)
 • CHECK: account_profiles_preferred_channel_chk (preferred_channel IN ('email', 'whatsapp'))
-1.9.2 Campos
+1.8.2 Campos
 • niche text null
 • preferred_channel text not null default 'email'
 • whatsapp text null
 • site_url text null
 • created_at timestamptz not null default now()
 • updated_at timestamptz not null default now()
-1.9.3 Segurança
+1.8.3 Segurança
 • Trigger Hub: não (sem triggers)
 • RLS: ativo (enable row level security)
-1.9.4 Policies
+1.8.4 Policies
 • account_profiles_select_member_or_platform (SELECT to public): is_platform_admin() OU membro ativo do tenant (account_users.account_id = account_profiles.account_id; account_users.user_id = auth.uid(); account_users.status='active')
 • account_profiles_insert_owner_admin_or_platform (INSERT to public): is_platform_admin() OU owner/admin ativo do tenant (account_users.role IN ('owner','admin'); status='active')
 • account_profiles_update_owner_admin_or_platform (UPDATE to public): is_platform_admin() OU owner/admin ativo do tenant (USING + WITH CHECK)
 
-1.10 account_landing_pages
-1.10.1 Função
+1.9 account_landing_pages
+1.9.1 Função
 • Persistência mínima de landing pages produtivas por conta na E19.
 • Criação inicial limitada a status `draft`.
 
-1.10.2 Colunas
+1.9.2 Colunas
 • id uuid primary key default gen_random_uuid()
 • account_id uuid not null
 • name text not null
@@ -229,58 +229,90 @@
 • created_at timestamptz not null default now()
 • updated_at timestamptz not null default now()
 
-1.10.3 Relacionamentos
+1.9.3 Relacionamentos
 • account_id referencia public.accounts(id) com ON UPDATE CASCADE e ON DELETE CASCADE.
 • created_by referencia auth.users(id) com ON UPDATE CASCADE e ON DELETE RESTRICT.
 
-1.10.4 Constraints
+1.9.4 Constraints
 • account_landing_pages_status_chk: status in ('draft').
 • account_landing_pages_slug_chk: slug no padrão seguro `^[a-z0-9]+(-[a-z0-9]+)*$`.
 • account_landing_pages_name_chk: nome não vazio após trim.
 • account_landing_pages_account_slug_uidx: UNIQUE (account_id, slug).
 
-1.10.5 Índices
+1.9.5 Índices
 • account_landing_pages_account_id_idx em account_id.
 • account_landing_pages_created_by_idx em created_by.
 • account_landing_pages_status_idx em status.
 
-1.10.6 Trigger
+1.9.6 Trigger
 • account_landing_pages_set_updated_at: executa public.tg_set_updated_at() antes de update.
 
-1.10.7 RLS / policies / grants
+1.9.7 RLS / policies / grants
 • RLS habilitado.
 • Policy account_landing_pages_select_member_or_platform: permite SELECT para platform admin ou membro ativo da conta.
 • authenticated: SELECT.
 • service_role: SELECT, INSERT, UPDATE, DELETE.
 • public e anon: sem grants.
 
-1.10.8 Observações de escopo
+1.9.8 Observações de escopo
 • Escrita deve ocorrer por fluxo server-side autorizado.
 • Criação inicial é apenas `draft`.
 • Publicação, render público, domínio customizado, analytics, A/B e IA runtime não fazem parte deste schema inicial.
 
-1.11 ai_readonly (role)
-1.11.1 Segurança (parâmetros)
+1.10 ai_readonly (role)
+1.10.1 Segurança (parâmetros)
 • LOGIN: sim
 • statement_timeout: 5s
-1.11.2 Escopo e grants (schema public)
+1.10.2 Escopo e grants (schema public)
 • Schema: public (USAGE)
 • Tabelas existentes em public: GRANT SELECT
 • Novas tabelas em public: default privileges com GRANT SELECT
 
-1.12 business_taxons
+1.11 business_taxons
 
-1.12.1 Chaves, constraints e relacionamentos
+1.11.1 Chaves, constraints e relacionamentos
 • PK: id uuid
 • UNIQUE: slug
 • CHECK: business_taxons_level_chk (level IN ('segment', 'niche', 'ultra_niche'))
 • FK: parent_id → business_taxons(id) ON UPDATE CASCADE ON DELETE SET NULL
 
-1.12.2 Campos
+1.11.2 Campos
 • parent_id uuid null
 • level text not null
 • name text not null
 • slug text not null
+• is_active boolean not null default true
+
+1.11.3 Segurança
+• Trigger Hub: não
+• RLS: ativo (enable row level security)
+• service_role: SELECT
+
+1.11.4 Policies
+• business_taxons_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
+• business_taxons_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
+• business_taxons_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
+• business_taxons_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
+
+1.11.5 Índices
+• business_taxons_name_normalized_idx (btree em normalize_taxon_match_text(name))
+• business_taxons_slug_normalized_idx (btree em normalize_taxon_match_text(replace(slug, '-', ' ')))
+• business_taxons_name_slug_fts_gin_idx (GIN em to_tsvector('portuguese', normalize_taxon_match_text(name) + slug normalizado))
+• business_taxons_name_normalized_trgm_gin_idx (GIN trigram em normalize_taxon_match_text(name))
+• business_taxons_slug_normalized_trgm_gin_idx (GIN trigram em slug normalizado)
+
+1.12 business_taxon_aliases
+
+1.12.1 Chaves, constraints e relacionamentos
+• PK: id uuid
+• UNIQUE: (taxon_id, alias_text_normalized)
+• FK: taxon_id → business_taxons(id) ON UPDATE CASCADE ON DELETE RESTRICT
+• Generated column: alias_text_normalized (normalização derivada de alias_text)
+
+1.12.2 Campos
+• taxon_id uuid not null
+• alias_text text not null
+• alias_text_normalized text generated always as stored
 • is_active boolean not null default true
 
 1.12.3 Segurança
@@ -289,51 +321,19 @@
 • service_role: SELECT
 
 1.12.4 Policies
-• business_taxons_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
-• business_taxons_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
-• business_taxons_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
-• business_taxons_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
-
-1.12.5 Índices
-• business_taxons_name_normalized_idx (btree em normalize_taxon_match_text(name))
-• business_taxons_slug_normalized_idx (btree em normalize_taxon_match_text(replace(slug, '-', ' ')))
-• business_taxons_name_slug_fts_gin_idx (GIN em to_tsvector('portuguese', normalize_taxon_match_text(name) + slug normalizado))
-• business_taxons_name_normalized_trgm_gin_idx (GIN trigram em normalize_taxon_match_text(name))
-• business_taxons_slug_normalized_trgm_gin_idx (GIN trigram em slug normalizado)
-
-1.13 business_taxon_aliases
-
-1.13.1 Chaves, constraints e relacionamentos
-• PK: id uuid
-• UNIQUE: (taxon_id, alias_text_normalized)
-• FK: taxon_id → business_taxons(id) ON UPDATE CASCADE ON DELETE RESTRICT
-• Generated column: alias_text_normalized (normalização derivada de alias_text)
-
-1.13.2 Campos
-• taxon_id uuid not null
-• alias_text text not null
-• alias_text_normalized text generated always as stored
-• is_active boolean not null default true
-
-1.13.3 Segurança
-• Trigger Hub: não
-• RLS: ativo (enable row level security)
-• service_role: SELECT
-
-1.13.4 Policies
 • business_taxon_aliases_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
 • business_taxon_aliases_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
 • business_taxon_aliases_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
 • business_taxon_aliases_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
 
-1.13.5 Índices
+1.12.5 Índices
 • business_taxon_aliases_alias_text_normalized_idx (btree em alias_text_normalized)
 • business_taxon_aliases_alias_text_normalized_fts_gin_idx (GIN em to_tsvector('portuguese', alias_text_normalized))
 • business_taxon_aliases_alias_text_normalized_trgm_gin_idx (GIN trigram em alias_text_normalized)
 
-1.14 account_taxonomy
+1.13 account_taxonomy
 
-1.14.1 Chaves, constraints e relacionamentos
+1.13.1 Chaves, constraints e relacionamentos
 • PK: id uuid
 • UNIQUE: (account_id, taxon_id)
 • CHECK: account_taxonomy_status_chk (status IN ('active', 'inactive'))
@@ -342,7 +342,7 @@
 • FK: taxon_id → business_taxons(id) ON UPDATE CASCADE ON DELETE RESTRICT
 • Nota: não há constraint/índice garantindo apenas um `is_primary = true` por conta nesta etapa.
 
-1.14.2 Campos
+1.13.2 Campos
 • account_id uuid not null
 • taxon_id uuid not null
 • is_primary boolean not null default false
@@ -351,21 +351,21 @@
 • created_at timestamptz not null default now()
 • updated_at timestamptz not null default now()
 
-1.14.3 Segurança
+1.13.3 Segurança
 • Trigger Hub: não
 • RLS: ativo (enable row level security)
 • service_role: SELECT, INSERT, UPDATE
 • anon/authenticated/public: sem acesso direto
 
-1.14.4 Policies
+1.13.4 Policies
 • account_taxonomy_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
 • account_taxonomy_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
 • account_taxonomy_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
 • account_taxonomy_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
 
-1.15 content_templates
+1.14 content_templates
 
-1.15.1 Chaves, constraints e relacionamentos
+1.14.1 Chaves, constraints e relacionamentos
 • PK: id uuid
 • UNIQUE: (template_key, version)
 • UNIQUE: (slug, version)
@@ -375,7 +375,7 @@
 • CHECK: content_templates_template_scope_chk (template_scope IN ('page', 'section'))
 • CHECK: content_templates_status_chk (status IN ('draft', 'active', 'archived'))
 
-1.15.2 Campos
+1.14.2 Campos
 • template_key text not null
 • name text not null
 • slug text not null
@@ -389,18 +389,18 @@
 • created_at timestamptz not null default now()
 • updated_at timestamptz not null default now()
 
-1.15.3 Segurança
+1.14.3 Segurança
 • Trigger Hub: não
 • RLS: ativo (enable row level security)
 • service_role: SELECT
 
-1.15.4 Policies
+1.14.4 Policies
 • content_templates_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
 • content_templates_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
 • content_templates_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
 • content_templates_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
 
-1.15.5 Registros-base de `commercial_activation`
+1.14.5 Registros-base de `commercial_activation`
 • Template de página: `commercial_activation_page`, slug `commercial-activation-page`, escopo `page`.
 • Módulos de seção: `hero`, `benefits`, `services`, `plans`, `differentials`, `how_it_works`, `faq` e `final_cta`.
 • Slugs especiais: `how-it-works` e `final-cta`; os demais coincidem com `template_key`.
@@ -410,15 +410,15 @@
 • Migration: `supabase/migrations/20260616142000_e18_commercial_activation_base_records.sql`.
 • Verificação: `supabase/snippets/e18_commercial_activation_base_records_verify.sql`.
 
-1.16 content_template_taxons
+1.15 content_template_taxons
 
-1.16.1 Chaves, constraints e relacionamentos
+1.15.1 Chaves, constraints e relacionamentos
 • PK: id uuid
 • CHECK: content_template_taxons_resolution_level_chk (resolution_level IN ('generic', 'segment', 'niche', 'ultra_niche'))
 • FK: template_id → content_templates(id) ON UPDATE CASCADE ON DELETE CASCADE
 • FK: taxon_id → business_taxons(id) ON UPDATE CASCADE ON DELETE RESTRICT
 
-1.16.2 Campos
+1.15.2 Campos
 • template_id uuid not null
 • taxon_id uuid not null
 • resolution_level text not null
@@ -428,20 +428,20 @@
 • created_at timestamptz not null default now()
 • updated_at timestamptz not null default now()
 
-1.16.3 Segurança
+1.15.3 Segurança
 • Trigger Hub: não
 • RLS: ativo (enable row level security)
 • service_role: SELECT
 
-1.16.4 Policies
+1.15.4 Policies
 • content_template_taxons_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
 • content_template_taxons_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
 • content_template_taxons_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
 • content_template_taxons_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
 
-1.17 taxon_market_research
+1.16 taxon_market_research
 
-1.17.1 Chaves, constraints e relacionamentos
+1.16.1 Chaves, constraints e relacionamentos
 • PK: id uuid
 • UNIQUE: (taxon_id, research_block, audience_scope, version)
 • UNIQUE auxiliar: (id, taxon_id, audience_scope, version)
@@ -449,7 +449,7 @@
 • CHECK: taxon_market_research_audience_scope_chk (audience_scope IN ('end_customer', 'business_buyer'))
 • FK: taxon_id → business_taxons(id) ON UPDATE CASCADE ON DELETE RESTRICT
 
-1.17.2 Campos
+1.16.2 Campos
 • taxon_id uuid not null
 • research_block text not null
 • Regra: texto governado por processo operacional; sem CHECK fechado nesta etapa
@@ -460,29 +460,29 @@
 • created_at timestamptz not null default now()
 • updated_at timestamptz not null default now()
 
-1.17.3 Índices
+1.16.3 Índices
 • taxon_market_research_taxon_block_audience_version_uidx (UNIQUE em taxon_id, research_block, audience_scope, version)
 • taxon_market_research_one_active_per_block_audience_uidx (UNIQUE parcial em taxon_id, research_block, audience_scope WHERE status = 'active')
 
-1.17.4 Segurança
+1.16.4 Segurança
 • Trigger Hub: não
 • RLS: ativo (enable row level security)
 • service_role: SELECT
 
-1.17.5 Policies
+1.16.5 Policies
 • taxon_market_research_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
 • taxon_market_research_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
 • taxon_market_research_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
 • taxon_market_research_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
 
-1.18 taxon_market_research_items
+1.17 taxon_market_research_items
 
-1.18.1 Chaves, constraints e relacionamentos
+1.17.1 Chaves, constraints e relacionamentos
 • PK: id uuid
 • FK: research_id → taxon_market_research(id) ON UPDATE CASCADE ON DELETE CASCADE
 • UNIQUE adicional: nenhuma nesta etapa
 
-1.18.2 Campos
+1.17.2 Campos
 • research_id uuid not null
 • item_key text not null
 • item_text text not null
@@ -493,25 +493,25 @@
 • created_at timestamptz not null default now()
 • updated_at timestamptz not null default now()
 
-1.18.3 Segurança
+1.17.3 Segurança
 • Trigger Hub: não
 • RLS: ativo (enable row level security)
 • service_role: SELECT
 
-1.18.4 Policies
+1.17.4 Policies
 • taxon_market_research_items_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
 • taxon_market_research_items_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
 • taxon_market_research_items_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
 • taxon_market_research_items_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
 
-1.19 taxon_message_guides
+1.18 taxon_message_guides
 
-1.19.1 Chaves, constraints e relacionamentos
+1.18.1 Chaves, constraints e relacionamentos
 • PK: id uuid
 • CHECK: taxon_message_guides_context_type_chk (context_type IN ('e10_5', 'landing_page', 'email', 'whatsapp'))
 • FK: research_id → taxon_market_research(id) ON UPDATE CASCADE ON DELETE CASCADE
 
-1.19.2 Campos
+1.18.2 Campos
 • research_id uuid not null
 • context_type text not null
 • guide_payload_json jsonb not null
@@ -520,19 +520,19 @@
 • created_at timestamptz not null default now()
 • updated_at timestamptz not null default now()
 
-1.19.3 Segurança
+1.18.3 Segurança
 • Trigger Hub: não
 • RLS: ativo (enable row level security)
 
-1.19.4 Policies
+1.18.4 Policies
 • taxon_message_guides_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
 • taxon_message_guides_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
 • taxon_message_guides_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
 • taxon_message_guides_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
 
-1.20 account_niche_resolutions
+1.19 account_niche_resolutions
 
-1.20.1 Chaves, constraints e relacionamentos
+1.19.1 Chaves, constraints e relacionamentos
 • CHECK: account_niche_resolutions_ai_status_chk
 • CHECK: account_niche_resolutions_ai_result_json_chk
 • CHECK: account_niche_resolutions_ai_ux_mode_chk
@@ -550,7 +550,7 @@
 • CHECK: resolution_status
 • CHECK: score entre 0 e 1 ou NULL
 
-1.20.2 Campos
+1.19.2 Campos
 • ai_status text null
 • ai_error_code text null
 • ai_model text null
@@ -584,19 +584,19 @@
 • created_at timestamptz not null default now()
 • updated_at timestamptz not null default now()
 
-1.20.3 Segurança
+1.19.3 Segurança
 • Trigger Hub: não
 • RLS: ativo
 • Policies: admin-only
 • Acesso direto removido de public, anon e authenticated
 • service_role: SELECT, INSERT e UPDATE
 
-1.20.4 Índices
+1.19.4 Índices
 • account_niche_resolutions_ai_suggested_taxon_id_idx
 
-1.21 content_template_compositions
+1.20 content_template_compositions
 
-1.21.1 Chaves, constraints e relacionamentos
+1.20.1 Chaves, constraints e relacionamentos
 • PK: id uuid
 • UNIQUE: (template_id, taxon_id, version)
 • UNIQUE auxiliar: (id, template_id, taxon_id, version)
@@ -606,11 +606,45 @@
 • FK: template_id → content_templates(id) ON UPDATE CASCADE ON DELETE RESTRICT
 • FK: taxon_id → business_taxons(id) ON UPDATE CASCADE ON DELETE RESTRICT
 
-1.21.2 Campos
+1.20.2 Campos
 • template_id uuid not null
 • taxon_id uuid not null
 • version integer not null default 1
 • status text not null default 'draft'
+• created_at timestamptz not null default now()
+• updated_at timestamptz not null default now()
+
+1.20.3 Segurança
+• Trigger Hub: não
+• RLS: ativo
+• anon/authenticated/public: sem acesso
+• service_role: SELECT
+
+1.20.4 Índices
+• `content_template_compositions_one_active_uidx`: UNIQUE parcial em (`template_id`, `taxon_id`) para `status = 'active'`.
+• `content_template_compositions_taxon_id_idx`: btree em `taxon_id`.
+
+1.20.5 Triggers
+• `content_template_compositions_set_updated_at`: executa `public.tg_set_updated_at()` antes de UPDATE.
+
+1.21 content_template_composition_items
+
+1.21.1 Chaves, constraints e relacionamentos
+• PK: id uuid
+• UNIQUE: (composition_id, sort_order)
+• CHECK: variant_key descritivo no formato `modulo.variante`
+• CHECK: sort_order >= 0
+• CHECK: config_json é objeto JSON
+• FK: composition_id → content_template_compositions(id) ON UPDATE CASCADE ON DELETE CASCADE
+• FK: module_template_id → content_templates(id) ON UPDATE CASCADE ON DELETE RESTRICT
+
+1.21.2 Campos
+• composition_id uuid not null
+• module_template_id uuid not null
+• variant_key text not null
+• sort_order integer not null
+• is_required boolean not null default true
+• config_json jsonb not null default '{}'
 • created_at timestamptz not null default now()
 • updated_at timestamptz not null default now()
 
@@ -621,48 +655,14 @@
 • service_role: SELECT
 
 1.21.4 Índices
-• `content_template_compositions_one_active_uidx`: UNIQUE parcial em (`template_id`, `taxon_id`) para `status = 'active'`.
-• `content_template_compositions_taxon_id_idx`: btree em `taxon_id`.
-
-1.21.5 Triggers
-• `content_template_compositions_set_updated_at`: executa `public.tg_set_updated_at()` antes de UPDATE.
-
-1.22 content_template_composition_items
-
-1.22.1 Chaves, constraints e relacionamentos
-• PK: id uuid
-• UNIQUE: (composition_id, sort_order)
-• CHECK: variant_key descritivo no formato `modulo.variante`
-• CHECK: sort_order >= 0
-• CHECK: config_json é objeto JSON
-• FK: composition_id → content_template_compositions(id) ON UPDATE CASCADE ON DELETE CASCADE
-• FK: module_template_id → content_templates(id) ON UPDATE CASCADE ON DELETE RESTRICT
-
-1.22.2 Campos
-• composition_id uuid not null
-• module_template_id uuid not null
-• variant_key text not null
-• sort_order integer not null
-• is_required boolean not null default true
-• config_json jsonb not null default '{}'
-• created_at timestamptz not null default now()
-• updated_at timestamptz not null default now()
-
-1.22.3 Segurança
-• Trigger Hub: não
-• RLS: ativo
-• anon/authenticated/public: sem acesso
-• service_role: SELECT
-
-1.22.4 Índices
 • `content_template_composition_items_module_template_id_idx`: btree em `module_template_id`.
 
-1.22.5 Triggers
+1.21.5 Triggers
 • `content_template_composition_items_set_updated_at`: executa `public.tg_set_updated_at()` antes de UPDATE.
 
-1.23 content_artifacts
+1.22 content_artifacts
 
-1.23.1 Chaves, constraints e relacionamentos
+1.22.1 Chaves, constraints e relacionamentos
 • PK: id uuid
 • UNIQUE: (template_id, composition_id, taxon_id, audience_scope, research_version, artifact_version)
 • UNIQUE parcial: no máximo um artefato `published` por (template_id, taxon_id, audience_scope)
@@ -675,7 +675,7 @@
 • FK composta: (composition_id, template_id, taxon_id, composition_version) → content_template_compositions(id, template_id, taxon_id, version)
 • FK: taxon_id → business_taxons(id) ON UPDATE CASCADE ON DELETE RESTRICT
 
-1.23.2 Campos
+1.22.2 Campos
 • template_id uuid not null
 • composition_id uuid not null
 • taxon_id uuid not null
@@ -692,7 +692,7 @@
 • published_at timestamptz null
 • archived_at timestamptz null
 
-1.23.3 Segurança
+1.22.3 Segurança
 • Trigger Hub: não
 • RLS: ativo
 • public/anon: sem acesso
@@ -703,22 +703,22 @@
   • content_artifacts_insert_admin_draft_only (INSERT to authenticated): is_super_admin() OU is_platform_admin(); somente `status = 'draft'`, `published_at IS NULL` e `archived_at IS NULL`
   • content_artifacts_update_admin_draft_content_only (UPDATE to authenticated): is_super_admin() OU is_platform_admin(); somente `status = 'draft'`, `published_at IS NULL` e `archived_at IS NULL` (USING + WITH CHECK)
 
-1.23.4 Índices
+1.22.4 Índices
 • `content_artifacts_one_published_uidx`: UNIQUE parcial em (`template_id`, `taxon_id`, `audience_scope`) para `status = 'published'`.
 • `content_artifacts_composition_id_idx`: btree em `composition_id`.
 • `content_artifacts_taxon_id_idx`: btree em `taxon_id`.
 
-1.23.5 Triggers
+1.22.5 Triggers
 • `content_artifacts_set_updated_at`: executa `public.tg_set_updated_at()` antes de UPDATE.
 
-1.24 content_artifact_research_sources
+1.23 content_artifact_research_sources
 
-1.24.1 Chaves, constraints e relacionamentos
+1.23.1 Chaves, constraints e relacionamentos
 • PK: (artifact_id, research_id)
 • FK composta: (artifact_id, taxon_id, audience_scope, research_version) → content_artifacts(id, taxon_id, audience_scope, research_version)
 • FK composta: (research_id, taxon_id, audience_scope, research_version) → taxon_market_research(id, taxon_id, audience_scope, version)
 
-1.24.2 Campos
+1.23.2 Campos
 • artifact_id uuid not null
 • research_id uuid not null
 • taxon_id uuid not null
@@ -726,7 +726,7 @@
 • research_version integer not null
 • created_at timestamptz not null default now()
 
-1.24.3 Segurança
+1.23.3 Segurança
 • Trigger Hub: não
 • RLS: ativo
 • public/anon: sem acesso
@@ -736,7 +736,7 @@
   • content_artifact_research_sources_select_admin_only (SELECT to authenticated): is_super_admin() OU is_platform_admin()
   • cars_insert_admin_business_buyer_only (INSERT to authenticated): is_super_admin() OU is_platform_admin(); somente `audience_scope = 'business_buyer'`
 
-1.24.4 Índices
+1.23.4 Índices
 • `content_artifact_research_sources_research_id_idx`: btree em `research_id`.
 
 2. Views

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data da última atualização: 30/06/2026
-• Documento: LP Factory 10 — Schema (DB Contract) v1.0.31
+• Data da última atualização: 02/07/2026
+• Documento: LP Factory 10 — Schema (DB Contract) v1.0.32
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -130,6 +130,51 @@
 • Não há payload bruto, dado de cartão, secret ou e-mail como chave de idempotência.
 • `public.plans` continua fonte parcial de metadados de plano e não prova entitlement comercial.
 • Account Dashboard consumirá a leitura efetiva apenas em fase futura; esta etapa não altera runtime.
+
+1.6 stripe_webhook_events
+1.6.1 Função
+• Idempotência e auditoria operacional mínima de eventos Stripe.
+• Não armazena payload bruto, secrets, dados de cartão ou PII.
+
+1.6.2 Colunas
+• id uuid primary key default gen_random_uuid()
+• event_id text not null
+• event_type text not null
+• provider text not null default 'stripe'
+• processing_status text not null
+• account_id uuid null
+• entitlement_id uuid null
+• external_reference text null
+• error_code text null
+• metadata_json jsonb not null default '{}'::jsonb
+• received_at timestamptz not null default now()
+• processed_at timestamptz null
+• created_at timestamptz not null default now()
+• updated_at timestamptz not null default now()
+
+1.6.3 Constraints e relacionamentos
+• UNIQUE: event_id
+• CHECK: provider = 'stripe'
+• CHECK: processing_status IN ('processing', 'processed', 'ignored', 'failed')
+• CHECK: event_id não vazio
+• CHECK: event_type não vazio
+• CHECK: external_reference não vazio quando existir
+• CHECK: error_code não vazio quando existir
+• CHECK: metadata_json deve ser objeto JSON
+• FK: account_id → accounts(id) ON UPDATE CASCADE ON DELETE SET NULL
+• FK: entitlement_id → account_commercial_entitlements(id) ON UPDATE CASCADE ON DELETE SET NULL
+
+1.6.4 Índices
+• stripe_webhook_events_event_type_idx
+• stripe_webhook_events_processing_status_idx
+• stripe_webhook_events_account_id_idx
+• stripe_webhook_events_external_reference_idx parcial quando external_reference IS NOT NULL
+
+1.6.5 Segurança
+• Trigger: stripe_webhook_events_set_updated_at usa public.tg_set_updated_at()
+• RLS: ativo
+• Grants: service_role com SELECT, INSERT e UPDATE
+• public, anon e authenticated sem grants
 
 1.6 partners
 • PK: id uuid

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -176,50 +176,50 @@
 • Grants: service_role com SELECT, INSERT e UPDATE
 • public, anon e authenticated sem grants
 
-1.6 partners
+1.7 partners
 • PK: id uuid
 • Campos: name, type (agency | reseller | affiliate), status (active | inactive | suspended)
 • Trigger Hub: não
 • RLS: conforme uso
 • Policies (TBD)
 
-1.7 partner_accounts
-1.7.1 Chaves e relacionamentos
+1.8 partner_accounts
+1.8.1 Chaves e relacionamentos
 • PK composto: (partner_id, account_id)
 • FK: partner_id → partners; account_id → accounts
-1.7.2 Segurança
+1.8.2 Segurança
 • Trigger Hub: sim
 • RLS: obrigatório
-1.7.3 Policies (TBD: preencher nomes reais no Supabase)
+1.8.3 Policies (TBD: preencher nomes reais no Supabase)
 • Select: platform_admin/partner autorizado
 • Insert/Update/Delete: governado via hub/regras administrativas
 
-1.8 account_profiles
-1.8.1 Chaves, constraints e relacionamentos
+1.9 account_profiles
+1.9.1 Chaves, constraints e relacionamentos
 • PK: account_id uuid (constraint account_profiles_pkey)
 • FK: account_id → accounts(id) ON DELETE CASCADE (constraint account_profiles_account_id_fkey)
 • CHECK: account_profiles_preferred_channel_chk (preferred_channel IN ('email', 'whatsapp'))
-1.8.2 Campos
+1.9.2 Campos
 • niche text null
 • preferred_channel text not null default 'email'
 • whatsapp text null
 • site_url text null
 • created_at timestamptz not null default now()
 • updated_at timestamptz not null default now()
-1.8.3 Segurança
+1.9.3 Segurança
 • Trigger Hub: não (sem triggers)
 • RLS: ativo (enable row level security)
-1.8.4 Policies
+1.9.4 Policies
 • account_profiles_select_member_or_platform (SELECT to public): is_platform_admin() OU membro ativo do tenant (account_users.account_id = account_profiles.account_id; account_users.user_id = auth.uid(); account_users.status='active')
 • account_profiles_insert_owner_admin_or_platform (INSERT to public): is_platform_admin() OU owner/admin ativo do tenant (account_users.role IN ('owner','admin'); status='active')
 • account_profiles_update_owner_admin_or_platform (UPDATE to public): is_platform_admin() OU owner/admin ativo do tenant (USING + WITH CHECK)
 
-1.9 account_landing_pages
-1.9.1 Função
+1.10 account_landing_pages
+1.10.1 Função
 • Persistência mínima de landing pages produtivas por conta na E19.
 • Criação inicial limitada a status `draft`.
 
-1.9.2 Colunas
+1.10.2 Colunas
 • id uuid primary key default gen_random_uuid()
 • account_id uuid not null
 • name text not null
@@ -229,90 +229,58 @@
 • created_at timestamptz not null default now()
 • updated_at timestamptz not null default now()
 
-1.9.3 Relacionamentos
+1.10.3 Relacionamentos
 • account_id referencia public.accounts(id) com ON UPDATE CASCADE e ON DELETE CASCADE.
 • created_by referencia auth.users(id) com ON UPDATE CASCADE e ON DELETE RESTRICT.
 
-1.9.4 Constraints
+1.10.4 Constraints
 • account_landing_pages_status_chk: status in ('draft').
 • account_landing_pages_slug_chk: slug no padrão seguro `^[a-z0-9]+(-[a-z0-9]+)*$`.
 • account_landing_pages_name_chk: nome não vazio após trim.
 • account_landing_pages_account_slug_uidx: UNIQUE (account_id, slug).
 
-1.9.5 Índices
+1.10.5 Índices
 • account_landing_pages_account_id_idx em account_id.
 • account_landing_pages_created_by_idx em created_by.
 • account_landing_pages_status_idx em status.
 
-1.9.6 Trigger
+1.10.6 Trigger
 • account_landing_pages_set_updated_at: executa public.tg_set_updated_at() antes de update.
 
-1.9.7 RLS / policies / grants
+1.10.7 RLS / policies / grants
 • RLS habilitado.
 • Policy account_landing_pages_select_member_or_platform: permite SELECT para platform admin ou membro ativo da conta.
 • authenticated: SELECT.
 • service_role: SELECT, INSERT, UPDATE, DELETE.
 • public e anon: sem grants.
 
-1.9.8 Observações de escopo
+1.10.8 Observações de escopo
 • Escrita deve ocorrer por fluxo server-side autorizado.
 • Criação inicial é apenas `draft`.
 • Publicação, render público, domínio customizado, analytics, A/B e IA runtime não fazem parte deste schema inicial.
 
-1.10 ai_readonly (role)
-1.10.1 Segurança (parâmetros)
+1.11 ai_readonly (role)
+1.11.1 Segurança (parâmetros)
 • LOGIN: sim
 • statement_timeout: 5s
-1.10.2 Escopo e grants (schema public)
+1.11.2 Escopo e grants (schema public)
 • Schema: public (USAGE)
 • Tabelas existentes em public: GRANT SELECT
 • Novas tabelas em public: default privileges com GRANT SELECT
 
-1.11 business_taxons
+1.12 business_taxons
 
-1.11.1 Chaves, constraints e relacionamentos
+1.12.1 Chaves, constraints e relacionamentos
 • PK: id uuid
 • UNIQUE: slug
 • CHECK: business_taxons_level_chk (level IN ('segment', 'niche', 'ultra_niche'))
 • FK: parent_id → business_taxons(id) ON UPDATE CASCADE ON DELETE SET NULL
 
-1.11.2 Campos
+1.12.2 Campos
 • parent_id uuid null
 • level text not null
 • name text not null
 • slug text not null
-• is_active boolean not null default true
-
-1.11.3 Segurança
-• Trigger Hub: não
-• RLS: ativo (enable row level security)
-• service_role: SELECT
-
-1.11.4 Policies
-• business_taxons_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
-• business_taxons_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
-• business_taxons_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
-• business_taxons_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
-
-1.11.5 Índices
-• business_taxons_name_normalized_idx (btree em normalize_taxon_match_text(name))
-• business_taxons_slug_normalized_idx (btree em normalize_taxon_match_text(replace(slug, '-', ' ')))
-• business_taxons_name_slug_fts_gin_idx (GIN em to_tsvector('portuguese', normalize_taxon_match_text(name) + slug normalizado))
-• business_taxons_name_normalized_trgm_gin_idx (GIN trigram em normalize_taxon_match_text(name))
-• business_taxons_slug_normalized_trgm_gin_idx (GIN trigram em slug normalizado)
-
-1.12 business_taxon_aliases
-
-1.12.1 Chaves, constraints e relacionamentos
-• PK: id uuid
-• UNIQUE: (taxon_id, alias_text_normalized)
-• FK: taxon_id → business_taxons(id) ON UPDATE CASCADE ON DELETE RESTRICT
-• Generated column: alias_text_normalized (normalização derivada de alias_text)
-
-1.12.2 Campos
-• taxon_id uuid not null
-• alias_text text not null
-• alias_text_normalized text generated always as stored
 • is_active boolean not null default true
 
 1.12.3 Segurança
@@ -321,19 +289,51 @@
 • service_role: SELECT
 
 1.12.4 Policies
+• business_taxons_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
+• business_taxons_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
+• business_taxons_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
+• business_taxons_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
+
+1.12.5 Índices
+• business_taxons_name_normalized_idx (btree em normalize_taxon_match_text(name))
+• business_taxons_slug_normalized_idx (btree em normalize_taxon_match_text(replace(slug, '-', ' ')))
+• business_taxons_name_slug_fts_gin_idx (GIN em to_tsvector('portuguese', normalize_taxon_match_text(name) + slug normalizado))
+• business_taxons_name_normalized_trgm_gin_idx (GIN trigram em normalize_taxon_match_text(name))
+• business_taxons_slug_normalized_trgm_gin_idx (GIN trigram em slug normalizado)
+
+1.13 business_taxon_aliases
+
+1.13.1 Chaves, constraints e relacionamentos
+• PK: id uuid
+• UNIQUE: (taxon_id, alias_text_normalized)
+• FK: taxon_id → business_taxons(id) ON UPDATE CASCADE ON DELETE RESTRICT
+• Generated column: alias_text_normalized (normalização derivada de alias_text)
+
+1.13.2 Campos
+• taxon_id uuid not null
+• alias_text text not null
+• alias_text_normalized text generated always as stored
+• is_active boolean not null default true
+
+1.13.3 Segurança
+• Trigger Hub: não
+• RLS: ativo (enable row level security)
+• service_role: SELECT
+
+1.13.4 Policies
 • business_taxon_aliases_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
 • business_taxon_aliases_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
 • business_taxon_aliases_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
 • business_taxon_aliases_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
 
-1.12.5 Índices
+1.13.5 Índices
 • business_taxon_aliases_alias_text_normalized_idx (btree em alias_text_normalized)
 • business_taxon_aliases_alias_text_normalized_fts_gin_idx (GIN em to_tsvector('portuguese', alias_text_normalized))
 • business_taxon_aliases_alias_text_normalized_trgm_gin_idx (GIN trigram em alias_text_normalized)
 
-1.13 account_taxonomy
+1.14 account_taxonomy
 
-1.13.1 Chaves, constraints e relacionamentos
+1.14.1 Chaves, constraints e relacionamentos
 • PK: id uuid
 • UNIQUE: (account_id, taxon_id)
 • CHECK: account_taxonomy_status_chk (status IN ('active', 'inactive'))
@@ -342,7 +342,7 @@
 • FK: taxon_id → business_taxons(id) ON UPDATE CASCADE ON DELETE RESTRICT
 • Nota: não há constraint/índice garantindo apenas um `is_primary = true` por conta nesta etapa.
 
-1.13.2 Campos
+1.14.2 Campos
 • account_id uuid not null
 • taxon_id uuid not null
 • is_primary boolean not null default false
@@ -351,21 +351,21 @@
 • created_at timestamptz not null default now()
 • updated_at timestamptz not null default now()
 
-1.13.3 Segurança
+1.14.3 Segurança
 • Trigger Hub: não
 • RLS: ativo (enable row level security)
 • service_role: SELECT, INSERT, UPDATE
 • anon/authenticated/public: sem acesso direto
 
-1.13.4 Policies
+1.14.4 Policies
 • account_taxonomy_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
 • account_taxonomy_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
 • account_taxonomy_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
 • account_taxonomy_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
 
-1.14 content_templates
+1.15 content_templates
 
-1.14.1 Chaves, constraints e relacionamentos
+1.15.1 Chaves, constraints e relacionamentos
 • PK: id uuid
 • UNIQUE: (template_key, version)
 • UNIQUE: (slug, version)
@@ -375,7 +375,7 @@
 • CHECK: content_templates_template_scope_chk (template_scope IN ('page', 'section'))
 • CHECK: content_templates_status_chk (status IN ('draft', 'active', 'archived'))
 
-1.14.2 Campos
+1.15.2 Campos
 • template_key text not null
 • name text not null
 • slug text not null
@@ -389,18 +389,18 @@
 • created_at timestamptz not null default now()
 • updated_at timestamptz not null default now()
 
-1.14.3 Segurança
+1.15.3 Segurança
 • Trigger Hub: não
 • RLS: ativo (enable row level security)
 • service_role: SELECT
 
-1.14.4 Policies
+1.15.4 Policies
 • content_templates_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
 • content_templates_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
 • content_templates_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
 • content_templates_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
 
-1.14.5 Registros-base de `commercial_activation`
+1.15.5 Registros-base de `commercial_activation`
 • Template de página: `commercial_activation_page`, slug `commercial-activation-page`, escopo `page`.
 • Módulos de seção: `hero`, `benefits`, `services`, `plans`, `differentials`, `how_it_works`, `faq` e `final_cta`.
 • Slugs especiais: `how-it-works` e `final-cta`; os demais coincidem com `template_key`.
@@ -410,15 +410,15 @@
 • Migration: `supabase/migrations/20260616142000_e18_commercial_activation_base_records.sql`.
 • Verificação: `supabase/snippets/e18_commercial_activation_base_records_verify.sql`.
 
-1.15 content_template_taxons
+1.16 content_template_taxons
 
-1.15.1 Chaves, constraints e relacionamentos
+1.16.1 Chaves, constraints e relacionamentos
 • PK: id uuid
 • CHECK: content_template_taxons_resolution_level_chk (resolution_level IN ('generic', 'segment', 'niche', 'ultra_niche'))
 • FK: template_id → content_templates(id) ON UPDATE CASCADE ON DELETE CASCADE
 • FK: taxon_id → business_taxons(id) ON UPDATE CASCADE ON DELETE RESTRICT
 
-1.15.2 Campos
+1.16.2 Campos
 • template_id uuid not null
 • taxon_id uuid not null
 • resolution_level text not null
@@ -428,20 +428,20 @@
 • created_at timestamptz not null default now()
 • updated_at timestamptz not null default now()
 
-1.15.3 Segurança
+1.16.3 Segurança
 • Trigger Hub: não
 • RLS: ativo (enable row level security)
 • service_role: SELECT
 
-1.15.4 Policies
+1.16.4 Policies
 • content_template_taxons_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
 • content_template_taxons_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
 • content_template_taxons_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
 • content_template_taxons_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
 
-1.16 taxon_market_research
+1.17 taxon_market_research
 
-1.16.1 Chaves, constraints e relacionamentos
+1.17.1 Chaves, constraints e relacionamentos
 • PK: id uuid
 • UNIQUE: (taxon_id, research_block, audience_scope, version)
 • UNIQUE auxiliar: (id, taxon_id, audience_scope, version)
@@ -449,7 +449,7 @@
 • CHECK: taxon_market_research_audience_scope_chk (audience_scope IN ('end_customer', 'business_buyer'))
 • FK: taxon_id → business_taxons(id) ON UPDATE CASCADE ON DELETE RESTRICT
 
-1.16.2 Campos
+1.17.2 Campos
 • taxon_id uuid not null
 • research_block text not null
 • Regra: texto governado por processo operacional; sem CHECK fechado nesta etapa
@@ -460,29 +460,29 @@
 • created_at timestamptz not null default now()
 • updated_at timestamptz not null default now()
 
-1.16.3 Índices
+1.17.3 Índices
 • taxon_market_research_taxon_block_audience_version_uidx (UNIQUE em taxon_id, research_block, audience_scope, version)
 • taxon_market_research_one_active_per_block_audience_uidx (UNIQUE parcial em taxon_id, research_block, audience_scope WHERE status = 'active')
 
-1.16.4 Segurança
+1.17.4 Segurança
 • Trigger Hub: não
 • RLS: ativo (enable row level security)
 • service_role: SELECT
 
-1.16.5 Policies
+1.17.5 Policies
 • taxon_market_research_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
 • taxon_market_research_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
 • taxon_market_research_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
 • taxon_market_research_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
 
-1.17 taxon_market_research_items
+1.18 taxon_market_research_items
 
-1.17.1 Chaves, constraints e relacionamentos
+1.18.1 Chaves, constraints e relacionamentos
 • PK: id uuid
 • FK: research_id → taxon_market_research(id) ON UPDATE CASCADE ON DELETE CASCADE
 • UNIQUE adicional: nenhuma nesta etapa
 
-1.17.2 Campos
+1.18.2 Campos
 • research_id uuid not null
 • item_key text not null
 • item_text text not null
@@ -493,25 +493,25 @@
 • created_at timestamptz not null default now()
 • updated_at timestamptz not null default now()
 
-1.17.3 Segurança
+1.18.3 Segurança
 • Trigger Hub: não
 • RLS: ativo (enable row level security)
 • service_role: SELECT
 
-1.17.4 Policies
+1.18.4 Policies
 • taxon_market_research_items_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
 • taxon_market_research_items_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
 • taxon_market_research_items_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
 • taxon_market_research_items_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
 
-1.18 taxon_message_guides
+1.19 taxon_message_guides
 
-1.18.1 Chaves, constraints e relacionamentos
+1.19.1 Chaves, constraints e relacionamentos
 • PK: id uuid
 • CHECK: taxon_message_guides_context_type_chk (context_type IN ('e10_5', 'landing_page', 'email', 'whatsapp'))
 • FK: research_id → taxon_market_research(id) ON UPDATE CASCADE ON DELETE CASCADE
 
-1.18.2 Campos
+1.19.2 Campos
 • research_id uuid not null
 • context_type text not null
 • guide_payload_json jsonb not null
@@ -520,19 +520,19 @@
 • created_at timestamptz not null default now()
 • updated_at timestamptz not null default now()
 
-1.18.3 Segurança
+1.19.3 Segurança
 • Trigger Hub: não
 • RLS: ativo (enable row level security)
 
-1.18.4 Policies
+1.19.4 Policies
 • taxon_message_guides_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()
 • taxon_message_guides_insert_admin_only (INSERT to public): is_super_admin() OU is_platform_admin()
 • taxon_message_guides_update_admin_only (UPDATE to public): is_super_admin() OU is_platform_admin() (USING + WITH CHECK)
 • taxon_message_guides_delete_admin_only (DELETE to public): is_super_admin() OU is_platform_admin()
 
-1.19 account_niche_resolutions
+1.20 account_niche_resolutions
 
-1.19.1 Chaves, constraints e relacionamentos
+1.20.1 Chaves, constraints e relacionamentos
 • CHECK: account_niche_resolutions_ai_status_chk
 • CHECK: account_niche_resolutions_ai_result_json_chk
 • CHECK: account_niche_resolutions_ai_ux_mode_chk
@@ -550,7 +550,7 @@
 • CHECK: resolution_status
 • CHECK: score entre 0 e 1 ou NULL
 
-1.19.2 Campos
+1.20.2 Campos
 • ai_status text null
 • ai_error_code text null
 • ai_model text null
@@ -584,19 +584,19 @@
 • created_at timestamptz not null default now()
 • updated_at timestamptz not null default now()
 
-1.19.3 Segurança
+1.20.3 Segurança
 • Trigger Hub: não
 • RLS: ativo
 • Policies: admin-only
 • Acesso direto removido de public, anon e authenticated
 • service_role: SELECT, INSERT e UPDATE
 
-1.19.4 Índices
+1.20.4 Índices
 • account_niche_resolutions_ai_suggested_taxon_id_idx
 
-1.20 content_template_compositions
+1.21 content_template_compositions
 
-1.20.1 Chaves, constraints e relacionamentos
+1.21.1 Chaves, constraints e relacionamentos
 • PK: id uuid
 • UNIQUE: (template_id, taxon_id, version)
 • UNIQUE auxiliar: (id, template_id, taxon_id, version)
@@ -606,45 +606,11 @@
 • FK: template_id → content_templates(id) ON UPDATE CASCADE ON DELETE RESTRICT
 • FK: taxon_id → business_taxons(id) ON UPDATE CASCADE ON DELETE RESTRICT
 
-1.20.2 Campos
+1.21.2 Campos
 • template_id uuid not null
 • taxon_id uuid not null
 • version integer not null default 1
 • status text not null default 'draft'
-• created_at timestamptz not null default now()
-• updated_at timestamptz not null default now()
-
-1.20.3 Segurança
-• Trigger Hub: não
-• RLS: ativo
-• anon/authenticated/public: sem acesso
-• service_role: SELECT
-
-1.20.4 Índices
-• `content_template_compositions_one_active_uidx`: UNIQUE parcial em (`template_id`, `taxon_id`) para `status = 'active'`.
-• `content_template_compositions_taxon_id_idx`: btree em `taxon_id`.
-
-1.20.5 Triggers
-• `content_template_compositions_set_updated_at`: executa `public.tg_set_updated_at()` antes de UPDATE.
-
-1.21 content_template_composition_items
-
-1.21.1 Chaves, constraints e relacionamentos
-• PK: id uuid
-• UNIQUE: (composition_id, sort_order)
-• CHECK: variant_key descritivo no formato `modulo.variante`
-• CHECK: sort_order >= 0
-• CHECK: config_json é objeto JSON
-• FK: composition_id → content_template_compositions(id) ON UPDATE CASCADE ON DELETE CASCADE
-• FK: module_template_id → content_templates(id) ON UPDATE CASCADE ON DELETE RESTRICT
-
-1.21.2 Campos
-• composition_id uuid not null
-• module_template_id uuid not null
-• variant_key text not null
-• sort_order integer not null
-• is_required boolean not null default true
-• config_json jsonb not null default '{}'
 • created_at timestamptz not null default now()
 • updated_at timestamptz not null default now()
 
@@ -655,14 +621,48 @@
 • service_role: SELECT
 
 1.21.4 Índices
-• `content_template_composition_items_module_template_id_idx`: btree em `module_template_id`.
+• `content_template_compositions_one_active_uidx`: UNIQUE parcial em (`template_id`, `taxon_id`) para `status = 'active'`.
+• `content_template_compositions_taxon_id_idx`: btree em `taxon_id`.
 
 1.21.5 Triggers
-• `content_template_composition_items_set_updated_at`: executa `public.tg_set_updated_at()` antes de UPDATE.
+• `content_template_compositions_set_updated_at`: executa `public.tg_set_updated_at()` antes de UPDATE.
 
-1.22 content_artifacts
+1.22 content_template_composition_items
 
 1.22.1 Chaves, constraints e relacionamentos
+• PK: id uuid
+• UNIQUE: (composition_id, sort_order)
+• CHECK: variant_key descritivo no formato `modulo.variante`
+• CHECK: sort_order >= 0
+• CHECK: config_json é objeto JSON
+• FK: composition_id → content_template_compositions(id) ON UPDATE CASCADE ON DELETE CASCADE
+• FK: module_template_id → content_templates(id) ON UPDATE CASCADE ON DELETE RESTRICT
+
+1.22.2 Campos
+• composition_id uuid not null
+• module_template_id uuid not null
+• variant_key text not null
+• sort_order integer not null
+• is_required boolean not null default true
+• config_json jsonb not null default '{}'
+• created_at timestamptz not null default now()
+• updated_at timestamptz not null default now()
+
+1.22.3 Segurança
+• Trigger Hub: não
+• RLS: ativo
+• anon/authenticated/public: sem acesso
+• service_role: SELECT
+
+1.22.4 Índices
+• `content_template_composition_items_module_template_id_idx`: btree em `module_template_id`.
+
+1.22.5 Triggers
+• `content_template_composition_items_set_updated_at`: executa `public.tg_set_updated_at()` antes de UPDATE.
+
+1.23 content_artifacts
+
+1.23.1 Chaves, constraints e relacionamentos
 • PK: id uuid
 • UNIQUE: (template_id, composition_id, taxon_id, audience_scope, research_version, artifact_version)
 • UNIQUE parcial: no máximo um artefato `published` por (template_id, taxon_id, audience_scope)
@@ -675,7 +675,7 @@
 • FK composta: (composition_id, template_id, taxon_id, composition_version) → content_template_compositions(id, template_id, taxon_id, version)
 • FK: taxon_id → business_taxons(id) ON UPDATE CASCADE ON DELETE RESTRICT
 
-1.22.2 Campos
+1.23.2 Campos
 • template_id uuid not null
 • composition_id uuid not null
 • taxon_id uuid not null
@@ -692,7 +692,7 @@
 • published_at timestamptz null
 • archived_at timestamptz null
 
-1.22.3 Segurança
+1.23.3 Segurança
 • Trigger Hub: não
 • RLS: ativo
 • public/anon: sem acesso
@@ -703,22 +703,22 @@
   • content_artifacts_insert_admin_draft_only (INSERT to authenticated): is_super_admin() OU is_platform_admin(); somente `status = 'draft'`, `published_at IS NULL` e `archived_at IS NULL`
   • content_artifacts_update_admin_draft_content_only (UPDATE to authenticated): is_super_admin() OU is_platform_admin(); somente `status = 'draft'`, `published_at IS NULL` e `archived_at IS NULL` (USING + WITH CHECK)
 
-1.22.4 Índices
+1.23.4 Índices
 • `content_artifacts_one_published_uidx`: UNIQUE parcial em (`template_id`, `taxon_id`, `audience_scope`) para `status = 'published'`.
 • `content_artifacts_composition_id_idx`: btree em `composition_id`.
 • `content_artifacts_taxon_id_idx`: btree em `taxon_id`.
 
-1.22.5 Triggers
+1.23.5 Triggers
 • `content_artifacts_set_updated_at`: executa `public.tg_set_updated_at()` antes de UPDATE.
 
-1.23 content_artifact_research_sources
+1.24 content_artifact_research_sources
 
-1.23.1 Chaves, constraints e relacionamentos
+1.24.1 Chaves, constraints e relacionamentos
 • PK: (artifact_id, research_id)
 • FK composta: (artifact_id, taxon_id, audience_scope, research_version) → content_artifacts(id, taxon_id, audience_scope, research_version)
 • FK composta: (research_id, taxon_id, audience_scope, research_version) → taxon_market_research(id, taxon_id, audience_scope, version)
 
-1.23.2 Campos
+1.24.2 Campos
 • artifact_id uuid not null
 • research_id uuid not null
 • taxon_id uuid not null
@@ -726,7 +726,7 @@
 • research_version integer not null
 • created_at timestamptz not null default now()
 
-1.23.3 Segurança
+1.24.3 Segurança
 • Trigger Hub: não
 • RLS: ativo
 • public/anon: sem acesso
@@ -736,7 +736,7 @@
   • content_artifact_research_sources_select_admin_only (SELECT to authenticated): is_super_admin() OU is_platform_admin()
   • cars_insert_admin_business_buyer_only (INSERT to authenticated): is_super_admin() OU is_platform_admin(); somente `audience_scope = 'business_buyer'`
 
-1.23.4 Índices
+1.24.4 Índices
 • `content_artifact_research_sources_research_id_idx`: btree em `research_id`.
 
 2. Views


### PR DESCRIPTION
### Motivation
- Registrar a conclusão da E9 Fase 7.2 e formalizar o webhook Stripe mínimo no roadmap.
- Declarar o contrato de banco de dados e auditoria operacional para eventos Stripe no schema.
- Explicitar requisitos técnicos e secrets necessários para validação do webhook no documento técnico e de plataforma.

### Description
- Atualizei `docs/roadmap.md` para `v1.5.87` e adicionei a seção "9.3.8 Webhook Stripe mínimo" com comportamento esperado, artefatos e changelog. 
- Atualizei `docs/schema.md` para `v1.0.32` e incluí o contrato detalhado da tabela `stripe_webhook_events` (função, colunas, constraints, índices e segurança). 
- Atualizei `docs/base-tecnica.md` para `v2.0.45` com regras técnicas do webhook (endpoint canônico, runtime, adapter, validação da assinatura, idempotência e persistência segura de entitlement). 
- Atualizei `docs/platform-config.md` para `v0.1.8` com uso/endpoint do webhook e adição do secret `STRIPE_WEBHOOK_SECRET` (sem versionar valor real). 

### Testing
- Executado `git diff --check` e não foram reportados problemas sintáticos com os diffs. 
- Inspeção com `git diff --name-only` e `git status --short --branch` mostrou alterações apenas em `docs/roadmap.md`, `docs/schema.md`, `docs/base-tecnica.md` e `docs/platform-config.md`. 
- `npm ci` e `npm run check` não aplicáveis por se tratar de alteração exclusivamente documental. 
- Branch usada: `work` and PR created with title `docs: registrar webhook Stripe mínimo`; push não executado because no remote configured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4669833abc832986b7e2f8017b1420)