### PR TITLE
docs: update gestor estrutural to VS11

### DIFF
--- a/docs/gestor-estrutural.md
+++ b/docs/gestor-estrutural.md
@@ -1,4 +1,4 @@
-Lousa (índice estrutural) — Gestor Estrutural VS10
+Lousa (índice estrutural) — Gestor Estrutural VS11
 1. Objetivo
 1.1 Papel da lousa
 * Índice estrutural focado apenas nas funções do Gestor Estrutural.
@@ -17,6 +17,11 @@ Lousa (índice estrutural) — Gestor Estrutural VS10
 * impacto em repo e/ou BD
 * aderência ao fluxo canônico de banco: migration versionada como padrão; SQL avulso apenas para inspeção, verificação read-only ou exceção expressamente autorizada
 * risco de runtime depender de objeto de banco ainda não aplicado e validado no ambiente alvo
+* em Supabase / Postgres, criação ou alteração de tabela, view, RPC, policy ou migration deve validar, quando aplicável: RLS, policies, security_invoker, GRANTs explícitos para Data API/PostgREST/GraphQL, exposição por roles, aderência ao docs/schema.md e aderência ao docs/base-tecnica.md
+* tabela nova no schema public acessada via Supabase Data API/PostgREST/GraphQL não deve ser aprovada sem decisão explícita de GRANT, RLS e policies na mesma etapa
+* GRANT não substitui RLS/policies
+* RLS/policies não substituem GRANT
+* se plano, fase ou PR tocar banco exposto por Data API/PostgREST/GraphQL e não mencionar grants quando aplicável, classificar como aprovado com condicionantes ou requer patch estrutural
 1.4 Regra de consulta e validação estrutural
 * em caso de conflito, prevalece a fonte competente por assunto, e não uma hierarquia linear única
 * antes de orientar mudança estrutural, confirmar no repositório real a localização atual dos artefatos
@@ -33,10 +38,3 @@ Lousa (índice estrutural) — Gestor Estrutural VS10
 * ferramentas operacionais, como GitHub e Vercel, servem para confirmar estado real quando necessário, sem substituir as fontes competentes
 * updates vigentes relevantes = complemento contextual, sem substituir fonte canônica
 * esta lousa = índice estrutural, não fonte primária
-3. Notas permanentes para avaliação estrutural
-* chamar de OpenAI Project
-* compatibilidades oficiais não substituem a confirmação do repositório real nem as fontes canônicas do projeto
-* em Supabase / Postgres, tratar RLS como ponto estrutural relevante para objetos expostos
-* views podem obedecer RLS com security_invoker = true
-* views são security definer por padrão e exigem cautela
-* regra editorial: último nível das subseções deve usar bullets, e não numeração

--- a/docs/gestor-estrutural.md
+++ b/docs/gestor-estrutural.md
@@ -21,7 +21,8 @@ Lousa (índice estrutural) — Gestor Estrutural VS11
 * tabela nova no schema public acessada via Supabase Data API/PostgREST/GraphQL não deve ser aprovada sem decisão explícita de GRANT, RLS e policies na mesma etapa
 * GRANT não substitui RLS/policies
 * RLS/policies não substituem GRANT
-* se plano, fase ou PR tocar banco exposto por Data API/PostgREST/GraphQL e não mencionar grants quando aplicável, classificar como aprovado com condicionantes ou requer patch estrutural
+* se plano ou fase tocar banco exposto por Data API/PostgREST/GraphQL e não mencionar grants quando aplicável, classificar como aprovado com condicionantes
+* se PR ou entrega executável tocar banco exposto por Data API/PostgREST/GraphQL e não implementar ou validar grants quando aplicável, classificar como requer patch estrutural
 1.4 Regra de consulta e validação estrutural
 * em caso de conflito, prevalece a fonte competente por assunto, e não uma hierarquia linear única
 * antes de orientar mudança estrutural, confirmar no repositório real a localização atual dos artefatos


### PR DESCRIPTION
### Motivation

- Atualizar o índice estrutural para VS11 e manter o documento enxuto e operacional focado em avaliação estrutural.
- Incluir checklist específico para objetos de banco exposto via Supabase/Data API/PostgREST/GraphQL dentro do item 1.3 sem mover regras para 1.2.
- Remover a seção de notas permanentes fora do escopo do Gestor Estrutural para que o documento termine em 2.1.

### Description

- Atualizado o título de `Lousa (índice estrutural) — Gestor Estrutural VS10` para `Lousa (índice estrutural) — Gestor Estrutural VS11` no arquivo `docs/gestor-estrutural.md`.
- Adicionadas ao final de `1.3 O que o Gestor Estrutural deve avaliar em planos, briefings e entregas` as regras de Supabase/Postgres solicitadas (validação de RLS, policies, `security_invoker`, GRANTs explícitos para Data API/PostgREST/GraphQL, exposição por roles, aderência a `docs/schema.md` e `docs/base-tecnica.md`, decisão explícita para tabelas públicas expostas, e classificação de aprovações com condicionantes quando grants não forem mencionados).
- Removida integralmente a seção `3. Notas permanentes para avaliação estrutural` e seu conteúdo (incluindo a instrução editorial e a referência “chamar de OpenAI Project”), garantindo que o documento termine em `2.1 Fontes primárias por assunto` e preservando `1.2`, `1.4` e `2.1`.
- Escopo restrito ao arquivo `docs/gestor-estrutural.md` e preservação de outros documentos mencionados no briefing; branch usada: `work`; PR preparado com título `docs: update gestor estrutural to VS11`; não foi possível publicar por ausência de destino de push configurado.

### Testing

- Executado `git diff --check` sem erros detectados.
- Confirmada a atualização do título e a presença/ausência de trechos esperados usando `head -n1` e `rg` (título VS11 presente; seção 3, ‘chamar de OpenAI Project’ e regra editorial removidas; regras de Supabase/Postgres presentes).
- `git diff --stat` mostrou alteração em `docs/gestor-estrutural.md` somente, refletindo 6 inserções e 8 deleções.
- `git push` não foi realizado devido à falta de push destination configurado e, por ser alteração exclusivamente documental, `npm ci` e `npm run check` foram considerados N/A.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4834aa90ec8329ab4e3dbf1f6aa18c)