### PR TITLE
docs: convert GitHub updates into active catalog (remove implemented items, add github#5–#8)

### DIFF
--- a/docs/github-up.md
+++ b/docs/github-up.md
@@ -17,95 +17,19 @@ O estado da plataforma deve ser separado do estado no projeto: `Não implementad
 
 Identificador canônico: `github#n`. A numeração não deve ser reutilizada.
 
+## Critério do catálogo ativo
+
+Este documento deve manter apenas recursos GitHub que ainda possam ser aproveitados pelo Gestor de Updates em algum caso atual, futuro ou condicional.
+
+Itens já implementados globalmente, absorvidos pela Base Técnica, duplicados, superados, deprecados ou sem aproveitamento concreto não permanecem no catálogo ativo.
+
+Recursos pagos, enterprise ou futuros podem permanecer quando ainda tiverem aproveitamento possível em algum caso específico.
+
+A rejeição ou adoção de cada item deve ser decidida caso a caso pelo Gestor de Updates, conforme o plano-base avaliado.
+
 Antes de registrar um item, confirmar fonte oficial, valor para o projeto, plano, limites, dependências e evidência de implementação.
 
 ## Updates registrados
-
-## github#1 — Permissões mínimas em workflows *(🟩 Estável)*
-
-2026-06-13
-
-### Status no Projeto
-
-- Status: Implementado globalmente no projeto.
-- Evidência: `.github/workflows/*` e `.github/workflows/security.yml`.
-
-### Descrição
-
-Permissões explícitas limitam o acesso do `GITHUB_TOKEN` ao necessário em cada workflow.
-
-### Valor para o Projeto
-
-- Reduz a superfície de acesso das automações e aplica o princípio do menor privilégio.
-
-### Ações Recomendadas
-
-1. Manter permissões explícitas nos workflows.
-2. Evitar `write-all`.
-
-### Fonte Oficial
-
-- [Workflow syntax for GitHub Actions — `permissions`](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#permissions)
-
----
-
-## github#2 — Grupos de concorrência em GitHub Actions *(🟩 Estável)*
-
-2026-06-13
-
-### Status no Projeto
-
-- Status: Implementado globalmente no projeto.
-- Evidência: workflows que usam `concurrency` e `cancel-in-progress`.
-
-### Descrição
-
-Grupos de concorrência controlam execuções simultâneas de workflows e permitem cancelar execuções anteriores ainda em andamento.
-
-### Valor para o Projeto
-
-- Evita execuções simultâneas conflitantes e reduz consumo desnecessário.
-
-### Ações Recomendadas
-
-1. Manter `concurrency` e `cancel-in-progress` nos workflows aplicáveis.
-2. Avaliar `queue: max` somente quando houver necessidade real de preservar execuções sequenciais.
-
-### Fonte Oficial
-
-- [Control the concurrency of workflows and jobs](https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs)
-
----
-
-## github#3 — Secret scanning e push protection *(🟨 Estável — disponibilidade por plano e tipo de repositório)*
-
-2026-06-13
-
-### Status no Projeto
-
-- Status: Implementado globalmente no projeto.
-- Evidência: no repositório público `AlcinoAfonso/LP-Factory-10`, em `Settings > Advanced Security`, `Secret Protection` e `Push protection` estão habilitados, conforme indicado pelos respectivos botões `Disable`.
-- Disponibilidade: ativa para o tipo e configuração atuais do repositório público; o plano nominal não foi identificado.
-
-### Descrição
-
-Secret scanning identifica credenciais expostas no repositório, enquanto push protection pode bloquear o envio de secrets compatíveis antes que sejam incorporados.
-
-### Valor para o Projeto
-
-- Ajuda a impedir commits com secrets de Supabase, Vercel, OpenAI e outros provedores.
-
-### Ações Recomendadas
-
-1. Manter `Secret Protection` e `Push protection` habilitados.
-2. Revisar alertas de secrets e eventuais bypasses quando ocorrerem.
-
-### Fonte Oficial
-
-- [Secret scanning](https://docs.github.com/code-security/secret-scanning/about-secret-scanning)
-- [Push protection](https://docs.github.com/code-security/concepts/secret-security/push-protection)
-
----
 
 ## github#4 — Workflows em PRs criados por bots após aprovação *(🟩 Estável)*
 
@@ -130,3 +54,127 @@ PRs criados por `github-actions[bot]` agora podem executar workflows de CI/CD ap
 ### Fonte Oficial
 
 - [Bot-created pull requests can run workflows if approved](https://github.blog/changelog/2026-06-11-bot-created-pull-requests-can-run-workflows-if-approved/)
+
+---
+
+## github#5 — Copilot CLI em GitHub Actions com GITHUB_TOKEN *(🟨 Avaliação futura)*
+
+2026-07-02
+
+### Status no Projeto
+
+- Status: Não implementado.
+- Evidência: não há workflow do LP Factory 10 usando Copilot CLI.
+
+### Descrição
+
+O GitHub permite executar Copilot CLI em GitHub Actions usando o `GITHUB_TOKEN` interno do workflow, sem necessidade de criar e armazenar um PAT de longa duração. O uso exige permissão específica `copilot-requests: write` e política de organização compatível.
+
+### Valor para o Projeto
+
+- Pode reduzir risco operacional se o projeto vier a usar Copilot CLI em workflows.
+- Evita armazenar PATs de longa duração para automações baseadas em Copilot CLI.
+- Mantém a decisão condicionada a custo, permissão, política de uso e caso real.
+
+### Ações Recomendadas
+
+1. Manter como avaliação futura.
+2. Não criar workflow com Copilot CLI sem decisão humana explícita.
+3. Se adotado futuramente, registrar permissão mínima, custo, política de uso e validação no documento técnico apropriado.
+
+### Fonte Oficial
+
+- [Copilot CLI no longer needs a personal access token in GitHub Actions](https://github.blog/changelog/2026-07-02-copilot-cli-no-longer-needs-a-personal-access-token-in-github-actions/)
+
+---
+
+## github#6 — AI credit session limits no Copilot CLI/SDK *(🧪 Public preview)*
+
+2026-07-01
+
+### Status no Projeto
+
+- Status: Não implementado.
+- Evidência: não há uso registrado de Copilot CLI ou Copilot SDK no projeto.
+
+### Descrição
+
+Recurso para limitar créditos de IA consumidos em uma sessão do Copilot CLI ou Copilot SDK, inclusive em execuções não interativas com `--max-ai-credits`.
+
+### Valor para o Projeto
+
+- Pode ajudar a controlar custo de agentes ou scripts assistidos por IA.
+- É relevante apenas se o projeto adotar Copilot CLI ou SDK em algum fluxo aprovado.
+- Reduz risco de gasto aberto em automações sem supervisão.
+
+### Ações Recomendadas
+
+1. Manter como avaliação futura.
+2. Não adotar Copilot CLI/SDK apenas por causa deste recurso.
+3. Se houver uso futuro, exigir limite explícito de créditos por sessão em scripts não interativos.
+
+### Fonte Oficial
+
+- [Set AI credit session limits in Copilot CLI and SDK](https://github.blog/changelog/2026-07-01-set-ai-credit-session-limits-in-copilot-cli-and-sdk/)
+
+---
+
+## github#7 — Secret scanning public monitoring for enterprises *(🧪 Public preview / Enterprise)*
+
+2026-07-01
+
+### Status no Projeto
+
+- Status: Não implementado.
+- Evidência: sem registro de uso de Enterprise Cloud com Secret Protection/Advanced Security para este recurso no LP Factory 10.
+
+### Descrição
+
+Recurso de monitoramento público de secrets para Enterprise, capaz de detectar segredos vazados em conteúdo público do GitHub fora dos repositórios próprios da organização, como forks pessoais, issues, pull requests e outros repositórios públicos.
+
+### Valor para o Projeto
+
+- Pode ser útil se o LP Factory 10 evoluir para estrutura Enterprise ou organização com domínio verificado.
+- Complementa secret scanning do repositório próprio ao monitorar vazamentos públicos atribuíveis à empresa.
+- Não substitui boas práticas locais de secrets, `.env`, GitHub Actions e push protection.
+
+### Ações Recomendadas
+
+1. Manter como recurso enterprise condicional.
+2. Não tratar como disponível no plano atual sem verificação explícita.
+3. Avaliar apenas se o projeto passar a usar GitHub Enterprise Cloud com Secret Protection ou Advanced Security.
+
+### Fonte Oficial
+
+- [Secret scanning public monitoring for enterprises](https://github.blog/changelog/2026-07-01-secret-scanning-public-monitoring-for-enterprises/)
+
+---
+
+## github#8 — Browser tools for GitHub Copilot in VS Code *(🟩 GA)*
+
+2026-07-01
+
+### Status no Projeto
+
+- Status: Não implementado.
+- Evidência: sem registro de uso operacional no fluxo atual do LP Factory 10.
+
+### Descrição
+
+Ferramentas de navegador para GitHub Copilot no VS Code que permitem ao agente abrir páginas, navegar, clicar, digitar, ler conteúdo, capturar erros de console, tirar screenshots e executar fluxos roteirizados, com controles de acesso, privacidade, permissões e domínios.
+
+### Valor para o Projeto
+
+- Pode apoiar diagnóstico manual assistido em previews, fluxos de UI e testes exploratórios.
+- Pode ser útil em investigação de bugs visuais ou comportamentais quando houver operador humano.
+- Não substitui QA manual, Playwright, Vercel Toolbar ou validação humana.
+
+### Ações Recomendadas
+
+1. Manter como avaliação futura de produtividade técnica.
+2. Não transformar em requisito do fluxo de QA.
+3. Se usado, registrar limites: domínios permitidos, dados sensíveis, aprovação humana e evidência capturada.
+
+### Fonte Oficial
+
+- [Browser tools for GitHub Copilot in VS Code are generally available](https://github.blog/changelog/2026-07-01-browser-tools-for-github-copilot-in-vs-code-are-generally-available/)


### PR DESCRIPTION
### Motivation

- Tornar `docs/github-up.md` um catálogo ativo que contenha apenas recursos GitHub ainda aproveitáveis por caso e evitar manter itens já implementados globalmente no repositório. 
- Remover do catálogo itens absorvidos pela base técnica (`github#1`, `github#2`, `github#3`) e adicionar recursos oficiais recentes que são condicionalmente úteis (`github#5` a `github#8`).
- Preservar a numeração canônica `github#n` sem renumerar IDs existentes nem reutilizar IDs removidos.

### Description

- Atualizei apenas o arquivo `docs/github-up.md` para inserir a seção `## Critério do catálogo ativo`, remover integralmente os blocos `github#1`, `github#2` e `github#3`, manter `github#4` como estava e adicionar `github#5` a `github#8` com descrição, status e fontes oficiais. 
- Os novos itens adicionados são: `github#5` (Copilot CLI em Actions com `GITHUB_TOKEN`), `github#6` (AI credit session limits no Copilot CLI/SDK), `github#7` (Secret scanning public monitoring for enterprises) e `github#8` (Browser tools for GitHub Copilot in VS Code), cada um com ações recomendadas e link de fonte. 
- Não foi alterado nenhum código, workflow, `package.json`, `package-lock.json` ou arquivo fora de `docs/github-up.md`. 
- Branch usada: `docs/github-up-active-catalog`, commit local criado: `189f535` with message `docs: update GitHub active catalog`.

### Testing

- Validações textuais automatizadas executadas e bem-sucedidas incluem: verificação de arquivo alterado (`git diff --name-only`), checagem de headings `rg '^## github#[0-9]+'`, verificação de ausência das ocorrências `github#1|github#2|github#3`, ausência da seção proibida `### Filtro na primeira varredura`, e ausência de tabelas Markdown; todos os checks passaram. 
- Verificações de integridade do repositório e commit (`git status`, `git diff --check`, `git commit`) foram executadas com sucesso localmente; o `git push -u origin docs/github-up-active-catalog` falhou por falta de `origin` configurado no ambiente. 
- `npm ci` e `npm run check` não foram executados pois a alteração é exclusivamente documental e os checks de sandbox foram dispensados por justificativa documental.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a490b397fec8329b2ddda8b73b19910)