### PR TITLE
docs: registrar protocolo de atualização dos catálogos

### DIFF
--- a/docs/gestor-updates.md
+++ b/docs/gestor-updates.md
@@ -212,3 +212,108 @@ prod#16
 * Dizer quais updates ajudam no diagnóstico.
 * Dizer quais updates não cabem.
 * Dizer o próximo passo mínimo e seguro.
+
+13. Protocolo para rodada de atualização dos catálogos
+
+13.1. Objetivo
+
+* Manter os catálogos de updates como catálogos ativos, não históricos completos.
+* Remover itens sem decisão futura útil.
+* Preservar rastreabilidade dos IDs.
+* Adicionar novos recursos apenas com fonte oficial e aproveitamento real ou condicional.
+
+13.2. Catálogos-alvo
+
+* `docs/supa-up.md`
+* `docs/vercel-up.md`
+* `docs/github-up.md`
+* `docs/prod-up.md`
+
+13.3. Ordem obrigatória da rodada
+
+* Ler o catálogo-alvo em `main`.
+* Consultar `docs/gestor-updates.md`.
+* Consultar `README.md` para escopo, MVP e princípios.
+* Consultar `docs/base-tecnica.md`, `docs/schema.md`, `docs/platform-config.md` ou `docs/roadmap.md` quando o update tocar stack, banco, plataforma, roadmap ou decisão já consolidada.
+* Classificar itens existentes antes de propor novos itens.
+* Fazer varredura em fonte oficial externa quando o catálogo depender de updates de plataforma/produto.
+* Entregar análise ao usuário antes do briefing para Codex.
+* Só depois gerar briefing determinístico para Codex.
+* Revisar o PR antes do merge.
+
+13.4. Regra de catálogo ativo
+
+Remover do catálogo ativo itens que estejam:
+
+* implementados globalmente;
+* absorvidos por Base Técnica, schema, roadmap ou outro documento normativo;
+* duplicados em outro catálogo;
+* deprecados, superados ou sem aproveitamento concreto;
+* genéricos demais para orientar decisão futura.
+
+Manter no catálogo ativo itens que sejam:
+
+* ainda não implementados;
+* úteis por caso;
+* pagos, enterprise ou futuros, desde que tenham aplicação plausível;
+* travas, referências ou validações úteis para decisões futuras.
+
+13.5. Regra de IDs canônicos e lacunas
+
+* IDs `supa#n`, `vercel#n`, `github#n` e `prod#n` são canônicos.
+* Não renumerar IDs.
+* Não preencher lacunas.
+* Não reutilizar IDs removidos.
+* IDs removidos ficam aposentados/reservados.
+* Lacunas numéricas são corretas.
+* Novos itens usam o próximo ID livre após o maior ID já usado no catálogo.
+* Exemplo: se `github#1`, `github#2` e `github#3` forem removidos, `github#4` continua sendo `github#4`; o próximo item novo é `github#5`.
+
+13.6. Briefing determinístico para Codex
+
+O briefing para Codex não deve pedir apenas para “revisar”, “melhorar” ou “atualizar” o catálogo.
+
+O briefing deve declarar objetivamente:
+
+* arquivo único a alterar;
+* arquivos proibidos de alterar;
+* IDs a remover;
+* IDs a manter;
+* IDs a atualizar;
+* novos IDs a criar;
+* texto ou estrutura esperada para novos blocos;
+* itens avaliados e não adicionados;
+* regra de não renumerar IDs;
+* regra de não reutilizar IDs removidos;
+* regra de manter lacunas numéricas;
+* validações textuais obrigatórias;
+* dispensa justificada de `npm ci` e `npm run check` quando for alteração apenas documental.
+
+13.7. Regras para novos itens
+
+* Só adicionar item novo com fonte oficial.
+* Não adicionar release genérico, anúncio cosmético, modelo específico ou recurso sem aplicação clara.
+* Não criar item novo para recurso já melhor coberto por outro catálogo.
+* Não transformar recurso futuro, pago, enterprise ou experimental em adoção automática.
+* Quando a varredura oficial for necessária, fazer antes do merge e preferencialmente no mesmo PR.
+
+13.8. Revisão do PR
+
+Antes de aprovar merge, conferir:
+
+* PR aberto, mergeable e não draft;
+* apenas o arquivo-alvo alterado;
+* itens removidos saíram integralmente;
+* itens mantidos não foram renumerados;
+* lacunas numéricas foram preservadas;
+* novos IDs seguem o próximo número livre;
+* não há `### Filtro na primeira varredura`;
+* não há tabela-resumo nova sem pedido;
+* não houve alteração de código, workflow, banco, rota, job, agente, automação, engine ou infraestrutura;
+* checks foram executados ou dispensados com justificativa documental.
+
+13.9. Decisão final
+
+* Aprovar merge quando o arquivo estiver correto, o escopo preservado e os IDs íntegros.
+* Não bloquear merge por descrição de PR desatualizada quando o arquivo final estiver correto e não houver risco real.
+* Pedir ajuste quando houver renumeração, alteração fora de escopo, item novo sem fonte oficial, reutilização de ID removido ou adoção automática de recurso condicional.

--- a/docs/gestor-updates.md
+++ b/docs/gestor-updates.md
@@ -219,29 +219,39 @@ prod#16
 
 * Manter os catálogos de updates como catálogos ativos, não históricos completos.
 * Remover itens sem decisão futura útil.
-* Preservar rastreabilidade dos IDs.
+* Preservar rastreabilidade dos IDs canônicos.
 * Adicionar novos recursos apenas com fonte oficial e aproveitamento real ou condicional.
+* Evitar que releases, anúncios ou recursos de plataforma virem escopo de implementação sem decisão humana.
 
-13.2. Catálogos-alvo
+13.2. Catálogos da rodada
 
-* `docs/supa-up.md`
-* `docs/vercel-up.md`
-* `docs/github-up.md`
-* `docs/prod-up.md`
+* `docs/supa-up.md` — Supabase, banco, Auth, RLS, Data API, logs, migrations, snippets, grants, extensões e integrações Supabase.
+* `docs/vercel-up.md` — Vercel, Next.js, React, runtime, deploy, Preview, cache, observabilidade, Toolbar, Comments, Flags, AI Cloud e framework.
+* `docs/github-up.md` — GitHub, Actions, workflows, PRs, reviews, branches, releases, secret scanning, code scanning, Dependabot, bots e permissões.
+* `docs/prod-up.md` — produto, UX, acessibilidade, aquisição, conversão, onboarding, monetização, analytics, performance percebida, automação comercial e experiências assistidas por IA.
 
-13.3. Ordem obrigatória da rodada
+13.3. Fontes de apoio da rodada
+
+* `README.md` para escopo, MVP e princípios do produto.
+* `docs/base-tecnica.md` quando o update tocar stack, runtime, segurança, imports, CI, logs, adapters ou implementação.
+* `docs/schema.md` quando o update tocar banco, RLS, grants, policies, migrations, views, RPCs ou funções.
+* `docs/platform-config.md` quando o update tocar plataforma, envs, secrets, endpoints, redirects, SMTP, DNS ou configuração operacional.
+* `docs/roadmap.md` quando o update tocar fase, escopo, prioridade, pendência ou decisão de produto.
+* Fonte oficial externa quando o catálogo depender de updates de plataforma ou produto.
+
+13.4. Ordem da análise
 
 * Ler o catálogo-alvo em `main`.
-* Consultar `docs/gestor-updates.md`.
-* Consultar `README.md` para escopo, MVP e princípios.
-* Consultar `docs/base-tecnica.md`, `docs/schema.md`, `docs/platform-config.md` ou `docs/roadmap.md` quando o update tocar stack, banco, plataforma, roadmap ou decisão já consolidada.
+* Identificar o maior ID já usado no catálogo.
 * Classificar itens existentes antes de propor novos itens.
-* Fazer varredura em fonte oficial externa quando o catálogo depender de updates de plataforma/produto.
-* Entregar análise ao usuário antes do briefing para Codex.
-* Só depois gerar briefing determinístico para Codex.
+* Verificar se itens existentes já foram implementados globalmente, absorvidos, duplicados, superados ou perderam aproveitamento.
+* Fazer varredura em fonte oficial externa quando houver necessidade de atualizar ou adicionar recursos.
+* Separar itens a remover, manter, atualizar, adicionar e não adicionar.
+* Entregar a análise ao usuário antes do briefing para Codex.
+* Gerar briefing determinístico para Codex.
 * Revisar o PR antes do merge.
 
-13.4. Regra de catálogo ativo
+13.5. Regra de catálogo ativo
 
 Remover do catálogo ativo itens que estejam:
 
@@ -258,7 +268,7 @@ Manter no catálogo ativo itens que sejam:
 * pagos, enterprise ou futuros, desde que tenham aplicação plausível;
 * travas, referências ou validações úteis para decisões futuras.
 
-13.5. Regra de IDs canônicos e lacunas
+13.6. Regra de IDs canônicos e lacunas
 
 * IDs `supa#n`, `vercel#n`, `github#n` e `prod#n` são canônicos.
 * Não renumerar IDs.
@@ -269,26 +279,6 @@ Manter no catálogo ativo itens que sejam:
 * Novos itens usam o próximo ID livre após o maior ID já usado no catálogo.
 * Exemplo: se `github#1`, `github#2` e `github#3` forem removidos, `github#4` continua sendo `github#4`; o próximo item novo é `github#5`.
 
-13.6. Briefing determinístico para Codex
-
-O briefing para Codex não deve pedir apenas para “revisar”, “melhorar” ou “atualizar” o catálogo.
-
-O briefing deve declarar objetivamente:
-
-* arquivo único a alterar;
-* arquivos proibidos de alterar;
-* IDs a remover;
-* IDs a manter;
-* IDs a atualizar;
-* novos IDs a criar;
-* texto ou estrutura esperada para novos blocos;
-* itens avaliados e não adicionados;
-* regra de não renumerar IDs;
-* regra de não reutilizar IDs removidos;
-* regra de manter lacunas numéricas;
-* validações textuais obrigatórias;
-* dispensa justificada de `npm ci` e `npm run check` quando for alteração apenas documental.
-
 13.7. Regras para novos itens
 
 * Só adicionar item novo com fonte oficial.
@@ -296,24 +286,27 @@ O briefing deve declarar objetivamente:
 * Não criar item novo para recurso já melhor coberto por outro catálogo.
 * Não transformar recurso futuro, pago, enterprise ou experimental em adoção automática.
 * Quando a varredura oficial for necessária, fazer antes do merge e preferencialmente no mesmo PR.
+* Registrar itens avaliados e não adicionados quando isso ajudar a evitar reabertura futura da mesma discussão.
 
-13.8. Revisão do PR
+13.8. Briefing determinístico para Codex
 
-Antes de aprovar merge, conferir:
+* Usar `docs/template-briefing-codex.md`.
+* Não pedir apenas para “revisar”, “melhorar” ou “atualizar” o catálogo.
+* Declarar objetivamente o arquivo alvo, arquivos proibidos, IDs a remover, IDs a manter, IDs a atualizar e novos IDs a criar.
+* Incluir texto exato ou estrutura esperada para novos blocos quando houver criação de itens.
+* Repetir no briefing as regras de não renumerar IDs, não reutilizar IDs removidos e preservar lacunas numéricas.
+* Informar itens avaliados e não adicionados quando houver varredura oficial.
+* Proibir alteração de arquivos fora do alvo e criação de banco, rota, job, agente, automação, engine, workflow ou infraestrutura sem decisão humana explícita.
 
-* PR aberto, mergeable e não draft;
-* apenas o arquivo-alvo alterado;
-* itens removidos saíram integralmente;
-* itens mantidos não foram renumerados;
-* lacunas numéricas foram preservadas;
-* novos IDs seguem o próximo número livre;
-* não há `### Filtro na primeira varredura`;
-* não há tabela-resumo nova sem pedido;
-* não houve alteração de código, workflow, banco, rota, job, agente, automação, engine ou infraestrutura;
-* checks foram executados ou dispensados com justificativa documental.
+13.9. Revisão do PR
 
-13.9. Decisão final
-
-* Aprovar merge quando o arquivo estiver correto, o escopo preservado e os IDs íntegros.
+* Conferir se apenas o arquivo-alvo foi alterado.
+* Conferir se itens removidos saíram integralmente.
+* Conferir se itens mantidos não foram renumerados.
+* Conferir se lacunas numéricas foram preservadas.
+* Conferir se novos IDs seguem o próximo número livre.
+* Conferir se itens novos têm fonte oficial e aproveitamento real ou condicional.
+* Conferir se recurso futuro, pago, enterprise ou experimental não virou adoção automática.
+* Conferir se não houve alteração de código, workflow, banco, rota, job, agente, automação, engine ou infraestrutura.
 * Não bloquear merge por descrição de PR desatualizada quando o arquivo final estiver correto e não houver risco real.
 * Pedir ajuste quando houver renumeração, alteração fora de escopo, item novo sem fonte oficial, reutilização de ID removido ou adoção automática de recurso condicional.

--- a/docs/gestor-updates.md
+++ b/docs/gestor-updates.md
@@ -153,61 +153,11 @@ docs/platform-config.md
 10. Regras de segurança específicas do Gestor de Updates
 
 * Além das regras do `AGENTS.md`, não expor payloads, PII, `content_json`, pesquisa bruta ou texto gerado em logs.
-* Em mudança de banco, consultar `docs/schema.md` e aplicar travas de `supa#58`.
+* Em mudança de banco, consultar `docs/schema.md` e aplicar as travas vigentes do catálogo Supabase ativo.
 * Em IA, confirmar ambiente, chave, modelo, custo e escopo.
 * Em produção, não assumir geração ativa sem decisão explícita.
 
-11. Updates recorrentes já consolidados
-
-supa#5
-
-* Logs seguros e diagnóstico técnico.
-
-supa#36
-
-* Leituras server-side via Data API/PostgREST.
-
-supa#40
-
-* Snippets SQL read-only versionados em supabase/snippets.
-
-supa#58
-
-* Trava para nova tabela, função, RPC, grant, policy ou migration.
-
-supa#59
-
-* Plugin Supabase como apoio, nunca dependência operacional.
-
-vercel#10
-
-* Observabilidade de rotas e redirects.
-
-vercel#13
-
-* Cancelamento automático de builds antigos no mesmo branch.
-
-github#1
-
-* Permissões mínimas em workflows.
-
-github#2
-
-* Concurrency e cancel-in-progress em Actions.
-
-github#3
-
-* Secret scanning e push protection.
-
-prod#14
-
-* Priorizar reconhecimento em UX inicial.
-
-prod#16
-
-* QA visual e validação de UX em Preview.
-
-12. Forma de conclusão
+11. Forma de conclusão
 
 * Dizer o que está confirmado.
 * Dizer o que ainda não foi validado.
@@ -215,9 +165,9 @@ prod#16
 * Dizer quais updates não cabem.
 * Dizer o próximo passo mínimo e seguro.
 
-13. Protocolo para rodada de atualização dos catálogos
+12. Protocolo para rodada de atualização dos catálogos
 
-13.1. Objetivo
+12.1. Objetivo
 
 * Manter os catálogos de updates como catálogos ativos, não históricos completos.
 * Remover itens sem decisão futura útil.
@@ -225,14 +175,14 @@ prod#16
 * Adicionar novos recursos apenas com fonte oficial e aproveitamento real ou condicional.
 * Evitar que releases, anúncios ou recursos de plataforma virem escopo de implementação sem decisão humana.
 
-13.2. Catálogos da rodada
+12.2. Catálogos da rodada
 
 * `docs/supa-up.md` — Supabase, banco, Auth, RLS, Data API, logs, migrations, snippets, grants, extensões e integrações Supabase.
 * `docs/vercel-up.md` — Vercel, Next.js, React, runtime, deploy, Preview, cache, observabilidade, Toolbar, Comments, Flags, AI Cloud e framework.
 * `docs/github-up.md` — GitHub, Actions, workflows, PRs, reviews, branches, releases, secret scanning, code scanning, Dependabot, bots e permissões.
 * `docs/prod-up.md` — produto, UX, acessibilidade, aquisição, conversão, onboarding, monetização, analytics, performance percebida, automação comercial e experiências assistidas por IA.
 
-13.3. Fontes de apoio da rodada
+12.3. Fontes de apoio da rodada
 
 * `README.md` para escopo, MVP e princípios do produto.
 * `docs/base-tecnica.md` quando o update tocar stack, runtime, segurança, imports, CI, logs, adapters ou implementação.
@@ -241,7 +191,7 @@ prod#16
 * `docs/roadmap.md` quando o update tocar fase, escopo, prioridade, pendência ou decisão de produto.
 * Fonte oficial externa quando o catálogo depender de updates de plataforma ou produto.
 
-13.4. Ordem da análise
+12.4. Ordem da análise
 
 * Ler o catálogo-alvo em `main`.
 * Identificar o maior ID já usado no catálogo.
@@ -253,7 +203,7 @@ prod#16
 * Gerar briefing determinístico para Codex.
 * Revisar o PR antes do merge.
 
-13.5. Regra de catálogo ativo
+12.5. Regra de catálogo ativo
 
 Remover do catálogo ativo itens que estejam:
 
@@ -270,7 +220,7 @@ Manter no catálogo ativo itens que sejam:
 * pagos, enterprise ou futuros, desde que tenham aplicação plausível;
 * travas, referências ou validações úteis para decisões futuras.
 
-13.6. Regra de IDs canônicos e lacunas
+12.6. Regra de IDs canônicos e lacunas
 
 * IDs `supa#n`, `vercel#n`, `github#n` e `prod#n` são canônicos.
 * Não renumerar IDs.
@@ -279,9 +229,9 @@ Manter no catálogo ativo itens que sejam:
 * IDs removidos ficam aposentados/reservados.
 * Lacunas numéricas são corretas.
 * Novos itens usam o próximo ID livre após o maior ID já usado no catálogo.
-* Exemplo: se `github#1`, `github#2` e `github#3` forem removidos, `github#4` continua sendo `github#4`; o próximo item novo é `github#5`.
+* Exemplo: se IDs intermediários forem removidos, os IDs seguintes continuam inalterados; o próximo item novo usa o número livre após o maior ID já usado no catálogo.
 
-13.7. Regras para novos itens
+12.7. Regras para novos itens
 
 * Só adicionar item novo com fonte oficial.
 * Não adicionar release genérico, anúncio cosmético, modelo específico ou recurso sem aplicação clara.
@@ -290,7 +240,7 @@ Manter no catálogo ativo itens que sejam:
 * Quando a varredura oficial for necessária, fazer antes do merge e preferencialmente no mesmo PR.
 * Registrar itens avaliados e não adicionados quando isso ajudar a evitar reabertura futura da mesma discussão.
 
-13.8. Briefing determinístico para Codex
+12.8. Briefing determinístico para Codex
 
 * Usar `docs/template-briefing-codex.md`.
 * Não pedir apenas para “revisar”, “melhorar” ou “atualizar” o catálogo.
@@ -300,7 +250,7 @@ Manter no catálogo ativo itens que sejam:
 * Informar itens avaliados e não adicionados quando houver varredura oficial.
 * Proibir alteração de arquivos fora do alvo e criação de banco, rota, job, agente, automação, engine, workflow ou infraestrutura sem decisão humana explícita.
 
-13.9. Revisão do PR
+12.9. Revisão do PR
 
 * Conferir se apenas o arquivo-alvo foi alterado.
 * Conferir se itens removidos saíram integralmente.

--- a/docs/gestor-updates.md
+++ b/docs/gestor-updates.md
@@ -128,30 +128,32 @@ docs/platform-config.md
 * Antecipa A/B, flags, CMS, multicanal, LP Builder ou analytics avançado sem caso aprovado.
 * Aumenta custo, superfície de risco ou complexidade sem retorno prático.
 
-8. Regras para branches
+8. Regras para avaliação de branches e PRs
 
-* Comparar sempre com main.
-* Listar arquivos alterados.
-* Abrir arquivos relevantes.
-* Avaliar apenas o escopo pedido.
+* Aplicar o `AGENTS.md` para regras operacionais de branch, publicação, validação, checks e entrega.
+* No escopo do Gestor de Updates, avaliar se o PR usou updates aplicáveis, ignorou updates obrigatórios ou introduziu updates indevidos.
 * Declarar updates aplicados, ausentes, indevidos e não aplicáveis.
-* Aprovar, reprovar ou aprovar com ressalva.
-* Se houver ajuste, entregar instrução curta ao Executor.
+* Aprovar, reprovar ou aprovar com ressalva conforme impacto no MVP, segurança, custo, banco, infra, automações e escopo.
+* Se houver ajuste, entregar instrução curta e determinística ao Executor.
 
-9. Regras para briefings
+9. Regras para briefings do Gestor de Updates
 
-* Citar docs de referência.
-* Declarar fase alvo.
-* Separar escopo positivo e negativo.
-* Declarar updates aplicáveis.
-* Classificar cada update como implementação, referência, validação, trava ou não aplicável.
-* Incluir critérios de parada.
-* Não transformar update em nova frente sem decisão do Estrategista.
+* Usar `docs/template-briefing-codex.md` como estrutura do briefing.
+* Não duplicar a estrutura do template neste documento.
+* Acrescentar ao briefing apenas as decisões específicas do Gestor de Updates:
+  * fase ou caso avaliado;
+  * docs de referência usados;
+  * updates aplicáveis;
+  * updates ausentes, indevidos ou não aplicáveis;
+  * classificação de cada update como implementação, referência, validação, trava ou não aplicável;
+  * escopo positivo e negativo;
+  * critérios de parada;
+  * proibição de transformar update em nova frente sem decisão do Estrategista.
 
-10. Regras de segurança
+10. Regras de segurança específicas do Gestor de Updates
 
-* Não expor secrets, payloads, PII, content_json, pesquisa bruta ou texto gerado em logs.
-* Em mudança de banco, consultar docs/schema.md e aplicar travas de supa#58.
+* Além das regras do `AGENTS.md`, não expor payloads, PII, `content_json`, pesquisa bruta ou texto gerado em logs.
+* Em mudança de banco, consultar `docs/schema.md` e aplicar travas de `supa#58`.
 * Em IA, confirmar ambiente, chave, modelo, custo e escopo.
 * Em produção, não assumir geração ativa sem decisão explícita.
 

--- a/docs/gestor-updates.md
+++ b/docs/gestor-updates.md
@@ -128,13 +128,12 @@ docs/platform-config.md
 * Antecipa A/B, flags, CMS, multicanal, LP Builder ou analytics avançado sem caso aprovado.
 * Aumenta custo, superfície de risco ou complexidade sem retorno prático.
 
-8. Regras para avaliação de branches e PRs
+8. Avaliação de updates em entregas
 
-* Aplicar o `AGENTS.md` para regras operacionais de branch, publicação, validação, checks e entrega.
-* No escopo do Gestor de Updates, avaliar se o PR usou updates aplicáveis, ignorou updates obrigatórios ou introduziu updates indevidos.
-* Declarar updates aplicados, ausentes, indevidos e não aplicáveis.
-* Aprovar, reprovar ou aprovar com ressalva conforme impacto no MVP, segurança, custo, banco, infra, automações e escopo.
-* Se houver ajuste, entregar instrução curta e determinística ao Executor.
+* Verificar se a entrega aplicou updates pertinentes ao caso.
+* Indicar updates obrigatórios ausentes, updates usados indevidamente e updates não aplicáveis.
+* Avaliar impacto no MVP, segurança, custo, banco, infraestrutura, automações e escopo.
+* Quando houver ajuste, entregar instrução curta e determinística ao Executor.
 
 9. Regras para briefings do Gestor de Updates
 

--- a/docs/gestor-updates.md
+++ b/docs/gestor-updates.md
@@ -149,12 +149,12 @@ docs/platform-config.md
   * critérios de parada;
   * proibição de transformar update em nova frente sem decisão do Estrategista.
 
-10. Regras de segurança específicas do Gestor de Updates
+10. Segurança específica do Gestor de Updates
 
-* Além das regras do `AGENTS.md`, não expor payloads, PII, `content_json`, pesquisa bruta ou texto gerado em logs.
-* Em mudança de banco, consultar `docs/schema.md` e aplicar as travas vigentes do catálogo Supabase ativo.
+* Em banco, consultar `docs/schema.md`, `docs/base-tecnica.md` e o catálogo Supabase vigente.
 * Em IA, confirmar ambiente, chave, modelo, custo e escopo.
 * Em produção, não assumir geração ativa sem decisão explícita.
+* Não transformar update de segurança em nova infraestrutura sem caso real aprovado.
 
 11. Forma de conclusão
 
@@ -249,15 +249,11 @@ Manter no catálogo ativo itens que sejam:
 * Informar itens avaliados e não adicionados quando houver varredura oficial.
 * Proibir alteração de arquivos fora do alvo e criação de banco, rota, job, agente, automação, engine, workflow ou infraestrutura sem decisão humana explícita.
 
-12.9. Revisão do PR
+12.9. Conferência do catálogo
 
-* Conferir se apenas o arquivo-alvo foi alterado.
 * Conferir se itens removidos saíram integralmente.
 * Conferir se itens mantidos não foram renumerados.
 * Conferir se lacunas numéricas foram preservadas.
 * Conferir se novos IDs seguem o próximo número livre.
 * Conferir se itens novos têm fonte oficial e aproveitamento real ou condicional.
 * Conferir se recurso futuro, pago, enterprise ou experimental não virou adoção automática.
-* Conferir se não houve alteração de código, workflow, banco, rota, job, agente, automação, engine ou infraestrutura.
-* Não bloquear merge por descrição de PR desatualizada quando o arquivo final estiver correto e não houver risco real.
-* Pedir ajuste quando houver renumeração, alteração fora de escopo, item novo sem fonte oficial, reutilização de ID removido ou adoção automática de recurso condicional.


### PR DESCRIPTION
### Motivation

* Registrar formalmente o processo usado na rodada de atualização dos catálogos para preservar regras importantes (catálogo ativo, IDs canônicos, lacunas, briefing determinístico, varredura e revisão de PR). 

### Description

* Adicionada ao final de `docs/gestor-updates.md` a seção `13. Protocolo para rodada de atualização dos catálogos` contendo subseções de objetivo, catálogos-alvo, ordem obrigatória, regras de catálogo ativo, IDs canônicos, briefing para Codex, regras para novos itens, revisão de PR e decisão final. 
* Preservei a numeração e o conteúdo anterior (seção `12. Forma de conclusão`) sem renumerar seções existentes e sem tocar outros arquivos. 
* Alteração commitada localmente na branch `work` com o commit `d2b873c docs: registrar protocolo de atualização dos catálogos` e PR gerado pela ferramenta interna; `git push` falhou por não haver destino remoto configurado. 

### Testing

* `git diff --name-only` confirmou que apenas `docs/gestor-updates.md` foi alterado antes do commit, e `git diff --stat` mostrou `1 file changed, 105 insertions(+)`. 
* `rg -n '^[0-9]+(\.[0-9]+)?\. ' docs/gestor-updates.md` confirmou que as seções existentes permaneceram 1–12 e que a nova seção 13 foi adicionada ao final. 
* `git diff --check` não reportou problemas de whitespace e `git diff --exit-code -- . ':(exclude)docs/gestor-updates.md'` confirmou ausência de alterações fora do arquivo-alvo. 
* `npm ci` e `npm run check` não foram executados por se tratar de alteração exclusivamente documental; `git push` falhou com `fatal: No configured push destination.`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4915f521a08329b96d24de8e1dfff8)