### PR TITLE
feat: implementa concessão manual E9.7

### DIFF
--- a/app/admin/(protected)/contas/[accountId]/actions.ts
+++ b/app/admin/(protected)/contas/[accountId]/actions.ts
@@ -1,0 +1,88 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { requirePlatformAdmin } from "@/lib/access/guards";
+import {
+  cancelAdminManualCommercialEntitlement,
+  grantAdminManualCommercialEntitlement,
+} from "@/lib/admin/adapters/adminCommercialEntitlementsAdapter";
+import { createClient } from "@/lib/supabase/server";
+
+export async function grantManualCommercialEntitlementAction(formData: FormData) {
+  const gate = await requirePlatformAdmin();
+  const accountId = String(formData.get("accountId") ?? "").trim();
+  const targetPath = getAccountPath(accountId);
+
+  if (!gate.allowed) {
+    redirect(gate.redirect === "/auth/login" ? "/auth/login?next=%2Fadmin%2Fcontas" : "/auth/confirm/info");
+  }
+
+  const operatorUserId = await readCurrentUserId();
+  if (!operatorUserId) {
+    redirect(`${targetPath}?manual_entitlement=unauthorized`);
+  }
+
+  const result = await grantAdminManualCommercialEntitlement({
+    accountId,
+    planKey: String(formData.get("planKey") ?? ""),
+    expiresAt: String(formData.get("expiresAt") ?? ""),
+    manualReason: String(formData.get("manualReason") ?? ""),
+    operatorUserId,
+  });
+
+  revalidatePath(targetPath);
+
+  if (!result.ok) {
+    redirect(`${targetPath}?manual_entitlement=${encodeURIComponent(result.reason)}`);
+  }
+
+  redirect(`${targetPath}?manual_entitlement=${result.operation}`);
+}
+
+export async function cancelManualCommercialEntitlementAction(formData: FormData) {
+  const gate = await requirePlatformAdmin();
+  const accountId = String(formData.get("accountId") ?? "").trim();
+  const targetPath = getAccountPath(accountId);
+
+  if (!gate.allowed) {
+    redirect(gate.redirect === "/auth/login" ? "/auth/login?next=%2Fadmin%2Fcontas" : "/auth/confirm/info");
+  }
+
+  const operatorUserId = await readCurrentUserId();
+  if (!operatorUserId) {
+    redirect(`${targetPath}?manual_entitlement=unauthorized`);
+  }
+
+  const result = await cancelAdminManualCommercialEntitlement({
+    accountId,
+    manualReason: String(formData.get("cancelReason") ?? ""),
+    operatorUserId,
+  });
+
+  revalidatePath(targetPath);
+
+  if (!result.ok) {
+    redirect(`${targetPath}?manual_entitlement=${encodeURIComponent(result.reason)}`);
+  }
+
+  redirect(`${targetPath}?manual_entitlement=canceled`);
+}
+
+async function readCurrentUserId() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error || !user) return null;
+  return user.id;
+}
+
+function getAccountPath(accountId: string) {
+  return accountId
+    ? `/admin/contas/${encodeURIComponent(accountId)}`
+    : "/admin/contas";
+}

--- a/app/admin/(protected)/contas/[accountId]/page.tsx
+++ b/app/admin/(protected)/contas/[accountId]/page.tsx
@@ -194,6 +194,7 @@ export default async function AdminAccountDetailPage({ params, searchParams }: A
               className="h-10 w-full rounded-md border border-border bg-background px-3 text-sm outline-none ring-brand-600/20 transition focus:ring-4"
               name="expiresAt"
               placeholder="2026-12-31T23:59:59Z"
+              defaultValue={manualEntitlement?.expiresAt ?? ""}
             />
           </label>
           <div className="flex items-end">

--- a/app/admin/(protected)/contas/[accountId]/page.tsx
+++ b/app/admin/(protected)/contas/[accountId]/page.tsx
@@ -6,20 +6,32 @@ import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
 import { AdminStatusBadge, accountStatusTone } from "@/components/admin/AdminStatusBadge";
 import { EmptyState } from "@/components/ui/empty-state";
 import { formatAdminDate, formatPercent } from "@/lib/admin/adminFormat";
+import { getAdminManualCommercialEntitlementState } from "@/lib/admin/adapters/adminCommercialEntitlementsAdapter";
 import { getAdminAccountDetail } from "@/lib/admin/adapters/adminReadOnlyAdapter";
+import {
+  cancelManualCommercialEntitlementAction,
+  grantManualCommercialEntitlementAction,
+} from "./actions";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 type AdminAccountDetailPageProps = {
   params: Promise<{ accountId: string }>;
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
 };
 
-export default async function AdminAccountDetailPage({ params }: AdminAccountDetailPageProps) {
+export default async function AdminAccountDetailPage({ params, searchParams }: AdminAccountDetailPageProps) {
   const { accountId } = await params;
-  const account = await getAdminAccountDetail(accountId);
+  const paramsValue = (await searchParams) ?? {};
+  const [account, manualEntitlement] = await Promise.all([
+    getAdminAccountDetail(accountId),
+    getAdminManualCommercialEntitlementState(accountId),
+  ]);
 
   if (!account) notFound();
+
+  const event = getParam(paramsValue.manual_entitlement);
 
   return (
     <div className="space-y-6">
@@ -132,6 +144,84 @@ export default async function AdminAccountDetailPage({ params }: AdminAccountDet
           )}
         </div>
       </section>
+
+      <section className="rounded-lg border border-border bg-card p-5 shadow-card">
+        <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+          <div>
+            <h2 className="text-sm font-semibold text-card-foreground">Entitlement manual</h2>
+            {manualEntitlement ? (
+              <dl className="mt-4 grid gap-3 text-sm md:grid-cols-3">
+                <Detail label="Plano" value={manualEntitlement.planNameSnapshot} />
+                <Detail label="Status" value={manualEntitlement.status} />
+                <Detail label="Expira em" value={formatAdminDate(manualEntitlement.expiresAt)} />
+              </dl>
+            ) : (
+              <p className="mt-3 text-sm text-muted-foreground">Nenhuma liberacao manual registrada.</p>
+            )}
+          </div>
+          {event ? (
+            <AdminStatusBadge tone={eventTone(event)}>{event}</AdminStatusBadge>
+          ) : null}
+        </div>
+
+        <form action={grantManualCommercialEntitlementAction} className="mt-5 grid gap-3 md:grid-cols-[160px_minmax(0,1fr)_220px_auto]">
+          <input name="accountId" type="hidden" value={account.id} />
+          <label className="space-y-1">
+            <span className="text-xs font-medium text-muted-foreground">Plano</span>
+            <select
+              className="h-10 w-full rounded-md border border-border bg-background px-3 text-sm outline-none ring-brand-600/20 transition focus:ring-4"
+              name="planKey"
+              defaultValue={manualEntitlement?.planKey ?? "lite"}
+            >
+              <option value="starter">Starter</option>
+              <option value="lite">Lite</option>
+              <option value="pro">Pro</option>
+              <option value="ultra">Ultra</option>
+            </select>
+          </label>
+          <label className="space-y-1">
+            <span className="text-xs font-medium text-muted-foreground">Justificativa</span>
+            <input
+              className="h-10 w-full rounded-md border border-border bg-background px-3 text-sm outline-none ring-brand-600/20 transition focus:ring-4"
+              name="manualReason"
+              placeholder="Piloto, venda assistida ou excecao controlada"
+              required
+            />
+          </label>
+          <label className="space-y-1">
+            <span className="text-xs font-medium text-muted-foreground">Expira em</span>
+            <input
+              className="h-10 w-full rounded-md border border-border bg-background px-3 text-sm outline-none ring-brand-600/20 transition focus:ring-4"
+              name="expiresAt"
+              placeholder="2026-12-31T23:59:59Z"
+            />
+          </label>
+          <div className="flex items-end">
+            <button className="h-10 rounded-md bg-brand-600 px-4 text-sm font-medium text-white transition hover:bg-brand-700">
+              Salvar
+            </button>
+          </div>
+        </form>
+
+        {manualEntitlement?.status === "ativo" ? (
+          <form action={cancelManualCommercialEntitlementAction} className="mt-4 grid gap-3 md:grid-cols-[minmax(0,1fr)_auto]">
+            <input name="accountId" type="hidden" value={account.id} />
+            <label className="space-y-1">
+              <span className="text-xs font-medium text-muted-foreground">Motivo do cancelamento</span>
+              <input
+                className="h-10 w-full rounded-md border border-border bg-background px-3 text-sm outline-none ring-brand-600/20 transition focus:ring-4"
+                name="cancelReason"
+                required
+              />
+            </label>
+            <div className="flex items-end">
+              <button className="h-10 rounded-md border border-border px-4 text-sm font-medium text-muted-foreground transition hover:bg-muted">
+                Cancelar manual
+              </button>
+            </div>
+          </form>
+        ) : null}
+      </section>
     </div>
   );
 }
@@ -143,4 +233,14 @@ function Detail({ label, value, children }: { label: string; value?: string; chi
       <dd className="break-words text-foreground">{children ?? value}</dd>
     </div>
   );
+}
+
+function getParam(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] ?? null : value ?? null;
+}
+
+function eventTone(event: string) {
+  return event === "created" || event === "updated" || event === "canceled"
+    ? "success"
+    : "warning";
 }

--- a/docs/lousa-plano-base-e9-7.md
+++ b/docs/lousa-plano-base-e9-7.md
@@ -73,6 +73,7 @@ Fontes: chat, `AGENTS.md`, `docs/prompt-estrategista.md`, `docs/roadmap.md`, `do
 
 * Automação: não.
 * Objetivo: implementar o menor mecanismo aprovado na Fase 1 para registrar `origin = liberacao_manual`.
+* Status: concluída em 04/07/2026.
 * Direção:
   * reaproveitar schema existente;
   * evitar UI ampla;
@@ -88,6 +89,15 @@ Fontes: chat, `AGENTS.md`, `docs/prompt-estrategista.md`, `docs/roadmap.md`, `do
   * não há consulta Stripe;
   * não há bypass do signal comercial.
 * Condição: esta fase não pode ser enviada ao Executor antes da conclusão da Fase 1.
+* Resultado da execução:
+  * Criado o boundary Admin server-only `lib/admin/adapters/adminCommercialEntitlementsAdapter.ts`.
+  * Criado o path de mutação `app/admin/(protected)/contas/[accountId]/actions.ts`, protegido por `requirePlatformAdmin`.
+  * A superfície `app/admin/(protected)/contas/[accountId]/page.tsx` recebeu mecanismo mínimo para conceder/atualizar e cancelar entitlement manual, sem criar dashboard/admin amplo.
+  * A escrita usa `createServiceClient()` e persiste somente em `public.account_commercial_entitlements`.
+  * Concessão manual grava `origin = liberacao_manual`, `status = ativo`, plano canônico, vigência validada e `metadata_json` mínimo.
+  * Conflito com entitlement efetivo `plano_pago_confirmado` ou `trial` falha fechado.
+  * Entitlement manual `ativo` existente é atualizado em vez de criar duplicidade.
+  * Não houve Stripe, checkout, webhook, migration, tabela, RPC, policy, grant, trigger, LP Builder, job, agente ou automação.
 
 3.3 Fase 3 — Validação de entitlement e gate
 
@@ -103,7 +113,7 @@ Fontes: chat, `AGENTS.md`, `docs/prompt-estrategista.md`, `docs/roadmap.md`, `do
   * `supa#40` pode apoiar validação read-only.
 * Saída: evidência objetiva de que a liberação manual ativa elegibilidade sem alterar o gate produtivo.
 
-Próxima ação: após merge/consolidação deste PR, enviar ao Executor a Fase 2 — Mecanismo mínimo de concessão, limitada estritamente ao contrato operacional fechado na Fase 1.
+Próxima ação: após merge/consolidação deste PR, enviar ao Executor a Fase 3 — Validação de entitlement e gate.
 
 4. Escopo negativo e critérios de parada
 

--- a/lib/admin/adapters/adminCommercialEntitlementsAdapter.ts
+++ b/lib/admin/adapters/adminCommercialEntitlementsAdapter.ts
@@ -43,7 +43,8 @@ type AdminCommercialEntitlementFailureReason =
   | "entitlement_insert_failed"
   | "entitlement_update_failed"
   | "missing_entitlement_id"
-  | "manual_entitlement_not_found";
+  | "manual_entitlement_not_found"
+  | "duplicate_manual_entitlement";
 
 export type AdminManualCommercialEntitlementState = {
   id: string;
@@ -102,8 +103,8 @@ export async function grantAdminManualCommercialEntitlement(
   const now = new Date();
   const startsAt = now.toISOString();
   const confirmedAt = startsAt;
-  const expiresAt = normalizeExpiresAt(input.expiresAt, now);
-  if (expiresAt === "invalid") return { ok: false, reason: "invalid_expires_at" };
+  const expiresAtInput = normalizeExpiresAt(input.expiresAt, now);
+  if (expiresAtInput === "invalid") return { ok: false, reason: "invalid_expires_at" };
 
   const supabase = createServiceClient();
   const accountState = await readAccountState(supabase, accountId);
@@ -117,6 +118,8 @@ export async function grantAdminManualCommercialEntitlement(
 
   const existingManual = await readActiveManualEntitlement(supabase, accountId);
   if (!existingManual.ok) return { ok: false, reason: existingManual.reason };
+
+  const expiresAt = expiresAtInput ?? existingManual.expiresAt ?? null;
 
   const payload = {
     account_id: accountId,
@@ -141,12 +144,17 @@ export async function grantAdminManualCommercialEntitlement(
   };
 
   if (existingManual.entitlementId) {
-    const { data, error } = await supabase
+    let updateQuery: any = supabase
       .from("account_commercial_entitlements")
       .update(payload)
       .eq("id", existingManual.entitlementId)
-      .select("id")
-      .single();
+      .select("id");
+
+    if (typeof updateQuery?.maxAffected === "function") {
+      updateQuery = updateQuery.maxAffected(1);
+    }
+
+    const { data, error } = await updateQuery.single();
 
     if (error) return { ok: false, reason: "entitlement_update_failed" };
     return typeof data?.id === "string"
@@ -161,9 +169,32 @@ export async function grantAdminManualCommercialEntitlement(
     .single();
 
   if (error) return { ok: false, reason: "entitlement_insert_failed" };
-  return typeof data?.id === "string"
-    ? { ok: true, entitlementId: data.id, operation: "created" }
-    : { ok: false, reason: "missing_entitlement_id" };
+  if (typeof data?.id !== "string") return { ok: false, reason: "missing_entitlement_id" };
+
+  const postInsertManual = await readActiveManualEntitlement(supabase, accountId);
+  if (!postInsertManual.ok) {
+    if (postInsertManual.reason === "duplicate_manual_entitlement") {
+      await cancelManualEntitlementById({
+        supabase,
+        entitlementId: data.id,
+        operatorUserId: input.operatorUserId,
+        manualReason: "duplicate_manual_entitlement_detected",
+      });
+    }
+
+    return { ok: false, reason: postInsertManual.reason };
+  }
+  if (postInsertManual.entitlementId !== data.id) {
+    await cancelManualEntitlementById({
+      supabase,
+      entitlementId: data.id,
+      operatorUserId: input.operatorUserId,
+      manualReason: "duplicate_manual_entitlement_detected",
+    });
+    return { ok: false, reason: "duplicate_manual_entitlement" };
+  }
+
+  return { ok: true, entitlementId: data.id, operation: "created" };
 }
 
 export async function cancelAdminManualCommercialEntitlement(
@@ -186,7 +217,7 @@ export async function cancelAdminManualCommercialEntitlement(
   }
 
   const canceledAt = new Date().toISOString();
-  const { data, error } = await supabase
+  let updateQuery: any = supabase
     .from("account_commercial_entitlements")
     .update({
       status: "cancelado",
@@ -200,13 +231,47 @@ export async function cancelAdminManualCommercialEntitlement(
       },
     })
     .eq("id", existingManual.entitlementId)
-    .select("id")
-    .single();
+    .select("id");
+
+  if (typeof updateQuery?.maxAffected === "function") {
+    updateQuery = updateQuery.maxAffected(1);
+  }
+
+  const { data, error } = await updateQuery.single();
 
   if (error) return { ok: false, reason: "entitlement_update_failed" };
   return typeof data?.id === "string"
     ? { ok: true, entitlementId: data.id, operation: "canceled" }
     : { ok: false, reason: "missing_entitlement_id" };
+}
+
+async function cancelManualEntitlementById(input: {
+  supabase: ReturnType<typeof createServiceClient>;
+  entitlementId: string;
+  operatorUserId: string;
+  manualReason: string;
+}) {
+  const canceledAt = new Date().toISOString();
+  let updateQuery: any = input.supabase
+    .from("account_commercial_entitlements")
+    .update({
+      status: "cancelado",
+      canceled_at: canceledAt,
+      metadata_json: {
+        manual_reason: input.manualReason,
+        canceled_by_user_id: input.operatorUserId,
+        canceled_at: canceledAt,
+        source_surface: MANUAL_SOURCE_SURFACE,
+        operation: "cancel_manual_entitlement",
+      },
+    })
+    .eq("id", input.entitlementId);
+
+  if (typeof updateQuery?.maxAffected === "function") {
+    updateQuery = updateQuery.maxAffected(1);
+  }
+
+  await updateQuery;
 }
 
 function normalizePlanKey(value: string): ManualPlanKey | null {
@@ -275,21 +340,34 @@ async function readActiveManualEntitlement(
   supabase: ReturnType<typeof createServiceClient>,
   accountId: string,
 ): Promise<
-  | { ok: true; entitlementId: string | null }
-  | { ok: false; reason: Extract<AdminCommercialEntitlementFailureReason, "entitlement_lookup_failed"> }
+  | { ok: true; entitlementId: string | null; expiresAt: string | null }
+  | {
+      ok: false;
+      reason: Extract<
+        AdminCommercialEntitlementFailureReason,
+        "entitlement_lookup_failed" | "duplicate_manual_entitlement"
+      >;
+    }
 > {
   const { data, error } = await supabase
     .from("account_commercial_entitlements")
-    .select("id")
+    .select("id,expires_at")
     .eq("account_id", accountId)
     .eq("origin", "liberacao_manual")
     .eq("status", "ativo")
     .order("updated_at", { ascending: false })
-    .limit(1)
-    .maybeSingle();
+    .limit(2);
 
   if (error) return { ok: false, reason: "entitlement_lookup_failed" };
-  return { ok: true, entitlementId: typeof data?.id === "string" ? data.id : null };
+  const rows = Array.isArray(data) ? data : [];
+  if (rows.length > 1) return { ok: false, reason: "duplicate_manual_entitlement" };
+
+  const row = rows[0];
+  return {
+    ok: true,
+    entitlementId: typeof row?.id === "string" ? row.id : null,
+    expiresAt: typeof row?.expires_at === "string" ? row.expires_at : null,
+  };
 }
 
 function isUuid(value: string) {

--- a/lib/admin/adapters/adminCommercialEntitlementsAdapter.ts
+++ b/lib/admin/adapters/adminCommercialEntitlementsAdapter.ts
@@ -1,0 +1,299 @@
+import "server-only";
+
+import { createServiceClient } from "@/lib/supabase/service";
+
+const PLAN_NAME_SNAPSHOT = {
+  starter: "Starter",
+  lite: "Lite",
+  pro: "Pro",
+  ultra: "Ultra",
+} as const;
+
+const MANUAL_SOURCE_SURFACE = "admin_account_detail";
+
+type ManualPlanKey = keyof typeof PLAN_NAME_SNAPSHOT;
+
+type GrantManualEntitlementInput = {
+  accountId: string;
+  planKey: string;
+  manualReason: string;
+  expiresAt?: string | null;
+  operatorUserId: string;
+};
+
+type CancelManualEntitlementInput = {
+  accountId: string;
+  manualReason: string;
+  operatorUserId: string;
+};
+
+type AdminCommercialEntitlementResult =
+  | { ok: true; entitlementId: string; operation: "created" | "updated" | "canceled" }
+  | { ok: false; reason: AdminCommercialEntitlementFailureReason };
+
+type AdminCommercialEntitlementFailureReason =
+  | "invalid_account_id"
+  | "account_not_found"
+  | "account_not_active"
+  | "invalid_plan_key"
+  | "invalid_manual_reason"
+  | "invalid_expires_at"
+  | "conflicting_effective_entitlement"
+  | "entitlement_lookup_failed"
+  | "entitlement_insert_failed"
+  | "entitlement_update_failed"
+  | "missing_entitlement_id"
+  | "manual_entitlement_not_found";
+
+export type AdminManualCommercialEntitlementState = {
+  id: string;
+  planKey: string;
+  planNameSnapshot: string;
+  status: string;
+  startsAt: string | null;
+  confirmedAt: string | null;
+  expiresAt: string | null;
+  canceledAt: string | null;
+  updatedAt: string | null;
+} | null;
+
+export async function getAdminManualCommercialEntitlementState(
+  accountId: string,
+): Promise<AdminManualCommercialEntitlementState> {
+  if (!isUuid(accountId)) return null;
+
+  const supabase = createServiceClient();
+  const { data, error } = await supabase
+    .from("account_commercial_entitlements")
+    .select("id,plan_key,plan_name_snapshot,status,starts_at,confirmed_at,expires_at,canceled_at,updated_at")
+    .eq("account_id", accountId)
+    .eq("origin", "liberacao_manual")
+    .order("updated_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error || !data) return null;
+
+  return {
+    id: data.id,
+    planKey: data.plan_key,
+    planNameSnapshot: data.plan_name_snapshot,
+    status: data.status,
+    startsAt: data.starts_at,
+    confirmedAt: data.confirmed_at,
+    expiresAt: data.expires_at,
+    canceledAt: data.canceled_at,
+    updatedAt: data.updated_at,
+  };
+}
+
+export async function grantAdminManualCommercialEntitlement(
+  input: GrantManualEntitlementInput,
+): Promise<AdminCommercialEntitlementResult> {
+  const accountId = input.accountId.trim();
+  if (!isUuid(accountId)) return { ok: false, reason: "invalid_account_id" };
+
+  const planKey = normalizePlanKey(input.planKey);
+  if (!planKey) return { ok: false, reason: "invalid_plan_key" };
+
+  const manualReason = normalizeManualReason(input.manualReason);
+  if (!manualReason) return { ok: false, reason: "invalid_manual_reason" };
+
+  const now = new Date();
+  const startsAt = now.toISOString();
+  const confirmedAt = startsAt;
+  const expiresAt = normalizeExpiresAt(input.expiresAt, now);
+  if (expiresAt === "invalid") return { ok: false, reason: "invalid_expires_at" };
+
+  const supabase = createServiceClient();
+  const accountState = await readAccountState(supabase, accountId);
+  if (!accountState.ok) return { ok: false, reason: accountState.reason };
+
+  const conflict = await readEffectiveEntitlementConflict(supabase, accountId);
+  if (!conflict.ok) return { ok: false, reason: conflict.reason };
+  if (conflict.hasConflict) {
+    return { ok: false, reason: "conflicting_effective_entitlement" };
+  }
+
+  const existingManual = await readActiveManualEntitlement(supabase, accountId);
+  if (!existingManual.ok) return { ok: false, reason: existingManual.reason };
+
+  const payload = {
+    account_id: accountId,
+    plan_key: planKey,
+    plan_name_snapshot: PLAN_NAME_SNAPSHOT[planKey],
+    origin: "liberacao_manual",
+    status: "ativo",
+    starts_at: startsAt,
+    confirmed_at: confirmedAt,
+    expires_at: expiresAt,
+    canceled_at: null,
+    external_provider: null,
+    external_reference: null,
+    idempotency_key: null,
+    metadata_json: {
+      manual_reason: manualReason,
+      granted_by_user_id: input.operatorUserId,
+      granted_at: confirmedAt,
+      source_surface: MANUAL_SOURCE_SURFACE,
+      operation: "grant_manual_entitlement",
+    },
+  };
+
+  if (existingManual.entitlementId) {
+    const { data, error } = await supabase
+      .from("account_commercial_entitlements")
+      .update(payload)
+      .eq("id", existingManual.entitlementId)
+      .select("id")
+      .single();
+
+    if (error) return { ok: false, reason: "entitlement_update_failed" };
+    return typeof data?.id === "string"
+      ? { ok: true, entitlementId: data.id, operation: "updated" }
+      : { ok: false, reason: "missing_entitlement_id" };
+  }
+
+  const { data, error } = await supabase
+    .from("account_commercial_entitlements")
+    .insert(payload)
+    .select("id")
+    .single();
+
+  if (error) return { ok: false, reason: "entitlement_insert_failed" };
+  return typeof data?.id === "string"
+    ? { ok: true, entitlementId: data.id, operation: "created" }
+    : { ok: false, reason: "missing_entitlement_id" };
+}
+
+export async function cancelAdminManualCommercialEntitlement(
+  input: CancelManualEntitlementInput,
+): Promise<AdminCommercialEntitlementResult> {
+  const accountId = input.accountId.trim();
+  if (!isUuid(accountId)) return { ok: false, reason: "invalid_account_id" };
+
+  const manualReason = normalizeManualReason(input.manualReason);
+  if (!manualReason) return { ok: false, reason: "invalid_manual_reason" };
+
+  const supabase = createServiceClient();
+  const accountState = await readAccountState(supabase, accountId);
+  if (!accountState.ok) return { ok: false, reason: accountState.reason };
+
+  const existingManual = await readActiveManualEntitlement(supabase, accountId);
+  if (!existingManual.ok) return { ok: false, reason: existingManual.reason };
+  if (!existingManual.entitlementId) {
+    return { ok: false, reason: "manual_entitlement_not_found" };
+  }
+
+  const canceledAt = new Date().toISOString();
+  const { data, error } = await supabase
+    .from("account_commercial_entitlements")
+    .update({
+      status: "cancelado",
+      canceled_at: canceledAt,
+      metadata_json: {
+        manual_reason: manualReason,
+        canceled_by_user_id: input.operatorUserId,
+        canceled_at: canceledAt,
+        source_surface: MANUAL_SOURCE_SURFACE,
+        operation: "cancel_manual_entitlement",
+      },
+    })
+    .eq("id", existingManual.entitlementId)
+    .select("id")
+    .single();
+
+  if (error) return { ok: false, reason: "entitlement_update_failed" };
+  return typeof data?.id === "string"
+    ? { ok: true, entitlementId: data.id, operation: "canceled" }
+    : { ok: false, reason: "missing_entitlement_id" };
+}
+
+function normalizePlanKey(value: string): ManualPlanKey | null {
+  const planKey = value.trim().toLowerCase();
+  return planKey in PLAN_NAME_SNAPSHOT ? (planKey as ManualPlanKey) : null;
+}
+
+function normalizeManualReason(value: string) {
+  const reason = value.trim();
+  if (!reason) return null;
+  return reason.slice(0, 500);
+}
+
+function normalizeExpiresAt(value: string | null | undefined, now: Date) {
+  const raw = value?.trim();
+  if (!raw) return null;
+
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) return "invalid";
+  if (parsed.getTime() <= now.getTime()) return "invalid";
+  return parsed.toISOString();
+}
+
+async function readAccountState(
+  supabase: ReturnType<typeof createServiceClient>,
+  accountId: string,
+): Promise<
+  | { ok: true }
+  | { ok: false; reason: Extract<AdminCommercialEntitlementFailureReason, "account_not_found" | "account_not_active"> }
+> {
+  const { data, error } = await supabase
+    .from("accounts")
+    .select("id,status")
+    .eq("id", accountId)
+    .maybeSingle();
+
+  if (error || !data) return { ok: false, reason: "account_not_found" };
+  if (data.status !== "active") return { ok: false, reason: "account_not_active" };
+  return { ok: true };
+}
+
+async function readEffectiveEntitlementConflict(
+  supabase: ReturnType<typeof createServiceClient>,
+  accountId: string,
+): Promise<
+  | { ok: true; hasConflict: boolean }
+  | { ok: false; reason: Extract<AdminCommercialEntitlementFailureReason, "entitlement_lookup_failed"> }
+> {
+  const { data, error } = await supabase
+    .from("v_account_commercial_entitlement_effective")
+    .select("origin,is_commercially_eligible")
+    .eq("account_id", accountId)
+    .maybeSingle();
+
+  if (error) return { ok: false, reason: "entitlement_lookup_failed" };
+
+  return {
+    ok: true,
+    hasConflict:
+      data?.is_commercially_eligible === true &&
+      (data.origin === "plano_pago_confirmado" || data.origin === "trial"),
+  };
+}
+
+async function readActiveManualEntitlement(
+  supabase: ReturnType<typeof createServiceClient>,
+  accountId: string,
+): Promise<
+  | { ok: true; entitlementId: string | null }
+  | { ok: false; reason: Extract<AdminCommercialEntitlementFailureReason, "entitlement_lookup_failed"> }
+> {
+  const { data, error } = await supabase
+    .from("account_commercial_entitlements")
+    .select("id")
+    .eq("account_id", accountId)
+    .eq("origin", "liberacao_manual")
+    .eq("status", "ativo")
+    .order("updated_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) return { ok: false, reason: "entitlement_lookup_failed" };
+  return { ok: true, entitlementId: typeof data?.id === "string" ? data.id : null };
+}
+
+function isUuid(value: string) {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    value,
+  );
+}


### PR DESCRIPTION
## Resumo
- cria o boundary Admin server-only `lib/admin/adapters/adminCommercialEntitlementsAdapter.ts`
- cria as Server Actions em `app/admin/(protected)/contas/[accountId]/actions.ts`, protegidas por `requirePlatformAdmin`
- adiciona mecanismo mínimo na superfície de detalhe da conta para conceder/atualizar/cancelar entitlement manual
- atualiza somente o estado da Fase 2 em `docs/lousa-plano-base-e9-7.md`

## Contrato E9.7 Fase 2
- persiste somente em `public.account_commercial_entitlements`
- concessão manual usa `origin = liberacao_manual` e `status = ativo`
- valida conta existente e `active`, plano canônico, vigência futura quando informada e operador autorizado
- conflito com entitlement efetivo `plano_pago_confirmado` ou `trial` falha fechado
- entitlement manual `ativo` existente é atualizado, não duplicado
- metadata mínima da concessão: `manual_reason`, `granted_by_user_id`, `granted_at`, `source_surface`, `operation`

## Fora do escopo preservado
- sem Fase 3
- sem Stripe, checkout, webhook ou LP Builder
- sem migration, tabela, RPC, policy, grant ou trigger
- sem Billing Engine, Customer Portal, trial operacional, job, agente ou automação
- sem alteração em `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/schema.md` ou `docs/lousa-plano-base-e9.md`

## Validação
- `npm ci`: OK; audit reportou 13 vulnerabilidades já existentes
- `npm run check`: OK; lint mantém 24 warnings pré-existentes fora do escopo e typecheck passou
- `git diff --cached --check`: OK
- preview local: `npm run dev` subiu em `http://localhost:3000`; GET `/admin/contas` retornou 500 por ausência de `NEXT_PUBLIC_SUPABASE_URL`/publishable key no ambiente local, antes da rota Admin