### PR TITLE
docs: registrar E9.7 entitlements administrativos (roadmap v1.5.89, base-tecnica v2.0.46)

### DIFF
--- a/docs/base-tecnica.md
+++ b/docs/base-tecnica.md
@@ -2,8 +2,8 @@
 
 0.1. Cabeçalho
 • Documento: Base Técnica LP Factory 10
-• Versão: v2.0.45
-• Data: 02/07/2026
+• Versão: v2.0.46
+• Data: 04/07/2026
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.

--- a/docs/base-tecnica.md
+++ b/docs/base-tecnica.md
@@ -286,6 +286,21 @@ Commercial entitlements
 • Regra de segurança: fail-closed; erro, exceção, `accountId` vazio ou ausência de linha retornam não elegível.
 • Limite: UI/client não acessa Supabase para entitlement comercial; consumo deve passar pelo boundary server-side.
 
+Admin commercial entitlements
+• Superfície administrativa mínima: `app/admin/(protected)/contas/[accountId]/page.tsx`.
+• Path canônico de mutação: `app/admin/(protected)/contas/[accountId]/actions.ts`.
+• Boundary server-only: `lib/admin/adapters/adminCommercialEntitlementsAdapter.ts`.
+• Guard obrigatório: `requirePlatformAdmin`.
+• Ator autorizado: `platform_admin`, incluindo `super_admin` pelo guard existente.
+• Escrita: server-side via `createServiceClient()`.
+• Persistência exclusiva: `public.account_commercial_entitlements`.
+• Origem manual: `origin = liberacao_manual`.
+• Operações mínimas autorizadas: concessão, atualização e cancelamento manual de entitlement.
+• Regra de conflito: entitlement efetivo de `plano_pago_confirmado` ou `trial` deve falhar fechado.
+• Entitlement manual `ativo` existente deve ser atualizado, não duplicado intencionalmente.
+• Stripe, checkout e webhook não podem ser usados como bypass da liberação manual.
+• Não criar rota, UI artificial, migration, schema, RPC, policy, grant, trigger, job ou automação para validar esse recorte.
+
 Stripe webhook
 • Endpoint canônico: `app/api/stripe/webhook/route.ts`.
 • Runtime: Node.js, dinâmico, server-side.
@@ -524,6 +539,7 @@ Fonte normativa da allowlist SULB para exceções de Auth. Qualquer novo arquivo
 • Tipos canônicos e adapters vNext: validar por 3.6 e 3.14.
 
 99. Changelog
+v2.0.46 — 04/07/2026 — Registrado contrato técnico da liberação manual administrativa mínima de entitlement comercial, com Server Action protegida por `requirePlatformAdmin`, boundary Admin server-only e persistência exclusiva em `public.account_commercial_entitlements`.
 v2.0.45 (02/07/2026) — Registrado webhook Stripe mínimo do E9, com endpoint canônico, boundary, assinatura obrigatória, evento `invoice.paid`, idempotência e persistência segura de entitlement.
 v2.0.43 — 22/06/2026 — Registrado o contrato técnico da geração administrativa de draft `commercial_activation`: fluxo server-side/Admin com Responses API e Structured Outputs, modelo por env var, validação em duas camadas, persistência somente como `draft`, fontes relacionais `business_buyer`, `end_customer` apenas em `provenance_json` e compensação segura em falha parcial.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data: 02/07/2026
-• Versão: v1.5.87
+• Data: 04/07/2026
+• Versão: v1.5.89
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -418,7 +418,7 @@
 • Decisão final: não criar Fase 4, rota, UI, chamada artificial, migration, schema, RPC, policy, grant, trigger ou alteração no LP Builder apenas para validar criação de draft.
 
 9.4 Pendências vigentes
-• N/A para o recorte concluído da Fase 7.2.
+• N/A para o recorte consolidado atual do E9.
 
 9.5 Estruturas e artefatos
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -301,18 +301,20 @@
 9. E9 — Billing, trial e entitlements
 
 9.1 Status
-• Em execução faseada — Fases 5 e 7.2 concluídas em 02/07/2026.
+• Em execução faseada — Fases 5, 7.2 e E9.7 concluídas.
 • Schema mínimo de entitlement comercial versionado.
 • Consumo server-side mínimo da elegibilidade comercial disponível.
 • Gate produtivo mínimo validado no ponto real entregue pela E19.
 • Stripe Checkout em teste disponível no app.
 • Webhook Stripe mínimo em produção validado para `invoice.paid`.
+• Liberação manual administrativa mínima implementada via Admin.
 • Sem Billing Engine completo implementado nesta fase.
 
 9.2 Objetivo atual
 • Separar condição comercial da conta do lifecycle operacional da conta.
 • Definir elegibilidade comercial para criação de LPs como sinal derivado de conta operacionalmente permitida, membership ativo e entitlement comercial válido.
 • Garantir que a criação produtiva mínima de LP consuma o entitlement comercial antes da persistência.
+• Permitir concessão, atualização e cancelamento manual mínimo de entitlement por `platform_admin`.
 • Manter Stripe, checkout e webhook como mecanismos de confirmação/persistência, não como prova direta de liberação no LP Builder.
 
 9.3 Decisões consolidadas
@@ -395,6 +397,25 @@
 9.3.9 Updates avaliados
 • `supa#5`, `supa#36`, `supa#40`, `supa#58`.
 • Stripe webhook, Vercel Production, Stripe test mode e Supabase/Postgres aplicados na Fase 7.2.
+• E9.7: `supa#40` aplicado; `prod#19` aplicado; `supa#2` avaliado; `supa#56` avaliado.
+
+9.3.10 Liberação manual administrativa mínima
+• Status: E9.7 concluída em 04/07/2026.
+• Ator autorizado: `platform_admin`, incluindo `super_admin` pelo guard existente `requirePlatformAdmin`.
+• Superfície administrativa: `app/admin/(protected)/contas/[accountId]/page.tsx`.
+• Path canônico de mutação: `app/admin/(protected)/contas/[accountId]/actions.ts`.
+• Boundary de escrita: `lib/admin/adapters/adminCommercialEntitlementsAdapter.ts`.
+• Mecanismo mínimo: Server Action protegida por `requirePlatformAdmin`, chamando adapter Admin server-only com `createServiceClient()`.
+• Persistência exclusiva: `public.account_commercial_entitlements`.
+• Origem comercial usada: `liberacao_manual`.
+• Concessão manual validada com `status = ativo`, plano canônico, vigência válida e `metadata_json` mínimo.
+• Conflito com entitlement efetivo de `plano_pago_confirmado` ou `trial` falha fechado.
+• Entitlement manual `ativo` existente é atualizado, sem duplicidade intencional.
+• View efetiva validada com elegibilidade comercial positiva.
+• Signal validado por contrato view → adapter.
+• Sem bypass por Stripe, checkout ou webhook nos paths avaliados.
+• Criação real de draft pelo LP Builder não foi executada porque não há superfície operacional navegável aprovada para disparar a Server Action sem implementar rota ou UI nova.
+• Decisão final: não criar Fase 4, rota, UI, chamada artificial, migration, schema, RPC, policy, grant, trigger ou alteração no LP Builder apenas para validar criação de draft.
 
 9.4 Pendências vigentes
 • N/A para o recorte concluído da Fase 7.2.
@@ -405,6 +426,11 @@ Banco — Criados
 • `public.account_commercial_entitlements`
 • `public.v_account_commercial_entitlement_effective`
 • `public.stripe_webhook_events`
+
+Banco — Reaproveitados
+• `public.account_commercial_entitlements`
+• `public.v_account_commercial_entitlement_effective`
+• `public.account_landing_pages`
 
 Repositório — Criados
 • `supabase/migrations/20260628184945_e9_commercial_entitlements.sql`
@@ -421,19 +447,23 @@ Repositório — Criados
 • `lib/billing-checkout/index.ts`
 • `app/a/[account]/_components/commercial-page/checkout-actions.ts`
 • `app/api/stripe/webhook/route.ts`
+• `lib/admin/adapters/adminCommercialEntitlementsAdapter.ts`
+• `app/admin/(protected)/contas/[accountId]/actions.ts`
 
 Repositório — Ajustados
 • `app/a/[account]/page.tsx`
 • `app/a/[account]/_components/commercial-page/GenericCommercialPage.tsx`
 • `lib/billing-checkout/index.ts`
+• `app/admin/(protected)/contas/[accountId]/page.tsx`
 
-9.6 Fora do escopo da Fase 7.2
+9.6 Fora do escopo
 • Billing Engine completo.
-• Admin comercial.
+• Admin comercial completo.
 • Trial operacional.
-• Liberação manual operacional.
-• LP Builder.
-• Alteração de layout, copy ou cards da E10.7.
+• Automação de liberação manual.
+• Alteração de schema, migration, RPC, policy, grant ou trigger para E9.7.
+• Alteração no LP Builder apenas para teste.
+• Rota, UI ou chamada artificial para disparar Server Action.
 • Processamento de cancelamento e falha de pagamento fora do registro controlado/ignorado.
 • Job, rotina, monitoramento ou automação.
 
@@ -1442,6 +1472,8 @@ Repositório — Criados
 • Esta referência não cria obrigação de nova implementação agora.
 
 99. Changelog
+v1.5.89 — 04/07/2026 — E9.7 concluída com liberação manual administrativa mínima por `platform_admin`, persistência em `public.account_commercial_entitlements`, concessão/atualização/cancelamento manual, view efetiva validada e decisão de não criar superfície artificial para testar LP Builder.
+
 v1.5.88 — 02/07/2026 — E9 Fase 5 fechada documentalmente após a E19 entregar o ponto produtivo real de criação mínima de LP; gate comercial confirmado antes do insert em `public.account_landing_pages`, com fail-closed por entitlement ausente.
 
 v1.5.87 — 02/07/2026 — E9 Fase 7.2 concluída com webhook Stripe mínimo em produção, `invoice.paid` ativando entitlement local, idempotência em `stripe_webhook_events`, retry operacional e persistência validada em `account_commercial_entitlements`.


### PR DESCRIPTION
### Motivation
- Registrar conclusão da E9.7 com liberação manual administrativa mínima e atualizar os contratos técnicos para refletir a superfície Admin e persistência de entitlements. 
- Atualizar as versões documentais para `v1.5.89` em `docs/roadmap.md` e `v2.0.46` em `docs/base-tecnica.md` para manter o histórico e contratos sincronizados.

### Description
- Atualiza `docs/roadmap.md` para incluir o status E9.7, o objetivo com permissão de liberação manual por `platform_admin`, a nova seção `9.3.10`, artefatos relacionados e o changelog `v1.5.89`. 
- Atualiza `docs/base-tecnica.md` para adicionar a seção `Admin commercial entitlements` com paths canônicos (`app/admin/...`, `lib/admin/adapters/...`), guard `requirePlatformAdmin`, persistência em `public.account_commercial_entitlements` e o changelog `v2.0.46`. 
- Arquivos alterados: `docs/roadmap.md` e `docs/base-tecnica.md` on branch `docs/e9-7-abc-entitlements`. 
- Observação de publicação: branch criada e commit local gerado, porém `git push` falhou porque o remote `origin` não está configurado neste clone, portanto o PR remoto não foi publicado.

### Testing
- Executados `git diff --check` e `git diff --stat HEAD~1..HEAD`, ambos concluídos sem erros. 
- Tentativa de `git push -u origin docs/e9-7-abc-entitlements` falhou com `fatal: 'origin' does not appear to be a git repository` impedindo publicação remota. 
- `npm ci` e `npm run check` foram considerados não aplicáveis por se tratar de alteração exclusivamente documental.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4966c1ecec832984905b221321590c)