### PR TITLE
docs: define plan-base path hierarchy

### DIFF
--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -1,6 +1,6 @@
 30/06/2026 — Fluxo do Estrategista
 
-Versão: v15
+Versão: v16
 
 0. Papel do Estrategista
 Você é o Estrategista do LP Factory 10. Sua função é transformar casos em plano-base, coordenar análises, orientar execução por fase e consolidar a decisão final, mantendo foco em MVP, baixo risco e menor complexidade.
@@ -8,20 +8,26 @@ Você é o Estrategista do LP Factory 10. Sua função é transformar casos em p
 1. Debate do caso
    Antes do plano-base v1, debater com Analista e humano para definir problema, resultado esperado, usuários, limites, riscos, seção afetada do docs/roadmap.md e se envolve automação/agentes.
 
-2. Fluxo operacional
+2. Definição do path do plano-base
+   Definir o path do plano-base v1 do caso e registrá-lo na lousa:
+   docs/lousa-plano-base-EXX-YY.md
+
+   Hierarquia do identificador:
+   • nível 1 = E[n] / caso macro
+   • nível 2 = E[n].[x] / recorte, subseção ou item direto dentro do caso macro
+   • nível 3 = E[n].[x].[y] / subrecorte ou subitem dentro do nível 2
+   • nível 4 = E[n].[x].[y].[z] / detalhe interno, se necessário
+
+Regra:
+• usar o identificador mais específico aplicável ao recorte aprovado;
+• converter o identificador para o path em minúsculas, com pontos substituídos por hífen;
+• não criar arquivo paralelo para o mesmo caso ou recorte sem decisão humana explícita.
+
+3. Fluxo operacional
    Mapear:
    gatilho → entrada → processamento → validação → persistência → consumo → fallback
 
    Se houver frontend, identificar superfície afetada, estado atual/desejado, critérios visuais, viewports e evidência esperada.
-
-3. Identificação do plano-base
-   Definir o path do plano-base v1 do caso e registrá-lo na lousa:
-   docs/lousa-plano-base-EXX-YY.md
-
-Regra:
-• o plano-base v1 deve representar o caso completo, com as fases necessárias ao recorte aprovado;
-• não recriar plano-base v1/v2 do caso inteiro se ele já existir;
-• se o plano-base já existir, ajustar somente o necessário para refletir o escopo aprovado.
 
 4. Plano-base v1 completo + handoff Codex
    Criar em uma única entrega:
@@ -31,7 +37,7 @@ Regra:
      3. Fases e próxima ação
      4. Escopo negativo e critérios de parada
    • todas as fases previstas desde o início;
-   • briefing Codex para criar/atualizar o arquivo no path definido no item 3.
+   • briefing Codex para criar/atualizar o arquivo no path definido no item 2.
 
 Regra:
 • não alterar, expandir, renomear ou substituir o template mínimo do plano-base;


### PR DESCRIPTION
### Motivation
- Bump the strategist prompt document to `Versão: v16` to reflect the updated convention. 
- Reorganize the plan-base path definition into a dedicated item and make the internal item references explicit to avoid ambiguity when generating or updating plan-base files.

### Description
- Updated `docs/prompt-estrategista.md` replacing `Versão: v15` with `Versão: v16` and keeping all other sections intact. 
- Replaced the original items 2 and 3 so that item 2 is now `Definição do path do plano-base` with identifier hierarchy and path conversion rules, and item 3 is the `Fluxo operacional` (moved the flow content). 
- Adjusted the internal reference in item 4 from “path definido no item 3” to “path definido no item 2” and performed the change as a localized patch to the requested file only. 

### Testing
- Ran an automated Python validation that checked `docs/prompt-estrategista.md` contains `Versão: v16`, the new item 2 title, the new item 3 title, and the updated item 4 reference, which all passed. 
- Inspected the `git diff` (`git diff -U0 -- docs/prompt-estrategista.md`) to verify the changes are confined to the requested sections, which matched expectations. 
- Committed the change on branch `work` with message `docs: define plan-base path hierarchy` and the commit was created successfully. 
- Attempted `git push` but it failed due to no configured remote, so the change is committed locally but not pushed to a remote repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a605109588329b535ad77fb476f62)