### PR TITLE
docs: reorganizar seção E9 do roadmap

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -300,7 +300,9 @@
 
 9. E9 — Billing, trial e entitlements
 
-9.1 Status
+9.1 Visão geral, objetivo e status
+
+9.1.1 Status geral
 • Em execução faseada — Fases 5, 7.2 e E9.7 concluídas.
 • Schema mínimo de entitlement comercial versionado.
 • Consumo server-side mínimo da elegibilidade comercial disponível.
@@ -310,28 +312,85 @@
 • Liberação manual administrativa mínima implementada via Admin.
 • Sem Billing Engine completo implementado nesta fase.
 
-9.2 Objetivo atual
+9.1.2 Objetivo
 • Separar condição comercial da conta do lifecycle operacional da conta.
 • Definir elegibilidade comercial para criação de LPs como sinal derivado de conta operacionalmente permitida, membership ativo e entitlement comercial válido.
 • Garantir que a criação produtiva mínima de LP consuma o entitlement comercial antes da persistência.
 • Permitir concessão, atualização e cancelamento manual mínimo de entitlement por `platform_admin`.
 • Manter Stripe, checkout e webhook como mecanismos de confirmação/persistência, não como prova direta de liberação no LP Builder.
 
-9.3 Decisões consolidadas
+9.1.3 Escopo atual
+• Base universal de entitlement comercial.
+• Stripe Checkout mínimo em teste.
+• Webhook Stripe mínimo para confirmação/persistência local.
+• Liberação manual administrativa mínima como origem comercial independente de provedor.
+• Gate produtivo mínimo do LP Builder consumindo signal server-side.
 
-9.3.1 Trial/plano como entitlement
-• Status: Concluído (definição)
-• Trial, plano e assinatura controlam permissões e limites de uso.
-• Trial, plano e assinatura não definem `accounts.status`.
+9.1.4 Pendências vigentes
+• N/A para o recorte consolidado atual do E9.
+
+9.1.5 Fora do escopo
+• Billing Engine completo.
+• Admin comercial completo.
+• Trial operacional.
+• Automação de liberação manual.
+• Alteração de schema, migration, RPC, policy, grant ou trigger para E9.7.
+• Alteração no LP Builder apenas para teste.
+• Rota, UI ou chamada artificial para disparar Server Action.
+• Processamento de cancelamento e falha de pagamento fora do registro controlado/ignorado.
+• Job, rotina, monitoramento ou automação.
+
+9.1.6 Observações
+• Este E9 registra o contrato macro consolidado de billing, trial e entitlements sem substituir `docs/base-tecnica.md` para runtime nem `docs/schema.md` para contrato de banco.
+• Provedores de checkout e webhooks são mecanismos de confirmação/persistência; a liberação produtiva é decidida pelo entitlement local efetivo.
+
+9.2 Base universal de entitlement comercial
+
+9.2.1 Objetivo, status e contrato
+• Status: Fases 1, 4, 5 e E9.7 concluídas.
+• Trial, plano, assinatura e liberação manual controlam permissões e limites de uso quando materializados como entitlement comercial válido.
+• Trial, plano, assinatura e liberação manual não definem `accounts.status`.
 • Expiração de trial/plano deve afetar permissões comerciais, não o lifecycle da conta.
+• Entitlement comercial é domínio próprio e não extensão de `lib/access`, `public.plans` ou `lib/access/plan.ts`.
 
-9.3.2 Lifecycle da conta separado de billing
+9.2.2 Separação entre lifecycle operacional e condição comercial
 • Status: Concluído (definição)
 • `accounts.status` representa lifecycle operacional da conta/setup.
 • `account_users.status` representa vínculo operacional do usuário com a conta.
 • Billing, trial, plano, assinatura e entitlement comercial representam condição comercial separada.
 
-9.3.3 Elegibilidade comercial para criação de LPs
+9.2.3 Origem comercial e confirmação
+• Status: Fase 1 concluída em 28/06/2026.
+• Origem inicial válida: plano pago confirmado.
+• Origens futuras possíveis: trial.
+• Origem operacional implementada para liberação administrativa mínima: `liberacao_manual`.
+• Provedor de checkout e webhook são mecanismos de confirmação/persistência, não origem comercial.
+• Entitlement comercial válido nasce de origem comercial válida e persistência local idempotente quando aplicável.
+
+9.2.4 Planos comerciais canônicos
+• Status: Fase 1 concluída em 28/06/2026.
+• Cards comerciais canônicos: Starter, Lite, Pro e Ultra.
+• Chaves esperadas: `starter`, `lite`, `pro` e `ultra`.
+• O legado `PlanId = "free" | "light" | "pro" | "ultra"` deve ser revisado ou aposentado antes do checkout.
+
+9.2.5 Modelo mínimo de entitlement comercial
+• Status: Fase 4 concluída em 28/06/2026.
+• Fonte de verdade: `public.account_commercial_entitlements`.
+• Contrato mínimo criado: `CommercialEntitlementSignal`.
+• Fallback fail-closed: `accountId` vazio, erro, exceção ou ausência de linha retornam não elegível.
+• Account Dashboard carrega o sinal server-side, mas ainda não aplica bloqueio produtivo.
+• Checkout, webhook, provedor, admin, trial operacional, liberação manual operacional, LP Builder e Billing Engine completo permanecem fora do recorte da Fase 4.
+
+9.2.6 View efetiva
+• Leitura efetiva: `public.v_account_commercial_entitlement_effective`.
+• View efetiva validada com elegibilidade comercial positiva no recorte E9.7.
+
+9.2.7 Signal server-side
+• Boundary server-side criado: `lib/commercial-entitlements/`.
+• Adapter criado: `getCommercialEntitlementSignal({ accountId })`.
+• Signal validado por contrato view → adapter.
+
+9.2.8 Gate do LP Builder
 • Status: Fases 1 e 5 concluídas.
 • Regra mínima: usuário autenticado + conta `active` + membership `active` + papel `owner`/`admin` + entitlement comercial válido.
 • Para gate de criação de LP, conta operacionalmente permitida significa `accounts.status = active`.
@@ -343,63 +402,7 @@
 • O LP Builder não consulta Stripe diretamente, não usa redirect de checkout como liberação e não usa apenas `accounts.status` como prova comercial.
 • A validação operacional direta da action é N/A neste recorte, pois não há superfície aprovada para disparo sem criar rota ou UI artificial.
 
-9.3.4 Origem comercial e confirmação
-• Status: Fase 1 concluída em 28/06/2026.
-• Origem inicial válida: plano pago confirmado.
-• Origens futuras possíveis: trial e liberação manual.
-• Provedor de checkout e webhook são mecanismos de confirmação/persistência, não origem comercial.
-• Entitlement comercial válido, no recorte inicial, nasce de plano pago confirmado e idempotentemente persistido em fase futura.
-
-9.3.5 Planos comerciais canônicos
-• Status: Fase 1 concluída em 28/06/2026.
-• Cards comerciais canônicos: Starter, Lite, Pro e Ultra.
-• Chaves esperadas: `starter`, `lite`, `pro` e `ultra`.
-• O legado `PlanId = "free" | "light" | "pro" | "ultra"` deve ser revisado ou aposentado antes do checkout.
-
-9.3.6 Modelo mínimo de entitlement comercial
-• Status: Fase 4 concluída em 28/06/2026.
-• Entitlement comercial é domínio próprio e não extensão de `lib/access`, `public.plans` ou `lib/access/plan.ts`.
-• Fonte de verdade: `public.account_commercial_entitlements`.
-• Leitura efetiva: `public.v_account_commercial_entitlement_effective`.
-• Boundary server-side criado: `lib/commercial-entitlements/`.
-• Contrato mínimo criado: `CommercialEntitlementSignal`.
-• Adapter criado: `getCommercialEntitlementSignal({ accountId })`.
-• Fallback fail-closed: `accountId` vazio, erro, exceção ou ausência de linha retornam não elegível.
-• Account Dashboard carrega o sinal server-side, mas ainda não aplica bloqueio produtivo.
-• Checkout, webhook, provedor, admin, trial operacional, liberação manual operacional, LP Builder e Billing Engine completo permanecem fora do recorte.
-
-9.3.7 Provedor de checkout mínimo
-• Status: Fase 6 concluída em 30/06/2026.
-• Provedor inicial: Stripe.
-• Ambiente inicial: teste.
-• Modo de Checkout: `subscription`.
-• Boundary criado: `lib/billing-checkout/`.
-• App cria Checkout Session server-side.
-• Stripe não substitui o entitlement local.
-• Redirect de sucesso não confirma pagamento nem libera entitlement.
-• `free` não vira plano pago.
-• `light` não entra no contrato novo.
-• `PlanId` legado não é contrato de negócio.
-• Webhook, assinatura do webhook, idempotência e persistência em `account_commercial_entitlements` ficam para a Fase 7.
-
-9.3.8 Webhook Stripe mínimo
-• Status: Fase 7.2 concluída em 02/07/2026.
-• Endpoint produtivo: `POST /api/stripe/webhook`.
-• Evento que ativa/renova entitlement: `invoice.paid`.
-• `checkout.session.completed` é evento auxiliar/ignorado e não libera entitlement.
-• `customer.subscription.deleted` e `invoice.payment_failed` ficam registrados como controlados/ignorados neste recorte.
-• Idempotência operacional: `stripe_webhook_events.event_id`.
-• Retry validado para evento `failed` e para `processing` antigo com `retry_reason = stale_processing`.
-• Persistência local validada em `public.account_commercial_entitlements`.
-• Redirect de sucesso continua sem liberar entitlement.
-• Payload bruto, secret, cartão e PII sensível não são persistidos.
-
-9.3.9 Updates avaliados
-• `supa#5`, `supa#36`, `supa#40`, `supa#58`.
-• Stripe webhook, Vercel Production, Stripe test mode e Supabase/Postgres aplicados na Fase 7.2.
-• E9.7: `supa#40` aplicado; `prod#19` aplicado; `supa#2` avaliado; `supa#56` avaliado.
-
-9.3.10 Liberação manual administrativa mínima
+9.2.9 Liberação manual administrativa mínima
 • Status: E9.7 concluída em 04/07/2026.
 • Ator autorizado: `platform_admin`, incluindo `super_admin` pelo guard existente `requirePlatformAdmin`.
 • Superfície administrativa: `app/admin/(protected)/contas/[accountId]/page.tsx`.
@@ -411,28 +414,132 @@
 • Concessão manual validada com `status = ativo`, plano canônico, vigência válida e `metadata_json` mínimo.
 • Conflito com entitlement efetivo de `plano_pago_confirmado` ou `trial` falha fechado.
 • Entitlement manual `ativo` existente é atualizado, sem duplicidade intencional.
-• View efetiva validada com elegibilidade comercial positiva.
-• Signal validado por contrato view → adapter.
 • Sem bypass por Stripe, checkout ou webhook nos paths avaliados.
 • Criação real de draft pelo LP Builder não foi executada porque não há superfície operacional navegável aprovada para disparar a Server Action sem implementar rota ou UI nova.
 • Decisão final: não criar Fase 4, rota, UI, chamada artificial, migration, schema, RPC, policy, grant, trigger ou alteração no LP Builder apenas para validar criação de draft.
 
-9.4 Pendências vigentes
-• N/A para o recorte consolidado atual do E9.
+9.2.10 Fail-closed, limites e ressalvas
+• Fallback fail-closed: `accountId` vazio, erro, exceção ou ausência de linha retornam não elegível.
+• Stripe não substitui o entitlement local.
+• Redirect de sucesso não confirma pagamento nem libera entitlement.
+• Sem entitlement comercial válido, a criação produtiva mínima de LP permanece bloqueada.
 
-9.5 Estruturas e artefatos
+9.3 Trial
 
-Banco — Criados
+9.3.1 Status, objetivo e contrato futuro
+• Status: previsto / não implementado operacionalmente no recorte consolidado atual.
+• Trial deve controlar permissões e limites de uso quando materializado como entitlement comercial válido.
+• Trial não define `accounts.status`.
+• Expiração de trial deve afetar permissões comerciais, não o lifecycle da conta.
+
+9.3.2 Trial como origem futura de entitlement
+• Trial permanece como origem futura possível de entitlement comercial.
+• Trial deve usar a cadeia universal de entitlement local efetivo antes de liberar criação produtiva.
+• Trial não deve ser confundido com liberação manual administrativa mínima.
+
+9.3.3 Vigência, expiração e limites a definir
+• Vigência, expiração e limites operacionais do trial ainda precisam ser definidos antes de implementação.
+• Expiração de trial/plano deve afetar permissões comerciais, não `accounts.status`.
+
+9.3.4 Pendências para implementação operacional
+• Definir contrato operacional do trial.
+• Definir origem, vigência, limites, expiração e auditoria do trial.
+• Implementar trial apenas por recorte futuro aprovado, sem inferir implementação a partir da liberação manual.
+
+9.4 Stripe
+
+9.4.1 Objetivo, status e contrato
+• Status: Checkout mínimo concluído na Fase 6; webhook mínimo concluído na Fase 7.2.
+• Provedor inicial: Stripe.
+• Ambiente inicial: teste.
+• Stripe é mecanismo de checkout/confirmação/persistência, não origem comercial autônoma no gate.
+
+9.4.2 Checkout mínimo
+• Status: Fase 6 concluída em 30/06/2026.
+• Modo de Checkout: `subscription`.
+• Boundary criado: `lib/billing-checkout/`.
+• App cria Checkout Session server-side.
+• `free` não vira plano pago.
+• `light` não entra no contrato novo.
+• `PlanId` legado não é contrato de negócio.
+
+9.4.3 Webhook mínimo
+• Status: Fase 7.2 concluída em 02/07/2026.
+• Endpoint produtivo: `POST /api/stripe/webhook`.
+• Persistência local validada em `public.account_commercial_entitlements`.
+• Payload bruto, secret, cartão e PII sensível não são persistidos.
+
+9.4.4 Eventos aceitos, auxiliares e ignorados
+• Evento que ativa/renova entitlement: `invoice.paid`.
+• `checkout.session.completed` é evento auxiliar/ignorado e não libera entitlement.
+• `customer.subscription.deleted` e `invoice.payment_failed` ficam registrados como controlados/ignorados neste recorte.
+
+9.4.5 Idempotência e persistência
+• Idempotência operacional: `stripe_webhook_events.event_id`.
+• Retry validado para evento `failed` e para `processing` antigo com `retry_reason = stale_processing`.
+• Webhook, assinatura do webhook, idempotência e persistência em `account_commercial_entitlements` foram tratados na Fase 7.
+
+9.4.6 Limites: Stripe não substitui entitlement local
+• Stripe não substitui o entitlement local.
+• Redirect de sucesso não confirma pagamento nem libera entitlement.
+• Sem bypass por Stripe, checkout ou webhook nos paths avaliados.
+
+9.5 Mercado Pago
+
+9.5.1 Status: previsto / não implementado
+• Mercado Pago está previsto apenas como hipótese futura de provedor.
+• Nenhuma implementação de Mercado Pago está consolidada no E9 atual.
+
+9.5.2 Critérios para abertura futura
+• Abrir somente por recorte futuro aprovado.
+• Manter provedor como mecanismo de confirmação/persistência, sem substituir entitlement local.
+
+9.5.3 Fora do escopo atual
+• Criar integração, rota, webhook, adapter, job, automação, schema, migration, policy, grant, trigger ou checkout Mercado Pago.
+
+9.6 Asaas
+
+9.6.1 Status: previsto / não implementado
+• Asaas está previsto apenas como hipótese futura de provedor.
+• Nenhuma implementação de Asaas está consolidada no E9 atual.
+
+9.6.2 Critérios para abertura futura
+• Abrir somente por recorte futuro aprovado.
+• Manter provedor como mecanismo de confirmação/persistência, sem substituir entitlement local.
+
+9.6.3 Fora do escopo atual
+• Criar integração, rota, webhook, adapter, job, automação, schema, migration, policy, grant, trigger ou checkout Asaas.
+
+9.7 Updates avaliados
+
+9.7.1 Supabase
+• `supa#5`, `supa#36`, `supa#40`, `supa#58`.
+• Supabase/Postgres aplicado na Fase 7.2.
+• E9.7: `supa#40` aplicado; `supa#2` avaliado; `supa#56` avaliado.
+
+9.7.2 Stripe / Produto
+• Stripe webhook, Stripe test mode e produto aplicados na Fase 7.2.
+• E9.7: `prod#19` aplicado.
+
+9.7.3 Vercel / GitHub
+• Vercel Production aplicado na Fase 7.2.
+
+9.7.4 Updates rejeitados ou apenas monitorados
+• Sem adoção de Stripe Sync Engine, Vercel Flags, Vercel Agent, AI Cloud, Private Blob, observabilidade nova ou GitHub/Copilot tooling no E9.7.
+
+9.8 Estruturas e artefatos
+
+9.8.1 Banco — criados
 • `public.account_commercial_entitlements`
 • `public.v_account_commercial_entitlement_effective`
 • `public.stripe_webhook_events`
 
-Banco — Reaproveitados
+9.8.2 Banco — reaproveitados
 • `public.account_commercial_entitlements`
 • `public.v_account_commercial_entitlement_effective`
 • `public.account_landing_pages`
 
-Repositório — Criados
+9.8.3 Repositório — criados
 • `supabase/migrations/20260628184945_e9_commercial_entitlements.sql`
 • `supabase/snippets/e9_phase_3_entitlements_verify.sql`
 • `supabase/migrations/20260701202632_e9_stripe_webhook_events.sql`
@@ -450,22 +557,11 @@ Repositório — Criados
 • `lib/admin/adapters/adminCommercialEntitlementsAdapter.ts`
 • `app/admin/(protected)/contas/[accountId]/actions.ts`
 
-Repositório — Ajustados
+9.8.4 Repositório — ajustados
 • `app/a/[account]/page.tsx`
 • `app/a/[account]/_components/commercial-page/GenericCommercialPage.tsx`
 • `lib/billing-checkout/index.ts`
 • `app/admin/(protected)/contas/[accountId]/page.tsx`
-
-9.6 Fora do escopo
-• Billing Engine completo.
-• Admin comercial completo.
-• Trial operacional.
-• Automação de liberação manual.
-• Alteração de schema, migration, RPC, policy, grant ou trigger para E9.7.
-• Alteração no LP Builder apenas para teste.
-• Rota, UI ou chamada artificial para disparar Server Action.
-• Processamento de cancelamento e falha de pagamento fora do registro controlado/ignorado.
-• Job, rotina, monitoramento ou automação.
 
 10. E10 — Account Dashboard (UX)
 
@@ -512,7 +608,7 @@ Repositório — Ajustados
 • Status: Concluído (exec) (13/02/2026)
 • Escopo final: entregar o fluxo ponta a ponta de “Primeiros passos” em `/a/[account]` quando `accounts.status=pending_setup`, com formulário inline, validação, persistência do perfil v1, promoção `pending_setup → active` e redirecionamento para o pós-setup.
 • Estado atual: onboarding v1 inline em `pending_setup`, com `name` obrigatório, `niche` obrigatório, `preferred_channel` opcional com default `email`, `whatsapp` obrigatório somente quando `preferred_channel=whatsapp` e `site_url` opcional com normalização para URL válida.
-• Dependências: E9.3.1.
+• Dependências: E9.2.1.
 • Nota: `setup_completed_at/account_setup_completed_at` não devem ser usados no runtime, no gating, no fluxo nem nos logs; ficam mantidos no DB apenas por segurança.
 
 10.4.1 Marcador legado de setup (deprecated)
@@ -587,7 +683,7 @@ Repositório — Ajustados
 • Escopo atual: separar o estado `active` do fluxo `pending_setup` e preparar a camada pós-setup do dashboard da conta.
 • Estado atual do runtime: `app/a/[account]/page.tsx` renderiza “Primeiros passos” somente para `accounts.status=pending_setup`; para conta autenticada fora desse estado, a rota ainda não entrega UX específica do E10.5.
 • Base já implementada no repo: estrutura de taxonomia/templates/guides no BD e pipeline operacional de resolução de nicho no pós-save do onboarding.
-• Dependências: E9.3.1, E10.4.6, E10.5.1, E10.5.2, E10.5.6.
+• Dependências: E9.2.1, E10.4.6, E10.5.1, E10.5.2, E10.5.6.
 • Nota: `setup_completed_at/account_setup_completed_at` não devem ser usados no runtime, no gating, no fluxo nem nos logs; ficam mantidos no DB apenas por segurança.
 
 10.5.1 Matriz “preparação vs produtivo” + enforcement (SSR + actions)
@@ -597,7 +693,7 @@ Repositório — Ajustados
 • fechar status/entitlements mínimos por rota/ação
 • declarar o sinal canônico de entitlement/limite efetivo
 • definir mensagens e CTAs de bloqueio coerentes com o E10.5
-• Dependências: E9.3.1, E10.5.
+• Dependências: E9.2.1, E10.5.
 • Fora de escopo: implementação da UX principal do E10.5 nesta etapa.
 
 10.5.2 Base do BD do E10.5

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -306,10 +306,8 @@
 9.1 Base universal de entitlement comercial
 
 9.1.1 Objetivo e status
+• Objetivo: definir a base universal de entitlement comercial.
 • Status: Fases 1, 4 e 5 concluídas.
-• Trial, plano, assinatura e liberação manual controlam permissões e limites de uso quando materializados como entitlement comercial válido.
-• Trial, plano, assinatura e liberação manual não definem `accounts.status`.
-• Entitlement comercial é domínio próprio e não extensão de `lib/access`, `public.plans` ou `lib/access/plan.ts`.
 
 9.1.2 Registros do recorte
 - Banco:
@@ -324,9 +322,12 @@
 
 9.1.3 Separação entre lifecycle operacional e condição comercial
 • Status: Concluído (definição)
+• Trial, plano, assinatura e liberação manual controlam permissões e limites de uso quando materializados como entitlement comercial válido.
+• Trial, plano, assinatura e liberação manual não definem `accounts.status`.
 • `accounts.status` representa lifecycle operacional da conta/setup.
 • `account_users.status` representa vínculo operacional do usuário com a conta.
 • Billing, trial, plano, assinatura e entitlement comercial representam condição comercial separada.
+• Entitlement comercial é domínio próprio e não extensão de `lib/access`, `public.plans` ou `lib/access/plan.ts`.
 
 9.1.4 Origem comercial e confirmação
 • Status: Fase 1 concluída em 28/06/2026.
@@ -377,9 +378,8 @@
 9.2 Liberação manual administrativa mínima
 
 9.2.1 Objetivo e status
-• Status: E9.7 concluída em 04/07/2026.
 • Objetivo: permitir concessão, atualização e cancelamento manual mínimo de entitlement por `platform_admin`.
-• Liberação manual administrativa mínima é origem comercial independente de provedor de pagamento e de trial operacional.
+• Status: E9.7 concluída em 04/07/2026.
 
 9.2.2 Registros do recorte
 - Banco:
@@ -393,6 +393,7 @@
   - Aplicados:
 
 9.2.3 Contrato operacional mínimo
+• Liberação manual administrativa mínima é origem comercial independente de provedor de pagamento e de trial operacional.
 • Ator autorizado: `platform_admin`, incluindo `super_admin` pelo guard existente `requirePlatformAdmin`.
 • Superfície administrativa: `app/admin/(protected)/contas/[accountId]/page.tsx`.
 • Path canônico de mutação: `app/admin/(protected)/contas/[accountId]/actions.ts`.
@@ -408,9 +409,8 @@
 9.3 Trial
 
 9.3.1 Objetivo e status
+• Objetivo: definir trial como origem futura de entitlement comercial.
 • Status: previsto / não implementado operacionalmente no recorte consolidado atual.
-• Trial deve controlar permissões e limites de uso quando materializado como entitlement comercial válido.
-• Trial não define `accounts.status`.
 
 9.3.2 Registros do recorte
 - Banco:
@@ -424,6 +424,8 @@
   - Aplicados:
 
 9.3.3 Trial como origem futura de entitlement
+• Trial deve controlar permissões e limites de uso quando materializado como entitlement comercial válido.
+• Trial não define `accounts.status`.
 • Trial permanece como origem futura possível de entitlement comercial.
 • Trial deve usar a cadeia universal de entitlement local efetivo antes de liberar criação produtiva.
 • Trial não deve ser confundido com liberação manual administrativa mínima.
@@ -439,10 +441,8 @@
 9.4 Stripe
 
 9.4.1 Objetivo e status
+• Objetivo: documentar o recorte mínimo de Stripe Checkout e webhook.
 • Status: Checkout mínimo concluído na Fase 6; webhook mínimo concluído na Fase 7.2.
-• Provedor inicial: Stripe.
-• Ambiente inicial: teste.
-• Stripe é mecanismo de checkout/confirmação/persistência, não origem comercial autônoma no gate.
 
 9.4.2 Registros do recorte
 - Banco:
@@ -457,6 +457,9 @@
 
 9.4.3 Checkout mínimo
 • Status: Fase 6 concluída em 30/06/2026.
+• Provedor inicial: Stripe.
+• Ambiente inicial: teste.
+• Stripe é mecanismo de checkout/confirmação/persistência, não origem comercial autônoma no gate.
 • Modo de Checkout: `subscription`.
 • Boundary criado: `lib/billing-checkout/`.
 • App cria Checkout Session server-side.
@@ -488,8 +491,8 @@
 9.5 Mercado Pago
 
 9.5.1 Objetivo e status
+• Objetivo: registrar Mercado Pago como provedor futuro possível.
 • Status: previsto / não implementado.
-• Mercado Pago está previsto apenas como hipótese futura; nenhuma implementação está consolidada no E9 atual.
 
 9.5.2 Registros do recorte
 - Banco:
@@ -503,6 +506,7 @@
   - Aplicados:
 
 9.5.3 Critérios para abertura futura
+• Mercado Pago está previsto apenas como hipótese futura; nenhuma implementação está consolidada no E9 atual.
 • Abrir somente por recorte futuro aprovado, seguindo o contrato universal do 9.1.
 
 9.5.4 Fora do escopo atual
@@ -511,8 +515,8 @@
 9.6 Asaas
 
 9.6.1 Objetivo e status
+• Objetivo: registrar Asaas como provedor futuro possível.
 • Status: previsto / não implementado.
-• Asaas está previsto apenas como hipótese futura; nenhuma implementação está consolidada no E9 atual.
 
 9.6.2 Registros do recorte
 - Banco:
@@ -526,6 +530,7 @@
   - Aplicados:
 
 9.6.3 Critérios para abertura futura
+• Asaas está previsto apenas como hipótese futura; nenhuma implementação está consolidada no E9 atual.
 • Abrir somente por recorte futuro aprovado, seguindo o contrato universal do 9.1.
 
 9.6.4 Fora do escopo atual

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -334,11 +334,7 @@
 • Admin comercial completo.
 • Trial operacional.
 • Automação de liberação manual.
-• Alteração de schema, migration, RPC, policy, grant ou trigger para E9.7.
-• Alteração no LP Builder apenas para teste.
-• Rota, UI ou chamada artificial para disparar Server Action.
-• Processamento de cancelamento e falha de pagamento fora do registro controlado/ignorado.
-• Job, rotina, monitoramento ou automação.
+• Novos providers, rotas, schema/migrations, jobs, automações, alterações no LP Builder e processamento completo de cancelamento/falha de pagamento.
 
 9.1.6 Observações
 • Este E9 registra o contrato macro consolidado de billing, trial e entitlements sem substituir `docs/base-tecnica.md` para runtime nem `docs/schema.md` para contrato de banco.
@@ -350,7 +346,6 @@
 • Status: Fases 1, 4, 5 e E9.7 concluídas.
 • Trial, plano, assinatura e liberação manual controlam permissões e limites de uso quando materializados como entitlement comercial válido.
 • Trial, plano, assinatura e liberação manual não definem `accounts.status`.
-• Expiração de trial/plano deve afetar permissões comerciais, não o lifecycle da conta.
 • Entitlement comercial é domínio próprio e não extensão de `lib/access`, `public.plans` ou `lib/access/plan.ts`.
 
 9.2.2 Separação entre lifecycle operacional e condição comercial
@@ -377,7 +372,6 @@
 • Status: Fase 4 concluída em 28/06/2026.
 • Fonte de verdade: `public.account_commercial_entitlements`.
 • Contrato mínimo criado: `CommercialEntitlementSignal`.
-• Fallback fail-closed: `accountId` vazio, erro, exceção ou ausência de linha retornam não elegível.
 • Account Dashboard carrega o sinal server-side, mas ainda não aplica bloqueio produtivo.
 • Checkout, webhook, provedor, admin, trial operacional, liberação manual operacional, LP Builder e Billing Engine completo permanecem fora do recorte da Fase 4.
 
@@ -414,14 +408,10 @@
 • Concessão manual validada com `status = ativo`, plano canônico, vigência válida e `metadata_json` mínimo.
 • Conflito com entitlement efetivo de `plano_pago_confirmado` ou `trial` falha fechado.
 • Entitlement manual `ativo` existente é atualizado, sem duplicidade intencional.
-• Sem bypass por Stripe, checkout ou webhook nos paths avaliados.
 • Criação real de draft pelo LP Builder não foi executada porque não há superfície operacional navegável aprovada para disparar a Server Action sem implementar rota ou UI nova.
-• Decisão final: não criar Fase 4, rota, UI, chamada artificial, migration, schema, RPC, policy, grant, trigger ou alteração no LP Builder apenas para validar criação de draft.
 
 9.2.10 Fail-closed, limites e ressalvas
 • Fallback fail-closed: `accountId` vazio, erro, exceção ou ausência de linha retornam não elegível.
-• Stripe não substitui o entitlement local.
-• Redirect de sucesso não confirma pagamento nem libera entitlement.
 • Sem entitlement comercial válido, a criação produtiva mínima de LP permanece bloqueada.
 
 9.3 Trial
@@ -430,7 +420,6 @@
 • Status: previsto / não implementado operacionalmente no recorte consolidado atual.
 • Trial deve controlar permissões e limites de uso quando materializado como entitlement comercial válido.
 • Trial não define `accounts.status`.
-• Expiração de trial deve afetar permissões comerciais, não o lifecycle da conta.
 
 9.3.2 Trial como origem futura de entitlement
 • Trial permanece como origem futura possível de entitlement comercial.
@@ -438,8 +427,7 @@
 • Trial não deve ser confundido com liberação manual administrativa mínima.
 
 9.3.3 Vigência, expiração e limites a definir
-• Vigência, expiração e limites operacionais do trial ainda precisam ser definidos antes de implementação.
-• Expiração de trial/plano deve afetar permissões comerciais, não `accounts.status`.
+• Vigência, expiração, limites e efeitos comerciais do trial ainda precisam ser definidos antes de implementação.
 
 9.3.4 Pendências para implementação operacional
 • Definir contrato operacional do trial.
@@ -482,33 +470,29 @@
 9.4.6 Limites: Stripe não substitui entitlement local
 • Stripe não substitui o entitlement local.
 • Redirect de sucesso não confirma pagamento nem libera entitlement.
-• Sem bypass por Stripe, checkout ou webhook nos paths avaliados.
+• Redirect, checkout e webhook não liberam o LP Builder sem entitlement local efetivo.
 
 9.5 Mercado Pago
 
 9.5.1 Status: previsto / não implementado
-• Mercado Pago está previsto apenas como hipótese futura de provedor.
-• Nenhuma implementação de Mercado Pago está consolidada no E9 atual.
+• Mercado Pago está previsto apenas como hipótese futura; nenhuma implementação está consolidada no E9 atual.
 
 9.5.2 Critérios para abertura futura
-• Abrir somente por recorte futuro aprovado.
-• Manter provedor como mecanismo de confirmação/persistência, sem substituir entitlement local.
+• Abrir somente por recorte futuro aprovado, seguindo o contrato universal do 9.2.
 
 9.5.3 Fora do escopo atual
-• Criar integração, rota, webhook, adapter, job, automação, schema, migration, policy, grant, trigger ou checkout Mercado Pago.
+• Permanece fora do escopo atual.
 
 9.6 Asaas
 
 9.6.1 Status: previsto / não implementado
-• Asaas está previsto apenas como hipótese futura de provedor.
-• Nenhuma implementação de Asaas está consolidada no E9 atual.
+• Asaas está previsto apenas como hipótese futura; nenhuma implementação está consolidada no E9 atual.
 
 9.6.2 Critérios para abertura futura
-• Abrir somente por recorte futuro aprovado.
-• Manter provedor como mecanismo de confirmação/persistência, sem substituir entitlement local.
+• Abrir somente por recorte futuro aprovado, seguindo o contrato universal do 9.2.
 
 9.6.3 Fora do escopo atual
-• Criar integração, rota, webhook, adapter, job, automação, schema, migration, policy, grant, trigger ou checkout Asaas.
+• Permanece fora do escopo atual.
 
 9.7 Updates avaliados
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -300,61 +300,35 @@
 
 9. E9 — Billing, trial e entitlements
 
-9.1 Visão geral, objetivo e status
+- Objetivo: Separar condição comercial da conta do lifecycle operacional da conta; definir elegibilidade comercial para criação de LPs por entitlement local efetivo; manter provedores de pagamento como mecanismos de confirmação/persistência, não como prova direta de liberação no LP Builder.
+- Status: Em execução faseada — base universal, Stripe mínimo, webhook mínimo, gate produtivo mínimo e liberação manual administrativa mínima concluídos; trial, Mercado Pago, Asaas e Billing Engine completo permanecem previstos/não implementados.
 
-9.1.1 Status geral
-• Em execução faseada — Fases 5, 7.2 e E9.7 concluídas.
-• Schema mínimo de entitlement comercial versionado.
-• Consumo server-side mínimo da elegibilidade comercial disponível.
-• Gate produtivo mínimo validado no ponto real entregue pela E19.
-• Stripe Checkout em teste disponível no app.
-• Webhook Stripe mínimo em produção validado para `invoice.paid`.
-• Liberação manual administrativa mínima implementada via Admin.
-• Sem Billing Engine completo implementado nesta fase.
+9.1 Base universal de entitlement comercial
 
-9.1.2 Objetivo
-• Separar condição comercial da conta do lifecycle operacional da conta.
-• Definir elegibilidade comercial para criação de LPs como sinal derivado de conta operacionalmente permitida, membership ativo e entitlement comercial válido.
-• Garantir que a criação produtiva mínima de LP consuma o entitlement comercial antes da persistência.
-• Permitir concessão, atualização e cancelamento manual mínimo de entitlement por `platform_admin`.
-• Manter Stripe, checkout e webhook como mecanismos de confirmação/persistência, não como prova direta de liberação no LP Builder.
-
-9.1.3 Escopo atual
-• Base universal de entitlement comercial.
-• Stripe Checkout mínimo em teste.
-• Webhook Stripe mínimo para confirmação/persistência local.
-• Liberação manual administrativa mínima como origem comercial independente de provedor.
-• Gate produtivo mínimo do LP Builder consumindo signal server-side.
-
-9.1.4 Pendências vigentes
-• N/A para o recorte consolidado atual do E9.
-
-9.1.5 Fora do escopo
-• Billing Engine completo.
-• Admin comercial completo.
-• Trial operacional.
-• Automação de liberação manual.
-• Novos providers, rotas, schema/migrations, jobs, automações, alterações no LP Builder e processamento completo de cancelamento/falha de pagamento.
-
-9.1.6 Observações
-• Este E9 registra o contrato macro consolidado de billing, trial e entitlements sem substituir `docs/base-tecnica.md` para runtime nem `docs/schema.md` para contrato de banco.
-• Provedores de checkout e webhooks são mecanismos de confirmação/persistência; a liberação produtiva é decidida pelo entitlement local efetivo.
-
-9.2 Base universal de entitlement comercial
-
-9.2.1 Objetivo, status e contrato
-• Status: Fases 1, 4, 5 e E9.7 concluídas.
+9.1.1 Objetivo e status
+• Status: Fases 1, 4 e 5 concluídas.
 • Trial, plano, assinatura e liberação manual controlam permissões e limites de uso quando materializados como entitlement comercial válido.
 • Trial, plano, assinatura e liberação manual não definem `accounts.status`.
 • Entitlement comercial é domínio próprio e não extensão de `lib/access`, `public.plans` ou `lib/access/plan.ts`.
 
-9.2.2 Separação entre lifecycle operacional e condição comercial
+9.1.2 Registros do recorte
+- Banco:
+  - Criados:
+  - Ajustados:
+- Repositório:
+  - Criados:
+  - Ajustados:
+  - Excluídos:
+- Updates:
+  - Aplicados:
+
+9.1.3 Separação entre lifecycle operacional e condição comercial
 • Status: Concluído (definição)
 • `accounts.status` representa lifecycle operacional da conta/setup.
 • `account_users.status` representa vínculo operacional do usuário com a conta.
 • Billing, trial, plano, assinatura e entitlement comercial representam condição comercial separada.
 
-9.2.3 Origem comercial e confirmação
+9.1.4 Origem comercial e confirmação
 • Status: Fase 1 concluída em 28/06/2026.
 • Origem inicial válida: plano pago confirmado.
 • Origens futuras possíveis: trial.
@@ -362,29 +336,29 @@
 • Provedor de checkout e webhook são mecanismos de confirmação/persistência, não origem comercial.
 • Entitlement comercial válido nasce de origem comercial válida e persistência local idempotente quando aplicável.
 
-9.2.4 Planos comerciais canônicos
+9.1.5 Planos comerciais canônicos
 • Status: Fase 1 concluída em 28/06/2026.
 • Cards comerciais canônicos: Starter, Lite, Pro e Ultra.
 • Chaves esperadas: `starter`, `lite`, `pro` e `ultra`.
 • O legado `PlanId = "free" | "light" | "pro" | "ultra"` deve ser revisado ou aposentado antes do checkout.
 
-9.2.5 Modelo mínimo de entitlement comercial
+9.1.6 Modelo mínimo de entitlement comercial
 • Status: Fase 4 concluída em 28/06/2026.
 • Fonte de verdade: `public.account_commercial_entitlements`.
 • Contrato mínimo criado: `CommercialEntitlementSignal`.
 • Account Dashboard carrega o sinal server-side, mas ainda não aplica bloqueio produtivo.
 • Checkout, webhook, provedor, admin, trial operacional, liberação manual operacional, LP Builder e Billing Engine completo permanecem fora do recorte da Fase 4.
 
-9.2.6 View efetiva
+9.1.7 View efetiva
 • Leitura efetiva: `public.v_account_commercial_entitlement_effective`.
 • View efetiva validada com elegibilidade comercial positiva no recorte E9.7.
 
-9.2.7 Signal server-side
+9.1.8 Signal server-side
 • Boundary server-side criado: `lib/commercial-entitlements/`.
 • Adapter criado: `getCommercialEntitlementSignal({ accountId })`.
 • Signal validado por contrato view → adapter.
 
-9.2.8 Gate do LP Builder
+9.1.9 Gate do LP Builder
 • Status: Fases 1 e 5 concluídas.
 • Regra mínima: usuário autenticado + conta `active` + membership `active` + papel `owner`/`admin` + entitlement comercial válido.
 • Para gate de criação de LP, conta operacionalmente permitida significa `accounts.status = active`.
@@ -396,8 +370,29 @@
 • O LP Builder não consulta Stripe diretamente, não usa redirect de checkout como liberação e não usa apenas `accounts.status` como prova comercial.
 • A validação operacional direta da action é N/A neste recorte, pois não há superfície aprovada para disparo sem criar rota ou UI artificial.
 
-9.2.9 Liberação manual administrativa mínima
+9.1.10 Fail-closed, limites e ressalvas
+• Fallback fail-closed: `accountId` vazio, erro, exceção ou ausência de linha retornam não elegível.
+• Sem entitlement comercial válido, a criação produtiva mínima de LP permanece bloqueada.
+
+9.2 Liberação manual administrativa mínima
+
+9.2.1 Objetivo e status
 • Status: E9.7 concluída em 04/07/2026.
+• Objetivo: permitir concessão, atualização e cancelamento manual mínimo de entitlement por `platform_admin`.
+• Liberação manual administrativa mínima é origem comercial independente de provedor de pagamento e de trial operacional.
+
+9.2.2 Registros do recorte
+- Banco:
+  - Criados:
+  - Ajustados:
+- Repositório:
+  - Criados:
+  - Ajustados:
+  - Excluídos:
+- Updates:
+  - Aplicados:
+
+9.2.3 Contrato operacional mínimo
 • Ator autorizado: `platform_admin`, incluindo `super_admin` pelo guard existente `requirePlatformAdmin`.
 • Superfície administrativa: `app/admin/(protected)/contas/[accountId]/page.tsx`.
 • Path canônico de mutação: `app/admin/(protected)/contas/[accountId]/actions.ts`.
@@ -410,39 +405,57 @@
 • Entitlement manual `ativo` existente é atualizado, sem duplicidade intencional.
 • Criação real de draft pelo LP Builder não foi executada porque não há superfície operacional navegável aprovada para disparar a Server Action sem implementar rota ou UI nova.
 
-9.2.10 Fail-closed, limites e ressalvas
-• Fallback fail-closed: `accountId` vazio, erro, exceção ou ausência de linha retornam não elegível.
-• Sem entitlement comercial válido, a criação produtiva mínima de LP permanece bloqueada.
-
 9.3 Trial
 
-9.3.1 Status, objetivo e contrato futuro
+9.3.1 Objetivo e status
 • Status: previsto / não implementado operacionalmente no recorte consolidado atual.
 • Trial deve controlar permissões e limites de uso quando materializado como entitlement comercial válido.
 • Trial não define `accounts.status`.
 
-9.3.2 Trial como origem futura de entitlement
+9.3.2 Registros do recorte
+- Banco:
+  - Criados:
+  - Ajustados:
+- Repositório:
+  - Criados:
+  - Ajustados:
+  - Excluídos:
+- Updates:
+  - Aplicados:
+
+9.3.3 Trial como origem futura de entitlement
 • Trial permanece como origem futura possível de entitlement comercial.
 • Trial deve usar a cadeia universal de entitlement local efetivo antes de liberar criação produtiva.
 • Trial não deve ser confundido com liberação manual administrativa mínima.
 
-9.3.3 Vigência, expiração e limites a definir
+9.3.4 Vigência, expiração e limites a definir
 • Vigência, expiração, limites e efeitos comerciais do trial ainda precisam ser definidos antes de implementação.
 
-9.3.4 Pendências para implementação operacional
+9.3.5 Pendências para implementação operacional
 • Definir contrato operacional do trial.
 • Definir origem, vigência, limites, expiração e auditoria do trial.
 • Implementar trial apenas por recorte futuro aprovado, sem inferir implementação a partir da liberação manual.
 
 9.4 Stripe
 
-9.4.1 Objetivo, status e contrato
+9.4.1 Objetivo e status
 • Status: Checkout mínimo concluído na Fase 6; webhook mínimo concluído na Fase 7.2.
 • Provedor inicial: Stripe.
 • Ambiente inicial: teste.
 • Stripe é mecanismo de checkout/confirmação/persistência, não origem comercial autônoma no gate.
 
-9.4.2 Checkout mínimo
+9.4.2 Registros do recorte
+- Banco:
+  - Criados:
+  - Ajustados:
+- Repositório:
+  - Criados:
+  - Ajustados:
+  - Excluídos:
+- Updates:
+  - Aplicados:
+
+9.4.3 Checkout mínimo
 • Status: Fase 6 concluída em 30/06/2026.
 • Modo de Checkout: `subscription`.
 • Boundary criado: `lib/billing-checkout/`.
@@ -451,47 +464,71 @@
 • `light` não entra no contrato novo.
 • `PlanId` legado não é contrato de negócio.
 
-9.4.3 Webhook mínimo
+9.4.4 Webhook mínimo
 • Status: Fase 7.2 concluída em 02/07/2026.
 • Endpoint produtivo: `POST /api/stripe/webhook`.
 • Persistência local validada em `public.account_commercial_entitlements`.
 • Payload bruto, secret, cartão e PII sensível não são persistidos.
 
-9.4.4 Eventos aceitos, auxiliares e ignorados
+9.4.5 Eventos aceitos, auxiliares e ignorados
 • Evento que ativa/renova entitlement: `invoice.paid`.
 • `checkout.session.completed` é evento auxiliar/ignorado e não libera entitlement.
 • `customer.subscription.deleted` e `invoice.payment_failed` ficam registrados como controlados/ignorados neste recorte.
 
-9.4.5 Idempotência e persistência
+9.4.6 Idempotência e persistência
 • Idempotência operacional: `stripe_webhook_events.event_id`.
 • Retry validado para evento `failed` e para `processing` antigo com `retry_reason = stale_processing`.
 • Webhook, assinatura do webhook, idempotência e persistência em `account_commercial_entitlements` foram tratados na Fase 7.
 
-9.4.6 Limites: Stripe não substitui entitlement local
+9.4.7 Limites: Stripe não substitui entitlement local
 • Stripe não substitui o entitlement local.
 • Redirect de sucesso não confirma pagamento nem libera entitlement.
 • Redirect, checkout e webhook não liberam o LP Builder sem entitlement local efetivo.
 
 9.5 Mercado Pago
 
-9.5.1 Status: previsto / não implementado
+9.5.1 Objetivo e status
+• Status: previsto / não implementado.
 • Mercado Pago está previsto apenas como hipótese futura; nenhuma implementação está consolidada no E9 atual.
 
-9.5.2 Critérios para abertura futura
-• Abrir somente por recorte futuro aprovado, seguindo o contrato universal do 9.2.
+9.5.2 Registros do recorte
+- Banco:
+  - Criados:
+  - Ajustados:
+- Repositório:
+  - Criados:
+  - Ajustados:
+  - Excluídos:
+- Updates:
+  - Aplicados:
 
-9.5.3 Fora do escopo atual
+9.5.3 Critérios para abertura futura
+• Abrir somente por recorte futuro aprovado, seguindo o contrato universal do 9.1.
+
+9.5.4 Fora do escopo atual
 • Permanece fora do escopo atual.
 
 9.6 Asaas
 
-9.6.1 Status: previsto / não implementado
+9.6.1 Objetivo e status
+• Status: previsto / não implementado.
 • Asaas está previsto apenas como hipótese futura; nenhuma implementação está consolidada no E9 atual.
 
-9.6.2 Critérios para abertura futura
-• Abrir somente por recorte futuro aprovado, seguindo o contrato universal do 9.2.
+9.6.2 Registros do recorte
+- Banco:
+  - Criados:
+  - Ajustados:
+- Repositório:
+  - Criados:
+  - Ajustados:
+  - Excluídos:
+- Updates:
+  - Aplicados:
 
-9.6.3 Fora do escopo atual
+9.6.3 Critérios para abertura futura
+• Abrir somente por recorte futuro aprovado, seguindo o contrato universal do 9.1.
+
+9.6.4 Fora do escopo atual
 • Permanece fora do escopo atual.
 
 9.7 Updates avaliados
@@ -592,7 +629,7 @@
 • Status: Concluído (exec) (13/02/2026)
 • Escopo final: entregar o fluxo ponta a ponta de “Primeiros passos” em `/a/[account]` quando `accounts.status=pending_setup`, com formulário inline, validação, persistência do perfil v1, promoção `pending_setup → active` e redirecionamento para o pós-setup.
 • Estado atual: onboarding v1 inline em `pending_setup`, com `name` obrigatório, `niche` obrigatório, `preferred_channel` opcional com default `email`, `whatsapp` obrigatório somente quando `preferred_channel=whatsapp` e `site_url` opcional com normalização para URL válida.
-• Dependências: E9.2.1.
+• Dependências: E9.1.1.
 • Nota: `setup_completed_at/account_setup_completed_at` não devem ser usados no runtime, no gating, no fluxo nem nos logs; ficam mantidos no DB apenas por segurança.
 
 10.4.1 Marcador legado de setup (deprecated)
@@ -667,7 +704,7 @@
 • Escopo atual: separar o estado `active` do fluxo `pending_setup` e preparar a camada pós-setup do dashboard da conta.
 • Estado atual do runtime: `app/a/[account]/page.tsx` renderiza “Primeiros passos” somente para `accounts.status=pending_setup`; para conta autenticada fora desse estado, a rota ainda não entrega UX específica do E10.5.
 • Base já implementada no repo: estrutura de taxonomia/templates/guides no BD e pipeline operacional de resolução de nicho no pós-save do onboarding.
-• Dependências: E9.2.1, E10.4.6, E10.5.1, E10.5.2, E10.5.6.
+• Dependências: E9.1.1, E10.4.6, E10.5.1, E10.5.2, E10.5.6.
 • Nota: `setup_completed_at/account_setup_completed_at` não devem ser usados no runtime, no gating, no fluxo nem nos logs; ficam mantidos no DB apenas por segurança.
 
 10.5.1 Matriz “preparação vs produtivo” + enforcement (SSR + actions)
@@ -677,7 +714,7 @@
 • fechar status/entitlements mínimos por rota/ação
 • declarar o sinal canônico de entitlement/limite efetivo
 • definir mensagens e CTAs de bloqueio coerentes com o E10.5
-• Dependências: E9.2.1, E10.5.
+• Dependências: E9.1.1, E10.5.
 • Fora de escopo: implementação da UX principal do E10.5 nesta etapa.
 
 10.5.2 Base do BD do E10.5


### PR DESCRIPTION
### Motivation
- Reestruturar a seção 9 (E9) de `docs/roadmap.md` em um modelo macro reutilizável que separe visão geral, base universal, trial, Stripe, provedores futuros, updates e artefatos. 
- Manter todo o conteúdo factual já consolidado sem alterar contrato técnico, runtime, schema, migrations, versões ou changelog. 
- Garantir que a `Liberação manual administrativa mínima` fique classificada como origem comercial na base universal (não como trial). 
- Atualizar referências internas que pontuem para a numeração antiga quando necessário para preservar links vivos do roadmap.

### Description
- Reescrevi e renumerei a seção E9 em `docs/roadmap.md`, adicionando `9.1 Visão geral, objetivo e status`, `9.2 Base universal de entitlement comercial`, `9.3 Trial`, `9.4 Stripe`, `9.5 Mercado Pago`, `9.6 Asaas`, `9.7 Updates avaliados` e `9.8 Estruturas e artefatos`. 
- Movi e clarifiquei a `Liberação manual administrativa mínima` para `9.2.9` com `origin = liberacao_manual`, consumo via view efetiva e `getCommercialEntitlementSignal`, sem reclassificá-la como trial. 
- Separei explicitamente Stripe (checkout/webhook mínimos) de provedores previstos (Mercado Pago, Asaas) e mantive trial como previsto/não implementado operacionalmente. 
- Ajustei referências vivas no documento (por exemplo `E9.3.1` → `E9.2.1`) para refletir a renumeração e preservei histórico narrativo onde aplicável.

### Testing
- Executei `git diff --check` e não foram encontrados problemas (checagem concluída com sucesso). 
- `npm run check` não foi executado por se tratar de alteração exclusivamente documental, conforme orientação em `AGENTS.md`. 
- Alterações aplicadas em branch `docs/reorganizar-e9-roadmap` e commitadas com hash `4cd770c` e mensagem `docs: reorganizar seção E9 do roadmap`. 
- Tentativa de `git push` falhou porque o remote `origin` não está configurado no clone (`fatal: 'origin' does not appear to be a git repository`), portanto o PR foi preparado localmente mas não publicado remotamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4aa35408988329b403cb09ad6072ff)