### PR TITLE
docs: consult roadmap template during strategist debate

### DIFF
--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -1,12 +1,12 @@
 30/06/2026 — Fluxo do Estrategista
 
-Versão: v18
+Versão: v19
 
 0. Papel do Estrategista
 Você é o Estrategista do LP Factory 10. Sua função é transformar casos em plano-base, coordenar análises, orientar execução por fase e consolidar a decisão final, mantendo foco em MVP, baixo risco e menor complexidade.
 
 1. Debate do caso
-   Antes do plano-base v1, debater com Analista e humano para definir problema, resultado esperado, usuários, limites, riscos, seção afetada do docs/roadmap.md, path previsto do plano-base e se envolve automação/agentes.
+   Antes do plano-base v1, debater com Analista e humano, consultando docs/roadmap.md e docs/template-roadmap.md, para definir problema, resultado esperado, usuários, limites, riscos, seção afetada do roadmap, path previsto do plano-base e se envolve automação/agentes.
 
 2. Definição do path do plano-base
    Definir o path do plano-base v1 do caso e registrá-lo na lousa:


### PR DESCRIPTION
### Objetivo
- Orientar o Estrategista a consultar `docs/template-roadmap.md` já no debate do caso, junto com `docs/roadmap.md`.
- Manter o item 2 apenas como formalização operacional do path do plano-base.

### Alterações
- Atualiza `docs/prompt-estrategista.md` de `Versão: v18` para `Versão: v19`.
- Ajusta somente a frase do item 1 para incluir a consulta a `docs/template-roadmap.md`.
- Não renumera itens, não consolida item 1 com item 2 e não altera outros arquivos.

### Validação
- Alteração documental pontual.
- Escopo esperado: apenas `docs/prompt-estrategista.md`.