### PR TITLE
docs: ajustar template do roadmap para recortes previstos

### DIFF
--- a/docs/template-roadmap.md
+++ b/docs/template-roadmap.md
@@ -4,18 +4,14 @@
 Definir o padrão estrutural para organizar casos macro no `docs/roadmap.md`.
 
 2. Estrutura padrão
-
-2.1 Recorte implementado ou materialmente ajustado
 ```md
 X. E[n] — Nome do caso macro
 - Objetivo:
 - Status:
-
-X.1 [Recorte funcional implementado]
+X.1 [Recorte funcional]
 X.1.1 Objetivo e status
 - Objetivo:
 - Status:
-
 X.1.2 Registros do recorte
 - Banco:
   - Criados:
@@ -26,37 +22,17 @@ X.1.2 Registros do recorte
   - Excluídos:
 - Updates:
   - Aplicados:
-
-X.1.3 [Implementação, definição, contrato, validação ou limite]
+X.1.3 [Implementação, definição, contrato, previsão, critério ou limite]
 - Status:
 - Conteúdo:
-```
-
-2.2 Recorte previsto, conceitual ou não implementado
-```md
-X. E[n] — Nome do caso macro
-- Objetivo:
+X.1.n [Implementação, definição, contrato, previsão, critério ou limite]
 - Status:
-
-X.2 [Recorte funcional previsto]
-X.2.1 Objetivo e status
-- Objetivo:
-- Status: previsto / não implementado.
-
-X.2.2 Critérios para abertura futura
-- Conteúdo:
-
-X.2.3 Fora do escopo atual
 - Conteúdo:
 ```
 
 3. Regras de hierarquia
-- Nível 1 = caso macro.
-- Nível 2 = recorte funcional.
-- `X.Y.1` = objetivo e status.
-- Para recortes implementados ou materialmente ajustados, `X.Y.2` = registros do recorte.
-- Para recortes previstos, conceituais ou não implementados, `X.Y.2` pode ser conteúdo específico, como critérios futuros, previsão ou fora do escopo.
-- `X.Y.3` até `X.Y.n` = conteúdo específico complementar.
+- Nível 1 = caso macro; nível 2 = recorte funcional.
+- `X.Y.1` = objetivo e status; `X.Y.2` = registros; `X.Y.3` até `X.Y.n` = conteúdo específico.
 - Nível 4 = exceção, só quando item de nível 3 ficar grande ou ambíguo; não deve ter objetivo, status ou registros próprios.
 
 4. Regras de registros
@@ -64,13 +40,10 @@ X.2.3 Fora do escopo atual
 - Consumo, leitura, citação, dependência ou reaproveitamento sem alteração material não entram em registros.
 - Update apenas avaliado, rejeitado ou monitorado não entra em registros do roadmap.
 - Se a avaliação gerar decisão permanente, registrar no conteúdo específico do recorte, não em `Updates`.
-- `Registros do recorte` só deve existir quando houver ao menos um registro real em Banco, Repositório ou Updates.
-- Não criar `Registros do recorte` apenas para preservar simetria.
-- Não manter categorias vazias de Banco, Repositório ou Updates em recortes previstos.
-- Recortes sem implementação material devem omitir registros.
+- `X.Y.2 Registros do recorte` deve ser usado quando houver implementação material ou registros reais.
+- Recortes previstos, conceituais ou não implementados podem omitir `Registros do recorte`.
 
 5. Regras anti-inflação
 - Não criar seção de notas por padrão, observações gerais em `Objetivo e status`, registros fora de `X.Y.2` ou subseções vazias.
-- Não criar `Registros do recorte` vazio em recortes previstos, conceituais ou não implementados.
-- Não criar subseções vazias para Banco, Repositório ou Updates.
-- Não transformar previsão futura em implementação apenas para preencher registros.
+- Não criar blocos vazios de Banco, Repositório ou Updates apenas para preservar simetria.
+- Não transformar previsão futura em implementação.

--- a/docs/template-roadmap.md
+++ b/docs/template-roadmap.md
@@ -4,14 +4,18 @@
 Definir o padrão estrutural para organizar casos macro no `docs/roadmap.md`.
 
 2. Estrutura padrão
+
+2.1 Recorte implementado ou materialmente ajustado
 ```md
 X. E[n] — Nome do caso macro
 - Objetivo:
 - Status:
-X.1 [Recorte funcional]
+
+X.1 [Recorte funcional implementado]
 X.1.1 Objetivo e status
 - Objetivo:
 - Status:
+
 X.1.2 Registros do recorte
 - Banco:
   - Criados:
@@ -22,17 +26,37 @@ X.1.2 Registros do recorte
   - Excluídos:
 - Updates:
   - Aplicados:
-X.1.3 [Implementação, definição, contrato, previsão, critério ou limite]
-- Status:
-- Conteúdo:
-X.1.n [Implementação, definição, contrato, previsão, critério ou limite]
+
+X.1.3 [Implementação, definição, contrato, validação ou limite]
 - Status:
 - Conteúdo:
 ```
 
+2.2 Recorte previsto, conceitual ou não implementado
+```md
+X. E[n] — Nome do caso macro
+- Objetivo:
+- Status:
+
+X.2 [Recorte funcional previsto]
+X.2.1 Objetivo e status
+- Objetivo:
+- Status: previsto / não implementado.
+
+X.2.2 Critérios para abertura futura
+- Conteúdo:
+
+X.2.3 Fora do escopo atual
+- Conteúdo:
+```
+
 3. Regras de hierarquia
-- Nível 1 = caso macro; nível 2 = recorte funcional.
-- `X.Y.1` = objetivo e status; `X.Y.2` = registros; `X.Y.3` até `X.Y.n` = conteúdo específico.
+- Nível 1 = caso macro.
+- Nível 2 = recorte funcional.
+- `X.Y.1` = objetivo e status.
+- Para recortes implementados ou materialmente ajustados, `X.Y.2` = registros do recorte.
+- Para recortes previstos, conceituais ou não implementados, `X.Y.2` pode ser conteúdo específico, como critérios futuros, previsão ou fora do escopo.
+- `X.Y.3` até `X.Y.n` = conteúdo específico complementar.
 - Nível 4 = exceção, só quando item de nível 3 ficar grande ou ambíguo; não deve ter objetivo, status ou registros próprios.
 
 4. Regras de registros
@@ -40,7 +64,13 @@ X.1.n [Implementação, definição, contrato, previsão, critério ou limite]
 - Consumo, leitura, citação, dependência ou reaproveitamento sem alteração material não entram em registros.
 - Update apenas avaliado, rejeitado ou monitorado não entra em registros do roadmap.
 - Se a avaliação gerar decisão permanente, registrar no conteúdo específico do recorte, não em `Updates`.
+- `Registros do recorte` só deve existir quando houver ao menos um registro real em Banco, Repositório ou Updates.
+- Não criar `Registros do recorte` apenas para preservar simetria.
+- Não manter categorias vazias de Banco, Repositório ou Updates em recortes previstos.
+- Recortes sem implementação material devem omitir registros.
 
 5. Regras anti-inflação
 - Não criar seção de notas por padrão, observações gerais em `Objetivo e status`, registros fora de `X.Y.2` ou subseções vazias.
-- Não transformar previsão futura em implementação.
+- Não criar `Registros do recorte` vazio em recortes previstos, conceituais ou não implementados.
+- Não criar subseções vazias para Banco, Repositório ou Updates.
+- Não transformar previsão futura em implementação apenas para preencher registros.


### PR DESCRIPTION
### Motivation
- The current roadmap template enforced a fixed `Registros do recorte` section for every slice, producing empty/noise blocks for planned or non-implemented slices.
- The intent is to support two clear patterns (implemented/material changes vs planned/conceptual) and require `Registros do recorte` only when there are real records to document.
- The change is exclusively documental and must not modify other files or reopen prior design decisions.

### Description
- Modified `docs/template-roadmap.md` to add two examples: `Recorte implementado ou materialmente ajustado` and `Recorte previsto, conceitual ou não implementado`.
- Updated hierarchy rules so that `X.Y.2` is `Registros do recorte` for implemented/material changes, while for planned slices `X.Y.2` can be used for criteria, previsão or fora do escopo.
- Added explicit rules that `Registros do recorte` must exist only when there is at least one real record and forbids empty subsections for `Banco`, `Repositório` or `Updates` in planned slices.
- Only `docs/template-roadmap.md` was changed on branch `docs/roadmap-template-recortes-previstos` with local commit `5164cc2`.

### Testing
- Ran `git diff --check` and it succeeded.
- Attempted `git push -u origin docs/roadmap-template-recortes-previstos` which failed because the remote `origin` is not configured in this clone.
- `npm ci` and `npm run check` were not executed because the modification is exclusively documental and these checks were considered not applicable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bed8910188329b0092fef968d8f89)