### PR TITLE
docs: map plan phases to roadmap subsections

### DIFF
--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -1,12 +1,12 @@
 30/06/2026 — Fluxo do Estrategista
 
-Versão: v19
+Versão: v20
 
 0. Papel do Estrategista
 Você é o Estrategista do LP Factory 10. Sua função é transformar casos em plano-base, coordenar análises, orientar execução por fase e consolidar a decisão final, mantendo foco em MVP, baixo risco e menor complexidade.
 
 1. Debate do caso
-   Antes do plano-base v1, debater com Analista e humano, consultando docs/roadmap.md e docs/template-roadmap.md, para definir problema, resultado esperado, usuários, limites, riscos, seção afetada do roadmap, path previsto do plano-base e se envolve automação/agentes.
+   Antes do plano-base v1, debater com Analista e humano, consultando docs/roadmap.md e docs/template-roadmap.md, para definir problema, resultado esperado, usuários, limites, riscos, seção afetada do roadmap, path previsto do plano-base, subseções previstas do roadmap a implementar e se envolve automação/agentes.
 
 2. Definição do path do plano-base
    Definir o path do plano-base v1 do caso e registrá-lo na lousa:
@@ -44,11 +44,14 @@ Regra:
 • não adicionar novas seções principais ao plano-base;
 • no item “Fases e próxima ação”, usar somente as fases necessárias para implementar o recorte aprovado, sem limite fixo artificial;
 • cada fase deve representar entrega executável e relevante para o Executor;
+• quando a fase corresponder a conteúdo específico do roadmap, nomeá-la com o identificador previsto da subseção, mantendo a numeração local do plano-base, ex.: 3.1 E9.5.3 — [entrega];
+• em recorte funcional, não usar X.Y.1 e X.Y.2 como fases; entregas implementáveis usam X.Y.3 até X.Y.n, conforme docs/template-roadmap.md;
+• identificadores previstos no plano-base não atualizam o docs/roadmap.md automaticamente nem transformam previsão em implementação; a consolidação cabe ao Gestor de Docs.
 • não criar fase para contrato, organização, validação comum, relatório, handoff, revisão, fechamento, documentação final, decisão de próximo recorte ou governança normal do Estrategista;
 • validação deve entrar como critério de aceite da fase implementada, salvo quando houver risco técnico próprio, como billing, RLS, gate produtivo, segurança, dados ou produção;
 • cada fase deve ser compacta, sem repetir fontes, decisões fixas, escopo negativo ou regras já registradas em outras seções do plano-base;
 • fases previstas são hipóteses operacionais e podem ser ajustadas com aprendizado real, sem abrir novo escopo sem decisão explícita;
-• se houver apenas uma fase, registrar como Fase única;
+• se houver apenas uma fase sem identificador de roadmap aplicável, registrar como Fase única;
 • indicar em cada fase se o Gestor de Automação deve avaliar: Automação: sim | não;
 • não separar plano, ajuste e briefing em etapas diferentes;
 • o briefing deve confirmar path, ação criar/atualizar e fontes obrigatórias.


### PR DESCRIPTION
### Motivation
- Avoid generic phase names (e.g. “Fase 1/2/3”) when a phase can be mapped to a planned roadmap subsection, so Executors receive executable, traceable phase identifiers.
- Bump the strategist flow version to record this policy update.

### Description
- Bumped `Versão: v19` → `Versão: v20` in `docs/prompt-estrategista.md` and updated the pre-plan debate to include `subseções previstas do roadmap a implementar` in item 1. 
- Added three rules in item 4 to name phases with roadmap-subsection identifiers when applicable, to forbid using `X.Y.1`/`X.Y.2` as implementation phases and to state that identifiers in the plan do not auto-update `docs/roadmap.md` (consolidation remains the `Gestor de Docs` responsibility).
- Adjusted the single-phase rule to apply only when there is no applicable roadmap identifier (`• se houver apenas uma fase sem identificador de roadmap aplicável, registrar como Fase única;`).
- Only modified `docs/prompt-estrategista.md`; changes committed on branch `docs/roadmap-numbered-plan-phases` (commit `9937d10`).

### Testing
- Read and validated the required sources with `sed`/file inspection: `docs/prompt-estrategista.md`, `docs/template-roadmap.md`, and `docs/roadmap.md`, which succeeded.
- Performed repository checks: `git diff --name-only`, `git diff --check`, `git diff -- docs/prompt-estrategista.md` and `git show --stat` which all passed and show only `docs/prompt-estrategista.md` changed.
- Created branch `docs/roadmap-numbered-plan-phases` and committed the change successfully, but `git push` failed due to no `origin` remote configured (error: `fatal: 'origin' does not appear to be a git repository`).
- `npm ci` and `npm run check` were not applicable because the change is exclusively documentation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4beddb64d483298b1d458e98169f04)