### PR TITLE
docs: add strategist update report guidance

### DIFF
--- a/docs/gestor-updates.md
+++ b/docs/gestor-updates.md
@@ -164,6 +164,21 @@ docs/platform-config.md
 * Dizer quais updates não cabem.
 * Dizer o próximo passo mínimo e seguro.
 
+11.1. Relatório opcional ao Estrategista
+
+* Após entregar a avaliação completa de updates de um plano-base, o Gestor de Updates deve perguntar se deve gerar um relatório otimizado ao Estrategista.
+* Esse relatório deve conter apenas os updates que merecem ser agregados ao plano-base.
+* A organização deve ser por fase, seção ou recorte do plano-base.
+* Para cada update incluído, informar:
+  * ID do update;
+  * tipo de uso: implementação, referência, validação ou trava;
+  * fase, seção ou recorte onde deve entrar;
+  * motivo objetivo;
+  * limite de escopo.
+* Não incluir a lista completa de updates rejeitados, salvo quando algum rejeitado funcionar como trava importante de escopo.
+* O relatório não deve criar fase nova, banco, rota, job, agente, automação, engine ou infraestrutura.
+* O relatório deve servir como insumo para o Estrategista decidir ajustes no plano-base, não como briefing automático ao Executor.
+
 12. Protocolo para rodada de atualização dos catálogos
 
 12.1. Objetivo


### PR DESCRIPTION
### Motivation
- Reduce noise for the Estrategista by providing an optional, concise report after a full updates assessment that lists only updates to be aggregated into the plano-base and prevents automatic execution or unnecessary scope expansion. 

### Description
- Inserted `11.1. Relatório opcional ao Estrategista` into `docs/gestor-updates.md` (between sections 11 and 12) which instructs the Gestor to ask whether to generate an optimized report containing only updates to be added to the plano-base, organized by phase/section/recorte and including for each update: ID, tipo de uso, phase/section, motivo objetivo and limite de escopo; the subsection forbids creating new phases, databases, routes, jobs, agents, automations, engines or infra and clarifies the report is an input for the Estrategista, not an automatic briefing to the Executor; change committed as `72a2d2f` on branch `work`.

### Testing
- Confirmed via `git diff --name-only` and `nl -ba docs/gestor-updates.md | sed -n '159,188p'` that only `docs/gestor-updates.md` was modified and the new `11.1` subsection is correctly placed, ran `git diff --check` and catalog-file diffs to verify no catalog changes (all succeeded); `npm ci` and `npm run check` were not executed because this is a documentation-only change; attempted `git push` failed with `fatal: No configured push destination` so the change is committed locally but not pushed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d074524fc832986206093c9fd4962)