### PR TITLE
feat: add landing_page technical contracts

### DIFF
--- a/docs/lousa-plano-base-e18-4.md
+++ b/docs/lousa-plano-base-e18-4.md
@@ -324,10 +324,11 @@ Recorte previsto do roadmap: `18.4 — Base de composição landing_page`.
 
 * Fase `18.4.3` concluída como decisão técnica investigativa.
 * Fase `18.4.4` concluída como definição documental do catálogo mínimo transversal para primeiro uso em `landing_page`.
+* Fase `18.4.5` concluída com contratos técnicos executáveis, registry, schemas/Zod e renderer mínimo de `landing_page` no repositório.
 * Próxima fase liberada:
-  * `18.4.5 Contratos técnicos, registry, schemas e renderer por canal`.
+  * `18.4.6 Resolver, validação de composição e limites de config_json`.
 * Travas mantidas:
-  * não criar resolver, registros-base de banco ou LP teste antes das fases correspondentes;
+  * não criar registros-base de banco ou LP teste antes das fases correspondentes;
   * não criar migration, alterar `docs/schema.md`, RLS, policies ou GRANTs sem necessidade demonstrada;
   * não transformar catálogo transversal controlado em engine multicanal ampla;
   * não reabrir hardening sem necessidade demonstrada.
@@ -405,6 +406,45 @@ Recorte previsto do roadmap: `18.4 — Base de composição landing_page`.
   * `docs/schema.md`, RLS, policies e GRANTs não foram alterados;
   * não foi criada LP teste, Admin, LP Builder, automação, job, agente ou workflow.
 * Próxima fase liberada: `18.4.5 Contratos técnicos, registry, schemas e renderer por canal`, limitada a transformar este catálogo conceitual em contratos técnicos executáveis sem assumir compatibilidade automática com `commercial_activation`.
+
+3.6. Resultado técnico de `18.4.5`
+
+* Status da fase: concluída com implementação técnica mínima no repositório.
+* Decisão: o catálogo conceitual de `landing_page` passou a ter contrato executável próprio, separado de `commercial_activation`.
+* Arquivos técnicos criados:
+  * `lib/conversion-content/landing-page/contracts.ts`;
+  * `lib/conversion-content/landing-page/schemas.ts`;
+  * `lib/conversion-content/landing-page/registry.ts`;
+  * `lib/conversion-content/landing-page/render-model.ts`;
+  * `lib/conversion-content/landing-page/renderer.tsx`;
+  * `lib/conversion-content/landing-page/fixture.ts`;
+  * `lib/conversion-content/landing-page/validation-cases.ts`;
+  * `lib/conversion-content/landing-page/index.ts`.
+* Arquivos técnicos ajustados:
+  * `lib/conversion-content/index.ts`;
+  * `package.json`.
+* Contrato técnico criado:
+  * canal fechado em `landing_page`;
+  * módulos permitidos: `hero`, `benefits`, `offer`, `social_proof`, `how_it_works`, `faq` e `final_cta`;
+  * variantes permitidas: `hero.lead_capture`, `benefits.cards`, `offer.summary`, `social_proof.simple`, `how_it_works.steps`, `faq.accordion` e `final_cta.simple`;
+  * registry técnico liga canal, módulo, variante, schema Zod e renderer;
+  * `buildLandingPageRenderModel` valida envelope, canal, item duplicado, item desconhecido, item obrigatório ausente, variante inexistente, incompatibilidade módulo/variante e conteúdo por schema;
+  * renderer mínimo usa somente o registry próprio de `landing_page`, com seções semânticas, headings associados por `aria-labelledby`, CTAs como links e estados inválidos fail-closed com retorno nulo.
+* Validação executável criada:
+  * script `validate:landing-page`;
+  * fixture sintética local, sem leitura de Supabase, sem criação de LP real e sem registros de banco.
+* Compatibilidade e limites:
+  * não há compatibilidade automática com `commercial_activation`;
+  * o renderer comercial existente permanece apenas como referência comparativa;
+  * não foi criado resolver final de composição nem integração com banco;
+  * `config_json` permanece sem semântica técnica final nesta fase e deverá ser limitado em `18.4.6`.
+* Não realizado nesta fase:
+  * não foi criada migration;
+  * `docs/schema.md` não foi alterado;
+  * RLS, policies e GRANTs não foram alterados;
+  * não foram criados registros-base no banco;
+  * não foi criada LP teste, Admin, LP Builder, automação, job, agente ou workflow.
+* Próxima fase liberada: `18.4.6 Resolver, validação de composição e limites de config_json`, limitada a resolver e validar composição sem abrir editor livre nem alterar banco sem necessidade demonstrada.
 
 4. Escopo negativo e critérios de parada
 

--- a/lib/conversion-content/index.ts
+++ b/lib/conversion-content/index.ts
@@ -1,6 +1,7 @@
 export * from "./contracts";
 export * from "./validation";
 export * from "./commercial-activation";
+export * as landingPage from "./landing-page";
 export {
   getCommercialActivationBundle,
   getCommercialActivationHierarchicalBundle,

--- a/lib/conversion-content/landing-page/contracts.ts
+++ b/lib/conversion-content/landing-page/contracts.ts
@@ -1,0 +1,24 @@
+export const LANDING_PAGE_CHANNEL = "landing_page" as const;
+
+export type LandingPageModuleKey =
+  | "hero"
+  | "benefits"
+  | "offer"
+  | "social_proof"
+  | "how_it_works"
+  | "faq"
+  | "final_cta";
+
+export type LandingPageCompositionItem = {
+  id: string;
+  moduleKey: LandingPageModuleKey;
+  variantKey: string;
+  sortOrder: number;
+  isRequired: boolean;
+  config: Record<string, unknown>;
+};
+
+export type LandingPageComposition = {
+  id: string;
+  items: LandingPageCompositionItem[];
+};

--- a/lib/conversion-content/landing-page/fixture.ts
+++ b/lib/conversion-content/landing-page/fixture.ts
@@ -1,0 +1,195 @@
+import type { LandingPageComposition } from "./contracts";
+import type { LandingPageContentV1 } from "./schemas";
+
+export const landingPageFixtureComposition: LandingPageComposition = {
+  id: "99999999-9999-4999-8999-999999999999",
+  items: [
+    {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaab101",
+      moduleKey: "hero",
+      variantKey: "hero.lead_capture",
+      sortOrder: 10,
+      isRequired: true,
+      config: {},
+    },
+    {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaab102",
+      moduleKey: "benefits",
+      variantKey: "benefits.cards",
+      sortOrder: 20,
+      isRequired: true,
+      config: {},
+    },
+    {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaab103",
+      moduleKey: "offer",
+      variantKey: "offer.summary",
+      sortOrder: 30,
+      isRequired: true,
+      config: {},
+    },
+    {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaab104",
+      moduleKey: "social_proof",
+      variantKey: "social_proof.simple",
+      sortOrder: 40,
+      isRequired: true,
+      config: {},
+    },
+    {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaab105",
+      moduleKey: "how_it_works",
+      variantKey: "how_it_works.steps",
+      sortOrder: 50,
+      isRequired: false,
+      config: {},
+    },
+    {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaab106",
+      moduleKey: "faq",
+      variantKey: "faq.accordion",
+      sortOrder: 60,
+      isRequired: false,
+      config: {},
+    },
+    {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaab107",
+      moduleKey: "final_cta",
+      variantKey: "final_cta.simple",
+      sortOrder: 70,
+      isRequired: true,
+      config: {},
+    },
+  ],
+};
+
+export const landingPageFixtureContent: LandingPageContentV1 = {
+  schema_version: 1,
+  channel: "landing_page",
+  sections: [
+    {
+      composition_item_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaab101",
+      content: {
+        eyebrow: "Landing page de exemplo",
+        title: "Uma oferta clara para um publico especifico.",
+        description:
+          "Fixture sintetica para validar contratos de landing_page sem criar registros de banco ou LP teste.",
+        primary_cta: { label: "Quero conversar", href: "/contato" },
+        secondary_cta: { label: "Ver como funciona", href: "/como-funciona" },
+        lead_prompt: "Receba uma proposta inicial",
+      },
+    },
+    {
+      composition_item_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaab102",
+      content: {
+        eyebrow: "Beneficios",
+        title: "Motivos objetivos para avancar",
+        items: [
+          {
+            title: "Mensagem focada",
+            description:
+              "A pagina apresenta a promessa e os ganhos esperados sem depender de estrutura comercial fixa.",
+          },
+          {
+            title: "Composicao controlada",
+            description:
+              "Cada secao usa modulo e variante conhecidos pelo registry de landing_page.",
+          },
+          {
+            title: "Validacao executavel",
+            description:
+              "Conteudo invalido e barrado antes de chegar ao renderer minimo.",
+          },
+        ],
+      },
+    },
+    {
+      composition_item_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaab103",
+      content: {
+        eyebrow: "Oferta",
+        title: "Resumo da entrega principal",
+        description:
+          "Use esta secao para explicar a oferta, servico ou produto sem exigir cards de planos.",
+        bullets: [
+          "Escopo inicial bem delimitado",
+          "Proximo passo de contato claro",
+          "Sem pricing obrigatorio no primeiro uso",
+        ],
+        cta: { label: "Entender a oferta", href: "/oferta" },
+      },
+    },
+    {
+      composition_item_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaab104",
+      content: {
+        eyebrow: "Confianca",
+        title: "Sinais simples de seguranca",
+        proof_items: [
+          {
+            title: "Evidencia controlada",
+            description:
+              "A prova social inicial e textual e nao depende de integracoes externas.",
+          },
+          {
+            title: "Sem compatibilidade automatica",
+            description:
+              "Os modulos comerciais existentes continuam apenas como referencia comparativa.",
+          },
+        ],
+      },
+    },
+    {
+      composition_item_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaab105",
+      content: {
+        eyebrow: "Processo",
+        title: "Como funciona",
+        steps: [
+          {
+            label: "01",
+            title: "Envio do contexto",
+            description: "A pessoa interessada informa o objetivo da demanda.",
+          },
+          {
+            label: "02",
+            title: "Avaliacao inicial",
+            description:
+              "O time avalia fit, escopo e proximos passos possiveis.",
+          },
+          {
+            label: "03",
+            title: "Resposta objetiva",
+            description:
+              "A pagina conduz para uma conversa ou proposta sem automacao ampla.",
+          },
+        ],
+      },
+    },
+    {
+      composition_item_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaab106",
+      content: {
+        eyebrow: "Duvidas",
+        title: "Perguntas frequentes",
+        questions: [
+          {
+            question: "Esta fixture cria uma LP real?",
+            answer:
+              "Nao. Ela valida contrato tecnico local sem rota publica, banco ou publicacao.",
+          },
+          {
+            question: "O renderer comercial e reutilizado?",
+            answer:
+              "Nao automaticamente. A compatibilidade precisa ser explicita por canal.",
+          },
+        ],
+      },
+    },
+    {
+      composition_item_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaab107",
+      content: {
+        title: "Pronto para o proximo passo",
+        description:
+          "O contrato minimo de landing_page pode ser evoluido nas fases seguintes com resolver e validacao de composicao.",
+        cta: { label: "Continuar", href: "/contato" },
+      },
+    },
+  ],
+};

--- a/lib/conversion-content/landing-page/index.ts
+++ b/lib/conversion-content/landing-page/index.ts
@@ -1,0 +1,6 @@
+export * from "./contracts";
+export * from "./fixture";
+export * from "./registry";
+export * from "./render-model";
+export * from "./renderer";
+export * from "./schemas";

--- a/lib/conversion-content/landing-page/registry.ts
+++ b/lib/conversion-content/landing-page/registry.ts
@@ -1,0 +1,84 @@
+import type { ZodType } from "zod";
+
+import { LANDING_PAGE_CHANNEL, type LandingPageModuleKey } from "./contracts";
+import {
+  benefitsCardsContentSchema,
+  faqAccordionContentSchema,
+  finalCtaSimpleContentSchema,
+  heroLeadCaptureContentSchema,
+  howItWorksStepsContentSchema,
+  offerSummaryContentSchema,
+  socialProofSimpleContentSchema,
+  type LandingPageSectionContentByVariant,
+  type LandingPageSectionVariant,
+} from "./schemas";
+
+type RegistryEntry<Variant extends LandingPageSectionVariant> = {
+  channel: typeof LANDING_PAGE_CHANNEL;
+  moduleKey: LandingPageModuleKey;
+  variantKey: Variant;
+  rendererKey: Variant;
+  schema: ZodType<LandingPageSectionContentByVariant[Variant]>;
+};
+
+type Registry = {
+  [Variant in LandingPageSectionVariant]: RegistryEntry<Variant>;
+};
+
+export const landingPageSectionRegistry = {
+  "hero.lead_capture": {
+    channel: LANDING_PAGE_CHANNEL,
+    moduleKey: "hero",
+    variantKey: "hero.lead_capture",
+    rendererKey: "hero.lead_capture",
+    schema: heroLeadCaptureContentSchema,
+  },
+  "benefits.cards": {
+    channel: LANDING_PAGE_CHANNEL,
+    moduleKey: "benefits",
+    variantKey: "benefits.cards",
+    rendererKey: "benefits.cards",
+    schema: benefitsCardsContentSchema,
+  },
+  "offer.summary": {
+    channel: LANDING_PAGE_CHANNEL,
+    moduleKey: "offer",
+    variantKey: "offer.summary",
+    rendererKey: "offer.summary",
+    schema: offerSummaryContentSchema,
+  },
+  "social_proof.simple": {
+    channel: LANDING_PAGE_CHANNEL,
+    moduleKey: "social_proof",
+    variantKey: "social_proof.simple",
+    rendererKey: "social_proof.simple",
+    schema: socialProofSimpleContentSchema,
+  },
+  "how_it_works.steps": {
+    channel: LANDING_PAGE_CHANNEL,
+    moduleKey: "how_it_works",
+    variantKey: "how_it_works.steps",
+    rendererKey: "how_it_works.steps",
+    schema: howItWorksStepsContentSchema,
+  },
+  "faq.accordion": {
+    channel: LANDING_PAGE_CHANNEL,
+    moduleKey: "faq",
+    variantKey: "faq.accordion",
+    rendererKey: "faq.accordion",
+    schema: faqAccordionContentSchema,
+  },
+  "final_cta.simple": {
+    channel: LANDING_PAGE_CHANNEL,
+    moduleKey: "final_cta",
+    variantKey: "final_cta.simple",
+    rendererKey: "final_cta.simple",
+    schema: finalCtaSimpleContentSchema,
+  },
+} satisfies Registry;
+
+export function isLandingPageSectionVariant(
+  value: string,
+): value is LandingPageSectionVariant {
+  return value in landingPageSectionRegistry;
+}

--- a/lib/conversion-content/landing-page/render-model.ts
+++ b/lib/conversion-content/landing-page/render-model.ts
@@ -1,0 +1,116 @@
+import type { LandingPageComposition } from "./contracts";
+import {
+  isLandingPageSectionVariant,
+  landingPageSectionRegistry,
+} from "./registry";
+import {
+  landingPageContentV1Schema,
+  type LandingPageSectionContent,
+  type LandingPageSectionVariant,
+} from "./schemas";
+
+export type LandingPageRenderSection = {
+  compositionItemId: string;
+  sortOrder: number;
+  moduleKey: string;
+  variantKey: LandingPageSectionVariant;
+  content: LandingPageSectionContent;
+};
+
+export type LandingPageRenderModel = {
+  schemaVersion: 1;
+  channel: "landing_page";
+  sections: LandingPageRenderSection[];
+};
+
+export type LandingPageRenderModelResult =
+  | { status: "ready"; model: LandingPageRenderModel }
+  | {
+      status: "invalid";
+      reason:
+        | "content_schema_invalid"
+        | "composition_item_duplicate"
+        | "composition_item_unknown"
+        | "composition_item_missing"
+        | "section_registry_invalid"
+        | "section_content_invalid";
+    };
+
+export function buildLandingPageRenderModel(input: {
+  composition: LandingPageComposition;
+  contentJson: unknown;
+  logSafeWarning?: (message: string, details: Record<string, unknown>) => void;
+}): LandingPageRenderModelResult {
+  const parsedContent = landingPageContentV1Schema.safeParse(input.contentJson);
+  if (!parsedContent.success) {
+    return { status: "invalid", reason: "content_schema_invalid" };
+  }
+
+  const compositionItems = new Map(
+    input.composition.items.map((item) => [item.id, item]),
+  );
+  const contentItems = new Map<
+    string,
+    (typeof parsedContent.data.sections)[number]
+  >();
+
+  for (const section of parsedContent.data.sections) {
+    if (contentItems.has(section.composition_item_id)) {
+      return { status: "invalid", reason: "composition_item_duplicate" };
+    }
+    if (!compositionItems.has(section.composition_item_id)) {
+      return { status: "invalid", reason: "composition_item_unknown" };
+    }
+    contentItems.set(section.composition_item_id, section);
+  }
+
+  const sections: LandingPageRenderSection[] = [];
+
+  for (const item of input.composition.items) {
+    if (!isLandingPageSectionVariant(item.variantKey)) {
+      return { status: "invalid", reason: "section_registry_invalid" };
+    }
+
+    const registryEntry = landingPageSectionRegistry[item.variantKey];
+    if (item.moduleKey !== registryEntry.moduleKey) {
+      return { status: "invalid", reason: "section_registry_invalid" };
+    }
+
+    const section = contentItems.get(item.id);
+    if (!section) {
+      if (item.isRequired) {
+        return { status: "invalid", reason: "composition_item_missing" };
+      }
+      continue;
+    }
+
+    const parsedSection = registryEntry.schema.safeParse(section.content);
+    if (!parsedSection.success) {
+      if (item.isRequired) {
+        return { status: "invalid", reason: "section_content_invalid" };
+      }
+      input.logSafeWarning?.("optional landing page section omitted", {
+        compositionItemId: item.id,
+        variantKey: item.variantKey,
+      });
+      continue;
+    }
+
+    sections.push({
+      compositionItemId: item.id,
+      sortOrder: item.sortOrder,
+      moduleKey: item.moduleKey,
+      variantKey: item.variantKey,
+      content: parsedSection.data,
+    });
+  }
+
+  return {
+    status: "ready",
+    model: {
+      schemaVersion: parsedContent.data.schema_version,
+      channel: parsedContent.data.channel,
+      sections: sections.sort((left, right) => left.sortOrder - right.sortOrder),
+    },
+  };
+}

--- a/lib/conversion-content/landing-page/renderer.tsx
+++ b/lib/conversion-content/landing-page/renderer.tsx
@@ -1,0 +1,403 @@
+import type { ComponentType } from "react";
+
+import { cn } from "@/lib/utils";
+import type { LandingPageComposition } from "./contracts";
+import { landingPageSectionRegistry } from "./registry";
+import {
+  buildLandingPageRenderModel,
+  type LandingPageRenderModel,
+  type LandingPageRenderSection,
+} from "./render-model";
+import type {
+  BenefitsCardsContent,
+  FaqAccordionContent,
+  FinalCtaSimpleContent,
+  HeroLeadCaptureContent,
+  HowItWorksStepsContent,
+  LandingPageSectionContentByVariant,
+  LandingPageSectionVariant,
+  OfferSummaryContent,
+  SocialProofSimpleContent,
+} from "./schemas";
+
+type RendererProps = {
+  composition: LandingPageComposition;
+  contentJson: unknown;
+};
+
+type SectionComponentProps<Variant extends LandingPageSectionVariant> = {
+  section: LandingPageRenderSection & {
+    variantKey: Variant;
+    content: LandingPageSectionContentByVariant[Variant];
+  };
+};
+
+type RendererRegistry = {
+  [Variant in LandingPageSectionVariant]: (typeof landingPageSectionRegistry)[Variant] & {
+    component: ComponentType<SectionComponentProps<Variant>>;
+  };
+};
+
+const primaryButton =
+  "inline-flex min-h-11 items-center justify-center rounded-md bg-primary px-5 py-3 text-sm font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2";
+const secondaryButton =
+  "inline-flex min-h-11 items-center justify-center rounded-md border border-graytech-300 bg-white px-5 py-3 text-sm font-semibold text-ink-900 shadow-sm transition-colors hover:bg-surface-app focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2";
+
+export const landingPageRendererRegistry = {
+  "hero.lead_capture": {
+    ...landingPageSectionRegistry["hero.lead_capture"],
+    component: HeroLeadCapture,
+  },
+  "benefits.cards": {
+    ...landingPageSectionRegistry["benefits.cards"],
+    component: BenefitsCards,
+  },
+  "offer.summary": {
+    ...landingPageSectionRegistry["offer.summary"],
+    component: OfferSummary,
+  },
+  "social_proof.simple": {
+    ...landingPageSectionRegistry["social_proof.simple"],
+    component: SocialProofSimple,
+  },
+  "how_it_works.steps": {
+    ...landingPageSectionRegistry["how_it_works.steps"],
+    component: HowItWorksSteps,
+  },
+  "faq.accordion": {
+    ...landingPageSectionRegistry["faq.accordion"],
+    component: FaqAccordion,
+  },
+  "final_cta.simple": {
+    ...landingPageSectionRegistry["final_cta.simple"],
+    component: FinalCtaSimple,
+  },
+} satisfies RendererRegistry;
+
+export function LandingPageRenderer({ composition, contentJson }: RendererProps) {
+  const resolved = buildLandingPageRenderModel({
+    composition,
+    contentJson,
+    logSafeWarning: (message, details) => {
+      console.warn(message, details);
+    },
+  });
+
+  if (resolved.status !== "ready") {
+    console.error("LandingPageRenderer invalid artifact", {
+      reason: resolved.reason,
+      compositionId: composition.id,
+    });
+    return null;
+  }
+
+  return <LandingPageSections model={resolved.model} />;
+}
+
+export function LandingPageSections({ model }: { model: LandingPageRenderModel }) {
+  return (
+    <article
+      className="overflow-hidden bg-white text-ink-900"
+      data-content-channel={model.channel}
+      data-content-schema-version={model.schemaVersion}
+    >
+      {model.sections.map((section) => (
+        <SectionRenderer key={section.compositionItemId} section={section} />
+      ))}
+    </article>
+  );
+}
+
+function SectionRenderer({ section }: { section: LandingPageRenderSection }) {
+  const Component = landingPageRendererRegistry[section.variantKey]
+    .component as ComponentType<{ section: LandingPageRenderSection }>;
+
+  return <Component section={section} />;
+}
+
+function HeroLeadCapture({
+  section,
+}: SectionComponentProps<"hero.lead_capture">) {
+  const content: HeroLeadCaptureContent = section.content;
+  const titleId = `${section.compositionItemId}-title`;
+
+  return (
+    <section
+      aria-labelledby={titleId}
+      className="bg-surface-app px-6 py-16 sm:px-10 lg:px-14"
+    >
+      <div className="mx-auto grid max-w-6xl gap-10 lg:grid-cols-[1.2fr_0.8fr] lg:items-center">
+        <div>
+          {content.eyebrow ? (
+            <p className="text-sm font-semibold uppercase tracking-[0.16em] text-brand-700">
+              {content.eyebrow}
+            </p>
+          ) : null}
+          <h1
+            id={titleId}
+            className="mt-4 text-4xl font-bold tracking-tight text-ink-900 sm:text-5xl"
+          >
+            {content.title}
+          </h1>
+          <p className="mt-5 max-w-2xl text-base leading-7 text-graytech-600 sm:text-lg">
+            {content.description}
+          </p>
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+            <a href={content.primary_cta.href} className={primaryButton}>
+              {content.primary_cta.label}
+            </a>
+            {content.secondary_cta ? (
+              <a href={content.secondary_cta.href} className={secondaryButton}>
+                {content.secondary_cta.label}
+              </a>
+            ) : null}
+          </div>
+        </div>
+        <div className="rounded-lg border border-surface-border bg-white p-6 shadow-card">
+          <p className="text-sm font-semibold text-ink-900">
+            {content.lead_prompt ?? "Solicite uma proposta"}
+          </p>
+          <div className="mt-5 space-y-3" aria-hidden="true">
+            <div className="h-11 rounded-md bg-graytech-100" />
+            <div className="h-11 rounded-md bg-graytech-100" />
+            <div className="h-24 rounded-md bg-graytech-100" />
+            <div className="h-11 rounded-md bg-primary/20" />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function BenefitsCards({ section }: SectionComponentProps<"benefits.cards">) {
+  const content: BenefitsCardsContent = section.content;
+  return (
+    <PageSection
+      compositionItemId={section.compositionItemId}
+      eyebrow={content.eyebrow}
+      title={content.title}
+    >
+      <div className="grid gap-4 md:grid-cols-3">
+        {content.items.map((item) => (
+          <InfoBlock
+            key={item.title}
+            title={item.title}
+            description={item.description}
+          />
+        ))}
+      </div>
+    </PageSection>
+  );
+}
+
+function OfferSummary({ section }: SectionComponentProps<"offer.summary">) {
+  const content: OfferSummaryContent = section.content;
+  return (
+    <PageSection
+      compositionItemId={section.compositionItemId}
+      eyebrow={content.eyebrow}
+      title={content.title}
+      muted
+    >
+      <div className="grid gap-8 lg:grid-cols-[1fr_0.8fr] lg:items-start">
+        <p className="text-base leading-7 text-graytech-600">
+          {content.description}
+        </p>
+        <div>
+          <ul className="space-y-3">
+            {content.bullets.map((bullet) => (
+              <li key={bullet} className="flex gap-3 text-sm text-ink-800">
+                <span
+                  aria-hidden="true"
+                  className="mt-2 size-2 rounded-full bg-state-success"
+                />
+                <span>{bullet}</span>
+              </li>
+            ))}
+          </ul>
+          {content.cta ? (
+            <a href={content.cta.href} className={cn(primaryButton, "mt-6")}>
+              {content.cta.label}
+            </a>
+          ) : null}
+        </div>
+      </div>
+    </PageSection>
+  );
+}
+
+function SocialProofSimple({
+  section,
+}: SectionComponentProps<"social_proof.simple">) {
+  const content: SocialProofSimpleContent = section.content;
+  return (
+    <PageSection
+      compositionItemId={section.compositionItemId}
+      eyebrow={content.eyebrow}
+      title={content.title}
+    >
+      <div className="grid gap-4 md:grid-cols-2">
+        {content.proof_items.map((item) => (
+          <InfoBlock
+            key={item.title}
+            title={item.title}
+            description={item.description}
+          />
+        ))}
+      </div>
+    </PageSection>
+  );
+}
+
+function HowItWorksSteps({
+  section,
+}: SectionComponentProps<"how_it_works.steps">) {
+  const content: HowItWorksStepsContent = section.content;
+  return (
+    <PageSection
+      compositionItemId={section.compositionItemId}
+      eyebrow={content.eyebrow}
+      title={content.title}
+      muted
+    >
+      <ol className="grid gap-4 md:grid-cols-3">
+        {content.steps.map((step) => (
+          <li
+            key={step.label}
+            className="rounded-lg border border-surface-border bg-white p-5 shadow-card"
+          >
+            <span className="text-sm font-bold text-brand-700">
+              {step.label}
+            </span>
+            <h3 className="mt-3 text-lg font-semibold text-ink-900">
+              {step.title}
+            </h3>
+            <p className="mt-2 text-sm leading-6 text-graytech-600">
+              {step.description}
+            </p>
+          </li>
+        ))}
+      </ol>
+    </PageSection>
+  );
+}
+
+function FaqAccordion({ section }: SectionComponentProps<"faq.accordion">) {
+  const content: FaqAccordionContent = section.content;
+  return (
+    <PageSection
+      compositionItemId={section.compositionItemId}
+      eyebrow={content.eyebrow}
+      title={content.title}
+    >
+      <div className="space-y-3">
+        {content.questions.map((item) => (
+          <details
+            key={item.question}
+            className="group rounded-lg border border-surface-border bg-white shadow-card"
+          >
+            <summary className="cursor-pointer list-none px-5 py-4 font-semibold text-ink-900 outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
+              <span className="flex items-center justify-between gap-4">
+                {item.question}
+                <span
+                  aria-hidden="true"
+                  className="text-xl text-brand-700 transition-transform group-open:rotate-45"
+                >
+                  +
+                </span>
+              </span>
+            </summary>
+            <p className="border-t border-surface-border px-5 py-4 text-sm leading-6 text-graytech-600">
+              {item.answer}
+            </p>
+          </details>
+        ))}
+      </div>
+    </PageSection>
+  );
+}
+
+function FinalCtaSimple({
+  section,
+}: SectionComponentProps<"final_cta.simple">) {
+  const content: FinalCtaSimpleContent = section.content;
+  const titleId = `${section.compositionItemId}-title`;
+
+  return (
+    <section
+      aria-labelledby={titleId}
+      className="bg-brand-50 px-6 py-14 text-center sm:px-10 lg:px-14"
+    >
+      <h2
+        id={titleId}
+        className="text-3xl font-bold tracking-tight text-brand-dark-900"
+      >
+        {content.title}
+      </h2>
+      <p className="mx-auto mt-4 max-w-2xl text-base leading-7 text-graytech-600">
+        {content.description}
+      </p>
+      <a href={content.cta.href} className={cn(primaryButton, "mt-7")}>
+        {content.cta.label}
+      </a>
+    </section>
+  );
+}
+
+function PageSection({
+  compositionItemId,
+  eyebrow,
+  title,
+  muted,
+  children,
+}: {
+  compositionItemId: string;
+  eyebrow?: string;
+  title: string;
+  muted?: boolean;
+  children: React.ReactNode;
+}) {
+  const titleId = `${compositionItemId}-title`;
+
+  return (
+    <section
+      aria-labelledby={titleId}
+      className={cn(
+        "px-6 py-12 sm:px-10 lg:px-14",
+        muted && "border-y border-surface-border bg-surface-app",
+      )}
+    >
+      <div className="max-w-2xl">
+        {eyebrow ? (
+          <p className="text-sm font-semibold uppercase tracking-[0.16em] text-brand-700">
+            {eyebrow}
+          </p>
+        ) : null}
+        <h2
+          id={titleId}
+          className="mt-3 text-2xl font-bold tracking-tight text-ink-900 sm:text-3xl"
+        >
+          {title}
+        </h2>
+      </div>
+      <div className="mt-8">{children}</div>
+    </section>
+  );
+}
+
+function InfoBlock({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="rounded-lg border border-surface-border bg-white p-5 shadow-card">
+      <h3 className="text-lg font-semibold text-ink-900">{title}</h3>
+      <p className="mt-2 text-sm leading-6 text-graytech-600">
+        {description}
+      </p>
+    </div>
+  );
+}

--- a/lib/conversion-content/landing-page/schemas.ts
+++ b/lib/conversion-content/landing-page/schemas.ts
@@ -1,0 +1,172 @@
+import { z } from "zod";
+
+const shortText = z.string().trim().min(1).max(96);
+const labelText = z.string().trim().min(1).max(48);
+const titleText = z.string().trim().min(1).max(140);
+const bodyText = z.string().trim().min(1).max(520);
+
+const internalPath = z
+  .string()
+  .trim()
+  .regex(/^\/(?!\/).+/, "href must start with a single slash");
+
+const httpsUrl = z
+  .string()
+  .trim()
+  .url()
+  .refine((value) => {
+    try {
+      const url = new URL(value);
+      return url.protocol === "https:" && Boolean(url.hostname);
+    } catch {
+      return false;
+    }
+  }, "href must be a valid https URL");
+
+const safeHref = z.union([internalPath, httpsUrl]);
+
+export const landingPageCtaSchema = z
+  .object({
+    label: labelText,
+    href: safeHref,
+  })
+  .strict();
+
+export const landingPageCardSchema = z
+  .object({
+    title: shortText,
+    description: bodyText,
+  })
+  .strict();
+
+export const heroLeadCaptureContentSchema = z
+  .object({
+    eyebrow: shortText.optional(),
+    title: titleText,
+    description: bodyText,
+    primary_cta: landingPageCtaSchema,
+    secondary_cta: landingPageCtaSchema.optional(),
+    lead_prompt: shortText.optional(),
+  })
+  .strict();
+
+export const benefitsCardsContentSchema = z
+  .object({
+    eyebrow: shortText.optional(),
+    title: titleText,
+    items: z.array(landingPageCardSchema).min(2).max(6),
+  })
+  .strict();
+
+export const offerSummaryContentSchema = z
+  .object({
+    eyebrow: shortText.optional(),
+    title: titleText,
+    description: bodyText,
+    bullets: z.array(shortText).min(2).max(6),
+    cta: landingPageCtaSchema.optional(),
+  })
+  .strict();
+
+export const socialProofSimpleContentSchema = z
+  .object({
+    eyebrow: shortText.optional(),
+    title: titleText,
+    proof_items: z.array(landingPageCardSchema).min(1).max(4),
+  })
+  .strict();
+
+export const howItWorksStepsContentSchema = z
+  .object({
+    eyebrow: shortText.optional(),
+    title: titleText,
+    steps: z
+      .array(
+        z
+          .object({
+            label: z.string().trim().min(1).max(12),
+            title: shortText,
+            description: bodyText,
+          })
+          .strict(),
+      )
+      .min(2)
+      .max(6),
+  })
+  .strict();
+
+export const faqAccordionContentSchema = z
+  .object({
+    eyebrow: shortText.optional(),
+    title: titleText,
+    questions: z
+      .array(
+        z
+          .object({
+            question: titleText,
+            answer: bodyText,
+          })
+          .strict(),
+      )
+      .min(2)
+      .max(8),
+  })
+  .strict();
+
+export const finalCtaSimpleContentSchema = z
+  .object({
+    title: titleText,
+    description: bodyText,
+    cta: landingPageCtaSchema,
+  })
+  .strict();
+
+export const landingPageSectionEnvelopeSchema = z
+  .object({
+    composition_item_id: z.string().uuid(),
+    content: z.record(z.string(), z.unknown()),
+  })
+  .strict();
+
+export const landingPageContentV1Schema = z
+  .object({
+    schema_version: z.literal(1),
+    channel: z.literal("landing_page"),
+    sections: z.array(landingPageSectionEnvelopeSchema).min(1).max(12),
+  })
+  .strict();
+
+export type LandingPageSectionVariant =
+  | "hero.lead_capture"
+  | "benefits.cards"
+  | "offer.summary"
+  | "social_proof.simple"
+  | "how_it_works.steps"
+  | "faq.accordion"
+  | "final_cta.simple";
+
+export type HeroLeadCaptureContent = z.infer<typeof heroLeadCaptureContentSchema>;
+export type BenefitsCardsContent = z.infer<typeof benefitsCardsContentSchema>;
+export type OfferSummaryContent = z.infer<typeof offerSummaryContentSchema>;
+export type SocialProofSimpleContent = z.infer<
+  typeof socialProofSimpleContentSchema
+>;
+export type HowItWorksStepsContent = z.infer<
+  typeof howItWorksStepsContentSchema
+>;
+export type FaqAccordionContent = z.infer<typeof faqAccordionContentSchema>;
+export type FinalCtaSimpleContent = z.infer<typeof finalCtaSimpleContentSchema>;
+export type LandingPageContentV1 = z.infer<typeof landingPageContentV1Schema>;
+
+export type LandingPageSectionContentByVariant = {
+  "hero.lead_capture": HeroLeadCaptureContent;
+  "benefits.cards": BenefitsCardsContent;
+  "offer.summary": OfferSummaryContent;
+  "social_proof.simple": SocialProofSimpleContent;
+  "how_it_works.steps": HowItWorksStepsContent;
+  "faq.accordion": FaqAccordionContent;
+  "final_cta.simple": FinalCtaSimpleContent;
+};
+
+export type LandingPageSectionContent =
+  LandingPageSectionContentByVariant[LandingPageSectionVariant];

--- a/lib/conversion-content/landing-page/validation-cases.ts
+++ b/lib/conversion-content/landing-page/validation-cases.ts
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+
+import {
+  landingPageFixtureComposition,
+  landingPageFixtureContent,
+} from "./fixture";
+import { buildLandingPageRenderModel } from "./render-model";
+import type { LandingPageContentV1 } from "./schemas";
+
+type Case = {
+  name: string;
+  run: () => void;
+};
+
+const requiredHeroId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaab101";
+const optionalFaqId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaab106";
+
+const cases: Case[] = [
+  {
+    name: "valid content resolves landing_page sections",
+    run: () => {
+      const result = buildLandingPageRenderModel({
+        composition: clone(landingPageFixtureComposition),
+        contentJson: clone(landingPageFixtureContent),
+      });
+
+      assert.equal(result.status, "ready");
+      assert.equal(result.model.channel, "landing_page");
+      assert.equal(result.model.sections.length, 7);
+    },
+  },
+  {
+    name: "duplicate composition item id invalidates content",
+    run: () => {
+      const content = clone(landingPageFixtureContent);
+      content.sections[1].composition_item_id = requiredHeroId;
+
+      const result = buildLandingPageRenderModel({
+        composition: clone(landingPageFixtureComposition),
+        contentJson: content,
+      });
+
+      assert.deepEqual(result, {
+        status: "invalid",
+        reason: "composition_item_duplicate",
+      });
+    },
+  },
+  {
+    name: "unknown composition item id invalidates content",
+    run: () => {
+      const content = clone(landingPageFixtureContent);
+      content.sections[0].composition_item_id =
+        "99999999-9999-4999-8999-999999999998";
+
+      const result = buildLandingPageRenderModel({
+        composition: clone(landingPageFixtureComposition),
+        contentJson: content,
+      });
+
+      assert.deepEqual(result, {
+        status: "invalid",
+        reason: "composition_item_unknown",
+      });
+    },
+  },
+  {
+    name: "module and variant mismatch invalidates content",
+    run: () => {
+      const composition = clone(landingPageFixtureComposition);
+      composition.items[0].moduleKey = "benefits";
+
+      const result = buildLandingPageRenderModel({
+        composition,
+        contentJson: clone(landingPageFixtureContent),
+      });
+
+      assert.deepEqual(result, {
+        status: "invalid",
+        reason: "section_registry_invalid",
+      });
+    },
+  },
+  {
+    name: "missing required section invalidates content",
+    run: () => {
+      const content = withoutSection(requiredHeroId);
+
+      const result = buildLandingPageRenderModel({
+        composition: clone(landingPageFixtureComposition),
+        contentJson: content,
+      });
+
+      assert.deepEqual(result, {
+        status: "invalid",
+        reason: "composition_item_missing",
+      });
+    },
+  },
+  {
+    name: "missing optional section is omitted",
+    run: () => {
+      const content = withoutSection(optionalFaqId);
+
+      const result = buildLandingPageRenderModel({
+        composition: clone(landingPageFixtureComposition),
+        contentJson: content,
+      });
+
+      assert.equal(result.status, "ready");
+      assert.equal(
+        result.model.sections.some(
+          (section) => section.compositionItemId === optionalFaqId,
+        ),
+        false,
+      );
+    },
+  },
+  {
+    name: "invalid required section schema invalidates content",
+    run: () => {
+      const content = clone(landingPageFixtureContent);
+      const hero = content.sections.find(
+        (section) => section.composition_item_id === requiredHeroId,
+      );
+      assert.ok(hero);
+      hero.content = { title: "Missing required landing page fields" };
+
+      const result = buildLandingPageRenderModel({
+        composition: clone(landingPageFixtureComposition),
+        contentJson: content,
+      });
+
+      assert.deepEqual(result, {
+        status: "invalid",
+        reason: "section_content_invalid",
+      });
+    },
+  },
+  {
+    name: "commercial_activation channel is rejected",
+    run: () => {
+      const content = {
+        ...clone(landingPageFixtureContent),
+        channel: "commercial_activation",
+      };
+
+      const result = buildLandingPageRenderModel({
+        composition: clone(landingPageFixtureComposition),
+        contentJson: content,
+      });
+
+      assert.deepEqual(result, {
+        status: "invalid",
+        reason: "content_schema_invalid",
+      });
+    },
+  },
+];
+
+for (const validationCase of cases) {
+  validationCase.run();
+  console.log(`ok - ${validationCase.name}`);
+}
+
+function withoutSection(compositionItemId: string): LandingPageContentV1 {
+  const content = clone(landingPageFixtureContent);
+  content.sections = content.sections.filter(
+    (section) => section.composition_item_id !== compositionItemId,
+  );
+  return content;
+}
+
+function clone<T>(value: T): T {
+  return globalThis.structuredClone(value);
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "check": "npm run lint && npm run typecheck",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "validate:commercial-activation": "tsx lib/conversion-content/commercial-activation/validation-cases.ts"
+    "validate:commercial-activation": "tsx lib/conversion-content/commercial-activation/validation-cases.ts",
+    "validate:landing-page": "tsx lib/conversion-content/landing-page/validation-cases.ts"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "1.1.7",


### PR DESCRIPTION
## O que mudou

- Cria contratos técnicos executáveis para `landing_page` em `lib/conversion-content/landing-page/`.
- Adiciona registry fechado ligando canal, módulo, variante, schema Zod e renderer.
- Adiciona schemas/Zod mínimos por variante do catálogo `18.4.4`.
- Adiciona renderer mínimo com baseline leve de acessibilidade.
- Adiciona fixture e validação executável local via `npm run validate:landing-page`.
- Atualiza o plano-base E18.4 com o resultado da fase `18.4.5`.

## Fora do escopo preservado

- Sem migration.
- Sem alteração em `docs/schema.md`.
- Sem alteração em RLS, policies ou GRANTs.
- Sem registros-base no banco.
- Sem resolver final, LP teste, Admin, LP Builder, automação, job, agente ou workflow.
- Sem compatibilidade automática com `commercial_activation`.

## Validação

- `npm ci`
- `npm run validate:landing-page`
- `npm run validate:commercial-activation`
- `npm run check`
- `git diff --check`

Observação: `npm ci` reportou vulnerabilidades já presentes na árvore instalada; não rodei `npm audit fix` por ficar fora do escopo desta fase.