### PR TITLE
docs: clarify specialist consolidation

### DIFF
--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -109,6 +109,9 @@ Regra:
 Regra:
 • a execução só começa após o plano-base consolidado v2 estar registrado no arquivo do caso;
 • consolidar somente decisões aceitas, rejeitadas ou pendentes das avaliações;
+• consolidar todos os retornos dos especialistas em uma única análise antes de alterar o plano-base;
+• classificar cada ponto como aceito, rejeitado, pendente ou já coberto pelo plano-base;
+• não aplicar ajustes isolados por especialista, salvo erro crítico ou decisão humana explícita;
 • ajustar o próprio arquivo do plano-base no mesmo PR inicial, mantendo o mesmo path: docs/lousa-plano-base-EXX-YY.md;
 • preservar o template mínimo de 4 seções do plano-base;
 • não gerar handoff Codex para atualizar o plano-base de v1 para v2;


### PR DESCRIPTION
### Motivation
- Tornar explícito no item 6 do fluxo do Estrategista que os retornos dos especialistas devem ser consolidados em uma única análise antes de qualquer alteração no plano-base para evitar ajustes precipitados por parecer isolado.

### Description
- Adicionadas três regras ao bloco de `6. Consolidação do plano-base v2 no mesmo PR` em `docs/prompt-estrategista.md` preservando `Versão: v21` e alterando somente esse arquivo: as regras exigem consolidar todos os retornos dos especialistas em uma única análise, classificar cada ponto como aceito/rejeitado/pendente/ou já coberto e proíbem ajustes isolados por especialista salvo exceção crítica.

### Testing
- Executados `git diff --check`, `git diff --name-only` e validação de conteúdo com `rg` para confirmar que somente `docs/prompt-estrategista.md` foi alterado e que as três linhas foram inseridas conforme solicitado, todos com sucesso; `npm ci` e `npm run check` não aplicáveis por se tratar de alteração documental.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d4bf61ff08329a7761058cec792a8)