### PR TITLE
18.4.6 resolver e validação de landing_page

### DIFF
--- a/docs/lousa-plano-base-e18-4.md
+++ b/docs/lousa-plano-base-e18-4.md
@@ -462,7 +462,8 @@ Recorte previsto do roadmap: `18.4 — Base de composição landing_page`.
   * `lib/conversion-content/landing-page/index.ts`.
 * Resolver/validador de composição:
   * valida item duplicado na composição antes de montar o mapa de itens;
-  * valida `sortOrder` inteiro, não negativo, estritamente crescente e sem duplicidade;
+  * valida `sortOrder` inteiro, não negativo e sem duplicidade;
+  * não exige que o array de entrada esteja ordenado e normaliza os itens por `sortOrder` antes do render model;
   * valida variante existente no registry fechado de `landing_page`;
   * valida compatibilidade explícita entre módulo e variante;
   * normaliza itens resolvidos para o render model somente depois de validar registry e `config_json`;
@@ -471,6 +472,7 @@ Recorte previsto do roadmap: `18.4 — Base de composição landing_page`.
   * `config_json` é override controlado por seção;
   * chaves permitidas nesta fase: `anchor_id` e `spacing`;
   * `anchor_id` deve seguir padrão seguro de âncora curta: letra minúscula inicial, letras minúsculas, números ou hífen, até 64 caracteres;
+  * `anchor_id` permanece opcional, mas deve ser único quando informado em mais de uma seção;
   * `spacing` aceita somente `compact`, `default` ou `spacious`;
   * objetos com chaves livres como renderer, schema, style, HTML, script ou props arbitrárias são rejeitados;
   * o renderer mínimo consome apenas esses overrides permitidos para `id` de seção e espaçamento vertical.

--- a/docs/lousa-plano-base-e18-4.md
+++ b/docs/lousa-plano-base-e18-4.md
@@ -325,12 +325,14 @@ Recorte previsto do roadmap: `18.4 — Base de composição landing_page`.
 * Fase `18.4.3` concluída como decisão técnica investigativa.
 * Fase `18.4.4` concluída como definição documental do catálogo mínimo transversal para primeiro uso em `landing_page`.
 * Fase `18.4.5` concluída com contratos técnicos executáveis, registry, schemas/Zod e renderer mínimo de `landing_page` no repositório.
+* Fase `18.4.6` concluída com resolver/validador final de composição `landing_page` e limites técnicos de `config_json`.
 * Próxima fase liberada:
-  * `18.4.6 Resolver, validação de composição e limites de config_json`.
+  * definição estratégica da próxima etapa de consumo, sem criar registros-base, LP teste, Admin ou LP Builder automaticamente.
 * Travas mantidas:
   * não criar registros-base de banco ou LP teste antes das fases correspondentes;
   * não criar migration, alterar `docs/schema.md`, RLS, policies ou GRANTs sem necessidade demonstrada;
   * não transformar catálogo transversal controlado em engine multicanal ampla;
+  * não abrir editor livre de `config_json`;
   * não reabrir hardening sem necessidade demonstrada.
 
 3.4. Resultado técnico de `18.4.3`
@@ -445,6 +447,54 @@ Recorte previsto do roadmap: `18.4 — Base de composição landing_page`.
   * não foram criados registros-base no banco;
   * não foi criada LP teste, Admin, LP Builder, automação, job, agente ou workflow.
 * Próxima fase liberada: `18.4.6 Resolver, validação de composição e limites de config_json`, limitada a resolver e validar composição sem abrir editor livre nem alterar banco sem necessidade demonstrada.
+
+3.7. Resultado técnico de `18.4.6`
+
+* Status da fase: concluída com implementação técnica no repositório.
+* Decisão: o primeiro uso de `landing_page` passa a ter resolver/validador final de composição antes do render model, com falha fechada para composições inválidas.
+* Arquivos técnicos criados:
+  * `lib/conversion-content/landing-page/composition-validator.ts`.
+* Arquivos técnicos ajustados:
+  * `lib/conversion-content/landing-page/render-model.ts`;
+  * `lib/conversion-content/landing-page/renderer.tsx`;
+  * `lib/conversion-content/landing-page/fixture.ts`;
+  * `lib/conversion-content/landing-page/validation-cases.ts`;
+  * `lib/conversion-content/landing-page/index.ts`.
+* Resolver/validador de composição:
+  * valida item duplicado na composição antes de montar o mapa de itens;
+  * valida `sortOrder` inteiro, não negativo, estritamente crescente e sem duplicidade;
+  * valida variante existente no registry fechado de `landing_page`;
+  * valida compatibilidade explícita entre módulo e variante;
+  * normaliza itens resolvidos para o render model somente depois de validar registry e `config_json`;
+  * mantém `commercial_activation` apenas como referência comparativa, sem compatibilidade automática.
+* Limites técnicos de `config_json`:
+  * `config_json` é override controlado por seção;
+  * chaves permitidas nesta fase: `anchor_id` e `spacing`;
+  * `anchor_id` deve seguir padrão seguro de âncora curta: letra minúscula inicial, letras minúsculas, números ou hífen, até 64 caracteres;
+  * `spacing` aceita somente `compact`, `default` ou `spacious`;
+  * objetos com chaves livres como renderer, schema, style, HTML, script ou props arbitrárias são rejeitados;
+  * o renderer mínimo consome apenas esses overrides permitidos para `id` de seção e espaçamento vertical.
+* Casos de validação cobertos por `validate:landing-page`:
+  * composição válida;
+  * item duplicado na composição;
+  * item duplicado no conteúdo;
+  * item desconhecido no conteúdo;
+  * variante inexistente;
+  * incompatibilidade módulo/variante;
+  * ordem inválida;
+  * `config_json` inválido;
+  * item obrigatório ausente;
+  * item opcional ausente;
+  * schema de conteúdo inválido;
+  * canal inválido;
+  * rejeição de variante de `commercial_activation` como compatível automaticamente.
+* Não realizado nesta fase:
+  * não foi criada migration;
+  * `docs/schema.md` não foi alterado;
+  * RLS, policies e GRANTs não foram alterados;
+  * não foram criados registros-base no banco;
+  * não foi criada LP teste, rota pública, Admin, LP Builder, automação, job, agente ou workflow.
+* Próxima etapa: depende de definição estratégica posterior; esta fase não libera, por si só, criação de registros-base, LP teste, Admin ou LP Builder.
 
 4. Escopo negativo e critérios de parada
 

--- a/lib/conversion-content/landing-page/composition-validator.ts
+++ b/lib/conversion-content/landing-page/composition-validator.ts
@@ -51,7 +51,8 @@ export function validateLandingPageComposition(
   composition: LandingPageComposition,
 ): LandingPageCompositionValidationResult {
   const itemIds = new Set<string>();
-  let previousSortOrder = Number.NEGATIVE_INFINITY;
+  const sortOrders = new Set<number>();
+  const anchorIds = new Set<string>();
   const items: LandingPageResolvedCompositionItem[] = [];
 
   for (const item of composition.items) {
@@ -63,11 +64,11 @@ export function validateLandingPageComposition(
     if (
       !Number.isInteger(item.sortOrder) ||
       item.sortOrder < 0 ||
-      item.sortOrder <= previousSortOrder
+      sortOrders.has(item.sortOrder)
     ) {
       return { status: "invalid", reason: "composition_order_invalid" };
     }
-    previousSortOrder = item.sortOrder;
+    sortOrders.add(item.sortOrder);
 
     if (!isLandingPageSectionVariant(item.variantKey)) {
       return { status: "invalid", reason: "section_registry_invalid" };
@@ -82,6 +83,12 @@ export function validateLandingPageComposition(
     if (!parsedConfig.success) {
       return { status: "invalid", reason: "config_json_invalid" };
     }
+    if (parsedConfig.data.anchor_id) {
+      if (anchorIds.has(parsedConfig.data.anchor_id)) {
+        return { status: "invalid", reason: "config_json_invalid" };
+      }
+      anchorIds.add(parsedConfig.data.anchor_id);
+    }
 
     items.push({
       ...item,
@@ -90,5 +97,8 @@ export function validateLandingPageComposition(
     });
   }
 
-  return { status: "valid", items };
+  return {
+    status: "valid",
+    items: items.sort((left, right) => left.sortOrder - right.sortOrder),
+  };
 }

--- a/lib/conversion-content/landing-page/composition-validator.ts
+++ b/lib/conversion-content/landing-page/composition-validator.ts
@@ -1,0 +1,94 @@
+import { z } from "zod";
+
+import type {
+  LandingPageComposition,
+  LandingPageCompositionItem,
+} from "./contracts";
+import {
+  isLandingPageSectionVariant,
+  landingPageSectionRegistry,
+} from "./registry";
+import type { LandingPageSectionVariant } from "./schemas";
+
+export const landingPageSectionConfigSchema = z
+  .object({
+    anchor_id: z
+      .string()
+      .trim()
+      .regex(/^[a-z][a-z0-9-]{0,63}$/)
+      .optional(),
+    spacing: z.enum(["compact", "default", "spacious"]).optional(),
+  })
+  .strict()
+  .refine((value) => Object.keys(value).length <= 2);
+
+export type LandingPageSectionConfig = z.infer<
+  typeof landingPageSectionConfigSchema
+>;
+
+export type LandingPageResolvedCompositionItem = Omit<
+  LandingPageCompositionItem,
+  "variantKey" | "config"
+> & {
+  variantKey: LandingPageSectionVariant;
+  config: LandingPageSectionConfig;
+};
+
+export type LandingPageCompositionValidationReason =
+  | "composition_item_duplicate"
+  | "composition_order_invalid"
+  | "section_registry_invalid"
+  | "config_json_invalid";
+
+export type LandingPageCompositionValidationResult =
+  | { status: "valid"; items: LandingPageResolvedCompositionItem[] }
+  | {
+      status: "invalid";
+      reason: LandingPageCompositionValidationReason;
+    };
+
+export function validateLandingPageComposition(
+  composition: LandingPageComposition,
+): LandingPageCompositionValidationResult {
+  const itemIds = new Set<string>();
+  let previousSortOrder = Number.NEGATIVE_INFINITY;
+  const items: LandingPageResolvedCompositionItem[] = [];
+
+  for (const item of composition.items) {
+    if (itemIds.has(item.id)) {
+      return { status: "invalid", reason: "composition_item_duplicate" };
+    }
+    itemIds.add(item.id);
+
+    if (
+      !Number.isInteger(item.sortOrder) ||
+      item.sortOrder < 0 ||
+      item.sortOrder <= previousSortOrder
+    ) {
+      return { status: "invalid", reason: "composition_order_invalid" };
+    }
+    previousSortOrder = item.sortOrder;
+
+    if (!isLandingPageSectionVariant(item.variantKey)) {
+      return { status: "invalid", reason: "section_registry_invalid" };
+    }
+
+    const registryEntry = landingPageSectionRegistry[item.variantKey];
+    if (item.moduleKey !== registryEntry.moduleKey) {
+      return { status: "invalid", reason: "section_registry_invalid" };
+    }
+
+    const parsedConfig = landingPageSectionConfigSchema.safeParse(item.config);
+    if (!parsedConfig.success) {
+      return { status: "invalid", reason: "config_json_invalid" };
+    }
+
+    items.push({
+      ...item,
+      variantKey: item.variantKey,
+      config: parsedConfig.data,
+    });
+  }
+
+  return { status: "valid", items };
+}

--- a/lib/conversion-content/landing-page/fixture.ts
+++ b/lib/conversion-content/landing-page/fixture.ts
@@ -10,7 +10,7 @@ export const landingPageFixtureComposition: LandingPageComposition = {
       variantKey: "hero.lead_capture",
       sortOrder: 10,
       isRequired: true,
-      config: {},
+      config: { anchor_id: "inicio", spacing: "spacious" },
     },
     {
       id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaab102",
@@ -50,7 +50,7 @@ export const landingPageFixtureComposition: LandingPageComposition = {
       variantKey: "faq.accordion",
       sortOrder: 60,
       isRequired: false,
-      config: {},
+      config: { anchor_id: "duvidas", spacing: "compact" },
     },
     {
       id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaab107",
@@ -58,7 +58,7 @@ export const landingPageFixtureComposition: LandingPageComposition = {
       variantKey: "final_cta.simple",
       sortOrder: 70,
       isRequired: true,
-      config: {},
+      config: { anchor_id: "contato-final" },
     },
   ],
 };

--- a/lib/conversion-content/landing-page/index.ts
+++ b/lib/conversion-content/landing-page/index.ts
@@ -1,3 +1,4 @@
+export * from "./composition-validator";
 export * from "./contracts";
 export * from "./fixture";
 export * from "./registry";

--- a/lib/conversion-content/landing-page/render-model.ts
+++ b/lib/conversion-content/landing-page/render-model.ts
@@ -1,8 +1,10 @@
 import type { LandingPageComposition } from "./contracts";
 import {
-  isLandingPageSectionVariant,
-  landingPageSectionRegistry,
-} from "./registry";
+  validateLandingPageComposition,
+  type LandingPageCompositionValidationReason,
+  type LandingPageSectionConfig,
+} from "./composition-validator";
+import { landingPageSectionRegistry } from "./registry";
 import {
   landingPageContentV1Schema,
   type LandingPageSectionContent,
@@ -14,6 +16,7 @@ export type LandingPageRenderSection = {
   sortOrder: number;
   moduleKey: string;
   variantKey: LandingPageSectionVariant;
+  config: LandingPageSectionConfig;
   content: LandingPageSectionContent;
 };
 
@@ -32,6 +35,8 @@ export type LandingPageRenderModelResult =
         | "composition_item_duplicate"
         | "composition_item_unknown"
         | "composition_item_missing"
+        | "composition_order_invalid"
+        | "config_json_invalid"
         | "section_registry_invalid"
         | "section_content_invalid";
     };
@@ -41,13 +46,21 @@ export function buildLandingPageRenderModel(input: {
   contentJson: unknown;
   logSafeWarning?: (message: string, details: Record<string, unknown>) => void;
 }): LandingPageRenderModelResult {
+  const parsedComposition = validateLandingPageComposition(input.composition);
+  if (parsedComposition.status !== "valid") {
+    return {
+      status: "invalid",
+      reason: parsedComposition.reason,
+    };
+  }
+
   const parsedContent = landingPageContentV1Schema.safeParse(input.contentJson);
   if (!parsedContent.success) {
     return { status: "invalid", reason: "content_schema_invalid" };
   }
 
   const compositionItems = new Map(
-    input.composition.items.map((item) => [item.id, item]),
+    parsedComposition.items.map((item) => [item.id, item]),
   );
   const contentItems = new Map<
     string,
@@ -66,16 +79,8 @@ export function buildLandingPageRenderModel(input: {
 
   const sections: LandingPageRenderSection[] = [];
 
-  for (const item of input.composition.items) {
-    if (!isLandingPageSectionVariant(item.variantKey)) {
-      return { status: "invalid", reason: "section_registry_invalid" };
-    }
-
+  for (const item of parsedComposition.items) {
     const registryEntry = landingPageSectionRegistry[item.variantKey];
-    if (item.moduleKey !== registryEntry.moduleKey) {
-      return { status: "invalid", reason: "section_registry_invalid" };
-    }
-
     const section = contentItems.get(item.id);
     if (!section) {
       if (item.isRequired) {
@@ -101,6 +106,7 @@ export function buildLandingPageRenderModel(input: {
       sortOrder: item.sortOrder,
       moduleKey: item.moduleKey,
       variantKey: item.variantKey,
+      config: item.config,
       content: parsedSection.data,
     });
   }
@@ -114,3 +120,5 @@ export function buildLandingPageRenderModel(input: {
     },
   };
 }
+
+export type { LandingPageCompositionValidationReason };

--- a/lib/conversion-content/landing-page/renderer.tsx
+++ b/lib/conversion-content/landing-page/renderer.tsx
@@ -123,8 +123,12 @@ function HeroLeadCapture({
 
   return (
     <section
+      id={section.config.anchor_id}
       aria-labelledby={titleId}
-      className="bg-surface-app px-6 py-16 sm:px-10 lg:px-14"
+      className={cn(
+        "bg-surface-app px-6 sm:px-10 lg:px-14",
+        getVerticalSpacingClass(section.config.spacing, "hero"),
+      )}
     >
       <div className="mx-auto grid max-w-6xl gap-10 lg:grid-cols-[1.2fr_0.8fr] lg:items-center">
         <div>
@@ -174,6 +178,7 @@ function BenefitsCards({ section }: SectionComponentProps<"benefits.cards">) {
   return (
     <PageSection
       compositionItemId={section.compositionItemId}
+      config={section.config}
       eyebrow={content.eyebrow}
       title={content.title}
     >
@@ -195,6 +200,7 @@ function OfferSummary({ section }: SectionComponentProps<"offer.summary">) {
   return (
     <PageSection
       compositionItemId={section.compositionItemId}
+      config={section.config}
       eyebrow={content.eyebrow}
       title={content.title}
       muted
@@ -233,6 +239,7 @@ function SocialProofSimple({
   return (
     <PageSection
       compositionItemId={section.compositionItemId}
+      config={section.config}
       eyebrow={content.eyebrow}
       title={content.title}
     >
@@ -256,6 +263,7 @@ function HowItWorksSteps({
   return (
     <PageSection
       compositionItemId={section.compositionItemId}
+      config={section.config}
       eyebrow={content.eyebrow}
       title={content.title}
       muted
@@ -287,6 +295,7 @@ function FaqAccordion({ section }: SectionComponentProps<"faq.accordion">) {
   return (
     <PageSection
       compositionItemId={section.compositionItemId}
+      config={section.config}
       eyebrow={content.eyebrow}
       title={content.title}
     >
@@ -325,8 +334,12 @@ function FinalCtaSimple({
 
   return (
     <section
+      id={section.config.anchor_id}
       aria-labelledby={titleId}
-      className="bg-brand-50 px-6 py-14 text-center sm:px-10 lg:px-14"
+      className={cn(
+        "bg-brand-50 px-6 text-center sm:px-10 lg:px-14",
+        getVerticalSpacingClass(section.config.spacing, "final"),
+      )}
     >
       <h2
         id={titleId}
@@ -346,12 +359,14 @@ function FinalCtaSimple({
 
 function PageSection({
   compositionItemId,
+  config,
   eyebrow,
   title,
   muted,
   children,
 }: {
   compositionItemId: string;
+  config: LandingPageRenderSection["config"];
   eyebrow?: string;
   title: string;
   muted?: boolean;
@@ -361,9 +376,11 @@ function PageSection({
 
   return (
     <section
+      id={config.anchor_id}
       aria-labelledby={titleId}
       className={cn(
-        "px-6 py-12 sm:px-10 lg:px-14",
+        "px-6 sm:px-10 lg:px-14",
+        getVerticalSpacingClass(config.spacing, "section"),
         muted && "border-y border-surface-border bg-surface-app",
       )}
     >
@@ -383,6 +400,35 @@ function PageSection({
       <div className="mt-8">{children}</div>
     </section>
   );
+}
+
+function getVerticalSpacingClass(
+  spacing: LandingPageRenderSection["config"]["spacing"],
+  scale: "hero" | "section" | "final",
+) {
+  const resolvedSpacing = spacing ?? "default";
+
+  if (scale === "hero") {
+    return {
+      compact: "py-12",
+      default: "py-16",
+      spacious: "py-20",
+    }[resolvedSpacing];
+  }
+
+  if (scale === "final") {
+    return {
+      compact: "py-12",
+      default: "py-14",
+      spacious: "py-16",
+    }[resolvedSpacing];
+  }
+
+  return {
+    compact: "py-10",
+    default: "py-12",
+    spacious: "py-16",
+  }[resolvedSpacing];
 }
 
 function InfoBlock({

--- a/lib/conversion-content/landing-page/validation-cases.ts
+++ b/lib/conversion-content/landing-page/validation-cases.ts
@@ -120,7 +120,22 @@ const cases: Case[] = [
     },
   },
   {
-    name: "invalid composition order invalidates composition",
+    name: "unordered composition resolves by sortOrder",
+    run: () => {
+      const composition = clone(landingPageFixtureComposition);
+      composition.items.reverse();
+
+      const result = buildLandingPageRenderModel({
+        composition,
+        contentJson: clone(landingPageFixtureContent),
+      });
+
+      assert.equal(result.status, "ready");
+      assert.equal(result.model.sections[0].compositionItemId, requiredHeroId);
+    },
+  },
+  {
+    name: "duplicate sortOrder invalidates composition",
     run: () => {
       const composition = clone(landingPageFixtureComposition);
       composition.items[1].sortOrder = composition.items[0].sortOrder;
@@ -133,6 +148,23 @@ const cases: Case[] = [
       assert.deepEqual(result, {
         status: "invalid",
         reason: "composition_order_invalid",
+      });
+    },
+  },
+  {
+    name: "duplicate anchor_id invalidates config_json",
+    run: () => {
+      const composition = clone(landingPageFixtureComposition);
+      composition.items[1].config = { anchor_id: "inicio" };
+
+      const result = buildLandingPageRenderModel({
+        composition,
+        contentJson: clone(landingPageFixtureContent),
+      });
+
+      assert.deepEqual(result, {
+        status: "invalid",
+        reason: "config_json_invalid",
       });
     },
   },

--- a/lib/conversion-content/landing-page/validation-cases.ts
+++ b/lib/conversion-content/landing-page/validation-cases.ts
@@ -27,6 +27,27 @@ const cases: Case[] = [
       assert.equal(result.status, "ready");
       assert.equal(result.model.channel, "landing_page");
       assert.equal(result.model.sections.length, 7);
+      assert.deepEqual(result.model.sections[0].config, {
+        anchor_id: "inicio",
+        spacing: "spacious",
+      });
+    },
+  },
+  {
+    name: "duplicate composition item invalidates composition",
+    run: () => {
+      const composition = clone(landingPageFixtureComposition);
+      composition.items[1].id = requiredHeroId;
+
+      const result = buildLandingPageRenderModel({
+        composition,
+        contentJson: clone(landingPageFixtureContent),
+      });
+
+      assert.deepEqual(result, {
+        status: "invalid",
+        reason: "composition_item_duplicate",
+      });
     },
   },
   {
@@ -65,6 +86,23 @@ const cases: Case[] = [
     },
   },
   {
+    name: "nonexistent variant invalidates composition",
+    run: () => {
+      const composition = clone(landingPageFixtureComposition);
+      composition.items[0].variantKey = "hero.unknown";
+
+      const result = buildLandingPageRenderModel({
+        composition,
+        contentJson: clone(landingPageFixtureContent),
+      });
+
+      assert.deepEqual(result, {
+        status: "invalid",
+        reason: "section_registry_invalid",
+      });
+    },
+  },
+  {
     name: "module and variant mismatch invalidates content",
     run: () => {
       const composition = clone(landingPageFixtureComposition);
@@ -78,6 +116,40 @@ const cases: Case[] = [
       assert.deepEqual(result, {
         status: "invalid",
         reason: "section_registry_invalid",
+      });
+    },
+  },
+  {
+    name: "invalid composition order invalidates composition",
+    run: () => {
+      const composition = clone(landingPageFixtureComposition);
+      composition.items[1].sortOrder = composition.items[0].sortOrder;
+
+      const result = buildLandingPageRenderModel({
+        composition,
+        contentJson: clone(landingPageFixtureContent),
+      });
+
+      assert.deepEqual(result, {
+        status: "invalid",
+        reason: "composition_order_invalid",
+      });
+    },
+  },
+  {
+    name: "invalid config_json invalidates composition",
+    run: () => {
+      const composition = clone(landingPageFixtureComposition);
+      composition.items[0].config = { renderer: "CommercialActivationHero" };
+
+      const result = buildLandingPageRenderModel({
+        composition,
+        contentJson: clone(landingPageFixtureContent),
+      });
+
+      assert.deepEqual(result, {
+        status: "invalid",
+        reason: "config_json_invalid",
       });
     },
   },
@@ -134,6 +206,23 @@ const cases: Case[] = [
       assert.deepEqual(result, {
         status: "invalid",
         reason: "section_content_invalid",
+      });
+    },
+  },
+  {
+    name: "commercial_activation variant is not auto-compatible",
+    run: () => {
+      const composition = clone(landingPageFixtureComposition);
+      composition.items[0].variantKey = "hero.default";
+
+      const result = buildLandingPageRenderModel({
+        composition,
+        contentJson: clone(landingPageFixtureContent),
+      });
+
+      assert.deepEqual(result, {
+        status: "invalid",
+        reason: "section_registry_invalid",
       });
     },
   },


### PR DESCRIPTION
## Escopo

Implementa somente a fase `18.4.6 — Resolver, validação de composição e limites de config_json`.

## Mudanças

- Cria `composition-validator.ts` para validar composição `landing_page` antes do render model.
- Limita `config_json` a override controlado com `anchor_id` e `spacing`.
- Integra a validação no render model e expõe config normalizada para o renderer mínimo.
- Amplia os casos de validação para item duplicado, item desconhecido, variante inexistente, incompatibilidade módulo/variante, ordem inválida, `config_json` inválido, canal inválido e rejeição de variante `commercial_activation` como compatível automaticamente.
- Atualiza `docs/lousa-plano-base-e18-4.md` com o resultado da fase.

## Fora do escopo preservado

- Sem migration.
- Sem alteração em `docs/schema.md`.
- Sem RLS, policies ou GRANTs.
- Sem registros-base no banco.
- Sem LP teste, rota pública, Admin, LP Builder, automação, job, agente ou workflow.

## Validação

- `npm ci` executado com sucesso; audit reportou 13 vulnerabilidades existentes.
- `npm run validate:landing-page` executado com sucesso.
- `npm run validate:commercial-activation` executado com sucesso.
- `npm run check` executado com sucesso; lint manteve 24 warnings existentes fora do escopo e 0 errors.
- `git diff --check` executado com sucesso.