### PR TITLE
docs: explicita decisão de roadmap no relatório do estrategista

### DIFF
--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -169,10 +169,12 @@ Usar relatório consolidado ao final do plano quando houver:
 • fase seguinte validando a fase anterior;
 • relatório por fase gerando repetição sem decisão nova.
 
-Registrar apenas o que ocorreu, manter os rótulos abaixo e marcar N/A quando não se aplicar.
+Registrar apenas o que ocorreu, informar a decisão documental do roadmap e marcar N/A quando não se aplicar.
 
-Implementado / definido
-• [itens objetivos do que foi implementado ou definido]
+Roadmap / decisão documental
+• Seção afetada: [E[n].[x] — nome]
+• Subseções a criar ou atualizar: [lista exata] | N/A
+• Não criar fora das subseções listadas sem decisão humana explícita.
 
 Updates aplicados
 • [tag, ex.: supa#5] — aplicado | avaliado | N/A — [efeito curto]


### PR DESCRIPTION
### Motivation
- Garantir que o item 10 do relatório ao Gestor de Docs registre explicitamente a decisão documental do roadmap, indicando a seção e as subseções exatas a criar ou atualizar para evitar criações não autorizadas.

### Description
- Substituí em `docs/prompt-estrategista.md` (item 10) a frase geral por uma instrução que exige "informar a decisão documental do roadmap" e troquei o rótulo `Implementado / definido` pelo bloco `Roadmap / decisão documental` contendo `Seção afetada`, `Subseções a criar ou atualizar` e a regra de não criar fora da lista sem decisão humana explícita.

### Testing
- Branch `docs/roadmap-decisao-relatorio-estrategista` criada, apenas o arquivo `docs/prompt-estrategista.md` foi alterado, commit `af43451` gerado e PR titulado `docs: explicita decisão de roadmap no relatório do estrategista` aberto; validações automatizadas confirmaram que `Versão: v21` foi preservada, apenas o item 10 foi modificado e as substituições foram aplicadas; `npm ci` e `npm run check` não se aplicam por se tratar de alteração exclusivamente documental.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d9efd458c8329b0dabcac5bd3f999)