### PR TITLE
docs: registra E18.4 landing_page (repo-only) em roadmap & base-tecnica

### DIFF
--- a/docs/base-tecnica.md
+++ b/docs/base-tecnica.md
@@ -2,8 +2,8 @@
 
 0.1. Cabeçalho
 • Documento: Base Técnica LP Factory 10
-• Versão: v2.0.46
-• Data: 04/07/2026
+• Versão: v2.0.47
+• Data: 07/07/2026
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -392,6 +392,21 @@ LP Builder
 • Se o insert das fontes relacionais falhar após criar o artifact, o draft recém-criado deve ser arquivado/invalidado e o fluxo deve retornar erro seguro, sem parecer concluído.
 • Logs devem registrar somente metadados operacionais seguros; não registrar prompt completo, pesquisa bruta, payload sensível ou resposta integral da IA.
 
+3.15.2 Conteúdo composicional de `landing_page`
+• Path canônico: `lib/conversion-content/landing-page/`.
+• `landing_page` tem contratos próprios, schemas Zod próprios, registry fechado, render model próprio, renderer mínimo e validação executável.
+• Catálogo mínimo permitido: `hero.lead_capture`, `benefits.cards`, `offer.summary`, `social_proof.simple`, `how_it_works.steps`, `faq.accordion` e `final_cta.simple`.
+• `landing_page` não herda compatibilidade automática de `commercial_activation`.
+• O registry próprio é a fonte canônica de canal, módulo, variante, schema e renderer.
+• Variante fora do catálogo, incompatibilidade módulo/variante, item duplicado, item desconhecido, canal inválido ou conteúdo fora do schema devem falhar fechado.
+• O resolver/validador deve normalizar itens por `sortOrder` antes do renderer.
+• `sortOrder` deve ser inteiro, não negativo e único.
+• `config_json` aceita somente `anchor_id` e `spacing`.
+• `anchor_id` é opcional, deve seguir padrão seguro de âncora curta e ser único quando informado.
+• `spacing` aceita somente `compact`, `default` ou `spacious`.
+• Chaves livres como `renderer`, `schema`, `style`, HTML, script ou props arbitrárias devem ser rejeitadas.
+• Casos executáveis: `npm run validate:landing-page`.
+
 4. DB Contract - Fonte única: PATH: docs/schema.md
 • Este documento não lista mais tabelas/views/functions/triggers/policies; isso está em PATH: docs/schema.md.
 • Trigger Hub é regra do contrato de DB (governança/auditoria). Fonte única e detalhes: PATH: docs/schema.md (seções 3.5 e 4.1).
@@ -539,6 +554,7 @@ Fonte normativa da allowlist SULB para exceções de Auth. Qualquer novo arquivo
 • Tipos canônicos e adapters vNext: validar por 3.6 e 3.14.
 
 99. Changelog
+v2.0.47 — 07/07/2026 — Registrado contrato técnico da base repo-only de composição `landing_page`, com path canônico, catálogo mínimo, registry fechado, schemas, renderer mínimo, resolver/validador e limites de `config_json`.
 v2.0.46 — 04/07/2026 — Registrado contrato técnico da liberação manual administrativa mínima de entitlement comercial, com Server Action protegida por `requirePlatformAdmin`, boundary Admin server-only e persistência exclusiva em `public.account_commercial_entitlements`.
 v2.0.45 (02/07/2026) — Registrado webhook Stripe mínimo do E9, com endpoint canônico, boundary, assinatura obrigatória, evento `invoice.paid`, idempotência e persistência segura de entitlement.
 v2.0.43 — 22/06/2026 — Registrado o contrato técnico da geração administrativa de draft `commercial_activation`: fluxo server-side/Admin com Responses API e Structured Outputs, modelo por env var, validação em duas camadas, persistência somente como `draft`, fontes relacionais `business_buyer`, `end_customer` apenas em `provenance_json` e compensação segura em falha parcial.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data: 04/07/2026
-• Versão: v1.5.89
+• Data: 07/07/2026
+• Versão: v1.5.90
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -1401,7 +1401,7 @@ Repositório — Ajustados
 
 18. E18 — Base transversal de templates, módulos, composições e artefatos
 - Objetivo: Definir infraestrutura e contratos reutilizáveis para famílias de templates por canal, templates versionados, módulos de conteúdo, seções de página, variantes, composições e artefatos finais persistidos; sustentar primeiro a E10.7 sem produzir diretamente a página comercial de um taxon; e permitir consumidores futuros somente como visão de evolução, sem antecipar sua implementação.
-- Status: Base transversal mínima de `commercial_activation` concluída e validada em 16/06/2026; primeiro recorte de banco/runtime e segundo recorte de contratos, renderer e registros-base aplicados; E10.7 desbloqueada como primeiro consumidor real; consumidores futuros permanecem como visão de evolução.
+- Status: Base transversal mínima de `commercial_activation` concluída e validada em 16/06/2026; base técnica repo-only de composição `landing_page` concluída em 07/07/2026; E10.7 desbloqueada como primeiro consumidor real; consumidores futuros permanecem como visão de evolução.
 
 18.1 Contrato transversal de templates, módulos, composições e artefatos
 
@@ -1610,6 +1610,96 @@ Repositório — Ajustados
   - A publicação deve arquivar o `published` anterior e publicar o novo `draft` na mesma operação segura.
   - A escrita administrativa precisa estar viabilizada antes da persistência do draft.
 
+18.4 Base de composição landing_page
+
+18.4.1 Objetivo e status
+- Objetivo: Consolidar `landing_page` como família técnica própria dentro da base transversal da E18, separada de `commercial_activation`, com catálogo, contratos executáveis, validação fail-closed e renderer próprio antes de qualquer consumo real.
+- Status: Concluída como base técnica interna repo-only.
+- Limite: não libera automaticamente registros-base, LP teste, rota pública, Admin, LP Builder, automação, job ou agente; próximo consumo depende de definição estratégica posterior.
+
+18.4.2 Registros do recorte
+- Banco:
+  - Criados: N/A.
+  - Ajustados: N/A.
+- Repositório:
+  - Criados:
+    - `lib/conversion-content/landing-page/contracts.ts`
+    - `lib/conversion-content/landing-page/schemas.ts`
+    - `lib/conversion-content/landing-page/registry.ts`
+    - `lib/conversion-content/landing-page/render-model.ts`
+    - `lib/conversion-content/landing-page/renderer.tsx`
+    - `lib/conversion-content/landing-page/fixture.ts`
+    - `lib/conversion-content/landing-page/validation-cases.ts`
+    - `lib/conversion-content/landing-page/composition-validator.ts`
+    - `lib/conversion-content/landing-page/index.ts`
+  - Ajustados:
+    - `lib/conversion-content/index.ts`
+    - `package.json`
+    - `package-lock.json`
+  - Excluídos: N/A.
+- Updates:
+  - Aplicados: N/A.
+
+18.4.3 Decisão de schema e banco
+- Status: N/A para implementação de banco/schema.
+- Decisão: o schema atual é suficiente para o início controlado de `landing_page`; a base foi tratada como contrato técnico repo-only.
+- Limite: registros-base futuros de `landing_page` dependem de decisão posterior.
+
+18.4.4 Catálogo mínimo landing_page
+- Decisão: `landing_page` passa a ter catálogo mínimo próprio, controlado no repositório.
+- Módulos permitidos no primeiro uso:
+  - `hero`
+  - `benefits`
+  - `offer`
+  - `social_proof`
+  - `how_it_works`
+  - `faq`
+  - `final_cta`
+- Variantes permitidas:
+  - `hero.lead_capture`
+  - `benefits.cards`
+  - `offer.summary`
+  - `social_proof.simple`
+  - `how_it_works.steps`
+  - `faq.accordion`
+  - `final_cta.simple`
+- Limite: `commercial_activation` permanece apenas como referência comparativa; não há compatibilidade automática entre `commercial_activation` e `landing_page`.
+
+18.4.5 Contratos técnicos, registry, schemas e renderer
+- Implementado:
+  - contratos TypeScript próprios;
+  - schemas Zod por conteúdo de seção;
+  - registry fechado;
+  - render model próprio;
+  - renderer mínimo;
+  - fixture sintética;
+  - casos executáveis de validação.
+- Decisão: o registry próprio de `landing_page` vincula canal, módulo, variante, schema e renderer, sem herdar compatibilidade de `commercial_activation`.
+- Validação: `npm run validate:landing-page`.
+
+18.4.6 Resolver, validação e limites de config_json
+- Implementado:
+  - resolver/validador final de composição antes do render model;
+  - normalização da composição válida antes do renderer;
+  - exposição de `config` normalizado para o renderer mínimo.
+- Validador de composição:
+  - rejeita item duplicado;
+  - rejeita `sortOrder` não inteiro, negativo ou duplicado;
+  - normaliza itens por `sortOrder`;
+  - rejeita variante inexistente;
+  - rejeita incompatibilidade entre módulo e variante;
+  - rejeita `config_json` fora do contrato.
+- Limites de `config_json`:
+  - `config_json` é override controlado por seção;
+  - chaves permitidas: `anchor_id` e `spacing`;
+  - `anchor_id` é opcional, seguro, curto e único quando informado;
+  - `spacing` aceita somente `compact`, `default` ou `spacious`;
+  - chaves livres como `renderer`, `schema`, `style`, HTML, script ou props arbitrárias são rejeitadas.
+- Consumo pelo renderer:
+  - `anchor_id` é usado como `id` de seção;
+  - `spacing` controla espaçamento vertical;
+  - nenhum outro override é aceito.
+
 19. E19 — LP Builder
 - Objetivo: Consolidar a seção do Core responsável pela criação, edição e organização de landing pages. No recorte atual, limitar E19 à criação mínima de LP por conta com status inicial `draft`.
 - Status: Em execução faseada — Fase 3 concluída em 30/06/2026. Criação produtiva mínima de LP por conta implementada; persistência mínima em `public.account_landing_pages` criada; boundary próprio do LP Builder criado em `lib/lp-builder/`; gate E9 aplicado antes da persistência. Editor visual, publicação, render público, domínio customizado, analytics, A/B, IA runtime e automações permanecem fora do recorte.
@@ -1760,6 +1850,8 @@ Repositório — Ajustados
   - Esta referência não cria obrigação de nova implementação agora.
 
 99. Changelog
+v1.5.90 — 07/07/2026 — E18.4 concluída como base técnica repo-only de composição `landing_page`, com catálogo mínimo, contratos técnicos, registry, schemas, renderer mínimo, resolver/validador e limites de `config_json`, sem liberação automática de registros-base, LP teste, rota pública, Admin, LP Builder, automação, job ou agente.
+
 v1.5.89 — 04/07/2026 — E9.7 concluída com liberação manual administrativa mínima por `platform_admin`, persistência em `public.account_commercial_entitlements`, concessão/atualização/cancelamento manual, view efetiva validada e decisão de não criar superfície artificial para testar LP Builder.
 
 v1.5.88 — 02/07/2026 — E9 Fase 5 fechada documentalmente após a E19 entregar o ponto produtivo real de criação mínima de LP; gate comercial confirmado antes do insert em `public.account_landing_pages`, com fail-closed por entitlement ausente.


### PR DESCRIPTION
### Motivation
- Registrar o estado final do recorte técnico `landing_page` como parte da E18 no `docs/roadmap.md` para refletir a conclusão do recorte repo-only em 07/07/2026. 
- Incluir regras técnicas aplicáveis ao consumo/validação composicional de `landing_page` em `docs/base-tecnica.md` como contrato reutilizável e fail-closed para implementações futuras.

### Description
- Atualiza `docs/roadmap.md` para `v1.5.90` (data `07/07/2026`) e substitui o trecho de status da E18 adicionando a nova seção `18.4 Base de composição landing_page` com objetivo, limites, catálogo mínimo, lista de arquivos de repositório relacionados e decisão de não liberar registros-base automaticamente. 
- Atualiza `docs/base-tecnica.md` para `v2.0.47` (data `07/07/2026`) e adiciona a seção `3.15.2 Conteúdo composicional de landing_page` descrevendo path canônico, catálogo permitido, regras de validação (fail-closed), normalização por `sortOrder`, limites de `config_json` e comando de validação `npm run validate:landing-page`. 
- Adiciona entradas correspondentes nos changelogs de ambos os documentos para registrar as versões novas (`v1.5.90` e `v2.0.47`). 
- Files changed: `docs/roadmap.md`, `docs/base-tecnica.md`; branch usada: `docs/abc-landing-page-e18-4`; commit: `5a43ccc` (mensagem: `docs: registra base landing_page repo-only`).

### Testing
- Executed `git diff --check` and `git diff --stat` with no whitespace or diff errors reported. 
- Commit created successfully (`git commit`) containing the two modified docs. 
- Attempted remote push with `git push -u origin docs/abc-landing-page-e18-4` but it failed because the local clone has no `origin` configured: `fatal: 'origin' does not appear to be a git repository`. 
- `npm ci` and `npm run check` were not executed as the changes are exclusivamente documentais and these checks are not applicable in this context.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4da39148b88329b9779f279b675f3d)