### PR TITLE
docs: adiciona template de blueprint

### DIFF
--- a/docs/template-blueprint.md
+++ b/docs/template-blueprint.md
@@ -1,0 +1,182 @@
+# Template de Pesquisa Profunda para Blueprint de Modulos de Landing Page
+
+## Objetivo
+
+Analise o nicho abaixo e gere um Blueprint independente para orientar a criacao e parametrizacao de modulos e variantes universais de landing pages de alta conversao.
+
+Nao crie uma landing page final.
+Nao use dados internos, itens estruturados ou composicao previa do nosso sistema.
+O objetivo e extrair padroes de mercado, CRO, UX, copy, prova, oferta e estrutura que possam virar modulos ou variantes reutilizaveis em qualquer nicho.
+
+## Nicho
+
+[NOME DO NICHO]
+
+## Publico-alvo da landing page
+
+[Ex.: comprador final, paciente, empresario, contratante, proprietario, lead B2B, lead B2C]
+
+## Objetivo de conversao
+
+[Ex.: gerar lead qualificado, agendar consulta, pedir orcamento, simular financiamento, falar no WhatsApp, baixar material, solicitar avaliacao]
+
+## Regiao ou mercado
+
+[Ex.: Brasil, Sao Paulo, mercado local, mercado nacional, nicho sem localizacao especifica]
+
+## Canais provaveis de trafego
+
+[Ex.: Google Ads, Meta Ads, SEO, Instagram bio, WhatsApp, trafego organico]
+
+## Tarefa da pesquisa
+
+Pesquise e sintetize:
+
+1. Padroes de landing pages de alta conversao nesse nicho ou em nichos comparaveis.
+2. Padroes de anuncios e ofertas ativas no mercado.
+3. Intencoes de busca e principais duvidas do publico.
+4. Boas praticas de CRO aplicaveis ao nicho.
+5. Padroes visuais, editoriais e de confianca.
+6. Tipos de prova exigidos para gerar credibilidade.
+7. Objecoes, riscos percebidos e barreiras de conversao.
+8. Modulos/secoes que aparecem como necessarios ou altamente recomendados.
+9. Variacoes de modulos que poderiam ser universais.
+10. Parametrizacoes recomendadas por modulo e campo.
+
+## Saida esperada
+
+Entregue o resultado nesta estrutura:
+
+### 1. Resumo estrategico do nicho
+
+- intencao dominante do publico;
+- nivel de consciencia;
+- principal dor;
+- principal desejo;
+- principal objecao;
+- principal risco percebido;
+- principal gatilho de conversao.
+
+### 2. Padroes observados no mercado
+
+Liste padroes recorrentes em LPs, sites, anuncios, paginas de captura e funis do nicho.
+
+### 3. Modulos recomendados
+
+Para cada modulo recomendado, informe:
+
+- nome conceitual do modulo;
+- funcao no funil;
+- quando usar;
+- quando evitar;
+- qual objecao resolve;
+- qual acao espera do usuario;
+- se deve ser universal ou especifico demais;
+- prioridade: alta, media ou baixa.
+
+### 4. Variantes recomendadas
+
+Para cada variante, informe:
+
+- modulo pai;
+- nome da variante;
+- cenario de uso;
+- campos necessarios;
+- campos opcionais;
+- comportamento mobile;
+- riscos de uso;
+- se parece reutilizavel em outros nichos.
+
+### 5. Parametrizacao editorial por campo
+
+Para cada campo importante, informe:
+
+- limite recomendado de caracteres;
+- fonte estrategica recomendada;
+- tom;
+- tipo de promessa permitida;
+- o que evitar;
+- exemplo bom;
+- exemplo ruim.
+
+Campos minimos a cobrir:
+
+- hero title;
+- hero subtitle;
+- CTA principal;
+- CTA secundario;
+- prova curta;
+- titulo de secao;
+- descricao de card;
+- FAQ question;
+- FAQ answer;
+- formulario ou pergunta de qualificacao;
+- nota de privacidade/confianca.
+
+### 6. Parametrizacao visual e UX
+
+Inclua recomendacoes para:
+
+- hierarquia visual;
+- densidade;
+- uso de imagens;
+- uso de icones;
+- prova social;
+- CTA fixo ou recorrente;
+- formulario;
+- mobile;
+- velocidade/performance;
+- acessibilidade basica.
+
+### 7. Criterios de qualidade
+
+Defina criterios para decidir se uma LP desse nicho parece:
+
+- moderna;
+- confiavel;
+- especifica;
+- persuasiva;
+- segura;
+- nao generica;
+- pronta para teste.
+
+### 8. Lacunas provaveis no catalogo de modulos
+
+Liste modulos ou variantes que provavelmente precisariam existir em uma plataforma universal de LPs para atender bem esse nicho.
+
+Classifique cada item como:
+
+- criar agora;
+- avaliar com mais nichos;
+- parametrizar modulo existente;
+- rejeitar por ser especifico demais.
+
+### 9. Fontes e evidencias
+
+Liste as fontes consultadas, separando:
+
+- LPs reais;
+- anuncios/funis;
+- SEO/intencao de busca;
+- CRO/UX;
+- dados de mercado;
+- compliance/regulacao;
+- benchmarks visuais.
+
+Para cada fonte, informe:
+
+- URL;
+- tipo de fonte;
+- data de acesso;
+- por que e relevante;
+- grau de confianca: alto, medio ou baixo.
+
+### 10. Decisoes recomendadas
+
+Finalize com:
+
+- modulos universais que deveriam existir;
+- variantes prioritarias;
+- parametrizacoes criticas;
+- riscos;
+- perguntas que precisam de decisao humana.

--- a/docs/template-blueprint.md
+++ b/docs/template-blueprint.md
@@ -6,6 +6,7 @@ Analise o nicho abaixo e gere um Blueprint independente para orientar a criacao 
 
 Nao crie uma landing page final.
 Nao use dados internos, itens estruturados ou composicao previa do nosso sistema.
+Nao classifique uma LP como alta conversao sem dado publico de conversao. Quando nao houver dado confiavel, use o termo referencia de mercado observada.
 O objetivo e extrair padroes de mercado, CRO, UX, copy, prova, oferta e estrutura que possam virar modulos ou variantes reutilizaveis em qualquer nicho.
 
 ## Nicho
@@ -42,6 +43,10 @@ Pesquise e sintetize:
 8. Modulos/secoes que aparecem como necessarios ou altamente recomendados.
 9. Variacoes de modulos que poderiam ser universais.
 10. Parametrizacoes recomendadas por modulo e campo.
+
+Regra obrigatoria:
+
+Toda recomendacao de modulo, variante ou parametro deve citar a fonte usada. Quando nao houver fonte suficiente, marque como hipotese e envie para decisao humana.
 
 ## Saida esperada
 
@@ -171,7 +176,17 @@ Para cada fonte, informe:
 - por que e relevante;
 - grau de confianca: alto, medio ou baixo.
 
-### 10. Decisoes recomendadas
+### 10. Mapa secao -> modulo/variante -> parametros
+
+Para cada secao recomendada, informe:
+
+- secao;
+- modulo ou variante sugerida;
+- parametros principais;
+- fonte usada;
+- status: aprovado, hipotese ou decisao humana pendente.
+
+### 11. Decisoes recomendadas
 
 Finalize com:
 


### PR DESCRIPTION
## Objetivo

Adicionar `docs/template-blueprint.md` como template inicial para pesquisa profunda independente de Blueprint de módulos e variantes de landing page.

## Escopo

- Cria apenas `docs/template-blueprint.md`.
- Não altera código, banco, migrations, workflows, rotas ou docs existentes.
- O template orienta pesquisa externa sem uso dos itens estruturados internos, para depois confrontar o resultado com a base do projeto.

## Validação

- `git diff --check`
- `git diff --cached --check`

`npm ci` e `npm run check` não foram executados por ser alteração exclusivamente documental.