### PR TITLE
docs: ABC E18.4 — parametrização raiz de `landing_page` (roadmap v1.5.91, base-tecnica v2.0.48)

### DIFF
--- a/docs/base-tecnica.md
+++ b/docs/base-tecnica.md
@@ -2,8 +2,8 @@
 
 0.1. Cabeçalho
 • Documento: Base Técnica LP Factory 10
-• Versão: v2.0.47
-• Data: 07/07/2026
+• Versão: v2.0.48
+• Data: 13/07/2026
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -392,20 +392,15 @@ LP Builder
 • Se o insert das fontes relacionais falhar após criar o artifact, o draft recém-criado deve ser arquivado/invalidado e o fluxo deve retornar erro seguro, sem parecer concluído.
 • Logs devem registrar somente metadados operacionais seguros; não registrar prompt completo, pesquisa bruta, payload sensível ou resposta integral da IA.
 
-3.15.2 Conteúdo composicional de `landing_page`
-• Path canônico: `lib/conversion-content/landing-page/`.
-• `landing_page` tem contratos próprios, schemas Zod próprios, registry fechado, render model próprio, renderer mínimo e validação executável.
-• Catálogo mínimo permitido: `hero.lead_capture`, `benefits.cards`, `offer.summary`, `social_proof.simple`, `how_it_works.steps`, `faq.accordion` e `final_cta.simple`.
-• `landing_page` não herda compatibilidade automática de `commercial_activation`.
-• O registry próprio é a fonte canônica de canal, módulo, variante, schema e renderer.
-• Variante fora do catálogo, incompatibilidade módulo/variante, item duplicado, item desconhecido, canal inválido ou conteúdo fora do schema devem falhar fechado.
-• O resolver/validador deve normalizar itens por `sortOrder` antes do renderer.
-• `sortOrder` deve ser inteiro, não negativo e único.
-• `config_json` aceita somente `anchor_id` e `spacing`.
-• `anchor_id` é opcional, deve seguir padrão seguro de âncora curta e ser único quando informado.
-• `spacing` aceita somente `compact`, `default` ou `spacious`.
-• Chaves livres como `renderer`, `schema`, `style`, HTML, script ou props arbitrárias devem ser rejeitadas.
-• Casos executáveis: `npm run validate:landing-page`.
+3.15.2 Parametrização raiz de `landing_page`
+• Boundary canônico: `lib/conversion-content/landing-page/`.
+• Fonte canônica dos parâmetros e versões: `root-registry.ts`; não duplicar seus valores ou listas em documentos ou contratos públicos.
+• Resolver versões e presets registrados por `root-resolver.ts`, com falha fechada e sem fallback implícito.
+• Validar o contrato raiz por `root-schema.ts`; a saída resolvida deve permanecer imutável.
+• Consumir o boundary pelo namespace `landingPageRoot` exportado em `lib/conversion-content/index.ts`.
+• Não reutilizar as APIs removidas de composição, módulos, variantes, renderer ou render model.
+• Especializações futuras devem preservar a precedência `raiz → módulo → variante`.
+• Casos executáveis: `npm run validate:landing-page-root`.
 
 4. DB Contract - Fonte única: PATH: docs/schema.md
 • Este documento não lista mais tabelas/views/functions/triggers/policies; isso está em PATH: docs/schema.md.
@@ -554,6 +549,7 @@ Fonte normativa da allowlist SULB para exceções de Auth. Qualquer novo arquivo
 • Tipos canônicos e adapters vNext: validar por 3.6 e 3.14.
 
 99. Changelog
+v2.0.48 — 13/07/2026 — Substituído o contrato antigo de composição `landing_page` pelo contrato técnico durável da parametrização raiz versionada, com registry canônico, resolução fail-closed, imutabilidade e validação executável.
 v2.0.47 — 07/07/2026 — Registrado contrato técnico da base repo-only de composição `landing_page`, com path canônico, catálogo mínimo, registry fechado, schemas, renderer mínimo, resolver/validador e limites de `config_json`.
 v2.0.46 — 04/07/2026 — Registrado contrato técnico da liberação manual administrativa mínima de entitlement comercial, com Server Action protegida por `requirePlatformAdmin`, boundary Admin server-only e persistência exclusiva em `public.account_commercial_entitlements`.
 v2.0.45 (02/07/2026) — Registrado webhook Stripe mínimo do E9, com endpoint canônico, boundary, assinatura obrigatória, evento `invoice.paid`, idempotência e persistência segura de entitlement.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data: 07/07/2026
-• Versão: v1.5.90
+• Data: 13/07/2026
+• Versão: v1.5.91
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -1401,7 +1401,7 @@ Repositório — Ajustados
 
 18. E18 — Base transversal de templates, módulos, composições e artefatos
 - Objetivo: Definir infraestrutura e contratos reutilizáveis para famílias de templates por canal, templates versionados, módulos de conteúdo, seções de página, variantes, composições e artefatos finais persistidos; sustentar primeiro a E10.7 sem produzir diretamente a página comercial de um taxon; e permitir consumidores futuros somente como visão de evolução, sem antecipar sua implementação.
-- Status: Base transversal mínima de `commercial_activation` concluída e validada em 16/06/2026; base técnica repo-only de composição `landing_page` concluída em 07/07/2026; E10.7 desbloqueada como primeiro consumidor real; consumidores futuros permanecem como visão de evolução.
+- Status: Base mínima de `commercial_activation` concluída; parametrização raiz versionada de `landing_page` concluída em 13/07/2026; implementação anterior de composição `landing_page` removida; parametrização de módulos e variantes permanece separada no recorte 18.5.
 
 18.1 Contrato transversal de templates, módulos, composições e artefatos
 
@@ -1450,6 +1450,7 @@ Repositório — Ajustados
     - `final_cta.simple`
   - As variantes descrevem comportamento estrutural ou funcional e não podem representar nichos.
   - A ampliação do catálogo depende de necessidade comprovada por consumidores reais.
+  - Para `landing_page`, a parametrização raiz pertence ao recorte 18.4; módulos e variantes permanecem separados no recorte 18.5.
 
 18.1.6 Contrato entre código e banco
 - Status: Definido como separação de responsabilidades.
@@ -1610,95 +1611,106 @@ Repositório — Ajustados
   - A publicação deve arquivar o `published` anterior e publicar o novo `draft` na mesma operação segura.
   - A escrita administrativa precisa estar viabilizada antes da persistência do draft.
 
-18.4 Base de composição landing_page
+18.4 Parametrização raiz da família `landing_page`
 
 18.4.1 Objetivo e status
-- Objetivo: Consolidar `landing_page` como família técnica própria dentro da base transversal da E18, separada de `commercial_activation`, com catálogo, contratos executáveis, validação fail-closed e renderer próprio antes de qualquer consumo real.
-- Status: Concluída como base técnica interna repo-only.
-- Limite: não libera automaticamente registros-base, LP teste, rota pública, Admin, LP Builder, automação, job ou agente; próximo consumo depende de definição estratégica posterior.
+
+* Objetivo: Consolidar a parametrização raiz versionada que define os parâmetros comuns da família `landing_page`.
+* Status: Concluída como implementação repo-only em 13/07/2026, com ciclo de vida inicial `hypothesis`.
 
 18.4.2 Registros do recorte
-- Banco:
-  - Criados: N/A.
-  - Ajustados: N/A.
-- Repositório:
-  - Criados:
-    - `lib/conversion-content/landing-page/contracts.ts`
-    - `lib/conversion-content/landing-page/schemas.ts`
-    - `lib/conversion-content/landing-page/registry.ts`
-    - `lib/conversion-content/landing-page/render-model.ts`
-    - `lib/conversion-content/landing-page/renderer.tsx`
-    - `lib/conversion-content/landing-page/fixture.ts`
-    - `lib/conversion-content/landing-page/validation-cases.ts`
-    - `lib/conversion-content/landing-page/composition-validator.ts`
-    - `lib/conversion-content/landing-page/index.ts`
-  - Ajustados:
-    - `lib/conversion-content/index.ts`
-    - `package.json`
-    - `package-lock.json`
-  - Excluídos: N/A.
-- Updates:
-  - Aplicados: N/A.
 
-18.4.3 Decisão de schema e banco
-- Status: N/A para implementação de banco/schema.
-- Decisão: o schema atual é suficiente para o início controlado de `landing_page`; a base foi tratada como contrato técnico repo-only.
-- Limite: registros-base futuros de `landing_page` dependem de decisão posterior.
+* Repositório:
 
-18.4.4 Catálogo mínimo landing_page
-- Decisão: `landing_page` passa a ter catálogo mínimo próprio, controlado no repositório.
-- Módulos permitidos no primeiro uso:
-  - `hero`
-  - `benefits`
-  - `offer`
-  - `social_proof`
-  - `how_it_works`
-  - `faq`
-  - `final_cta`
-- Variantes permitidas:
-  - `hero.lead_capture`
-  - `benefits.cards`
-  - `offer.summary`
-  - `social_proof.simple`
-  - `how_it_works.steps`
-  - `faq.accordion`
-  - `final_cta.simple`
-- Limite: `commercial_activation` permanece apenas como referência comparativa; não há compatibilidade automática entre `commercial_activation` e `landing_page`.
+  * Criados:
 
-18.4.5 Contratos técnicos, registry, schemas e renderer
-- Implementado:
-  - contratos TypeScript próprios;
-  - schemas Zod por conteúdo de seção;
-  - registry fechado;
-  - render model próprio;
-  - renderer mínimo;
-  - fixture sintética;
-  - casos executáveis de validação.
-- Decisão: o registry próprio de `landing_page` vincula canal, módulo, variante, schema e renderer, sem herdar compatibilidade de `commercial_activation`.
-- Validação: `npm run validate:landing-page`.
+    * `lib/conversion-content/landing-page/contracts.ts`
+    * `lib/conversion-content/landing-page/index.ts`
+    * `lib/conversion-content/landing-page/root-registry.ts`
+    * `lib/conversion-content/landing-page/root-resolver.ts`
+    * `lib/conversion-content/landing-page/root-schema.ts`
+    * `lib/conversion-content/landing-page/root-validation-cases.ts`
+  * Ajustados:
 
-18.4.6 Resolver, validação e limites de config_json
-- Implementado:
-  - resolver/validador final de composição antes do render model;
-  - normalização da composição válida antes do renderer;
-  - exposição de `config` normalizado para o renderer mínimo.
-- Validador de composição:
-  - rejeita item duplicado;
-  - rejeita `sortOrder` não inteiro, negativo ou duplicado;
-  - normaliza itens por `sortOrder`;
-  - rejeita variante inexistente;
-  - rejeita incompatibilidade entre módulo e variante;
-  - rejeita `config_json` fora do contrato.
-- Limites de `config_json`:
-  - `config_json` é override controlado por seção;
-  - chaves permitidas: `anchor_id` e `spacing`;
-  - `anchor_id` é opcional, seguro, curto e único quando informado;
-  - `spacing` aceita somente `compact`, `default` ou `spacious`;
-  - chaves livres como `renderer`, `schema`, `style`, HTML, script ou props arbitrárias são rejeitadas.
-- Consumo pelo renderer:
-  - `anchor_id` é usado como `id` de seção;
-  - `spacing` controla espaçamento vertical;
-  - nenhum outro override é aceito.
+    * `lib/conversion-content/index.ts`
+    * `package.json`
+  * Excluídos:
+
+    * `lib/conversion-content/landing-page/composition-validator.ts`
+    * `lib/conversion-content/landing-page/fixture.ts`
+    * `lib/conversion-content/landing-page/registry.ts`
+    * `lib/conversion-content/landing-page/render-model.ts`
+    * `lib/conversion-content/landing-page/renderer.tsx`
+    * `lib/conversion-content/landing-page/schemas.ts`
+    * `lib/conversion-content/landing-page/validation-cases.ts`
+
+18.4.3 Fonte canônica e versionamento
+
+* Status: Implementados.
+* Conteúdo:
+
+  * Registry raiz versionado como fonte canônica.
+  * Resolução por versão registrada, sem fallback implícito.
+  * Ciclo de vida inicial mantido como `hypothesis`.
+
+18.4.4 Parâmetros semânticos e editoriais
+
+* Status: Implementados na raiz.
+* Conteúdo:
+
+  * Papéis comuns, faixas recomendadas e limites técnicos absolutos.
+  * Valores exatos mantidos no registry canônico.
+
+18.4.5 Limites e evolução
+
+* Status: Definidos.
+* Conteúdo:
+
+  * Faixas recomendadas orientam a geração.
+  * Limites absolutos bloqueiam valores inválidos.
+  * Ampliação de limite absoluto exige nova versão raiz.
+
+18.4.6 Critérios visuais e responsivos
+
+* Status: Implementados na raiz.
+* Conteúdo:
+
+  * Critérios abstratos visuais, responsivos e de acessibilidade.
+  * Contrato detalhado mantido no registry canônico.
+
+18.4.7 Presets e espaçamento
+
+* Status: Implementados e versionados.
+* Conteúdo:
+
+  * Presets raiz e opções permitidas de espaçamento.
+  * Chaves e valores exatos mantidos no registry canônico.
+
+18.4.8 Resolver e validação
+
+* Status: Implementados.
+* Conteúdo:
+
+  * Schema estrito, resolução determinística e saída imutável.
+  * Falha fechada para versão, preset ou contrato inválido.
+  * Validação executável própria da parametrização raiz.
+
+18.4.9 Limites do recorte
+
+* Status: Preservados.
+* Conteúdo:
+
+  * A implementação antiga de composição e renderização foi removida.
+  * Módulos, variantes e suas especializações pertencem ao recorte 18.5.
+  * Não houve alteração de banco nem consumo real por LP.
+  * Os parâmetros permanecem como hipótese até validação por LP real.
+
+18.5 Parametrização de módulos e variantes `landing_page`
+
+18.5.1 Objetivo e status
+
+* Objetivo: Definir as especializações de módulos e variantes sobre a parametrização raiz da família `landing_page`.
+* Status: Planejada; não implementada no recorte 18.4.
 
 19. E19 — LP Builder
 - Objetivo: Consolidar a seção do Core responsável pela criação, edição e organização de landing pages. No recorte atual, limitar E19 à criação mínima de LP por conta com status inicial `draft`.
@@ -1850,6 +1862,8 @@ Repositório — Ajustados
   - Esta referência não cria obrigação de nova implementação agora.
 
 99. Changelog
+v1.5.91 — 13/07/2026 — E18.4 consolidada como parametrização raiz versionada da família `landing_page`; removida a implementação anterior de composição e separado o recorte futuro 18.5 para módulos e variantes.
+
 v1.5.90 — 07/07/2026 — E18.4 concluída como base técnica repo-only de composição `landing_page`, com catálogo mínimo, contratos técnicos, registry, schemas, renderer mínimo, resolver/validador e limites de `config_json`, sem liberação automática de registros-base, LP teste, rota pública, Admin, LP Builder, automação, job ou agente.
 
 v1.5.89 — 04/07/2026 — E9.7 concluída com liberação manual administrativa mínima por `platform_admin`, persistência em `public.account_commercial_entitlements`, concessão/atualização/cancelamento manual, view efetiva validada e decisão de não criar superfície artificial para testar LP Builder.


### PR DESCRIPTION
### Motivation
- Registrar que o recorte E18 passou a expor uma parametrização raiz versionada da família `landing_page` e que a implementação anterior de composição foi removida, separando módulos/variantes no recorte futuro 18.5.
- Atualizar os metadados dos documentos (`docs/roadmap.md` e `docs/base-tecnica.md`) com a nova versão/data para refletir o estado final consolidado.

### Description
- Substituídos trechos em `docs/roadmap.md`: atualizado cabeçalho (Data/Versão), substituída a seção 18.4 por uma nova seção de `Parametrização raiz da família landing_page`, adicionada a seção 18.5 para módulos/variantes e incluida a entrada de changelog `v1.5.91`.
- Substituído o bloco `3.15.2` em `docs/base-tecnica.md` por `Parametrização raiz de landing_page`, com referências ao `root-registry.ts`, `root-resolver.ts`, `root-schema.ts`, namespace `landingPageRoot` e caso executável `npm run validate:landing-page-root`, e adicionada a entrada de changelog `v2.0.48`.
- Arquivos alterados: `docs/roadmap.md` e `docs/base-tecnica.md`.
- Commit/branch: alterações commitadas na branch `work` (commit `c42771d`).

### Testing
- Executado `git diff --check` e sem alertas detectados (sucesso).
- `npm ci`: não aplicável por serem alterações exclusivamente documentais.
- `npm run check`: não aplicável por serem alterações exclusivamente documentais.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a562db54c5883299c93b1bda2ff3f8a)