### PR TITLE
docs: exige merge antes de acionar Executor

### DIFF
--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -81,10 +81,12 @@ Regra:
 • consolidar todos os retornos em uma única análise;
 • classificar os pontos como aceito, rejeitado, pendente ou já coberto;
 • alterar somente o plano-base do caso;
-• não abrir novo escopo sem decisão humana explícita.
+• não abrir novo escopo sem decisão humana explícita;
+• após a consolidação, solicitar ao humano o merge do PR;
+• não seguir ao item 7 antes da confirmação do merge.
 
 7. Instrução ao Executor
-   Enviar ao Executor o plano-base v2 completo, indicando a fase atual e as fontes obrigatórias, conforme docs/prompt-executor.md e AGENTS.md.
+   Após a confirmação do merge, referenciar o path do plano-base v2 na main, indicando a fase atual e as fontes obrigatórias, conforme docs/prompt-executor.md e AGENTS.md.
 
 Regra:
 • executar uma fase por vez, na ordem do plano;


### PR DESCRIPTION
### Motivation
- Tornar explícito no fluxo do Estrategista que o plano-base v2 deve ser consolidado no PR antes da execução. 
- Garantir que o Estrategista solicite o merge ao humano e que o item 7 só seja executado após confirmação do merge. 
- Assegurar que o Executor use como referência operacional o plano-base disponível na `main` sem ser responsável por verificar o merge.

### Description
- Substituídos integralmente os itens 6 e 7 em `docs/prompt-estrategista.md` para exigir consolidação dos retornos no mesmo PR, solicitação do merge ao humano e bloqueio do avanço ao item 7 até confirmação do merge. 
- O item 7 agora instrui que, após a confirmação do merge, o Executor deve referenciar o path do plano-base v2 na `main` e continuar fase a fase conforme `docs/prompt-executor.md` e `AGENTS.md`. 
- Preservada a linha `Versão: v21` e mantidos inalterados os itens 0–5 e 8–11, bem como arquivos e documentos fora do escopo.
- Apenas o arquivo `docs/prompt-estrategista.md` foi alterado na branch usada para a alteração (`docs/exige-merge-antes-executor`).

### Testing
- Executados `git diff --check`, `git status --short`, `git diff --name-only` e uma busca por trechos-chave com `rg`, todos indicando apenas a alteração prevista em `docs/prompt-estrategista.md`. 
- Validações textuais confirmaram que o item 6 exige solicitação e confirmação do merge antes de seguir e que o item 7 referencia o plano-base v2 na `main` mantendo `docs/prompt-executor.md` e `AGENTS.md` como fontes obrigatórias. 
- `npm ci` e `npm run check` foram considerados não aplicáveis por se tratar de alteração exclusivamente documental, e o push remoto não foi realizado porque não há destino de push configurado no clone (push falhou por falta de remote).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5676c5ddf88329b527f6d7ed86372f)