### PR TITLE
E10.8: resolver pesquisas estruturadas para landing_page

### DIFF
--- a/docs/lousa-plano-base-e10-8.md
+++ b/docs/lousa-plano-base-e10-8.md
@@ -2,7 +2,7 @@
 
 - Versão: v2
 - Data: 14/07/2026
-- Status: plano-base v2 consolidado; Executor ainda não liberado
+- Status: fase executada e validada na branch; aguarda revisão humana e merge
 - Recorte previsto para roadmap: `10.8 — Resolução de pesquisas estruturadas para landing_page`
 - Path canônico: `docs/lousa-plano-base-e10-8.md`
 - Fontes obrigatórias: `README.md`, `AGENTS.md`, `docs/prompt-estrategista.md`, `docs/template-roadmap.md`, `docs/template-briefing-codex.md`, `docs/prompt-executor.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/schema.md`, `docs/lp-planejamento.md`, `docs/supa-up.md`, `supabase/snippets/e10_5_5_nicho_carregamento.sql`, implementação e documentação atuais da E10.5.5, E10.5.6 e E10.7.
@@ -188,7 +188,7 @@
 
 ### 3.1. E10.8.3–10.8.5 — Resolver server-side completo para landing_page
 
-- Status: planejada.
+- Status: implementada e validada em 14/07/2026 na branch `feat/e10-8-research-resolution`; aguarda revisão humana e merge.
 - Objetivo: implementar o resolver compartilhado de elegibilidade, precedência, proveniência, falha fechada e consumo tipado definido na seção 2.
 - Automação: não.
 - Escopo executável:
@@ -222,7 +222,23 @@
   - nenhum registro de pesquisa existente é criado, editado, arquivado ou excluído;
   - nenhuma estrutura de banco, rota, UI, E10.7, E20 ou E19 é alterada;
   - diff limitado aos artefatos listados e a este plano-base.
-- Próxima ação após aprovação do plano-base v2: enviar o plano completo ao Executor, indicando esta fase como a única fase autorizada para execução.
+- Artefatos executados:
+  - `lib/conversion-content/landing-page/research-resolution/contracts.ts`;
+  - `lib/conversion-content/landing-page/research-resolution/resolver.ts`;
+  - `lib/conversion-content/landing-page/research-resolution/validation-cases.ts`;
+  - `lib/conversion-content/landing-page/research-resolution/index.ts`;
+  - `lib/conversion-content/adapters/landingPageResearchAdapter.ts`;
+  - exports separados em `lib/conversion-content/index.ts`;
+  - script `validate:landing-page-research` em `package.json`.
+- Evidências:
+  - `npm ci`: concluído;
+  - `npm run check`: aprovado com zero erros e 24 warnings preexistentes fora do diff;
+  - `npm run validate:landing-page-research`: 15 grupos de casos aprovados, cobrindo integralmente a matriz da seção 2.7, proveniência, ordenação e ausência de mistura parcial;
+  - inspeção read-only real no Supabase confirmou o taxon atendido ativo, o pai direto ativo, quatro blocos `business_buyer` próprios na versão 1 com 49 itens ativos e quatro blocos `business_buyer` no pai direto na versão 1 com 54 itens ativos, sem item ativo estruturalmente inválido;
+  - validação read-only real do DTO no resolver retornou `business_buyer.sourceRelation = own`, 49 itens próprios e 74 itens `end_customer` próprios, ambos na versão 1;
+  - nenhum registro, estrutura de banco, rota, UI, consumidor, parametrização raiz da E18.4 ou contrato da E10.7 foi alterado.
+- Decisão da fase: encerrar a única fase executável após revisão humana e merge do PR.
+- Próxima ação: revisar e fazer merge humano do PR; após o merge, habilitar o relatório final ao Gestor de Docs conforme `docs/prompt-estrategista.md`.
 
 ## 4. Escopo negativo e critérios de parada
 

--- a/docs/lousa-plano-base-e10-8.md
+++ b/docs/lousa-plano-base-e10-8.md
@@ -233,7 +233,7 @@
 - Evidências:
   - `npm ci`: concluído;
   - `npm run check`: aprovado com zero erros e 24 warnings preexistentes fora do diff;
-  - `npm run validate:landing-page-research`: 15 grupos de casos aprovados, cobrindo integralmente a matriz da seção 2.7, proveniência, ordenação e ausência de mistura parcial;
+  - `npm run validate:landing-page-research`: 17 grupos de casos aprovados, cobrindo integralmente a matriz da seção 2.7, proveniência, ordenação, ausência de mistura parcial e as regressões em que item ativo inválido impede fallback de conjunto próprio incompleto;
   - inspeção read-only real no Supabase confirmou o taxon atendido ativo, o pai direto ativo, quatro blocos `business_buyer` próprios na versão 1 com 49 itens ativos e quatro blocos `business_buyer` no pai direto na versão 1 com 54 itens ativos, sem item ativo estruturalmente inválido;
   - validação read-only real do DTO no resolver retornou `business_buyer.sourceRelation = own`, 49 itens próprios e 74 itens `end_customer` próprios, ambos na versão 1;
   - nenhum registro, estrutura de banco, rota, UI, consumidor, parametrização raiz da E18.4 ou contrato da E10.7 foi alterado.

--- a/lib/conversion-content/adapters/landingPageResearchAdapter.ts
+++ b/lib/conversion-content/adapters/landingPageResearchAdapter.ts
@@ -1,0 +1,375 @@
+import "server-only";
+
+import { createServiceClient } from "@/lib/supabase/service";
+import {
+  LANDING_PAGE_RESEARCH_BLOCKS,
+  isLandingPageResearchUuid,
+  resolveLandingPageResearch,
+  type LandingPageResearchItemDto,
+  type LandingPageResearchNormalizedSource,
+  type LandingPageResearchParentDto,
+  type LandingPageResearchResolutionResult,
+  type LandingPageResearchTaxonDto,
+} from "../landing-page/research-resolution";
+
+const AUDIENCE_SCOPES = ["business_buyer", "end_customer"] as const;
+type ServiceClient = ReturnType<typeof createServiceClient>;
+type ResearchRowsResult =
+  | Readonly<{
+      ok: true;
+      researches: LandingPageResearchParentDto[];
+      items: LandingPageResearchItemDto[];
+    }>
+  | Readonly<{
+      ok: false;
+      sourceStatus: "read_failed" | "not_normalizable";
+    }>;
+
+export async function resolveLandingPageResearchForTaxon(input: {
+  taxonId: string;
+  requestId?: string;
+}): Promise<LandingPageResearchResolutionResult> {
+  const taxonId = input.taxonId.trim();
+  if (!isLandingPageResearchUuid(taxonId)) {
+    return finishResolution({
+      taxonId,
+      requestId: input.requestId,
+      source: { status: "ready", taxons: [], researches: [], items: [] },
+    });
+  }
+
+  const supabase = createServiceClient();
+
+  try {
+    const { data: servedRow, error: servedError } = await supabase
+      .from("business_taxons")
+      .select("id,parent_id,is_active")
+      .eq("id", taxonId)
+      .limit(1)
+      .maybeSingle();
+
+    if (servedError) {
+      return finishResolution({
+        taxonId,
+        requestId: input.requestId,
+        source: { status: "read_failed" },
+      });
+    }
+    if (!servedRow) {
+      return finishResolution({
+        taxonId,
+        requestId: input.requestId,
+        source: { status: "ready", taxons: [], researches: [], items: [] },
+      });
+    }
+
+    const servedTaxon = normalizeTaxon(servedRow);
+    if (!servedTaxon) {
+      return finishResolution({
+        taxonId,
+        requestId: input.requestId,
+        source: { status: "not_normalizable" },
+      });
+    }
+
+    if (!servedTaxon.isActive) {
+      return finishResolution({
+        taxonId,
+        requestId: input.requestId,
+        source: {
+          status: "ready",
+          taxons: [servedTaxon],
+          researches: [],
+          items: [],
+        },
+      });
+    }
+
+    const ownResearch = await readResearchRows(
+      supabase,
+      servedTaxon.id,
+      AUDIENCE_SCOPES,
+    );
+    if (!ownResearch.ok) {
+      return finishResolution({
+        taxonId,
+        requestId: input.requestId,
+        source: { status: ownResearch.sourceStatus },
+      });
+    }
+
+    const ownSource: LandingPageResearchNormalizedSource = {
+      status: "ready",
+      taxons: [servedTaxon],
+      researches: ownResearch.researches,
+      items: ownResearch.items,
+    };
+    const ownResult = resolveLandingPageResearch({ taxonId, source: ownSource });
+    if (ownResult.ok || ownResult.error.code !== "DIRECT_PARENT_NOT_FOUND") {
+      return finishResolution({
+        taxonId,
+        requestId: input.requestId,
+        source: ownSource,
+      });
+    }
+    if (!servedTaxon.parentId) {
+      return finishResolution({
+        taxonId,
+        requestId: input.requestId,
+        source: ownSource,
+      });
+    }
+
+    const { data: parentRow, error: parentError } = await supabase
+      .from("business_taxons")
+      .select("id,parent_id,is_active")
+      .eq("id", servedTaxon.parentId)
+      .limit(1)
+      .maybeSingle();
+
+    if (parentError) {
+      return finishResolution({
+        taxonId,
+        requestId: input.requestId,
+        source: { status: "read_failed" },
+      });
+    }
+    if (!parentRow) {
+      return finishResolution({
+        taxonId,
+        requestId: input.requestId,
+        source: ownSource,
+      });
+    }
+
+    const parentTaxon = normalizeTaxon(parentRow);
+    if (!parentTaxon) {
+      return finishResolution({
+        taxonId,
+        requestId: input.requestId,
+        source: { status: "not_normalizable" },
+      });
+    }
+
+    if (!parentTaxon.isActive) {
+      return finishResolution({
+        taxonId,
+        requestId: input.requestId,
+        source: {
+          ...ownSource,
+          taxons: [servedTaxon, parentTaxon],
+        },
+      });
+    }
+
+    const parentResearch = await readResearchRows(supabase, parentTaxon.id, [
+      "business_buyer",
+    ]);
+    if (!parentResearch.ok) {
+      return finishResolution({
+        taxonId,
+        requestId: input.requestId,
+        source: { status: parentResearch.sourceStatus },
+      });
+    }
+
+    return finishResolution({
+      taxonId,
+      requestId: input.requestId,
+      source: {
+        status: "ready",
+        taxons: [servedTaxon, parentTaxon],
+        researches: [
+          ...ownResearch.researches,
+          ...parentResearch.researches,
+        ],
+        items: [...ownResearch.items, ...parentResearch.items],
+      },
+    });
+  } catch {
+    return finishResolution({
+      taxonId,
+      requestId: input.requestId,
+      source: { status: "read_failed" },
+    });
+  }
+}
+
+async function readResearchRows(
+  supabase: ServiceClient,
+  taxonId: string,
+  audienceScopes: readonly (typeof AUDIENCE_SCOPES)[number][],
+): Promise<ResearchRowsResult> {
+  const { data: researchRows, error: researchError } = await supabase
+    .from("taxon_market_research")
+    .select("id,taxon_id,research_block,audience_scope,version,status")
+    .eq("taxon_id", taxonId)
+    .in("research_block", [...LANDING_PAGE_RESEARCH_BLOCKS])
+    .in("audience_scope", [...audienceScopes])
+    .eq("status", "active");
+
+  if (researchError) return { ok: false, sourceStatus: "read_failed" };
+
+  const researches = normalizeRows(researchRows, normalizeResearch);
+  if (!researches) {
+    return { ok: false, sourceStatus: "not_normalizable" };
+  }
+
+  const researchIds = researches.map((research) => research.id);
+  if (researchIds.length === 0) {
+    return { ok: true, researches, items: [] };
+  }
+
+  const { data: itemRows, error: itemError } = await supabase
+    .from("taxon_market_research_items")
+    .select("id,research_id,item_key,item_text,priority,sort_order,is_active")
+    .in("research_id", researchIds);
+
+  if (itemError) return { ok: false, sourceStatus: "read_failed" };
+
+  const items = normalizeRows(itemRows, normalizeItem);
+  if (!items) return { ok: false, sourceStatus: "not_normalizable" };
+
+  return { ok: true, researches, items };
+}
+
+function finishResolution(input: {
+  taxonId: string;
+  requestId?: string;
+  source: LandingPageResearchNormalizedSource;
+}): LandingPageResearchResolutionResult {
+  const result = resolveLandingPageResearch({
+    taxonId: input.taxonId,
+    source: input.source,
+  });
+
+  if (result.ok) {
+    logResearchResolution("landing_page_research_resolution_completed", {
+      requestId: input.requestId,
+      taxonId: result.value.servedTaxonId,
+      status: "ok",
+      businessBuyerSourceRelation:
+        result.value.businessBuyer.sourceRelation,
+      businessBuyerSourceTaxonId: result.value.businessBuyer.sourceTaxonId,
+      businessBuyerVersion: result.value.businessBuyer.version,
+      endCustomerVersion: result.value.endCustomer.version,
+    });
+  } else {
+    logResearchResolution("landing_page_research_resolution_failed", {
+      requestId: input.requestId,
+      taxonId: isLandingPageResearchUuid(input.taxonId)
+        ? input.taxonId
+        : null,
+      status: "failed",
+      errorCode: result.error.code,
+      audienceScope: result.error.audienceScope,
+      sourceRelation: result.error.sourceRelation,
+      sourceTaxonId: result.error.sourceTaxonId,
+    });
+  }
+
+  return result;
+}
+
+function normalizeTaxon(value: unknown): LandingPageResearchTaxonDto | null {
+  if (!isRecord(value)) return null;
+  if (
+    typeof value.id !== "string" ||
+    !isLandingPageResearchUuid(value.id) ||
+    (value.parent_id !== null &&
+      (typeof value.parent_id !== "string" ||
+        !isLandingPageResearchUuid(value.parent_id))) ||
+    typeof value.is_active !== "boolean"
+  ) {
+    return null;
+  }
+
+  return {
+    id: value.id,
+    parentId: value.parent_id as string | null,
+    isActive: value.is_active,
+  };
+}
+
+function normalizeResearch(
+  value: unknown,
+): LandingPageResearchParentDto | null {
+  if (!isRecord(value)) return null;
+  if (
+    typeof value.id !== "string" ||
+    !isLandingPageResearchUuid(value.id) ||
+    typeof value.taxon_id !== "string" ||
+    !isLandingPageResearchUuid(value.taxon_id) ||
+    typeof value.research_block !== "string" ||
+    !(LANDING_PAGE_RESEARCH_BLOCKS as readonly string[]).includes(
+      value.research_block,
+    ) ||
+    typeof value.audience_scope !== "string" ||
+    !(AUDIENCE_SCOPES as readonly string[]).includes(value.audience_scope) ||
+    !Number.isInteger(value.version) ||
+    typeof value.status !== "string"
+  ) {
+    return null;
+  }
+
+  return {
+    id: value.id,
+    taxonId: value.taxon_id,
+    researchBlock: value.research_block,
+    audienceScope: value.audience_scope,
+    version: value.version as number,
+    status: value.status,
+  };
+}
+
+function normalizeItem(value: unknown): LandingPageResearchItemDto | null {
+  if (!isRecord(value)) return null;
+  if (
+    typeof value.id !== "string" ||
+    !isLandingPageResearchUuid(value.id) ||
+    typeof value.research_id !== "string" ||
+    !isLandingPageResearchUuid(value.research_id) ||
+    (value.item_key !== null && typeof value.item_key !== "string") ||
+    (value.item_text !== null && typeof value.item_text !== "string") ||
+    (value.priority !== null && !Number.isInteger(value.priority)) ||
+    (value.sort_order !== null && !Number.isInteger(value.sort_order)) ||
+    typeof value.is_active !== "boolean"
+  ) {
+    return null;
+  }
+
+  return {
+    id: value.id,
+    researchId: value.research_id,
+    itemKey: value.item_key as string | null,
+    itemText: value.item_text as string | null,
+    priority: value.priority as number | null,
+    sortOrder: value.sort_order as number | null,
+    isActive: value.is_active,
+  };
+}
+
+function normalizeRows<T>(
+  values: unknown,
+  normalize: (value: unknown) => T | null,
+): T[] | null {
+  if (!Array.isArray(values)) return null;
+  const normalized = values.map(normalize);
+  return normalized.some((value) => value === null)
+    ? null
+    : (normalized as T[]);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function logResearchResolution(
+  event: string,
+  details: Readonly<Record<string, unknown>>,
+): void {
+  const payload = Object.fromEntries(
+    Object.entries({ event, ...details }).filter(([, value]) => value !== undefined),
+  );
+  console.log(JSON.stringify(payload));
+}

--- a/lib/conversion-content/index.ts
+++ b/lib/conversion-content/index.ts
@@ -2,7 +2,9 @@ export * from "./contracts";
 export * from "./validation";
 export * from "./commercial-activation";
 export * as landingPageRoot from "./landing-page";
+export * as landingPageResearch from "./landing-page/research-resolution";
 export {
   getCommercialActivationBundle,
   getCommercialActivationHierarchicalBundle,
 } from "./adapters/commercialActivationAdapter";
+export { resolveLandingPageResearchForTaxon } from "./adapters/landingPageResearchAdapter";

--- a/lib/conversion-content/landing-page/research-resolution/contracts.ts
+++ b/lib/conversion-content/landing-page/research-resolution/contracts.ts
@@ -1,0 +1,119 @@
+export const LANDING_PAGE_RESEARCH_BLOCKS = [
+  "strategic_core",
+  "lp_overview",
+  "lp_sections",
+  "seo",
+] as const;
+
+export type LandingPageResearchBlock =
+  (typeof LANDING_PAGE_RESEARCH_BLOCKS)[number];
+export type LandingPageResearchAudienceScope =
+  | "business_buyer"
+  | "end_customer";
+export type LandingPageResearchSourceRelation = "own" | "direct_parent";
+
+export type LandingPageResearchTaxonDto = Readonly<{
+  id: string;
+  parentId: string | null;
+  isActive: boolean;
+}>;
+
+export type LandingPageResearchParentDto = Readonly<{
+  id: string;
+  taxonId: string;
+  researchBlock: string;
+  audienceScope: string;
+  version: number;
+  status: string;
+}>;
+
+export type LandingPageResearchItemDto = Readonly<{
+  id: string;
+  researchId: string;
+  itemKey: string | null;
+  itemText: string | null;
+  priority: number | null;
+  sortOrder: number | null;
+  isActive: boolean;
+}>;
+
+export type LandingPageResearchNormalizedSource =
+  | Readonly<{
+      status: "ready";
+      taxons: readonly LandingPageResearchTaxonDto[];
+      researches: readonly LandingPageResearchParentDto[];
+      items: readonly LandingPageResearchItemDto[];
+    }>
+  | Readonly<{ status: "read_failed" }>
+  | Readonly<{ status: "not_normalizable" }>;
+
+export type ResolveLandingPageResearchInput = Readonly<{
+  taxonId: string;
+  source: LandingPageResearchNormalizedSource;
+}>;
+
+export type ResolvedLandingPageResearchItem = Readonly<{
+  itemId: string;
+  researchId: string;
+  itemKey: string;
+  itemText: string;
+  priority: number;
+  sortOrder: number;
+  servedTaxonId: string;
+  sourceTaxonId: string;
+  sourceRelation: LandingPageResearchSourceRelation;
+  audienceScope: LandingPageResearchAudienceScope;
+  researchVersion: number;
+}>;
+
+export type ResolvedLandingPageResearchParent = Readonly<{
+  researchId: string;
+  researchBlock: LandingPageResearchBlock;
+  audienceScope: LandingPageResearchAudienceScope;
+  version: number;
+  sourceTaxonId: string;
+  items: readonly ResolvedLandingPageResearchItem[];
+}>;
+
+export type ResolvedLandingPageResearchAudience = Readonly<{
+  audienceScope: LandingPageResearchAudienceScope;
+  sourceTaxonId: string;
+  sourceRelation: LandingPageResearchSourceRelation;
+  version: number;
+  researches: readonly ResolvedLandingPageResearchParent[];
+}>;
+
+export type ResolvedLandingPageResearch = Readonly<{
+  servedTaxonId: string;
+  endCustomer: ResolvedLandingPageResearchAudience;
+  businessBuyer: ResolvedLandingPageResearchAudience;
+  versions: Readonly<{
+    endCustomer: number;
+    businessBuyer: number;
+  }>;
+}>;
+
+export type LandingPageResearchResolutionErrorCode =
+  | "INVALID_TAXON_ID"
+  | "READ_FAILED"
+  | "SOURCE_NOT_NORMALIZABLE"
+  | "TAXON_NOT_FOUND"
+  | "TAXON_INACTIVE"
+  | "DIRECT_PARENT_NOT_FOUND"
+  | "DIRECT_PARENT_INACTIVE"
+  | "RESEARCH_MISSING"
+  | "RESEARCH_INCOMPLETE"
+  | "RESEARCH_INVALID"
+  | "RESEARCH_AMBIGUOUS";
+
+export type LandingPageResearchResolutionError = Readonly<{
+  code: LandingPageResearchResolutionErrorCode;
+  message: string;
+  audienceScope?: LandingPageResearchAudienceScope;
+  sourceTaxonId?: string;
+  sourceRelation?: LandingPageResearchSourceRelation;
+}>;
+
+export type LandingPageResearchResolutionResult =
+  | Readonly<{ ok: true; value: ResolvedLandingPageResearch }>
+  | Readonly<{ ok: false; error: LandingPageResearchResolutionError }>;

--- a/lib/conversion-content/landing-page/research-resolution/index.ts
+++ b/lib/conversion-content/landing-page/research-resolution/index.ts
@@ -1,0 +1,5 @@
+export * from "./contracts";
+export {
+  isLandingPageResearchUuid,
+  resolveLandingPageResearch,
+} from "./resolver";

--- a/lib/conversion-content/landing-page/research-resolution/resolver.ts
+++ b/lib/conversion-content/landing-page/research-resolution/resolver.ts
@@ -214,28 +214,15 @@ function resolveAudience(input: {
     byBlock.set(block, research);
   }
 
-  if (LANDING_PAGE_RESEARCH_BLOCKS.some((block) => !byBlock.has(block))) {
-    return audienceFailure(
-      "RESEARCH_INCOMPLETE",
-      "The active research set does not contain every required block",
-      input,
-    );
-  }
-
   const seenItemIds = new Set<string>();
-  const resolvedResearches = [];
-  for (const block of LANDING_PAGE_RESEARCH_BLOCKS) {
-    const research = byBlock.get(block)!;
+  const activeItemsByResearchId = new Map<
+    string,
+    readonly LandingPageResearchItemDto[]
+  >();
+  for (const research of byBlock.values()) {
     const activeItems = input.items.filter(
       (item) => item.researchId === research.id && item.isActive,
     );
-    if (activeItems.length === 0) {
-      return audienceFailure(
-        "RESEARCH_INCOMPLETE",
-        "A required research block has no active items",
-        input,
-      );
-    }
     const activeItemIds = new Set(activeItems.map((item) => item.id));
     if (
       activeItems.some((item) => !isValidActiveItem(item, research.id)) ||
@@ -248,10 +235,32 @@ function resolveAudience(input: {
         input,
       );
     }
+    for (const item of activeItems) seenItemIds.add(item.id);
+    activeItemsByResearchId.set(research.id, activeItems);
+  }
+
+  if (LANDING_PAGE_RESEARCH_BLOCKS.some((block) => !byBlock.has(block))) {
+    return audienceFailure(
+      "RESEARCH_INCOMPLETE",
+      "The active research set does not contain every required block",
+      input,
+    );
+  }
+
+  const resolvedResearches = [];
+  for (const block of LANDING_PAGE_RESEARCH_BLOCKS) {
+    const research = byBlock.get(block)!;
+    const activeItems = activeItemsByResearchId.get(research.id) ?? [];
+    if (activeItems.length === 0) {
+      return audienceFailure(
+        "RESEARCH_INCOMPLETE",
+        "A required research block has no active items",
+        input,
+      );
+    }
 
     const items = activeItems
       .map((item) => {
-        seenItemIds.add(item.id);
         return {
           itemId: item.id,
           researchId: research.id,

--- a/lib/conversion-content/landing-page/research-resolution/resolver.ts
+++ b/lib/conversion-content/landing-page/research-resolution/resolver.ts
@@ -1,0 +1,377 @@
+import {
+  LANDING_PAGE_RESEARCH_BLOCKS,
+  type LandingPageResearchAudienceScope,
+  type LandingPageResearchBlock,
+  type LandingPageResearchItemDto,
+  type LandingPageResearchParentDto,
+  type LandingPageResearchResolutionError,
+  type LandingPageResearchResolutionErrorCode,
+  type LandingPageResearchResolutionResult,
+  type LandingPageResearchSourceRelation,
+  type LandingPageResearchTaxonDto,
+  type ResolveLandingPageResearchInput,
+  type ResolvedLandingPageResearchAudience,
+  type ResolvedLandingPageResearchItem,
+} from "./contracts";
+
+type AudienceResolution =
+  | Readonly<{ ok: true; value: ResolvedLandingPageResearchAudience }>
+  | Readonly<{ ok: false; error: LandingPageResearchResolutionError }>;
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isLandingPageResearchUuid(value: string): boolean {
+  return UUID_PATTERN.test(value);
+}
+
+export function resolveLandingPageResearch(
+  input: ResolveLandingPageResearchInput,
+): LandingPageResearchResolutionResult {
+  const taxonId = input.taxonId.trim();
+  if (!taxonId || !isLandingPageResearchUuid(taxonId)) {
+    return failure("INVALID_TAXON_ID", "taxon_id must be a valid UUID");
+  }
+
+  if (input.source.status === "read_failed") {
+    return failure("READ_FAILED", "Research source read failed");
+  }
+  if (input.source.status === "not_normalizable") {
+    return failure(
+      "SOURCE_NOT_NORMALIZABLE",
+      "Research source could not be normalized",
+    );
+  }
+
+  const servedTaxonMatches = input.source.taxons.filter(
+    (taxon) => taxon.id === taxonId,
+  );
+  if (servedTaxonMatches.length === 0) {
+    return failure("TAXON_NOT_FOUND", "Served taxon was not found");
+  }
+  if (servedTaxonMatches.length > 1) {
+    return failure(
+      "SOURCE_NOT_NORMALIZABLE",
+      "Served taxon source is ambiguous",
+    );
+  }
+
+  const servedTaxon = servedTaxonMatches[0];
+  if (!isValidTaxon(servedTaxon)) {
+    return failure(
+      "SOURCE_NOT_NORMALIZABLE",
+      "Served taxon source could not be normalized",
+    );
+  }
+  if (!servedTaxon.isActive) {
+    return failure("TAXON_INACTIVE", "Served taxon is inactive");
+  }
+
+  const endCustomer = resolveAudience({
+    servedTaxonId: taxonId,
+    sourceTaxonId: taxonId,
+    sourceRelation: "own",
+    audienceScope: "end_customer",
+    researches: input.source.researches,
+    items: input.source.items,
+  });
+  if (!endCustomer.ok) return endCustomer;
+
+  const ownBusinessBuyer = resolveAudience({
+    servedTaxonId: taxonId,
+    sourceTaxonId: taxonId,
+    sourceRelation: "own",
+    audienceScope: "business_buyer",
+    researches: input.source.researches,
+    items: input.source.items,
+  });
+
+  let businessBuyer: AudienceResolution = ownBusinessBuyer;
+  if (
+    !ownBusinessBuyer.ok &&
+    (ownBusinessBuyer.error.code === "RESEARCH_MISSING" ||
+      ownBusinessBuyer.error.code === "RESEARCH_INCOMPLETE")
+  ) {
+    const parentResult = resolveDirectParent(servedTaxon, input.source.taxons);
+    if (!parentResult.ok) return parentResult;
+
+    businessBuyer = resolveAudience({
+      servedTaxonId: taxonId,
+      sourceTaxonId: parentResult.value.id,
+      sourceRelation: "direct_parent",
+      audienceScope: "business_buyer",
+      researches: input.source.researches,
+      items: input.source.items,
+    });
+  }
+
+  if (!businessBuyer.ok) return businessBuyer;
+
+  return {
+    ok: true,
+    value: deepFreeze({
+      servedTaxonId: taxonId,
+      endCustomer: endCustomer.value,
+      businessBuyer: businessBuyer.value,
+      versions: {
+        endCustomer: endCustomer.value.version,
+        businessBuyer: businessBuyer.value.version,
+      },
+    }),
+  };
+}
+
+function resolveDirectParent(
+  servedTaxon: LandingPageResearchTaxonDto,
+  taxons: readonly LandingPageResearchTaxonDto[],
+):
+  | Readonly<{ ok: true; value: LandingPageResearchTaxonDto }>
+  | Readonly<{ ok: false; error: LandingPageResearchResolutionError }> {
+  if (!servedTaxon.parentId) {
+    return failure(
+      "DIRECT_PARENT_NOT_FOUND",
+      "Direct parent is required for business_buyer fallback",
+    );
+  }
+
+  const parentMatches = taxons.filter(
+    (taxon) => taxon.id === servedTaxon.parentId,
+  );
+  if (parentMatches.length === 0) {
+    return failure("DIRECT_PARENT_NOT_FOUND", "Direct parent was not found");
+  }
+  if (parentMatches.length > 1 || !isValidTaxon(parentMatches[0])) {
+    return failure(
+      "SOURCE_NOT_NORMALIZABLE",
+      "Direct parent source could not be normalized",
+    );
+  }
+  if (!parentMatches[0].isActive) {
+    return failure("DIRECT_PARENT_INACTIVE", "Direct parent is inactive");
+  }
+
+  return { ok: true, value: parentMatches[0] };
+}
+
+function resolveAudience(input: {
+  servedTaxonId: string;
+  sourceTaxonId: string;
+  sourceRelation: LandingPageResearchSourceRelation;
+  audienceScope: LandingPageResearchAudienceScope;
+  researches: readonly LandingPageResearchParentDto[];
+  items: readonly LandingPageResearchItemDto[];
+}): AudienceResolution {
+  const researches = input.researches.filter(
+    (research) =>
+      research.taxonId === input.sourceTaxonId &&
+      research.audienceScope === input.audienceScope &&
+      research.status === "active" &&
+      isRequiredBlock(research.researchBlock),
+  );
+
+  if (researches.length === 0) {
+    return audienceFailure(
+      "RESEARCH_MISSING",
+      "No active research set was found",
+      input,
+    );
+  }
+
+  if (
+    researches.some(
+      (research) =>
+        !isLandingPageResearchUuid(research.id) ||
+        !Number.isInteger(research.version),
+    )
+  ) {
+    return audienceFailure(
+      "RESEARCH_INVALID",
+      "Research parent metadata is invalid",
+      input,
+    );
+  }
+
+  const versions = new Set(researches.map((research) => research.version));
+  if (versions.size > 1) {
+    return audienceFailure(
+      "RESEARCH_AMBIGUOUS",
+      "Active research blocks are split across versions",
+      input,
+    );
+  }
+
+  const version = researches[0].version;
+  const byBlock = new Map<LandingPageResearchBlock, (typeof researches)[number]>();
+  for (const research of researches) {
+    const block = research.researchBlock as LandingPageResearchBlock;
+    if (byBlock.has(block)) {
+      return audienceFailure(
+        "RESEARCH_AMBIGUOUS",
+        "More than one active research parent exists for a required block",
+        input,
+      );
+    }
+    byBlock.set(block, research);
+  }
+
+  if (LANDING_PAGE_RESEARCH_BLOCKS.some((block) => !byBlock.has(block))) {
+    return audienceFailure(
+      "RESEARCH_INCOMPLETE",
+      "The active research set does not contain every required block",
+      input,
+    );
+  }
+
+  const seenItemIds = new Set<string>();
+  const resolvedResearches = [];
+  for (const block of LANDING_PAGE_RESEARCH_BLOCKS) {
+    const research = byBlock.get(block)!;
+    const activeItems = input.items.filter(
+      (item) => item.researchId === research.id && item.isActive,
+    );
+    if (activeItems.length === 0) {
+      return audienceFailure(
+        "RESEARCH_INCOMPLETE",
+        "A required research block has no active items",
+        input,
+      );
+    }
+    const activeItemIds = new Set(activeItems.map((item) => item.id));
+    if (
+      activeItems.some((item) => !isValidActiveItem(item, research.id)) ||
+      activeItemIds.size !== activeItems.length ||
+      activeItems.some((item) => seenItemIds.has(item.id))
+    ) {
+      return audienceFailure(
+        "RESEARCH_INVALID",
+        "A required research block has an invalid active item",
+        input,
+      );
+    }
+
+    const items = activeItems
+      .map((item) => {
+        seenItemIds.add(item.id);
+        return {
+          itemId: item.id,
+          researchId: research.id,
+          itemKey: item.itemKey!,
+          itemText: item.itemText!,
+          priority: item.priority!,
+          sortOrder: item.sortOrder!,
+          servedTaxonId: input.servedTaxonId,
+          sourceTaxonId: input.sourceTaxonId,
+          sourceRelation: input.sourceRelation,
+          audienceScope: input.audienceScope,
+          researchVersion: version,
+        } satisfies ResolvedLandingPageResearchItem;
+      })
+      .sort(compareItems);
+
+    resolvedResearches.push({
+      researchId: research.id,
+      researchBlock: block,
+      audienceScope: input.audienceScope,
+      version,
+      sourceTaxonId: input.sourceTaxonId,
+      items,
+    });
+  }
+
+  return {
+    ok: true,
+    value: {
+      audienceScope: input.audienceScope,
+      sourceTaxonId: input.sourceTaxonId,
+      sourceRelation: input.sourceRelation,
+      version,
+      researches: resolvedResearches,
+    },
+  };
+}
+
+function isValidTaxon(taxon: LandingPageResearchTaxonDto): boolean {
+  return (
+    isLandingPageResearchUuid(taxon.id) &&
+    (taxon.parentId === null || isLandingPageResearchUuid(taxon.parentId)) &&
+    typeof taxon.isActive === "boolean"
+  );
+}
+
+function isRequiredBlock(value: string): value is LandingPageResearchBlock {
+  return (LANDING_PAGE_RESEARCH_BLOCKS as readonly string[]).includes(value);
+}
+
+function isValidActiveItem(
+  item: LandingPageResearchItemDto,
+  researchId: string,
+): boolean {
+  return (
+    isLandingPageResearchUuid(item.id) &&
+    item.researchId === researchId &&
+    typeof item.itemKey === "string" &&
+    item.itemKey.trim().length > 0 &&
+    typeof item.itemText === "string" &&
+    item.itemText.trim().length > 0 &&
+    Number.isInteger(item.priority) &&
+    Number.isInteger(item.sortOrder)
+  );
+}
+
+function compareItems(
+  left: ResolvedLandingPageResearchItem,
+  right: ResolvedLandingPageResearchItem,
+): number {
+  return (
+    left.sortOrder - right.sortOrder ||
+    compareText(left.itemKey, right.itemKey) ||
+    compareText(left.itemId, right.itemId)
+  );
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function audienceFailure(
+  code: Extract<
+    LandingPageResearchResolutionErrorCode,
+    | "RESEARCH_MISSING"
+    | "RESEARCH_INCOMPLETE"
+    | "RESEARCH_INVALID"
+    | "RESEARCH_AMBIGUOUS"
+  >,
+  message: string,
+  input: {
+    audienceScope: LandingPageResearchAudienceScope;
+    sourceTaxonId: string;
+    sourceRelation: LandingPageResearchSourceRelation;
+  },
+): AudienceResolution {
+  return failure(code, message, {
+    audienceScope: input.audienceScope,
+    sourceTaxonId: input.sourceTaxonId,
+    sourceRelation: input.sourceRelation,
+  });
+}
+
+function failure(
+  code: LandingPageResearchResolutionErrorCode,
+  message: string,
+  details: Omit<LandingPageResearchResolutionError, "code" | "message"> = {},
+): Readonly<{ ok: false; error: LandingPageResearchResolutionError }> {
+  return { ok: false, error: { code, message, ...details } };
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === "object") {
+    for (const property of Object.getOwnPropertyNames(value)) {
+      const nested = value[property as keyof T];
+      if (nested && typeof nested === "object" && !Object.isFrozen(nested)) {
+        deepFreeze(nested);
+      }
+    }
+    Object.freeze(value);
+  }
+  return value;
+}

--- a/lib/conversion-content/landing-page/research-resolution/validation-cases.ts
+++ b/lib/conversion-content/landing-page/research-resolution/validation-cases.ts
@@ -85,6 +85,60 @@ const cases: readonly ValidationCase[] = [
     },
   },
   {
+    name: "invalid active own item wins over a missing own block",
+    run: () => {
+      const source = completeSource();
+      removeBlock(source, SERVED_TAXON_ID, "business_buyer", "seo");
+      const invalidItem = findItem(
+        source,
+        SERVED_TAXON_ID,
+        "business_buyer",
+      );
+      replaceItem(source, invalidItem.id, { itemText: "" });
+
+      const result = resolve(SERVED_TAXON_ID, source);
+      assertAudienceFailure(
+        result,
+        "RESEARCH_INVALID",
+        "business_buyer",
+        "own",
+      );
+      if (result.ok) throw new Error("Expected audience failure");
+      assert.equal(result.error.sourceTaxonId, SERVED_TAXON_ID);
+    },
+  },
+  {
+    name: "invalid active own item wins over an empty own block",
+    run: () => {
+      const source = completeSource();
+      const emptyResearch = findResearch(
+        source,
+        SERVED_TAXON_ID,
+        "business_buyer",
+        "seo",
+      );
+      source.items = source.items.filter(
+        (item) => item.researchId !== emptyResearch.id,
+      );
+      const invalidItem = findItem(
+        source,
+        SERVED_TAXON_ID,
+        "business_buyer",
+      );
+      replaceItem(source, invalidItem.id, { itemText: "" });
+
+      const result = resolve(SERVED_TAXON_ID, source);
+      assertAudienceFailure(
+        result,
+        "RESEARCH_INVALID",
+        "business_buyer",
+        "own",
+      );
+      if (result.ok) throw new Error("Expected audience failure");
+      assert.equal(result.error.sourceTaxonId, SERVED_TAXON_ID);
+    },
+  },
+  {
     name: "complete own business_buyer ignores an incomplete parent",
     run: () => {
       const source = completeSource();

--- a/lib/conversion-content/landing-page/research-resolution/validation-cases.ts
+++ b/lib/conversion-content/landing-page/research-resolution/validation-cases.ts
@@ -1,0 +1,552 @@
+import assert from "node:assert/strict";
+
+import {
+  LANDING_PAGE_RESEARCH_BLOCKS,
+  type LandingPageResearchAudienceScope,
+  type LandingPageResearchItemDto,
+  type LandingPageResearchNormalizedSource,
+  type LandingPageResearchParentDto,
+  type LandingPageResearchTaxonDto,
+} from "./contracts";
+import { resolveLandingPageResearch } from "./resolver";
+
+const SERVED_TAXON_ID = "11111111-1111-4111-8111-111111111111";
+const PARENT_TAXON_ID = "22222222-2222-4222-8222-222222222222";
+const MISSING_TAXON_ID = "33333333-3333-4333-8333-333333333333";
+
+type MutableSource = {
+  status: "ready";
+  taxons: LandingPageResearchTaxonDto[];
+  researches: LandingPageResearchParentDto[];
+  items: LandingPageResearchItemDto[];
+};
+
+type ValidationCase = Readonly<{
+  name: string;
+  run: () => void;
+}>;
+
+let nextItemOrdinal = 1;
+
+const cases: readonly ValidationCase[] = [
+  {
+    name: "missing or malformed taxon_id fails closed",
+    run: () => {
+      assertFailure(resolve("", completeSource()), "INVALID_TAXON_ID");
+      assertFailure(resolve("not-a-uuid", completeSource()), "INVALID_TAXON_ID");
+    },
+  },
+  {
+    name: "missing or inactive served taxon fails closed",
+    run: () => {
+      assertFailure(
+        resolve(MISSING_TAXON_ID, completeSource()),
+        "TAXON_NOT_FOUND",
+      );
+
+      const inactive = completeSource();
+      replaceTaxon(inactive, SERVED_TAXON_ID, { isActive: false });
+      assertFailure(resolve(SERVED_TAXON_ID, inactive), "TAXON_INACTIVE");
+    },
+  },
+  {
+    name: "complete own business_buyer wins over complete direct parent",
+    run: () => {
+      const result = assertSuccess(resolve(SERVED_TAXON_ID, completeSource()));
+      assert.equal(result.businessBuyer.sourceRelation, "own");
+      assert.equal(result.businessBuyer.sourceTaxonId, SERVED_TAXON_ID);
+    },
+  },
+  {
+    name: "missing own business_buyer uses complete direct parent",
+    run: () => {
+      const source = completeSource();
+      removeSet(source, SERVED_TAXON_ID, "business_buyer");
+
+      const result = assertSuccess(resolve(SERVED_TAXON_ID, source));
+      assert.equal(result.businessBuyer.sourceRelation, "direct_parent");
+      assert.equal(result.businessBuyer.sourceTaxonId, PARENT_TAXON_ID);
+    },
+  },
+  {
+    name: "incomplete own business_buyer uses the whole direct parent set",
+    run: () => {
+      const source = completeSource();
+      removeBlock(source, SERVED_TAXON_ID, "business_buyer", "seo");
+
+      const result = assertSuccess(resolve(SERVED_TAXON_ID, source));
+      assert.equal(result.businessBuyer.sourceRelation, "direct_parent");
+      assert.equal(
+        result.businessBuyer.researches.every(
+          (research) => research.sourceTaxonId === PARENT_TAXON_ID,
+        ),
+        true,
+      );
+    },
+  },
+  {
+    name: "complete own business_buyer ignores an incomplete parent",
+    run: () => {
+      const source = completeSource();
+      removeBlock(source, PARENT_TAXON_ID, "business_buyer", "seo");
+
+      const result = assertSuccess(resolve(SERVED_TAXON_ID, source));
+      assert.equal(result.businessBuyer.sourceRelation, "own");
+    },
+  },
+  {
+    name: "invalid or ambiguous own business_buyer is never masked by parent",
+    run: () => {
+      const invalid = completeSource();
+      const ownItem = findItem(invalid, SERVED_TAXON_ID, "business_buyer");
+      replaceItem(invalid, ownItem.id, { itemText: "" });
+      assertAudienceFailure(
+        resolve(SERVED_TAXON_ID, invalid),
+        "RESEARCH_INVALID",
+        "business_buyer",
+        "own",
+      );
+
+      const ambiguous = completeSource();
+      duplicateResearchParent(
+        ambiguous,
+        SERVED_TAXON_ID,
+        "business_buyer",
+        "strategic_core",
+      );
+      assertAudienceFailure(
+        resolve(SERVED_TAXON_ID, ambiguous),
+        "RESEARCH_AMBIGUOUS",
+        "business_buyer",
+        "own",
+      );
+    },
+  },
+  {
+    name: "every invalid end_customer state fails on the served taxon",
+    run: () => {
+      const missing = completeSource();
+      removeSet(missing, SERVED_TAXON_ID, "end_customer");
+      assertAudienceFailure(
+        resolve(SERVED_TAXON_ID, missing),
+        "RESEARCH_MISSING",
+        "end_customer",
+        "own",
+      );
+
+      const incomplete = completeSource();
+      removeBlock(incomplete, SERVED_TAXON_ID, "end_customer", "seo");
+      assertAudienceFailure(
+        resolve(SERVED_TAXON_ID, incomplete),
+        "RESEARCH_INCOMPLETE",
+        "end_customer",
+        "own",
+      );
+
+      const invalid = completeSource();
+      const item = findItem(invalid, SERVED_TAXON_ID, "end_customer");
+      replaceItem(invalid, item.id, { itemKey: " " });
+      assertAudienceFailure(
+        resolve(SERVED_TAXON_ID, invalid),
+        "RESEARCH_INVALID",
+        "end_customer",
+        "own",
+      );
+
+      const ambiguous = completeSource();
+      duplicateResearchParent(
+        ambiguous,
+        SERVED_TAXON_ID,
+        "end_customer",
+        "strategic_core",
+      );
+      assertAudienceFailure(
+        resolve(SERVED_TAXON_ID, ambiguous),
+        "RESEARCH_AMBIGUOUS",
+        "end_customer",
+        "own",
+      );
+    },
+  },
+  {
+    name: "missing direct parent fails when own business_buyer is not eligible",
+    run: () => {
+      const withoutParentId = completeSource();
+      removeSet(withoutParentId, SERVED_TAXON_ID, "business_buyer");
+      replaceTaxon(withoutParentId, SERVED_TAXON_ID, { parentId: null });
+      assertFailure(
+        resolve(SERVED_TAXON_ID, withoutParentId),
+        "DIRECT_PARENT_NOT_FOUND",
+      );
+
+      const missingParent = completeSource();
+      removeSet(missingParent, SERVED_TAXON_ID, "business_buyer");
+      missingParent.taxons = missingParent.taxons.filter(
+        (taxon) => taxon.id !== PARENT_TAXON_ID,
+      );
+      assertFailure(
+        resolve(SERVED_TAXON_ID, missingParent),
+        "DIRECT_PARENT_NOT_FOUND",
+      );
+    },
+  },
+  {
+    name: "inactive or ineligible direct parent fails closed",
+    run: () => {
+      const inactiveParent = completeSource();
+      removeSet(inactiveParent, SERVED_TAXON_ID, "business_buyer");
+      replaceTaxon(inactiveParent, PARENT_TAXON_ID, { isActive: false });
+      assertFailure(
+        resolve(SERVED_TAXON_ID, inactiveParent),
+        "DIRECT_PARENT_INACTIVE",
+      );
+
+      const missingParentSet = completeSource();
+      removeSet(missingParentSet, SERVED_TAXON_ID, "business_buyer");
+      removeSet(missingParentSet, PARENT_TAXON_ID, "business_buyer");
+      assertAudienceFailure(
+        resolve(SERVED_TAXON_ID, missingParentSet),
+        "RESEARCH_MISSING",
+        "business_buyer",
+        "direct_parent",
+      );
+    },
+  },
+  {
+    name: "active blocks split across versions are ambiguous",
+    run: () => {
+      const source = completeSource();
+      const research = findResearch(
+        source,
+        SERVED_TAXON_ID,
+        "business_buyer",
+        "seo",
+      );
+      replaceResearch(source, research.id, { version: 2 });
+
+      assertAudienceFailure(
+        resolve(SERVED_TAXON_ID, source),
+        "RESEARCH_AMBIGUOUS",
+        "business_buyer",
+        "own",
+      );
+    },
+  },
+  {
+    name: "more than one complete active version is ambiguous",
+    run: () => {
+      const source = completeSource();
+      addSet(source, SERVED_TAXON_ID, "business_buyer", 2);
+
+      assertAudienceFailure(
+        resolve(SERVED_TAXON_ID, source),
+        "RESEARCH_AMBIGUOUS",
+        "business_buyer",
+        "own",
+      );
+    },
+  },
+  {
+    name: "structurally invalid active item fails the set",
+    run: () => {
+      const source = completeSource();
+      const item = findItem(source, SERVED_TAXON_ID, "business_buyer");
+      replaceItem(source, item.id, { priority: null });
+
+      assertAudienceFailure(
+        resolve(SERVED_TAXON_ID, source),
+        "RESEARCH_INVALID",
+        "business_buyer",
+        "own",
+      );
+    },
+  },
+  {
+    name: "read failure or non-normalizable source fails closed",
+    run: () => {
+      assertFailure(
+        resolveLandingPageResearch({
+          taxonId: SERVED_TAXON_ID,
+          source: { status: "read_failed" },
+        }),
+        "READ_FAILED",
+      );
+      assertFailure(
+        resolveLandingPageResearch({
+          taxonId: SERVED_TAXON_ID,
+          source: { status: "not_normalizable" },
+        }),
+        "SOURCE_NOT_NORMALIZABLE",
+      );
+    },
+  },
+  {
+    name: "result preserves provenance, ordering and source atomicity",
+    run: () => {
+      const source = completeSource();
+      const firstResearch = findResearch(
+        source,
+        SERVED_TAXON_ID,
+        "business_buyer",
+        "strategic_core",
+      );
+      source.items.push(
+        makeItem(firstResearch.id, "zeta", 0, 2),
+        makeItem(firstResearch.id, "alpha", 0, 2),
+        {
+          ...makeItem(firstResearch.id, "inactive", 0, 0),
+          itemText: null,
+          isActive: false,
+        },
+      );
+      source.researches.push({
+        id: makeUuid("70000000", source.researches.length + 1),
+        taxonId: SERVED_TAXON_ID,
+        researchBlock: "future_block",
+        audienceScope: "business_buyer",
+        version: 1,
+        status: "active",
+      });
+
+      const result = assertSuccess(resolve(SERVED_TAXON_ID, source));
+      assert.deepEqual(
+        result.businessBuyer.researches.map((research) => research.researchBlock),
+        LANDING_PAGE_RESEARCH_BLOCKS,
+      );
+      assert.deepEqual(
+        result.businessBuyer.researches[0].items.map((item) => item.itemKey),
+        ["strategic_core_key", "alpha", "zeta"],
+      );
+      assert.equal(
+        result.businessBuyer.researches.every(
+          (research) =>
+            research.sourceTaxonId === SERVED_TAXON_ID &&
+            research.version === result.businessBuyer.version &&
+            research.items.every(
+              (item) =>
+                item.servedTaxonId === SERVED_TAXON_ID &&
+                item.sourceTaxonId === SERVED_TAXON_ID &&
+                item.sourceRelation === "own" &&
+                item.audienceScope === "business_buyer" &&
+                item.researchVersion === result.businessBuyer.version &&
+                item.researchId === research.researchId,
+            ),
+        ),
+        true,
+      );
+      assert.equal(Object.isFrozen(result), true);
+    },
+  },
+];
+
+for (const validationCase of cases) {
+  validationCase.run();
+  console.log(`ok - ${validationCase.name}`);
+}
+
+function resolve(taxonId: string, source: MutableSource) {
+  return resolveLandingPageResearch({ taxonId, source });
+}
+
+function completeSource(): MutableSource {
+  const source: MutableSource = {
+    status: "ready",
+    taxons: [
+      { id: SERVED_TAXON_ID, parentId: PARENT_TAXON_ID, isActive: true },
+      { id: PARENT_TAXON_ID, parentId: null, isActive: true },
+    ],
+    researches: [],
+    items: [],
+  };
+  addSet(source, SERVED_TAXON_ID, "end_customer", 1);
+  addSet(source, SERVED_TAXON_ID, "business_buyer", 1);
+  addSet(source, PARENT_TAXON_ID, "business_buyer", 1);
+  return source;
+}
+
+function addSet(
+  source: MutableSource,
+  taxonId: string,
+  audienceScope: LandingPageResearchAudienceScope,
+  version: number,
+): void {
+  for (const block of LANDING_PAGE_RESEARCH_BLOCKS) {
+    const researchId = makeUuid("40000000", source.researches.length + 1);
+    source.researches.push({
+      id: researchId,
+      taxonId,
+      researchBlock: block,
+      audienceScope,
+      version,
+      status: "active",
+    });
+    source.items.push(makeItem(researchId, `${block}_key`, 3, 1));
+  }
+}
+
+function makeItem(
+  researchId: string,
+  itemKey: string,
+  priority: number,
+  sortOrder: number,
+): LandingPageResearchItemDto {
+  return {
+    id: makeUuid("50000000", nextItemOrdinal++),
+    researchId,
+    itemKey,
+    itemText: `${itemKey} text`,
+    priority,
+    sortOrder,
+    isActive: true,
+  };
+}
+
+function makeUuid(prefix: string, ordinal: number): string {
+  return `${prefix}-0000-4000-8000-${String(ordinal).padStart(12, "0")}`;
+}
+
+function removeSet(
+  source: MutableSource,
+  taxonId: string,
+  audienceScope: LandingPageResearchAudienceScope,
+): void {
+  const ids = new Set(
+    source.researches
+      .filter(
+        (research) =>
+          research.taxonId === taxonId &&
+          research.audienceScope === audienceScope,
+      )
+      .map((research) => research.id),
+  );
+  source.researches = source.researches.filter(
+    (research) => !ids.has(research.id),
+  );
+  source.items = source.items.filter((item) => !ids.has(item.researchId));
+}
+
+function removeBlock(
+  source: MutableSource,
+  taxonId: string,
+  audienceScope: LandingPageResearchAudienceScope,
+  researchBlock: string,
+): void {
+  const research = findResearch(
+    source,
+    taxonId,
+    audienceScope,
+    researchBlock,
+  );
+  source.researches = source.researches.filter((row) => row.id !== research.id);
+  source.items = source.items.filter((item) => item.researchId !== research.id);
+}
+
+function duplicateResearchParent(
+  source: MutableSource,
+  taxonId: string,
+  audienceScope: LandingPageResearchAudienceScope,
+  researchBlock: string,
+): void {
+  const original = findResearch(
+    source,
+    taxonId,
+    audienceScope,
+    researchBlock,
+  );
+  const duplicateId = makeUuid("60000000", source.researches.length + 1);
+  source.researches.push({ ...original, id: duplicateId });
+  source.items.push(makeItem(duplicateId, `${researchBlock}_duplicate`, 2, 2));
+}
+
+function findResearch(
+  source: MutableSource,
+  taxonId: string,
+  audienceScope: LandingPageResearchAudienceScope,
+  researchBlock: string,
+): LandingPageResearchParentDto {
+  const research = source.researches.find(
+    (row) =>
+      row.taxonId === taxonId &&
+      row.audienceScope === audienceScope &&
+      row.researchBlock === researchBlock,
+  );
+  assert.ok(research);
+  return research;
+}
+
+function findItem(
+  source: MutableSource,
+  taxonId: string,
+  audienceScope: LandingPageResearchAudienceScope,
+): LandingPageResearchItemDto {
+  const research = source.researches.find(
+    (row) =>
+      row.taxonId === taxonId && row.audienceScope === audienceScope,
+  );
+  assert.ok(research);
+  const item = source.items.find((row) => row.researchId === research.id);
+  assert.ok(item);
+  return item;
+}
+
+function replaceTaxon(
+  source: MutableSource,
+  taxonId: string,
+  patch: Partial<LandingPageResearchTaxonDto>,
+): void {
+  source.taxons = source.taxons.map((taxon) =>
+    taxon.id === taxonId ? { ...taxon, ...patch } : taxon,
+  );
+}
+
+function replaceResearch(
+  source: MutableSource,
+  researchId: string,
+  patch: Partial<LandingPageResearchParentDto>,
+): void {
+  source.researches = source.researches.map((research) =>
+    research.id === researchId ? { ...research, ...patch } : research,
+  );
+}
+
+function replaceItem(
+  source: MutableSource,
+  itemId: string,
+  patch: Partial<LandingPageResearchItemDto>,
+): void {
+  source.items = source.items.map((item) =>
+    item.id === itemId ? { ...item, ...patch } : item,
+  );
+}
+
+function assertSuccess(
+  result: ReturnType<typeof resolveLandingPageResearch>,
+) {
+  if (!result.ok) assert.fail(`Expected success, received ${result.error.code}`);
+  assert.equal(result.ok, true);
+  return result.value;
+}
+
+function assertFailure(
+  result: ReturnType<typeof resolveLandingPageResearch>,
+  code: string,
+): void {
+  assert.equal(result.ok, false);
+  if (result.ok) throw new Error("Expected resolution failure");
+  assert.equal(result.error.code, code);
+}
+
+function assertAudienceFailure(
+  result: ReturnType<typeof resolveLandingPageResearch>,
+  code: string,
+  audienceScope: LandingPageResearchAudienceScope,
+  sourceRelation: "own" | "direct_parent",
+): void {
+  assertFailure(result, code);
+  if (result.ok) throw new Error("Expected audience failure");
+  assert.equal(result.error.audienceScope, audienceScope);
+  assert.equal(result.error.sourceRelation, sourceRelation);
+}
+
+const _sourceContractCheck: LandingPageResearchNormalizedSource = completeSource();
+void _sourceContractCheck;

--- a/lib/conversion-content/landing-page/research-resolution/validation-cases.ts
+++ b/lib/conversion-content/landing-page/research-resolution/validation-cases.ts
@@ -115,16 +115,21 @@ const cases: readonly ValidationCase[] = [
         source,
         SERVED_TAXON_ID,
         "business_buyer",
-        "seo",
+        "strategic_core",
       );
       source.items = source.items.filter(
-        (item) => item.researchId !== emptyResearch.id,
+        (item) => item.researchId !== emptyResearch.id || !item.isActive,
       );
-      const invalidItem = findItem(
+      const invalidResearch = findResearch(
         source,
         SERVED_TAXON_ID,
         "business_buyer",
+        "lp_overview",
       );
+      const invalidItem = source.items.find(
+        (item) => item.researchId === invalidResearch.id && item.isActive,
+      );
+      assert.ok(invalidItem);
       replaceItem(source, invalidItem.id, { itemText: "" });
 
       const result = resolve(SERVED_TAXON_ID, source);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "check": "npm run lint && npm run typecheck",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "validate:commercial-activation": "tsx lib/conversion-content/commercial-activation/validation-cases.ts",
-    "validate:landing-page-root": "tsx lib/conversion-content/landing-page/root-validation-cases.ts"
+    "validate:landing-page-root": "tsx lib/conversion-content/landing-page/root-validation-cases.ts",
+    "validate:landing-page-research": "tsx lib/conversion-content/landing-page/research-resolution/validation-cases.ts"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "1.1.7",


### PR DESCRIPTION
## O que mudou

- cria o boundary `landing-page/research-resolution` com contratos tipados e resolver puro;
- adiciona adapter server-side read-only para Supabase, com normalização, precedência própria/pai e logging seguro;
- cobre integralmente a matriz da seção 2.7 com fixtures executáveis;
- exporta o resolver separadamente de `landingPageRoot` e registra o script `validate:landing-page-research`;
- atualiza somente o plano-base da E10.8 com execução, evidências e próxima ação.

## Por quê

A E10.8 precisa entregar a E20 e à E19 um conjunto único, completo, determinístico e rastreável de pesquisas `landing_page`, sem duplicar resolução de taxon nem criar persistência. O conjunto `end_customer` permanece próprio; `business_buyer` usa o próprio quando elegível e consulta somente o pai direto quando o próprio está ausente ou incompleto.

## Impacto

- nenhuma alteração de banco, migration, view, RPC, policy, grant ou dados;
- nenhuma rota, UI, cache, consumidor, E10.7, E20, E19 ou parametrização raiz da E18.4 alterada;
- falhas de entrada, leitura, ausência, incompletude, invalidade e ambiguidade são tipadas e fechadas;
- logs não incluem `item_text`, pesquisas integrais, PII, credenciais ou secrets.

## Validação

- `npm ci`: concluído;
- `npm run check`: aprovado com zero erros; 24 warnings preexistentes fora do diff;
- `npm run validate:landing-page-research`: 17 grupos de casos aprovados;
- inspeção Supabase read-only: próprio `business_buyer` v1 com 49 itens, pai direto `business_buyer` v1 com 54 itens, ambos completos e válidos;
- smoke read-only com DTO real: resultado escolheu `business_buyer.sourceRelation = own`, preservando 49 itens próprios e 74 itens `end_customer` próprios.

Não executar merge por automação; PR aguarda avaliação humana.