### PR TITLE
docs: registrar GitHub CLI no Gestor Codex

### DIFF
--- a/docs/gestor-codex.md
+++ b/docs/gestor-codex.md
@@ -37,6 +37,14 @@ Configurações sustentam o fluxo local adotado para editar, validar e publicar 
 **Valor:** conclui o fluxo local sem interface gráfica.
 **Limite:** requer remote e autenticação válidos.
 
+### GitHub CLI (`gh`)
+
+**Aptidão:** criar PRs e consultar recursos do GitHub pelo terminal.
+**Estado:** não adotado; indisponível no teste de publicação que retornou `gh` não reconhecido.
+**Valor:** pode reduzir etapas manuais ao criar PRs, consultar PRs, checks e diffs depois do `git push`.
+**Limite:** não é dependência obrigatória do fluxo local; não instalar ferramenta nem alterar autenticação durante tarefas do Executor.
+**Fallback:** quando `gh` estiver indisponível, seguir `AGENTS.md`: concluir commit/push e entregar link de criação do PR.
+
 **Outras configurações:** GitHub Web é a fonte de verdade para PRs, Actions, preview e merge; GitHub Desktop está fora do fluxo principal; não há hooks, conexões ou worktrees ativos.
 
 ## 4. Plugins


### PR DESCRIPTION
## Resumo

- Registra o estado do GitHub CLI (`gh`) como não adotado/indisponível no teste atual.
- Documenta valor, limite e fallback para o fluxo `git push` + link de criação do PR conforme `AGENTS.md`.

## Validação

- Alteração exclusivamente documental.
- `npm ci`: não aplicável.
- `npm run check`: não aplicável.

## Observações

- Não fazer merge por aqui; merge final deve ocorrer pelo GitHub Web após validação humana.