### PR TITLE
docs: consolida plano-base v2 da E20.2

### DIFF
--- a/docs/lousa-plano-base-e20-2.md
+++ b/docs/lousa-plano-base-e20-2.md
@@ -1,9 +1,9 @@
 14/07/2026 — Plano-base E20.2 — Catálogo de entradas por taxon
 
-Fontes: chat, `README.md`, `AGENTS.md`, `docs/prompt-estrategista.md`, `docs/template-roadmap.md`, `docs/template-briefing-codex.md`, `docs/prompt-executor.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/schema.md`, `docs/lp-planejamento.md`, `docs/lousa-plano-base-e10-8.md`, contratos atuais de planos, contas, taxons e landing pages, `Pesquisa bruta para corretor de imóveis de médio padrão.pdf`, `Projeto Piloto Imobiliário.pdf` e avaliações do Analista de 14/07/2026.
+Fontes: chat, `README.md`, `AGENTS.md`, `docs/prompt-estrategista.md`, `docs/template-roadmap.md`, `docs/template-briefing-codex.md`, `docs/prompt-executor.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/schema.md`, `docs/lp-planejamento.md`, `docs/lousa-plano-base-e10-8.md`, `docs/supa-up.md`, `docs/prod-up.md`, contratos atuais de planos, contas, taxons e landing pages, `Pesquisa bruta para corretor de imóveis de médio padrão.pdf`, `Projeto Piloto Imobiliário.pdf`, avaliações do Analista, do Gestor Estrutural e do Gestor de Updates e decisões humanas de 14/07/2026.
 
-- Versão: v1.
-- Status: plano-base v1 criado em PR vivo; avaliação única dos especialistas pendente; Executor não autorizado.
+- Versão: v2.
+- Status: plano-base v2 consolidado no PR #573; merge humano pendente; Executor não autorizado.
 - Recorte previsto para roadmap: `20.2 — Catálogo de entradas por taxon`.
 - Path canônico: `docs/lousa-plano-base-e20-2.md`.
 
@@ -12,28 +12,29 @@ Fontes: chat, `README.md`, `AGENTS.md`, `docs/prompt-estrategista.md`, `docs/tem
 ### 1.1. Problema e resultado esperado
 
 - O projeto ainda não possui um contrato canônico que declare quais dados uma conta, negócio, oferta, campanha ou LP pode ou deve fornecer para a geração de `landing_page`.
-- O recorte deve definir o `lp_generation_input_catalog` sem confundi-lo com parametrização, módulos, variantes, composição, pesquisas da E10, conteúdo produzido ou LP final.
+- O recorte define o `lp_generation_input_catalog` sem confundi-lo com parametrização, módulos, variantes, composição, pesquisas da E10, conteúdo produzido ou LP final.
 - O resultado esperado é uma fonte declarativa versionada, resolvida por `taxon + plano`, com primeiro catálogo concreto validado no recorte imobiliário.
-- O catálogo aplicável deve integrar os critérios de prontidão da futura E20.3, sem avaliar nesta etapa se uma conta concreta já forneceu todos os valores.
+- O catálogo aplicável integra os critérios futuros de prontidão do taxon, sem avaliar nesta etapa se uma conta concreta já forneceu os valores.
 
 ### 1.2. Estado real confirmado
 
-- A E18.4 já possui parametrização raiz repo-only e versionada para `landing_page`.
+- A E18.4 possui parametrização raiz repo-only e versionada para `landing_page`.
 - A E18.5 permanece responsável por módulos e variantes e não é dependência para definir entradas operacionais da E20.2.
-- A E10.8 possui plano-base v2 e implementação em PR próprio para resolver pesquisas estruturadas; a E20.2 não deve reimplementar essa precedência.
+- A E10.8 possui boundary próprio para resolver pesquisas estruturadas; a E20.2 não reimplementa sua precedência.
 - `account_profiles` contém apenas dados mínimos de perfil e não representa o catálogo completo de geração.
 - `account_landing_pages` contém apenas identidade mínima da LP e status inicial `draft`.
 - Os planos comerciais confirmados são `starter`, `lite`, `pro` e `ultra`.
-- Não existe fonte aprovada que determine campos diferentes entre esses quatro planos.
+- Não existe fonte aprovada que determine campos diferentes entre os quatro planos na v1 do catálogo.
 - Não foi demonstrada necessidade de tabela, campo, view, RPC, migration, rota, UI, API, configuração dinâmica ou persistência nova.
 - A E20 ainda não está materializada em `docs/roadmap.md`; `docs/lp-planejamento.md` é a decisão conceitual obrigatória deste recorte.
 
 ### 1.3. Função das fontes empíricas
 
-- `Pesquisa bruta para corretor de imóveis de médio padrão.pdf` é a fonte empírica principal para levantar candidatos de entrada.
-- `Projeto Piloto Imobiliário.pdf` é fonte contextual complementar para comprovar operação real, campanhas, formulários, WhatsApp, qualificação e processo comercial.
-- Nenhuma informação dessas fontes entra automaticamente no catálogo.
-- Cada candidato deve passar pela barreira de admissão da seção 2.2 antes de ser incorporado.
+- `Pesquisa bruta para corretor de imóveis de médio padrão.pdf` é a fonte empírica principal para levantar candidatos.
+- `Projeto Piloto Imobiliário.pdf` é fonte contextual complementar para comprovar o uso real de páginas, formulários, WhatsApp, e-mail, campanhas por imóvel ou região, qualificação e processo comercial.
+- As fontes PDF não são contratos técnicos nem entram automaticamente no catálogo.
+- A evidência necessária para execução está resumida por `field_key` neste plano e deverá ser preservada no registry, sem copiar conteúdo sensível.
+- Cada candidato passa pela barreira de admissão da seção 2.2.
 
 ### 1.4. Decisões fixas do debate
 
@@ -41,26 +42,58 @@ Fontes: chat, `README.md`, `AGENTS.md`, `docs/prompt-estrategista.md`, `docs/tem
   - definição declarativa dos campos;
   - valores operacionais fornecidos pela conta, negócio, oferta, campanha ou LP;
   - snapshot dos valores efetivamente usados em uma geração.
-- A E20.2 implementa somente a primeira camada.
+- A E20.2 implementa somente a definição declarativa.
 - Valores operacionais e snapshot pertencem ao futuro plano da E19.4.
 - A fonte canônica inicial será versionada no repositório.
 - A resolução seguirá `universal → segmento → nicho → ultranicho`.
-- Taxon de ultranicho pode herdar normalmente sem possuir camada própria.
+- Taxon de ultranicho pode herdar normalmente sem camada própria.
 - Somente a criação ou utilização de camada específica de ultranicho depende de autorização humana registrada.
-- O primeiro catálogo não terá camada própria de ultranicho para `corretor de imóveis de médio padrão`; ele validará a herança das camadas de segmento e nicho.
+- O primeiro catálogo não terá camada própria de ultranicho para `corretor de imóveis de médio padrão`.
 - Todos os campos v1 serão aplicáveis igualmente a `starter`, `lite`, `pro` e `ultra`.
-- Restrição por plano só poderá surgir em nova versão e com decisão comercial explícita.
-- `paid_search_keyword_map` será opcional e somente aplicável quando a origem de tráfego for busca paga.
+- Restrição futura por plano exige decisão comercial explícita e nova versão.
+- `paid_search_keyword_map` permanece opcional e só é aplicável quando a origem de tráfego for busca paga.
+- A v1 real não contém especialização de campo entre camadas; o contrato suporta somente especializações determinísticas para evolução e fixtures.
 - Automação, agente, job, workflow ou rotina recorrente não se aplicam.
 
 ### 1.5. Limites de responsabilidade
 
 - A E10.8 resolve pesquisas e proveniência; não define entradas da conta.
 - A E18 define parametrizações, módulos e variantes; não define valores operacionais do negócio.
-- A E20.2 define o catálogo declarativo; não coleta valores.
-- A E20.3 consumirá o catálogo resolvido para prontidão e autorização controlada.
-- A E19.4 apresentará os campos, receberá valores, gerará a LP e preservará snapshot.
+- A E20.2 define catálogo declarativo e resolve sua aplicabilidade; não coleta valores.
+- A E20.3 combina a validade do catálogo com os demais critérios de prontidão do taxon.
+- A E19.4 valida separadamente a completude dos valores exigidos para cada geração, gera a LP e preserva snapshot.
 - A E12 poderá conferir o resultado em superfície administrativa futura, mas não será fonte do contrato.
+- O plano informado ao resolver é uma entrada já determinada pelo fluxo comercial responsável.
+- A E20.2 não concede entitlement, não autoriza conta de teste, não valida assinatura e não libera geração.
+
+### 1.6. Consolidação dos especialistas
+
+- Aceitos:
+  - incluir origem esperada do valor no modelo declarativo;
+  - fechar valores permitidos para origem, tipos e validações;
+  - registrar validação e evidência resumida para cada campo concreto;
+  - separar os destinos de conversão por canal;
+  - limitar especialização v1 a propriedades comparáveis deterministicamente;
+  - mover `transaction_intent`, `financing_support_available` e `document_support_available` para o nicho `corretor de imóveis`;
+  - separar explicitamente prontidão de taxon na E20.3 e completude de valores na E19.4;
+  - definir ordenação determinística;
+  - incorporar `supa#40` como snippet read-only versionado para comprovar a cadeia taxonômica;
+  - incorporar `prod#19` como trava entre aplicabilidade declarativa por plano e entitlement comercial;
+  - preservar evidência resumida no plano e no registry.
+- Já cobertos:
+  - boundary repo-only;
+  - ausência de banco, rota, UI e adapter;
+  - herança sem camada própria de ultranicho;
+  - equivalência funcional entre planos na v1;
+  - `paid_search_keyword_map` opcional;
+  - única fase material e `Automação: não`.
+- Rejeitados:
+  - comparador genérico de regex, formatos textuais ou expressões livres;
+  - transformação automática da pesquisa em campos;
+  - uso do plano do catálogo como autorização comercial;
+  - consulta de Stripe, assinatura, grants ou Supabase pelo resolver puro;
+  - duplicação da herança do catálogo no snippet SQL.
+- Pendentes: nenhum ponto de contrato para consolidação da v2.
 
 ## 2. Contrato do caso
 
@@ -71,26 +104,29 @@ Fontes: chat, `README.md`, `AGENTS.md`, `docs/prompt-estrategista.md`, `docs/tem
 - Entrada:
   - versão do catálogo;
   - plano entre `starter`, `lite`, `pro` e `ultra`;
-  - cadeia normalizada e ativa do taxon atendido, preservando nível, identidade e ancestrais aplicáveis.
+  - cadeia normalizada e ativa do taxon atendido, preservando identidade, slug, nível e ancestrais aplicáveis;
+  - autorização de camada própria de ultranicho, somente quando existir.
 - Processamento:
   - validar versão, plano e cadeia taxonômica;
   - carregar a definição universal;
   - aplicar as camadas existentes de segmento e nicho;
   - aplicar camada de ultranicho somente quando existir e estiver autorizada;
-  - adicionar campos novos e resolver especializações pelo mesmo `field_key`;
-  - preservar a proveniência de cada propriedade efetiva;
+  - acrescentar campos novos;
+  - aplicar especializações permitidas pelo mesmo `field_key`;
+  - preservar proveniência das definições e propriedades;
+  - ordenar deterministicamente;
   - produzir catálogo resolvido sem valores operacionais.
 - Validação:
-  - aplicar invariantes, especialização, condições, tipos, planos, snapshot e matriz de casos.
+  - aplicar invariantes, condições, tipos, validações, especializações, planos, evidência, snapshot e matriz de casos.
 - Persistência:
   - somente definição declarativa versionada no repositório.
 - Consumo:
   - E20.3 recebe validade e catálogo resolvido;
-  - E19.4 futuramente recebe o mesmo contrato para coleta e geração.
+  - E19.4 futuramente recebe o contrato para coleta, validação de valores, geração e snapshot.
 - Fallback:
   - ausência de camada própria de nicho ou ultranicho mantém a herança válida;
   - camada existente inválida ou conflitante bloqueia a resolução;
-  - não gerar campos por IA nem inferir valores ausentes.
+  - não gerar campos por IA, não inferir valores ausentes e não corrigir catálogo inválido silenciosamente.
 
 ### 2.2. Barreira de admissão dos campos
 
@@ -103,7 +139,7 @@ Cada campo candidato deve demonstrar cumulativamente que:
 - não define módulo, variante ou composição;
 - não é copy, promessa, dor, objeção, FAQ, vocabulário ou conteúdo já produzido;
 - não duplica outro campo herdado com a mesma finalidade;
-- possui origem esperada, tipo, validação, obrigatoriedade, relação com plano e política de snapshot definidos.
+- possui origem esperada, tipo, validação, obrigação, relação com plano, política de snapshot e evidência definidos.
 
 Dores, objeções, medos, vocabulário, FAQ, diretrizes de copy e ordem de seções não entram no catálogo.
 
@@ -113,26 +149,60 @@ Cada definição de campo deve possuir:
 
 - `field_key` estável e único na cadeia resolvida;
 - finalidade semântica objetiva;
-- camada de origem: universal, segmento, nicho ou ultranicho;
-- taxon de origem quando não universal;
+- camada de origem: `universal`, `segment`, `niche` ou `ultra_niche`;
+- identidade do taxon de origem quando não universal;
 - `value_type`;
-- `value_scope`: `account`, `business`, `offer`, `campaign` ou `landing_page`;
+- `value_scope`;
+- `expected_value_origin`;
 - obrigação: `required`, `optional` ou `conditional`;
 - `required_when`, somente quando a obrigação for condicional;
-- `applicable_when`, quando o campo só puder ser apresentado ou fornecido em determinado contexto;
+- `applicable_when`, quando o campo só puder ser apresentado em determinado contexto;
 - validação declarativa compatível com o tipo;
-- planos permitidos;
+- `allowed_plans`;
 - política de snapshot;
-- base de evidência resumida;
-- versão do catálogo em que a definição foi criada.
+- resumo de evidência;
+- referências de evidência;
+- versão em que a definição foi criada.
 
-A forma exata dos tipos TypeScript pertence à implementação repo-only, mas não pode criar contrato externo, rota ou payload de API nesta etapa.
+Valores permitidos para `value_scope`:
 
-### 2.4. Tipos e condições v1
+- `account`;
+- `business`;
+- `offer`;
+- `campaign`;
+- `landing_page`.
 
-Tipos permitidos na v1:
+Valores permitidos para `expected_value_origin`:
+
+- `account_provided`;
+- `business_provided`;
+- `offer_provided`;
+- `campaign_provided`;
+- `landing_page_provided`.
+
+Esses valores indicam origem conceitual e não pressupõem tabela, coluna, endpoint ou formato de persistência.
+
+Política de snapshot v1:
+
+- `include_if_used`.
+
+Referências de evidência permitidas na v1:
+
+- `decision:lp-planning`;
+- `decision:e20-2-human`;
+- `technical:current-contracts`;
+- `empirical:real-estate-research`;
+- `context:real-estate-pilot`.
+
+O registry deve armazenar resumo suficiente para rastrear a admissão de cada campo sem depender de acesso aos PDFs durante runtime.
+
+### 2.4. Tipos e validações v1
+
+Tipos permitidos:
 
 - `string`;
+- `phone`;
+- `email`;
 - `url`;
 - `enum`;
 - `string_list`;
@@ -140,64 +210,135 @@ Tipos permitidos na v1:
 - `number_range`;
 - `keyword_map`.
 
+Validações-base:
+
+- `string`:
+  - texto normalizado, sem apenas espaços e com pelo menos um caractere;
+  - sem validação adicional quando o campo declarar `type_only`.
+- `phone`:
+  - valor canônico em formato E.164, com `+` e de 8 a 15 dígitos;
+  - não aceitar texto livre, ramal ou URL.
+- `email`:
+  - endereço de e-mail sintaticamente válido após normalização;
+  - não aceitar múltiplos endereços no mesmo valor.
+- `url`:
+  - URL absoluta `https`;
+  - não aceitar URL relativa, `javascript:`, `data:` ou protocolo diferente.
+- `enum`:
+  - valor pertencente ao conjunto fechado declarado pelo campo.
+- `string_list`:
+  - lista de textos não vazios, normalizados e sem duplicidade após comparação case-insensitive;
+  - quando não houver limites adicionais, declarar `type_only`.
+- `boolean`:
+  - somente `true` ou `false`.
+- `number_range`:
+  - limite mínimo e máximo finitos e não negativos;
+  - mínimo menor ou igual ao máximo;
+  - moeda `BRL` no primeiro catálogo imobiliário.
+- `keyword_map`:
+  - lista não vazia quando fornecida;
+  - cada item contém `keyword_or_cluster` não vazio e `message_anchor` não vazio;
+  - `ad_context` é opcional, mas não pode ser vazio quando presente;
+  - `keyword_or_cluster` não pode se repetir após normalização case-insensitive.
+
 Condições v1:
 
-- devem referenciar um único `field_key` existente;
-- operadores permitidos: igualdade ou pertencimento a conjunto;
+- referenciam exatamente um `field_key` existente;
+- operadores permitidos: `equals` e `in`;
+- o valor comparado deve ser compatível com o tipo do campo referenciado;
 - não haverá expressão livre, código executável, árvore arbitrária ou engine de regras;
+- condição não pode referenciar o próprio campo;
 - referências circulares, ausentes ou incompatíveis bloqueiam a resolução.
 
 ### 2.5. Especialização entre camadas
 
 Propriedades imutáveis para o mesmo `field_key`:
 
-- identidade do campo;
+- identidade;
 - finalidade semântica;
 - `value_type`;
 - `value_scope`;
-- política de snapshot.
+- `expected_value_origin`;
+- condições `required_when` e `applicable_when`;
+- política de snapshot;
+- versão de criação;
+- referências e resumo de evidência.
 
-Propriedades que podem ser especializadas explicitamente em camada inferior:
+Propriedades especializáveis na v1:
 
 - obrigação;
-- `required_when`;
-- `applicable_when`;
-- validação;
-- planos permitidos.
+- `allowed_plans`;
+- conjunto permitido de um `enum`;
+- `min_items` e `max_items` de `string_list`, quando declarados;
+- limites mínimo e máximo de `number_range`, quando declarados.
 
-Regras:
+Comparadores determinísticos:
 
+- obrigação:
+  - `optional → conditional`;
+  - `optional → required`;
+  - `conditional → required`;
+  - qualquer relaxamento falha.
+- planos:
+  - o conjunto especializado deve ser subconjunto não vazio do conjunto herdado.
+- enum:
+  - o conjunto especializado deve ser subconjunto não vazio do conjunto herdado.
+- `string_list`:
+  - `min_items` pode aumentar;
+  - `max_items` pode diminuir;
+  - o resultado deve preservar `min_items <= max_items`.
+- `number_range`:
+  - mínimo permitido pode aumentar;
+  - máximo permitido pode diminuir;
+  - o resultado deve preservar mínimo menor ou igual ao máximo.
+
+Limites:
+
+- condição não pode ser alterada por especialização na v1;
+- formato, regex, texto livre ou validação customizada não podem ser especializados;
+- campo herdado não pode ser removido ou desativado;
 - propriedades não sobrescritas permanecem herdadas;
-- camada inferior pode adicionar campo novo;
-- obrigação só pode ficar mais restritiva: `optional → conditional|required` e `conditional → required`;
-- condição pode ser adicionada ou restringida, nunca removida para ampliar aplicação silenciosamente;
-- validação pode restringir enum, formato, quantidade ou faixa, mas não ampliar o contrato herdado;
-- planos permitidos só podem ser reduzidos, nunca ampliados além do pai;
-- campo herdado não pode ser removido ou desativado na v1;
-- alteração de propriedade imutável exige novo `field_key` e nova versão do catálogo;
-- especialização inválida bloqueia a resolução e não pode ser ignorada.
+- campo novo é permitido em camada inferior;
+- especialização inválida bloqueia a resolução;
+- o catálogo concreto v1 não usa especialização real; o suporte existe para evolução controlada e casos de validação.
 
-### 2.6. Herança, precedência e ultranicho
+### 2.6. Herança, precedência, ordenação e ultranicho
 
-- Ordem de resolução: universal, segmento, nicho e ultranicho autorizado.
-- A camada inferior vence somente nas propriedades explicitamente especializadas.
+- Ordem de resolução:
+  - universal;
+  - segmento;
+  - nicho;
+  - ultranicho autorizado.
+- Campos universais permanecem na ordem em que aparecem no registry universal.
+- Novos campos de segmento são acrescentados ao final, na ordem do registry da camada.
+- Novos campos de nicho são acrescentados depois dos campos de segmento, na ordem do registry da camada.
+- Novos campos de ultranicho autorizado são acrescentados ao final, na ordem do registry da camada.
+- Especialização preserva a posição original do campo herdado.
+- Não ordenar alfabeticamente nem por `field_key`.
+- Duplicidade de `field_key` sem especialização válida bloqueia a resolução.
 - Ausência de camada inferior não é erro.
-- Taxon de ultranicho sem camada própria recebe normalmente o catálogo herdado.
+- Taxon de ultranicho sem camada própria recebe o catálogo herdado.
 - Falha somente quando existir ou for solicitada camada específica de ultranicho sem autorização humana registrada.
-- A primeira versão deve resolver o taxon `corretor-de-imoveis-de-medio-padrao` sem camada própria de ultranicho.
-- A identidade exata do segmento ancestral deve ser confirmada no estado real antes da implementação do registry; não criar ou renomear taxon neste plano.
+- A primeira versão deve resolver `corretor-de-imoveis-de-medio-padrao` sem camada própria.
+- A identidade e os slugs reais da cadeia serão confirmados por inspeção read-only antes do registry.
+- A fase não cria, renomeia, ativa, desativa ou religa taxon.
 
-### 2.7. Relação com planos
+### 2.7. Relação com planos e entitlement
 
-- O resolver exige plano conhecido para produzir contrato estável de consumo.
-- Na v1, todos os campos efetivos devem declarar os quatro planos.
-- O resultado para o mesmo taxon deve ser funcionalmente equivalente nos quatro planos.
-- O plano não altera obrigatoriedade, tipo, validação, herança ou snapshot na v1.
-- Diferença futura exige evidência comercial, nova versão do catálogo e plano-base próprio quando material.
+- O resolver exige um plano conhecido para produzir contrato estável de consumo.
+- Na v1, todos os campos efetivos declaram `starter`, `lite`, `pro` e `ultra`.
+- O resultado para o mesmo taxon é funcionalmente equivalente nos quatro planos.
+- A equivalência do catálogo não significa igualdade comercial entre os planos.
+- Os planos declarados no catálogo representam somente aplicabilidade contratual dos campos.
+- Eles não concedem entitlement, não autorizam conta de teste, não liberam geração e não substituem E9 ou `public.account_commercial_entitlements`.
+- O consumidor fornece um plano previamente determinado pelo fluxo comercial responsável.
+- O resolver não consulta Stripe, assinatura, grants, `account_commercial_entitlements` ou banco.
+- `prod#19` é apenas referência e trava de responsabilidade.
+- Redução futura de campos por plano exige decisão comercial, nova versão do catálogo e plano-base próprio quando material.
 
 ### 2.8. Separação dos valores futuros e snapshot
 
-A E20.2 deve deixar explícito que o valor futuro se vinculará conceitualmente a:
+O valor futuro se vinculará conceitualmente a:
 
 - `field_key`;
 - versão do catálogo;
@@ -211,170 +352,268 @@ Limites:
 - a E20.2 não define tabela, coluna, JSON persistido, rota, action ou formulário;
 - a E19.4 decidirá a persistência operacional;
 - a E19.4 deverá preservar no snapshot a versão do catálogo e os valores efetivamente usados;
-- todos os campos v1 terão política `include_if_used`;
-- valor não utilizado na geração não deve ser incluído artificialmente no snapshot.
+- todos os campos v1 usam `include_if_used`;
+- valor não usado na geração não entra artificialmente no snapshot.
 
 ### 2.9. `paid_search_keyword_map`
 
-- `field_key`: `paid_search_keyword_map`.
 - Camada: universal.
 - Tipo: `keyword_map`.
 - Escopo: `campaign`.
-- Obrigação: opcional.
-- Aplicabilidade: somente quando `traffic_source = paid_search`.
-- Planos: `starter`, `lite`, `pro` e `ultra`.
+- Origem esperada: `campaign_provided`.
+- Obrigação: `optional`.
+- Aplicabilidade: `traffic_source equals paid_search`.
+- Validação: regras de `keyword_map` da seção 2.4.
+- Planos: os quatro.
 - Snapshot: `include_if_used`.
+- Evidência:
+  - `docs/lp-planejamento.md` autoriza mapa opcional para message match;
+  - a pesquisa imobiliária confirma demanda orientada por localização, tipologia e intenção de busca.
+- Referências:
+  - `decision:lp-planning`;
+  - `empirical:real-estate-research`.
 - Finalidade:
-  - alinhar termo ou cluster de busca, contexto do anúncio ou oferta e âncora de mensagem da LP;
-  - sustentar message match sem substituir pesquisas da E10;
-  - não alterar módulos, variantes, composição ou parametrizações.
+  - alinhar termo ou cluster de busca, contexto do anúncio e âncora factual de mensagem;
+  - sustentar message match sem substituir E10.
 - Restrições:
   - não autoriza keyword stuffing;
-  - não cria conteúdo automaticamente;
-  - não permite termos incompatíveis com a oferta real;
-  - não é obrigatório mesmo em campanha de busca paga.
+  - não produz copy;
+  - não permite termo incompatível com oferta real;
+  - não é obrigatório mesmo com busca paga.
 
 ### 2.10. Primeiro catálogo concreto v1
 
-#### 2.10.1. Camada universal
+#### 2.10.1. Políticas comuns
+
+- Todos os campos:
+  - são criados na versão 1;
+  - permitem os quatro planos;
+  - usam snapshot `include_if_used`;
+  - possuem consumidor futuro E19.4;
+  - não definem estrutura, copy ou composição.
+- Quando a validação declarar `type_only`, nenhuma regra adicional além da validação-base do tipo pode ser inventada.
+- As evidências abaixo são suficientes para implementação do registry; os PDFs permanecem fontes empíricas externas, não dependências de runtime.
+
+#### 2.10.2. Camada universal
 
 - `business_display_name`:
   - tipo `string`;
   - escopo `business`;
-  - obrigatório;
-  - finalidade: identificar factual e publicamente o negócio ou profissional atendido.
+  - origem `business_provided`;
+  - obrigação `required`;
+  - validação: texto normalizado não vazio; sem limite adicional;
+  - evidência: toda LP precisa identificar factual e publicamente o negócio ou profissional atendido;
+  - referências: `decision:lp-planning`, `technical:current-contracts`.
 - `funnel_stage`:
   - tipo `enum` com `bofu`, `mofu` e `tofu`;
   - escopo `landing_page`;
-  - obrigatório;
-  - finalidade: informar a intenção da LP sem criar composição própria por estágio.
+  - origem `landing_page_provided`;
+  - obrigação `required`;
+  - validação: conjunto fechado declarado;
+  - evidência: `docs/lp-planejamento.md` define BOFU, MOFU e TOFU como intenção informada para a LP, separada do canal;
+  - referência: `decision:lp-planning`.
 - `traffic_source`:
   - tipo `enum` com `paid_search`, `paid_social`, `organic`, `whatsapp`, `qr_code` e `other`;
   - escopo `campaign`;
-  - opcional.
+  - origem `campaign_provided`;
+  - obrigação `optional`;
+  - validação: conjunto fechado declarado;
+  - evidência: `docs/lp-planejamento.md` separa origem de tráfego da intenção da LP;
+  - referência: `decision:lp-planning`.
 - `primary_conversion_channel`:
   - tipo `enum` com `whatsapp`, `form`, `phone`, `email` e `external_url`;
   - escopo `landing_page`;
-  - obrigatório.
-- `primary_conversion_destination`:
-  - tipo `string`;
+  - origem `landing_page_provided`;
+  - obrigação `required`;
+  - validação: conjunto fechado declarado;
+  - evidência: pesquisa e piloto comprovam conversão por WhatsApp, formulários e e-mail; telefone e URL externa permanecem destinos operacionais explícitos aprovados no debate;
+  - referências: `empirical:real-estate-research`, `context:real-estate-pilot`, `decision:e20-2-human`.
+- `whatsapp_destination`:
+  - tipo `phone`;
   - escopo `landing_page`;
-  - condicionalmente obrigatório quando o canal for `whatsapp`, `phone`, `email` ou `external_url`.
+  - origem `landing_page_provided`;
+  - obrigação `conditional`;
+  - `required_when` e `applicable_when`: `primary_conversion_channel equals whatsapp`;
+  - validação: E.164;
+  - evidência: WhatsApp é CTA recorrente na pesquisa e canal real do piloto;
+  - referências: `empirical:real-estate-research`, `context:real-estate-pilot`.
+- `phone_destination`:
+  - tipo `phone`;
+  - escopo `landing_page`;
+  - origem `landing_page_provided`;
+  - obrigação `conditional`;
+  - `required_when` e `applicable_when`: `primary_conversion_channel equals phone`;
+  - validação: E.164;
+  - evidência: destino telefônico foi mantido como canal operacional explícito no contrato aprovado;
+  - referência: `decision:e20-2-human`.
+- `email_destination`:
+  - tipo `email`;
+  - escopo `landing_page`;
+  - origem `landing_page_provided`;
+  - obrigação `conditional`;
+  - `required_when` e `applicable_when`: `primary_conversion_channel equals email`;
+  - validação: e-mail único válido;
+  - evidência: e-mail é canal previsto no produto e no piloto;
+  - referências: `technical:current-contracts`, `context:real-estate-pilot`.
+- `external_url_destination`:
+  - tipo `url`;
+  - escopo `landing_page`;
+  - origem `landing_page_provided`;
+  - obrigação `conditional`;
+  - `required_when` e `applicable_when`: `primary_conversion_channel equals external_url`;
+  - validação: URL absoluta `https`;
+  - evidência: URL externa foi mantida como destino operacional explícito no contrato aprovado;
+  - referência: `decision:e20-2-human`.
 - `privacy_policy_url`:
   - tipo `url`;
   - escopo `business`;
-  - condicionalmente obrigatório quando o canal for `form`.
+  - origem `business_provided`;
+  - obrigação `conditional`;
+  - `required_when` e `applicable_when`: `primary_conversion_channel equals form`;
+  - validação: URL absoluta `https`;
+  - evidência: pesquisa observa política e consentimento quando existe formulário;
+  - referência: `empirical:real-estate-research`.
 - `paid_search_keyword_map`:
   - contrato definido na seção 2.9.
 
-#### 2.10.2. Camada do segmento imobiliário
+#### 2.10.3. Camada do segmento imobiliário
+
+- `service_locations`:
+  - tipo `string_list`;
+  - escopo `business`;
+  - origem `business_provided`;
+  - obrigação `required`;
+  - validação: lista única e não vazia; sem quantidade máxima ou mínima adicional;
+  - evidência: pesquisa identifica jornada e descoberta orientadas por cidade, bairro e região; piloto prevê campanhas e atuação por região;
+  - referências: `empirical:real-estate-research`, `context:real-estate-pilot`.
+- `property_types`:
+  - tipo `string_list`;
+  - escopo `offer`;
+  - origem `offer_provided`;
+  - obrigação `optional`;
+  - validação: lista única e não vazia quando fornecida; sem allowlist global;
+  - evidência: portais e pesquisa estruturam descoberta por tipologia; a lista real depende da oferta;
+  - referência: `empirical:real-estate-research`.
+- `property_price_range`:
+  - tipo `number_range`;
+  - escopo `offer`;
+  - origem `offer_provided`;
+  - obrigação `optional`;
+  - validação: faixa não negativa, ordenada e em BRL;
+  - evidência: faixa de preço e capacidade financeira aparecem como filtros e insumos recorrentes;
+  - referências: `empirical:real-estate-research`, `context:real-estate-pilot`.
+- `property_stage`:
+  - tipo `enum` com `launch`, `under_construction`, `ready`, `used` e `mixed`;
+  - escopo `offer`;
+  - origem `offer_provided`;
+  - obrigação `optional`;
+  - validação: conjunto fechado declarado;
+  - evidência: pesquisa e piloto distinguem lançamentos, imóveis em construção, prontos e usados como estado real da oferta;
+  - referências: `empirical:real-estate-research`, `context:real-estate-pilot`.
+
+#### 2.10.4. Camada do nicho corretor de imóveis
 
 - `transaction_intent`:
   - tipo `enum` com `buy`, `sell`, `valuation` e `mixed`;
   - escopo `landing_page`;
-  - obrigatório.
-- `service_locations`:
-  - tipo `string_list`;
-  - escopo `business`;
-  - obrigatório;
-  - finalidade: declarar cidades, regiões, bairros ou micro-regiões realmente atendidos.
-- `property_types`:
-  - tipo `string_list`;
-  - escopo `offer`;
-  - opcional.
-- `property_price_range`:
-  - tipo `number_range`;
-  - escopo `offer`;
-  - opcional.
-- `property_stage`:
-  - tipo `enum` com `launch`, `under_construction`, `ready`, `used` e `mixed`;
-  - escopo `offer`;
-  - opcional.
+  - origem `landing_page_provided`;
+  - obrigação `required`;
+  - validação: conjunto fechado declarado;
+  - evidência: pesquisa diferencia LP de compra, venda/captação, avaliação e fluxo híbrido no contexto do corretor;
+  - referência: `empirical:real-estate-research`.
 - `financing_support_available`:
   - tipo `boolean`;
   - escopo `business`;
-  - opcional.
+  - origem `business_provided`;
+  - obrigação `optional`;
+  - validação: tipo somente;
+  - evidência: pesquisa e piloto mostram financiamento como serviço e apoio possível do corretor, não como propriedade universal do segmento;
+  - referências: `empirical:real-estate-research`, `context:real-estate-pilot`.
 - `document_support_available`:
   - tipo `boolean`;
   - escopo `business`;
-  - opcional.
-
-#### 2.10.3. Camada do nicho corretor de imóveis
-
+  - origem `business_provided`;
+  - obrigação `optional`;
+  - validação: tipo somente;
+  - evidência: pesquisa e piloto mostram orientação documental como apoio possível do corretor;
+  - referências: `empirical:real-estate-research`, `context:real-estate-pilot`.
 - `creci_registration`:
   - tipo `string`;
   - escopo `business`;
-  - obrigatório;
-  - finalidade: preservar credencial factual verificável do profissional.
+  - origem `business_provided`;
+  - obrigação `required`;
+  - validação: texto normalizado não vazio; sem regex regional inventada;
+  - regra adicional: a E19.4 deverá exigir confirmação por fonte oficial antes de usar a credencial como prova;
+  - evidência: pesquisa identifica CRECI como credencial verificável e o piloto trata a atuação profissional da corretora;
+  - referências: `empirical:real-estate-research`, `context:real-estate-pilot`.
 - `attendance_modes`:
-  - tipo `string_list`;
+  - tipo `string_list` com valores permitidos `in_person` e `remote`;
   - escopo `business`;
-  - opcional;
-  - finalidade: declarar atendimento presencial, remoto ou combinação real disponível.
+  - origem `business_provided`;
+  - obrigação `optional`;
+  - validação: subconjunto não vazio e sem duplicidade quando fornecido;
+  - evidência: o processo comercial do corretor pode combinar atendimento presencial e remoto;
+  - referências: `empirical:real-estate-research`, `context:real-estate-pilot`.
 
-#### 2.10.4. Camada do ultranicho corretor de imóveis de médio padrão
+#### 2.10.5. Camada do ultranicho corretor de imóveis de médio padrão
 
 - Nenhum campo próprio na v1.
-- O taxon deve herdar integralmente as camadas universal, segmento e nicho.
-- Faixa de preço, tipologia e estágio já são entradas operacionais do segmento e não justificam camada própria.
-
-#### 2.10.5. Políticas comuns
-
-- Todos os campos são permitidos nos quatro planos.
-- Todos usam snapshot `include_if_used`.
-- Nenhum campo define estrutura da página.
-- Nenhum campo substitui pesquisa, copy ou conteúdo produzido.
-- Valores e limites exatos não definidos acima devem permanecer ausentes, em vez de serem inventados pelo Executor.
+- O taxon herda integralmente universal, segmento e nicho.
+- Faixa de preço, tipologia e estágio já são entradas do segmento e não justificam camada própria.
+- Necessidade futura específica depende de evidência, consumidor real e autorização humana.
 
 ### 2.11. Critério de prontidão do catálogo
 
-O resultado da E20.2 pode ser marcado como catálogo válido quando:
+O resultado da E20.2 é catálogo válido quando:
 
 - a versão existe e é única;
 - o plano é conhecido;
-- a cadeia taxonômica é coerente;
+- a cadeia taxonômica é coerente e ativa;
 - toda camada aplicada é válida;
 - camada própria de ultranicho, quando existir, possui autorização;
-- cada campo efetivo possui todas as propriedades obrigatórias;
-- não há duplicidade não declarada;
+- cada campo possui todas as propriedades obrigatórias;
+- não há duplicidade sem especialização válida;
 - não há mudança de propriedade imutável;
-- especializações respeitam as regras da seção 2.5;
-- condições apontam para campos existentes e não são circulares;
+- especializações respeitam os comparadores da seção 2.5;
+- condições apontam para campos existentes, são compatíveis e não circulares;
 - tipos e validações são coerentes;
-- todos os campos possuem origem esperada e política de snapshot;
-- `paid_search_keyword_map` respeita sua aplicabilidade;
-- o resultado preserva a proveniência das camadas e propriedades.
+- todos os campos possuem origem, evidência e política de snapshot;
+- `paid_search_keyword_map` respeita aplicabilidade e validação;
+- proveniência e ordem determinística são preservadas.
 
-Esse sinal não significa que uma conta já forneceu os valores. A completude de valores pertence à E19.4 e será combinada pela E20.3 com os demais critérios de prontidão.
+A E20.3 combina essa validade com os demais critérios de prontidão do taxon. A E19.4 valida separadamente a completude dos valores exigidos para cada geração.
 
 ### 2.12. Resultado tipado
 
-O sucesso deve preservar, no mínimo:
+O sucesso preserva, no mínimo:
 
-- versão do catálogo;
+- versão;
 - taxon atendido;
-- plano;
+- plano recebido;
 - cadeia de camadas utilizada;
-- campos efetivos na ordem determinística do registry;
+- campos efetivos em ordem determinística;
 - definição efetiva de cada campo;
 - camada e taxon de origem;
-- propriedades especializadas e sua origem;
-- sinal de catálogo válido para consumo pela E20.3.
+- propriedades especializadas e sua proveniência;
+- resumo e referências de evidência;
+- sinal de catálogo válido.
 
-A falha deve distinguir, no mínimo:
+A falha distingue, no mínimo:
 
 - versão inválida ou ausente;
 - plano inválido;
 - cadeia taxonômica inválida;
 - camada inválida;
-- ultranicho específico sem autorização;
+- camada própria de ultranicho sem autorização;
 - campo duplicado sem especialização válida;
-- conflito de tipo ou propriedade imutável;
-- especialização que amplia contrato herdado;
-- condição inválida, ausente ou circular;
+- conflito em propriedade imutável;
+- especialização não comparável ou que amplia contrato;
+- condição inválida, ausente, incompatível ou circular;
+- validação incompatível com o tipo;
+- evidência ou origem ausente;
 - contrato do `paid_search_keyword_map` inválido.
 
-Nenhum resultado contém valores reais da conta ou snapshot de geração.
+Nenhum resultado contém valores reais, assinatura, entitlement ou snapshot de geração.
 
 ### 2.13. Boundary técnico canônico
 
@@ -388,58 +627,101 @@ Nenhum resultado contém valores reais da conta ou snapshot de geração.
   - `validation-cases.ts`;
   - `index.ts`.
 - Export agregado:
-  - ajustar `lib/conversion-content/index.ts` com namespace separado `landingPageInputCatalog`.
+  - ajustar `lib/conversion-content/index.ts` com namespace `landingPageInputCatalog`.
 - Script:
   - adicionar `validate:landing-page-input-catalog` em `package.json`.
-- Não criar adapter de banco na E20.2.
-- O resolver recebe cadeia taxonômica normalizada do consumidor e não consulta Supabase.
-- Não alterar os arquivos da parametrização raiz da E18.4 nem o boundary da E10.8.
-- Não adicionar dependência nova.
+- Validação read-only versionada:
+  - criar `supabase/snippets/e20_2_taxon_chain_verify.sql`.
+- Não criar adapter de banco.
+- O resolver recebe cadeia normalizada do consumidor e não consulta Supabase.
+- Não alterar parametrização raiz da E18.4 nem boundary da E10.8.
+- Não adicionar dependência.
 
-### 2.14. Matriz mínima de validação
+### 2.14. Snippet de cadeia taxonômica — `supa#40`
+
+O snippet deve:
+
+- consultar somente `public.business_taxons`;
+- usar `SELECT` ou `WITH` read-only;
+- declarar o slug do taxon atendido em CTE de parâmetros claramente editável;
+- retornar a cadeia até o segmento;
+- mostrar `id`, `name`, `slug`, `level`, `is_active`, `parent_id` e profundidade;
+- permitir comprovar identidade, nível, atividade e relações pai-filho usadas pelo registry;
+- limitar o resultado à cadeia do taxon solicitado;
+- ser executado antes da codificação das camadas.
+
+O snippet não pode:
+
+- escrever dados;
+- criar ou renomear taxon;
+- alterar atividade ou relação parental;
+- reproduzir a herança do catálogo;
+- virar dependência de runtime;
+- substituir o resolver puro.
+
+### 2.15. Matriz mínima de validação
 
 - versão inexistente: falhar;
 - plano desconhecido: falhar;
-- cadeia de taxon inválida ou fora de ordem: falhar;
-- catálogo universal válido sem camada específica: resolver;
-- segmento e nicho válidos: combinar em ordem;
+- cadeia inválida, inativa ou fora de ordem: falhar;
+- universal válido sem camada específica: resolver;
+- segmento e nicho válidos: combinar e ordenar;
 - ultranicho sem camada própria: herdar e resolver;
-- camada própria de ultranicho autorizada: resolver;
-- camada própria de ultranicho sem autorização: falhar;
-- campo novo em camada inferior: adicionar;
-- especialização explícita válida: preservar propriedades não alteradas;
-- mudança de `value_type`, finalidade, escopo ou snapshot: falhar;
+- camada própria autorizada: resolver;
+- camada própria não autorizada: falhar;
+- campo novo em camada inferior: acrescentar ao final da camada;
+- especialização válida: preservar posição e propriedades não alteradas;
+- alteração de identidade, tipo, escopo, origem, condição, snapshot ou evidência: falhar;
 - obrigação mais restritiva: aceitar;
 - obrigação relaxada: falhar;
-- validação restringida: aceitar;
-- validação ampliada: falhar;
-- planos reduzidos: aceitar em fixture estrutural, sem aplicar na v1 real;
-- planos ampliados além do pai: falhar;
-- referência de condição ausente: falhar;
+- enum reduzido: aceitar;
+- enum ampliado: falhar;
+- planos reduzidos: aceitar em fixture estrutural;
+- planos ampliados: falhar;
+- limites de lista ou faixa restringidos: aceitar;
+- limites ampliados ou incoerentes: falhar;
+- especialização textual, regex ou formato customizado: falhar;
+- referência de condição ausente ou incompatível: falhar;
 - condição circular: falhar;
+- cada destino de conversão deve aparecer somente no canal correspondente;
+- canal `form` exige `privacy_policy_url`;
 - `paid_search_keyword_map` ausente com busca paga: aceitar;
 - mapa presente sem busca paga: falhar;
+- mapa inválido: falhar;
 - mapa válido com busca paga: resolver;
-- primeiro catálogo imobiliário nos quatro planos: produzir resultado equivalente;
-- taxon de médio padrão: confirmar ausência de camada própria e herança integral;
-- saída não deve conter valores operacionais nem snapshot.
+- catálogo imobiliário nos quatro planos: resultado funcionalmente equivalente;
+- taxon de médio padrão: ausência de camada própria e herança integral;
+- saída: sem valores operacionais, entitlement ou snapshot;
+- registry e resultado: profundamente imutáveis.
 
 ## 3. Fases e próxima ação
 
 ### 3.1. E20.2.3–E20.2.6 — Contrato, catálogo imobiliário v1 e resolver repo-only
 
-- Status: planejada.
+- Status: planejada; bloqueada até merge humano deste plano-base v2.
 - Automação: não.
+- Fontes obrigatórias de execução:
+  - `README.md`;
+  - `AGENTS.md`;
+  - `docs/prompt-executor.md`;
+  - `docs/base-tecnica.md`;
+  - `docs/schema.md`;
+  - `docs/lp-planejamento.md`;
+  - `docs/supa-up.md`, item `supa#40`;
+  - `docs/prod-up.md`, item `prod#19`;
+  - este plano-base v2 na `main`;
+  - repositório real.
 - Objetivo:
-  - implementar o contrato declarativo, versionamento, herança, especialização, primeiro catálogo concreto, `paid_search_keyword_map`, resolver e sinal de prontidão definidos na seção 2.
+  - implementar contrato declarativo, registry v1, herança, especialização determinística, primeiro catálogo imobiliário, `paid_search_keyword_map`, resolver, snippet de verificação e sinal de validade.
 - Escopo executável:
-  - confirmar por inspeção read-only a cadeia real do taxon imobiliário e seus slugs antes de codificar as camadas;
+  - confirmar por inspeção read-only a cadeia real do taxon e seus slugs;
+  - criar e executar o snippet da seção 2.14;
   - implementar somente os paths da seção 2.13;
-  - implementar o registry v1 com as definições da seção 2.10;
-  - manter o ultranicho de médio padrão sem camada própria;
-  - criar validação executável para toda a matriz da seção 2.14;
-  - garantir saída imutável e falha fechada;
-  - exportar o namespace e adicionar o script de validação;
+  - implementar o registry exatamente com a seção 2.10;
+  - manter o ultranicho sem camada própria;
+  - criar validação executável para a seção 2.15;
+  - garantir imutabilidade profunda e falha fechada;
+  - exportar namespace e adicionar script;
   - executar `npm ci`, `npm run check` e `npm run validate:landing-page-input-catalog`;
   - registrar neste plano a evidência, decisão e próxima ação da fase.
 - Artefatos previstos:
@@ -449,54 +731,64 @@ Nenhum resultado contém valores reais da conta ou snapshot de geração.
   - criar `lib/conversion-content/landing-page/input-catalog/resolver.ts`;
   - criar `lib/conversion-content/landing-page/input-catalog/validation-cases.ts`;
   - criar `lib/conversion-content/landing-page/input-catalog/index.ts`;
+  - criar `supabase/snippets/e20_2_taxon_chain_verify.sql`;
   - ajustar `lib/conversion-content/index.ts`;
   - ajustar `package.json`;
   - ajustar somente este plano-base para registrar execução.
 - Critérios de aceite:
+  - snippet confirma a cadeia real sem escrita;
   - matriz completa aprovada;
-  - primeiro catálogo concreto contém somente campos admitidos pela seção 2.2;
-  - taxon de médio padrão resolve por herança sem camada própria;
-  - planos não produzem diferenças artificiais;
-  - especializações são explícitas e restritivas;
+  - cada campo concreto contém origem, validação e evidência;
+  - destinos de conversão são separados e condicionais por canal;
+  - segmento contém somente campos reutilizáveis no imobiliário;
+  - campos próprios do corretor permanecem no nicho;
+  - médio padrão resolve por herança sem camada própria;
+  - planos não produzem diferenças artificiais nem autorização comercial;
+  - especializações são somente as determinísticas;
+  - ordenação segue a seção 2.6;
   - `paid_search_keyword_map` permanece opcional;
-  - resultado preserva proveniência e sinal de validade;
-  - nenhuma pesquisa da E10 é copiada para o catálogo;
-  - nenhum valor operacional ou snapshot é persistido;
-  - nenhuma tabela, migration, rota, UI, API, adapter de banco, E20.3 ou E19.4 é criada ou alterada;
-  - diff limitado aos artefatos previstos e a este plano-base.
-- Próxima ação após consolidação do plano-base v2 e merge humano:
-  - enviar o plano completo ao Executor, autorizando somente esta fase.
+  - resultado preserva proveniência, evidência e validade;
+  - nenhuma pesquisa da E10 é copiada;
+  - nenhum valor ou snapshot é persistido;
+  - nenhuma tabela, migration, rota, UI, API, adapter, Stripe, E20.3 ou E19.4 é criada ou alterada;
+  - diff limitado aos artefatos previstos e a este plano.
+- Próxima ação após merge humano:
+  - instruir o Executor somente para esta fase.
 
 ## 4. Escopo negativo e critérios de parada
 
 ### 4.1. Escopo negativo
 
-- Coleta, edição ou persistência de valores da conta.
+- Coleta, edição ou persistência de valores.
 - Snapshot da geração.
 - Tabela, campo, view, RPC, trigger, policy, grant ou migration.
-- Rota, API, Server Action, formulário, Admin Dashboard ou Account Dashboard.
+- Rota, API, Server Action, formulário, Admin ou Account Dashboard.
 - Alteração de `account_profiles` ou `account_landing_pages`.
 - Parametrização, módulo, variante, composição ou renderer.
 - Pesquisa `business_buyer` ou `end_customer`, itens estruturados ou resolver da E10.8.
 - Geração de copy, FAQ, promessa, objeção, prova textual ou conteúdo final.
-- Geração, revisão, edição, publicação ou tracking de LP.
+- Geração, revisão, publicação ou tracking de LP.
 - Diferenciação entre planos sem fonte comercial aprovada.
+- Entitlement, assinatura, Stripe, grants ou autorização de conta.
 - Camada própria de ultranicho sem decisão humana.
-- Engine de regras, expressão livre, configuração dinâmica ou banco configurável.
+- Engine de regras, expressão livre, comparador genérico, configuração dinâmica ou banco configurável.
 - IA, automação, agente, job, fila, cache, workflow ou infraestrutura nova.
-- Alteração automática de `docs/roadmap.md`, `docs/base-tecnica.md` ou `docs/schema.md` durante a execução.
+- Alteração automática de `docs/roadmap.md`, `docs/base-tecnica.md` ou `docs/schema.md`.
 
 ### 4.2. Critérios de parada
 
-- Parar se a cadeia real de taxons divergir materialmente do recorte aprovado ou não permitir identificar segmento, nicho e ultranicho de forma única.
+- Parar se a cadeia real divergir materialmente ou não identificar segmento, nicho e ultranicho de forma única.
 - Parar antes de criar ou alterar taxon.
-- Parar se algum campo proposto não possuir consumidor real previsto na E19.4.
-- Parar se um candidato duplicar resultado da E10, parâmetro da E18, composição ou conteúdo produzido.
-- Parar se o contrato exigir relaxamento silencioso de campo herdado.
-- Parar se a solução repo-only não puder garantir versão, herança, proveniência e falha fechada.
-- Parar antes de propor persistência, adapter de banco, rota, UI ou configuração dinâmica.
-- Parar se surgir necessidade de diferenciar planos sem decisão comercial explícita.
-- Parar se a implementação exigir alterar E10.8, E18.4, E18.5, E20.3 ou E19.4.
+- Parar se algum campo não possuir consumidor real previsto na E19.4.
+- Parar se candidato duplicar E10, E18, composição ou conteúdo.
+- Parar se faltar origem, validação ou evidência para campo concreto.
+- Parar se o contrato exigir condição ou validação não comparável na especialização v1.
+- Parar se exigir relaxamento de campo herdado.
+- Parar se a solução repo-only não garantir versão, herança, proveniência, ordenação e falha fechada.
+- Parar antes de propor persistência, adapter, rota, UI ou configuração dinâmica.
+- Parar se surgir diferenciação de planos sem decisão comercial.
+- Parar se plano do catálogo precisar autorizar entitlement ou geração.
+- Parar se implementação exigir alterar E10.8, E18.4, E18.5, E20.3 ou E19.4.
 - Parar se houver necessidade de campo novo não previsto na seção 2.10; devolver ao Estrategista com evidência e consumidor.
 
 ### 4.3. Decisão ao fim da fase

--- a/docs/lousa-plano-base-e20-2.md
+++ b/docs/lousa-plano-base-e20-2.md
@@ -1,0 +1,505 @@
+14/07/2026 — Plano-base E20.2 — Catálogo de entradas por taxon
+
+Fontes: chat, `README.md`, `AGENTS.md`, `docs/prompt-estrategista.md`, `docs/template-roadmap.md`, `docs/template-briefing-codex.md`, `docs/prompt-executor.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/schema.md`, `docs/lp-planejamento.md`, `docs/lousa-plano-base-e10-8.md`, contratos atuais de planos, contas, taxons e landing pages, `Pesquisa bruta para corretor de imóveis de médio padrão.pdf`, `Projeto Piloto Imobiliário.pdf` e avaliações do Analista de 14/07/2026.
+
+- Versão: v1.
+- Status: plano-base v1 criado em PR vivo; avaliação única dos especialistas pendente; Executor não autorizado.
+- Recorte previsto para roadmap: `20.2 — Catálogo de entradas por taxon`.
+- Path canônico: `docs/lousa-plano-base-e20-2.md`.
+
+## 1. Estado e decisões fixas
+
+### 1.1. Problema e resultado esperado
+
+- O projeto ainda não possui um contrato canônico que declare quais dados uma conta, negócio, oferta, campanha ou LP pode ou deve fornecer para a geração de `landing_page`.
+- O recorte deve definir o `lp_generation_input_catalog` sem confundi-lo com parametrização, módulos, variantes, composição, pesquisas da E10, conteúdo produzido ou LP final.
+- O resultado esperado é uma fonte declarativa versionada, resolvida por `taxon + plano`, com primeiro catálogo concreto validado no recorte imobiliário.
+- O catálogo aplicável deve integrar os critérios de prontidão da futura E20.3, sem avaliar nesta etapa se uma conta concreta já forneceu todos os valores.
+
+### 1.2. Estado real confirmado
+
+- A E18.4 já possui parametrização raiz repo-only e versionada para `landing_page`.
+- A E18.5 permanece responsável por módulos e variantes e não é dependência para definir entradas operacionais da E20.2.
+- A E10.8 possui plano-base v2 e implementação em PR próprio para resolver pesquisas estruturadas; a E20.2 não deve reimplementar essa precedência.
+- `account_profiles` contém apenas dados mínimos de perfil e não representa o catálogo completo de geração.
+- `account_landing_pages` contém apenas identidade mínima da LP e status inicial `draft`.
+- Os planos comerciais confirmados são `starter`, `lite`, `pro` e `ultra`.
+- Não existe fonte aprovada que determine campos diferentes entre esses quatro planos.
+- Não foi demonstrada necessidade de tabela, campo, view, RPC, migration, rota, UI, API, configuração dinâmica ou persistência nova.
+- A E20 ainda não está materializada em `docs/roadmap.md`; `docs/lp-planejamento.md` é a decisão conceitual obrigatória deste recorte.
+
+### 1.3. Função das fontes empíricas
+
+- `Pesquisa bruta para corretor de imóveis de médio padrão.pdf` é a fonte empírica principal para levantar candidatos de entrada.
+- `Projeto Piloto Imobiliário.pdf` é fonte contextual complementar para comprovar operação real, campanhas, formulários, WhatsApp, qualificação e processo comercial.
+- Nenhuma informação dessas fontes entra automaticamente no catálogo.
+- Cada candidato deve passar pela barreira de admissão da seção 2.2 antes de ser incorporado.
+
+### 1.4. Decisões fixas do debate
+
+- Separar obrigatoriamente:
+  - definição declarativa dos campos;
+  - valores operacionais fornecidos pela conta, negócio, oferta, campanha ou LP;
+  - snapshot dos valores efetivamente usados em uma geração.
+- A E20.2 implementa somente a primeira camada.
+- Valores operacionais e snapshot pertencem ao futuro plano da E19.4.
+- A fonte canônica inicial será versionada no repositório.
+- A resolução seguirá `universal → segmento → nicho → ultranicho`.
+- Taxon de ultranicho pode herdar normalmente sem possuir camada própria.
+- Somente a criação ou utilização de camada específica de ultranicho depende de autorização humana registrada.
+- O primeiro catálogo não terá camada própria de ultranicho para `corretor de imóveis de médio padrão`; ele validará a herança das camadas de segmento e nicho.
+- Todos os campos v1 serão aplicáveis igualmente a `starter`, `lite`, `pro` e `ultra`.
+- Restrição por plano só poderá surgir em nova versão e com decisão comercial explícita.
+- `paid_search_keyword_map` será opcional e somente aplicável quando a origem de tráfego for busca paga.
+- Automação, agente, job, workflow ou rotina recorrente não se aplicam.
+
+### 1.5. Limites de responsabilidade
+
+- A E10.8 resolve pesquisas e proveniência; não define entradas da conta.
+- A E18 define parametrizações, módulos e variantes; não define valores operacionais do negócio.
+- A E20.2 define o catálogo declarativo; não coleta valores.
+- A E20.3 consumirá o catálogo resolvido para prontidão e autorização controlada.
+- A E19.4 apresentará os campos, receberá valores, gerará a LP e preservará snapshot.
+- A E12 poderá conferir o resultado em superfície administrativa futura, mas não será fonte do contrato.
+
+## 2. Contrato do caso
+
+### 2.1. Fluxo operacional
+
+- Gatilho:
+  - E20.3 ou futuro consumidor solicita o catálogo aplicável a um taxon e plano.
+- Entrada:
+  - versão do catálogo;
+  - plano entre `starter`, `lite`, `pro` e `ultra`;
+  - cadeia normalizada e ativa do taxon atendido, preservando nível, identidade e ancestrais aplicáveis.
+- Processamento:
+  - validar versão, plano e cadeia taxonômica;
+  - carregar a definição universal;
+  - aplicar as camadas existentes de segmento e nicho;
+  - aplicar camada de ultranicho somente quando existir e estiver autorizada;
+  - adicionar campos novos e resolver especializações pelo mesmo `field_key`;
+  - preservar a proveniência de cada propriedade efetiva;
+  - produzir catálogo resolvido sem valores operacionais.
+- Validação:
+  - aplicar invariantes, especialização, condições, tipos, planos, snapshot e matriz de casos.
+- Persistência:
+  - somente definição declarativa versionada no repositório.
+- Consumo:
+  - E20.3 recebe validade e catálogo resolvido;
+  - E19.4 futuramente recebe o mesmo contrato para coleta e geração.
+- Fallback:
+  - ausência de camada própria de nicho ou ultranicho mantém a herança válida;
+  - camada existente inválida ou conflitante bloqueia a resolução;
+  - não gerar campos por IA nem inferir valores ausentes.
+
+### 2.2. Barreira de admissão dos campos
+
+Cada campo candidato deve demonstrar cumulativamente que:
+
+- o valor será fornecido ou confirmado pela conta, negócio atendido, oferta, campanha ou LP;
+- existe consumidor real previsto na futura E19.4;
+- não é resultado das pesquisas estruturadas resolvidas pela E10.8;
+- não é parâmetro da E18;
+- não define módulo, variante ou composição;
+- não é copy, promessa, dor, objeção, FAQ, vocabulário ou conteúdo já produzido;
+- não duplica outro campo herdado com a mesma finalidade;
+- possui origem esperada, tipo, validação, obrigatoriedade, relação com plano e política de snapshot definidos.
+
+Dores, objeções, medos, vocabulário, FAQ, diretrizes de copy e ordem de seções não entram no catálogo.
+
+### 2.3. Modelo declarativo mínimo
+
+Cada definição de campo deve possuir:
+
+- `field_key` estável e único na cadeia resolvida;
+- finalidade semântica objetiva;
+- camada de origem: universal, segmento, nicho ou ultranicho;
+- taxon de origem quando não universal;
+- `value_type`;
+- `value_scope`: `account`, `business`, `offer`, `campaign` ou `landing_page`;
+- obrigação: `required`, `optional` ou `conditional`;
+- `required_when`, somente quando a obrigação for condicional;
+- `applicable_when`, quando o campo só puder ser apresentado ou fornecido em determinado contexto;
+- validação declarativa compatível com o tipo;
+- planos permitidos;
+- política de snapshot;
+- base de evidência resumida;
+- versão do catálogo em que a definição foi criada.
+
+A forma exata dos tipos TypeScript pertence à implementação repo-only, mas não pode criar contrato externo, rota ou payload de API nesta etapa.
+
+### 2.4. Tipos e condições v1
+
+Tipos permitidos na v1:
+
+- `string`;
+- `url`;
+- `enum`;
+- `string_list`;
+- `boolean`;
+- `number_range`;
+- `keyword_map`.
+
+Condições v1:
+
+- devem referenciar um único `field_key` existente;
+- operadores permitidos: igualdade ou pertencimento a conjunto;
+- não haverá expressão livre, código executável, árvore arbitrária ou engine de regras;
+- referências circulares, ausentes ou incompatíveis bloqueiam a resolução.
+
+### 2.5. Especialização entre camadas
+
+Propriedades imutáveis para o mesmo `field_key`:
+
+- identidade do campo;
+- finalidade semântica;
+- `value_type`;
+- `value_scope`;
+- política de snapshot.
+
+Propriedades que podem ser especializadas explicitamente em camada inferior:
+
+- obrigação;
+- `required_when`;
+- `applicable_when`;
+- validação;
+- planos permitidos.
+
+Regras:
+
+- propriedades não sobrescritas permanecem herdadas;
+- camada inferior pode adicionar campo novo;
+- obrigação só pode ficar mais restritiva: `optional → conditional|required` e `conditional → required`;
+- condição pode ser adicionada ou restringida, nunca removida para ampliar aplicação silenciosamente;
+- validação pode restringir enum, formato, quantidade ou faixa, mas não ampliar o contrato herdado;
+- planos permitidos só podem ser reduzidos, nunca ampliados além do pai;
+- campo herdado não pode ser removido ou desativado na v1;
+- alteração de propriedade imutável exige novo `field_key` e nova versão do catálogo;
+- especialização inválida bloqueia a resolução e não pode ser ignorada.
+
+### 2.6. Herança, precedência e ultranicho
+
+- Ordem de resolução: universal, segmento, nicho e ultranicho autorizado.
+- A camada inferior vence somente nas propriedades explicitamente especializadas.
+- Ausência de camada inferior não é erro.
+- Taxon de ultranicho sem camada própria recebe normalmente o catálogo herdado.
+- Falha somente quando existir ou for solicitada camada específica de ultranicho sem autorização humana registrada.
+- A primeira versão deve resolver o taxon `corretor-de-imoveis-de-medio-padrao` sem camada própria de ultranicho.
+- A identidade exata do segmento ancestral deve ser confirmada no estado real antes da implementação do registry; não criar ou renomear taxon neste plano.
+
+### 2.7. Relação com planos
+
+- O resolver exige plano conhecido para produzir contrato estável de consumo.
+- Na v1, todos os campos efetivos devem declarar os quatro planos.
+- O resultado para o mesmo taxon deve ser funcionalmente equivalente nos quatro planos.
+- O plano não altera obrigatoriedade, tipo, validação, herança ou snapshot na v1.
+- Diferença futura exige evidência comercial, nova versão do catálogo e plano-base próprio quando material.
+
+### 2.8. Separação dos valores futuros e snapshot
+
+A E20.2 deve deixar explícito que o valor futuro se vinculará conceitualmente a:
+
+- `field_key`;
+- versão do catálogo;
+- taxon atendido;
+- plano resolvido;
+- escopo do valor;
+- identidade da conta e da LP quando aplicável.
+
+Limites:
+
+- a E20.2 não define tabela, coluna, JSON persistido, rota, action ou formulário;
+- a E19.4 decidirá a persistência operacional;
+- a E19.4 deverá preservar no snapshot a versão do catálogo e os valores efetivamente usados;
+- todos os campos v1 terão política `include_if_used`;
+- valor não utilizado na geração não deve ser incluído artificialmente no snapshot.
+
+### 2.9. `paid_search_keyword_map`
+
+- `field_key`: `paid_search_keyword_map`.
+- Camada: universal.
+- Tipo: `keyword_map`.
+- Escopo: `campaign`.
+- Obrigação: opcional.
+- Aplicabilidade: somente quando `traffic_source = paid_search`.
+- Planos: `starter`, `lite`, `pro` e `ultra`.
+- Snapshot: `include_if_used`.
+- Finalidade:
+  - alinhar termo ou cluster de busca, contexto do anúncio ou oferta e âncora de mensagem da LP;
+  - sustentar message match sem substituir pesquisas da E10;
+  - não alterar módulos, variantes, composição ou parametrizações.
+- Restrições:
+  - não autoriza keyword stuffing;
+  - não cria conteúdo automaticamente;
+  - não permite termos incompatíveis com a oferta real;
+  - não é obrigatório mesmo em campanha de busca paga.
+
+### 2.10. Primeiro catálogo concreto v1
+
+#### 2.10.1. Camada universal
+
+- `business_display_name`:
+  - tipo `string`;
+  - escopo `business`;
+  - obrigatório;
+  - finalidade: identificar factual e publicamente o negócio ou profissional atendido.
+- `funnel_stage`:
+  - tipo `enum` com `bofu`, `mofu` e `tofu`;
+  - escopo `landing_page`;
+  - obrigatório;
+  - finalidade: informar a intenção da LP sem criar composição própria por estágio.
+- `traffic_source`:
+  - tipo `enum` com `paid_search`, `paid_social`, `organic`, `whatsapp`, `qr_code` e `other`;
+  - escopo `campaign`;
+  - opcional.
+- `primary_conversion_channel`:
+  - tipo `enum` com `whatsapp`, `form`, `phone`, `email` e `external_url`;
+  - escopo `landing_page`;
+  - obrigatório.
+- `primary_conversion_destination`:
+  - tipo `string`;
+  - escopo `landing_page`;
+  - condicionalmente obrigatório quando o canal for `whatsapp`, `phone`, `email` ou `external_url`.
+- `privacy_policy_url`:
+  - tipo `url`;
+  - escopo `business`;
+  - condicionalmente obrigatório quando o canal for `form`.
+- `paid_search_keyword_map`:
+  - contrato definido na seção 2.9.
+
+#### 2.10.2. Camada do segmento imobiliário
+
+- `transaction_intent`:
+  - tipo `enum` com `buy`, `sell`, `valuation` e `mixed`;
+  - escopo `landing_page`;
+  - obrigatório.
+- `service_locations`:
+  - tipo `string_list`;
+  - escopo `business`;
+  - obrigatório;
+  - finalidade: declarar cidades, regiões, bairros ou micro-regiões realmente atendidos.
+- `property_types`:
+  - tipo `string_list`;
+  - escopo `offer`;
+  - opcional.
+- `property_price_range`:
+  - tipo `number_range`;
+  - escopo `offer`;
+  - opcional.
+- `property_stage`:
+  - tipo `enum` com `launch`, `under_construction`, `ready`, `used` e `mixed`;
+  - escopo `offer`;
+  - opcional.
+- `financing_support_available`:
+  - tipo `boolean`;
+  - escopo `business`;
+  - opcional.
+- `document_support_available`:
+  - tipo `boolean`;
+  - escopo `business`;
+  - opcional.
+
+#### 2.10.3. Camada do nicho corretor de imóveis
+
+- `creci_registration`:
+  - tipo `string`;
+  - escopo `business`;
+  - obrigatório;
+  - finalidade: preservar credencial factual verificável do profissional.
+- `attendance_modes`:
+  - tipo `string_list`;
+  - escopo `business`;
+  - opcional;
+  - finalidade: declarar atendimento presencial, remoto ou combinação real disponível.
+
+#### 2.10.4. Camada do ultranicho corretor de imóveis de médio padrão
+
+- Nenhum campo próprio na v1.
+- O taxon deve herdar integralmente as camadas universal, segmento e nicho.
+- Faixa de preço, tipologia e estágio já são entradas operacionais do segmento e não justificam camada própria.
+
+#### 2.10.5. Políticas comuns
+
+- Todos os campos são permitidos nos quatro planos.
+- Todos usam snapshot `include_if_used`.
+- Nenhum campo define estrutura da página.
+- Nenhum campo substitui pesquisa, copy ou conteúdo produzido.
+- Valores e limites exatos não definidos acima devem permanecer ausentes, em vez de serem inventados pelo Executor.
+
+### 2.11. Critério de prontidão do catálogo
+
+O resultado da E20.2 pode ser marcado como catálogo válido quando:
+
+- a versão existe e é única;
+- o plano é conhecido;
+- a cadeia taxonômica é coerente;
+- toda camada aplicada é válida;
+- camada própria de ultranicho, quando existir, possui autorização;
+- cada campo efetivo possui todas as propriedades obrigatórias;
+- não há duplicidade não declarada;
+- não há mudança de propriedade imutável;
+- especializações respeitam as regras da seção 2.5;
+- condições apontam para campos existentes e não são circulares;
+- tipos e validações são coerentes;
+- todos os campos possuem origem esperada e política de snapshot;
+- `paid_search_keyword_map` respeita sua aplicabilidade;
+- o resultado preserva a proveniência das camadas e propriedades.
+
+Esse sinal não significa que uma conta já forneceu os valores. A completude de valores pertence à E19.4 e será combinada pela E20.3 com os demais critérios de prontidão.
+
+### 2.12. Resultado tipado
+
+O sucesso deve preservar, no mínimo:
+
+- versão do catálogo;
+- taxon atendido;
+- plano;
+- cadeia de camadas utilizada;
+- campos efetivos na ordem determinística do registry;
+- definição efetiva de cada campo;
+- camada e taxon de origem;
+- propriedades especializadas e sua origem;
+- sinal de catálogo válido para consumo pela E20.3.
+
+A falha deve distinguir, no mínimo:
+
+- versão inválida ou ausente;
+- plano inválido;
+- cadeia taxonômica inválida;
+- camada inválida;
+- ultranicho específico sem autorização;
+- campo duplicado sem especialização válida;
+- conflito de tipo ou propriedade imutável;
+- especialização que amplia contrato herdado;
+- condição inválida, ausente ou circular;
+- contrato do `paid_search_keyword_map` inválido.
+
+Nenhum resultado contém valores reais da conta ou snapshot de geração.
+
+### 2.13. Boundary técnico canônico
+
+- Boundary: `lib/conversion-content/landing-page/input-catalog/`.
+- Fluxo: registry versionado → schema estrito → resolver puro → resultado tipado.
+- Arquivos previstos:
+  - `contracts.ts`;
+  - `registry.ts`;
+  - `schema.ts`;
+  - `resolver.ts`;
+  - `validation-cases.ts`;
+  - `index.ts`.
+- Export agregado:
+  - ajustar `lib/conversion-content/index.ts` com namespace separado `landingPageInputCatalog`.
+- Script:
+  - adicionar `validate:landing-page-input-catalog` em `package.json`.
+- Não criar adapter de banco na E20.2.
+- O resolver recebe cadeia taxonômica normalizada do consumidor e não consulta Supabase.
+- Não alterar os arquivos da parametrização raiz da E18.4 nem o boundary da E10.8.
+- Não adicionar dependência nova.
+
+### 2.14. Matriz mínima de validação
+
+- versão inexistente: falhar;
+- plano desconhecido: falhar;
+- cadeia de taxon inválida ou fora de ordem: falhar;
+- catálogo universal válido sem camada específica: resolver;
+- segmento e nicho válidos: combinar em ordem;
+- ultranicho sem camada própria: herdar e resolver;
+- camada própria de ultranicho autorizada: resolver;
+- camada própria de ultranicho sem autorização: falhar;
+- campo novo em camada inferior: adicionar;
+- especialização explícita válida: preservar propriedades não alteradas;
+- mudança de `value_type`, finalidade, escopo ou snapshot: falhar;
+- obrigação mais restritiva: aceitar;
+- obrigação relaxada: falhar;
+- validação restringida: aceitar;
+- validação ampliada: falhar;
+- planos reduzidos: aceitar em fixture estrutural, sem aplicar na v1 real;
+- planos ampliados além do pai: falhar;
+- referência de condição ausente: falhar;
+- condição circular: falhar;
+- `paid_search_keyword_map` ausente com busca paga: aceitar;
+- mapa presente sem busca paga: falhar;
+- mapa válido com busca paga: resolver;
+- primeiro catálogo imobiliário nos quatro planos: produzir resultado equivalente;
+- taxon de médio padrão: confirmar ausência de camada própria e herança integral;
+- saída não deve conter valores operacionais nem snapshot.
+
+## 3. Fases e próxima ação
+
+### 3.1. E20.2.3–E20.2.6 — Contrato, catálogo imobiliário v1 e resolver repo-only
+
+- Status: planejada.
+- Automação: não.
+- Objetivo:
+  - implementar o contrato declarativo, versionamento, herança, especialização, primeiro catálogo concreto, `paid_search_keyword_map`, resolver e sinal de prontidão definidos na seção 2.
+- Escopo executável:
+  - confirmar por inspeção read-only a cadeia real do taxon imobiliário e seus slugs antes de codificar as camadas;
+  - implementar somente os paths da seção 2.13;
+  - implementar o registry v1 com as definições da seção 2.10;
+  - manter o ultranicho de médio padrão sem camada própria;
+  - criar validação executável para toda a matriz da seção 2.14;
+  - garantir saída imutável e falha fechada;
+  - exportar o namespace e adicionar o script de validação;
+  - executar `npm ci`, `npm run check` e `npm run validate:landing-page-input-catalog`;
+  - registrar neste plano a evidência, decisão e próxima ação da fase.
+- Artefatos previstos:
+  - criar `lib/conversion-content/landing-page/input-catalog/contracts.ts`;
+  - criar `lib/conversion-content/landing-page/input-catalog/registry.ts`;
+  - criar `lib/conversion-content/landing-page/input-catalog/schema.ts`;
+  - criar `lib/conversion-content/landing-page/input-catalog/resolver.ts`;
+  - criar `lib/conversion-content/landing-page/input-catalog/validation-cases.ts`;
+  - criar `lib/conversion-content/landing-page/input-catalog/index.ts`;
+  - ajustar `lib/conversion-content/index.ts`;
+  - ajustar `package.json`;
+  - ajustar somente este plano-base para registrar execução.
+- Critérios de aceite:
+  - matriz completa aprovada;
+  - primeiro catálogo concreto contém somente campos admitidos pela seção 2.2;
+  - taxon de médio padrão resolve por herança sem camada própria;
+  - planos não produzem diferenças artificiais;
+  - especializações são explícitas e restritivas;
+  - `paid_search_keyword_map` permanece opcional;
+  - resultado preserva proveniência e sinal de validade;
+  - nenhuma pesquisa da E10 é copiada para o catálogo;
+  - nenhum valor operacional ou snapshot é persistido;
+  - nenhuma tabela, migration, rota, UI, API, adapter de banco, E20.3 ou E19.4 é criada ou alterada;
+  - diff limitado aos artefatos previstos e a este plano-base.
+- Próxima ação após consolidação do plano-base v2 e merge humano:
+  - enviar o plano completo ao Executor, autorizando somente esta fase.
+
+## 4. Escopo negativo e critérios de parada
+
+### 4.1. Escopo negativo
+
+- Coleta, edição ou persistência de valores da conta.
+- Snapshot da geração.
+- Tabela, campo, view, RPC, trigger, policy, grant ou migration.
+- Rota, API, Server Action, formulário, Admin Dashboard ou Account Dashboard.
+- Alteração de `account_profiles` ou `account_landing_pages`.
+- Parametrização, módulo, variante, composição ou renderer.
+- Pesquisa `business_buyer` ou `end_customer`, itens estruturados ou resolver da E10.8.
+- Geração de copy, FAQ, promessa, objeção, prova textual ou conteúdo final.
+- Geração, revisão, edição, publicação ou tracking de LP.
+- Diferenciação entre planos sem fonte comercial aprovada.
+- Camada própria de ultranicho sem decisão humana.
+- Engine de regras, expressão livre, configuração dinâmica ou banco configurável.
+- IA, automação, agente, job, fila, cache, workflow ou infraestrutura nova.
+- Alteração automática de `docs/roadmap.md`, `docs/base-tecnica.md` ou `docs/schema.md` durante a execução.
+
+### 4.2. Critérios de parada
+
+- Parar se a cadeia real de taxons divergir materialmente do recorte aprovado ou não permitir identificar segmento, nicho e ultranicho de forma única.
+- Parar antes de criar ou alterar taxon.
+- Parar se algum campo proposto não possuir consumidor real previsto na E19.4.
+- Parar se um candidato duplicar resultado da E10, parâmetro da E18, composição ou conteúdo produzido.
+- Parar se o contrato exigir relaxamento silencioso de campo herdado.
+- Parar se a solução repo-only não puder garantir versão, herança, proveniência e falha fechada.
+- Parar antes de propor persistência, adapter de banco, rota, UI ou configuração dinâmica.
+- Parar se surgir necessidade de diferenciar planos sem decisão comercial explícita.
+- Parar se a implementação exigir alterar E10.8, E18.4, E18.5, E20.3 ou E19.4.
+- Parar se houver necessidade de campo novo não previsto na seção 2.10; devolver ao Estrategista com evidência e consumidor.
+
+### 4.3. Decisão ao fim da fase
+
+- Registrar somente uma decisão: avançar, ajustar, bloquear ou encerrar.
+- Como existe uma única fase executável, aprovação integral encerra a E20.2 e habilita o relatório final ao Gestor de Docs.


### PR DESCRIPTION
## Objetivo

Consolidar o plano-base v2 de `20.2 — Catálogo de entradas por taxon`, conforme `docs/lp-planejamento.md`, o debate humano e a rodada única de especialistas.

## Consolidação dos especialistas

- inclui origem esperada, validação e evidência resumida para cada `field_key` concreto;
- separa destinos condicionais de WhatsApp, telefone, e-mail e URL externa;
- limita especializações a propriedades comparáveis deterministicamente;
- move `transaction_intent`, `financing_support_available` e `document_support_available` para o nicho `corretor de imóveis`;
- define ordenação determinística das camadas;
- separa validade do catálogo na E20.3 da completude de valores na E19.4;
- adota `supa#40` com o snippet read-only previsto em `supabase/snippets/e20_2_taxon_chain_verify.sql`;
- adota `prod#19` como trava entre aplicabilidade declarativa por plano e entitlement comercial.

## Contrato consolidado

- catálogo declarativo repo-only, separado de valores operacionais e snapshot;
- herança `universal → segmento → nicho → ultranicho`;
- ultranicho herda normalmente e só recebe camada própria com autorização humana;
- primeiro catálogo concreto imobiliário sem camada própria para médio padrão;
- todos os campos v1 comuns a `starter`, `lite`, `pro` e `ultra`;
- `paid_search_keyword_map` opcional;
- boundary `lib/conversion-content/landing-page/input-catalog/`;
- uma única fase executável, marcada como `Automação: não`.

## Escopo

- altera somente `docs/lousa-plano-base-e20-2.md`;
- não altera código, banco, migrations, schema, roadmap, rotas, UI, E10.8, E18, E19 ou E20.3;
- não concede entitlement, não integra Stripe e não autoriza geração;
- não envia implementação ao Executor antes do merge deste plano-base v2 na `main`.

## Validação

- rodada única do Analista, Gestor Estrutural e Gestor de Updates consolidada;
- diff limitado ao plano-base;
- `npm ci`: não aplicável, alteração exclusivamente documental;
- `npm run check`: não aplicável, alteração exclusivamente documental.

## Próximo passo

Revisão e merge humano do PR. Após confirmação do merge, o Estrategista poderá instruir o Executor somente para a fase `E20.2.3–E20.2.6`.