### PR TITLE
docs: register landing_page research-resolution (E10.8) in roadmap and base-tecnica

### DIFF
--- a/docs/base-tecnica.md
+++ b/docs/base-tecnica.md
@@ -2,8 +2,8 @@
 
 0.1. Cabeçalho
 • Documento: Base Técnica LP Factory 10
-• Versão: v2.0.48
-• Data: 13/07/2026
+• Versão: v2.0.49
+• Data: 14/07/2026
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -402,6 +402,17 @@ LP Builder
 • Especializações futuras devem preservar a precedência `raiz → módulo → variante`.
 • Casos executáveis: `npm run validate:landing-page-root`.
 
+3.15.3 Resolução de pesquisas estruturadas de `landing_page`
+• Boundary canônico: `lib/conversion-content/landing-page/research-resolution/`.
+• Adapter server-side canônico: `lib/conversion-content/adapters/landingPageResearchAdapter.ts`.
+• Consumidores devem usar `resolveLandingPageResearchForTaxon` e não consultar as tabelas diretamente nem reimplementar precedência ou herança.
+• A entrada é o `taxon_id` já resolvido; este fluxo não resolve conta ou nicho e não cria persistência.
+• `end_customer` usa somente o taxon atendido; `business_buyer` prioriza o conjunto próprio e admite somente o pai direto quando o próprio estiver ausente ou incompleto.
+• Conjunto próprio inválido ou ambíguo deve falhar fechado, sem mistura parcial ou mascaramento pelo pai.
+• O resultado deve preservar a proveniência das fontes e versões efetivamente usadas.
+• O resolver puro não registra logs; o adapter pode registrar somente metadados seguros, sem conteúdo das pesquisas, PII, credenciais ou secrets.
+• Casos executáveis: `npm run validate:landing-page-research`.
+
 4. DB Contract - Fonte única: PATH: docs/schema.md
 • Este documento não lista mais tabelas/views/functions/triggers/policies; isso está em PATH: docs/schema.md.
 • Trigger Hub é regra do contrato de DB (governança/auditoria). Fonte única e detalhes: PATH: docs/schema.md (seções 3.5 e 4.1).
@@ -549,6 +560,8 @@ Fonte normativa da allowlist SULB para exceções de Auth. Qualquer novo arquivo
 • Tipos canônicos e adapters vNext: validar por 3.6 e 3.14.
 
 99. Changelog
+v2.0.49 — 14/07/2026 — Registrado o contrato técnico durável da resolução de pesquisas estruturadas de `landing_page`, com adapter server-side, resolver puro, precedência própria/pai direto, proveniência e falha fechada.
+
 v2.0.48 — 13/07/2026 — Substituído o contrato antigo de composição `landing_page` pelo contrato técnico durável da parametrização raiz versionada, com registry canônico, resolução fail-closed, imutabilidade e validação executável.
 v2.0.47 — 07/07/2026 — Registrado contrato técnico da base repo-only de composição `landing_page`, com path canônico, catálogo mínimo, registry fechado, schemas, renderer mínimo, resolver/validador e limites de `config_json`.
 v2.0.46 — 04/07/2026 — Registrado contrato técnico da liberação manual administrativa mínima de entitlement comercial, com Server Action protegida por `requirePlatformAdmin`, boundary Admin server-only e persistência exclusiva em `public.account_commercial_entitlements`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data: 13/07/2026
-• Versão: v1.5.91
+• Data: 14/07/2026
+• Versão: v1.5.92
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -1085,6 +1085,68 @@ Repositório — Ajustados
 • A E10.7 não pode bloquear o acesso à página comercial.
 • O runtime público não pode consumir `draft`, `archived` nem chamar IA para renderizar a página comercial.
 
+10.8 Resolução de pesquisas estruturadas para `landing_page`
+
+10.8.1 Objetivo e status
+
+* Objetivo: Disponibilizar um conjunto único, completo, determinístico e rastreável de pesquisas estruturadas para futuros consumidores de `landing_page`.
+* Status: Concluída e validada em 14/07/2026.
+
+10.8.2 Registros do recorte
+
+* Repositório:
+
+  * Criados:
+
+    * `lib/conversion-content/landing-page/research-resolution/contracts.ts`
+    * `lib/conversion-content/landing-page/research-resolution/resolver.ts`
+    * `lib/conversion-content/landing-page/research-resolution/validation-cases.ts`
+    * `lib/conversion-content/landing-page/research-resolution/index.ts`
+    * `lib/conversion-content/adapters/landingPageResearchAdapter.ts`
+  * Ajustados:
+
+    * `lib/conversion-content/index.ts`
+    * `package.json`
+* Updates:
+
+  * Aplicados:
+
+    * `supa#40`
+    * `supa#5`
+
+10.8.3 Contrato de resolução e elegibilidade
+
+* Status: Implementado.
+* Conteúdo:
+
+  * Entrada por `taxon_id` do taxon atendido, já resolvido pelo fluxo responsável.
+  * Execução server-side e read-only, sem persistência nova.
+  * Cada público deve resultar em um único conjunto completo e elegível.
+  * Saída tipada e rastreável para consumo futuro pela E20 e pela E19.
+
+10.8.4 Precedência, proveniência e falha fechada
+
+* Status: Implementadas.
+* Conteúdo:
+
+  * `end_customer` é resolvido exclusivamente no taxon atendido.
+  * O conjunto próprio completo de `business_buyer` vence sempre.
+  * O pai direto só pode ser usado quando o conjunto próprio estiver ausente ou incompleto.
+  * Conjunto próprio inválido ou ambíguo falha fechado e não pode ser mascarado pelo pai.
+  * Não há mistura de blocos, fontes ou versões, nem consulta além do pai direto.
+  * O resultado preserva taxons, relação de origem, pesquisas, itens e versões usados.
+
+10.8.5 Validação e limites do recorte
+
+* Status: Validada.
+* Conteúdo:
+
+  * Matriz executável aprovada por `npm run validate:landing-page-research`.
+  * Evidência read-only real confirmou a precedência do conjunto próprio sobre o pai elegível.
+  * O adapter registra somente eventos estruturados e metadados seguros.
+  * Nenhuma estrutura ou dado de banco, rota, UI, cache ou persistência foi criado ou alterado.
+  * E10.7, E18.4, E19, E20, automações, agentes e jobs permaneceram fora do recorte.
+
 11. E11 — Gestão de Usuários e Convites
 
 11.1 Status
@@ -1862,6 +1924,8 @@ Repositório — Ajustados
   - Esta referência não cria obrigação de nova implementação agora.
 
 99. Changelog
+v1.5.92 — 14/07/2026 — E10.8 concluída com resolução server-side, read-only, tipada e fail-closed das pesquisas estruturadas de `landing_page`, preservando precedência, atomicidade e proveniência sem alteração de banco ou implementação dos consumidores futuros.
+
 v1.5.91 — 13/07/2026 — E18.4 consolidada como parametrização raiz versionada da família `landing_page`; removida a implementação anterior de composição e separado o recorte futuro 18.5 para módulos e variantes.
 
 v1.5.90 — 07/07/2026 — E18.4 concluída como base técnica repo-only de composição `landing_page`, com catálogo mínimo, contratos técnicos, registry, schemas, renderer mínimo, resolver/validador e limites de `config_json`, sem liberação automática de registros-base, LP teste, rota pública, Admin, LP Builder, automação, job ou agente.


### PR DESCRIPTION
### Motivation

- Record the final, validated state of the landing_page structured-research resolution as an implemented, server-side, read-only, typed and fail‑closed contract.  
- Expose the canonical resolver/adapter boundary and usage rules so future consumers use the single resolver and do not reimplement precedence or persistence.  
- Bump document headers and changelogs to reflect the new stable contracts and the validated slice.

### Description

- Updated `docs/roadmap.md` header to `v1.5.92` and added section `10.8 Resolução de pesquisas estruturadas para landing_page` containing objective, repository artifacts (created/adjusted), resolution contract, precedence/provenance rules and validation/limits.  
- Updated `docs/base-tecnica.md` header to `v2.0.49` and added section `3.15.3 Resolução de pesquisas estruturadas de landing_page` with the canonical boundary, server-side adapter path, resolver usage rule, precedence/fail-closed rule and safe-logging guidance.  
- Added changelog entries `v1.5.92` (roadmap) and `v2.0.49` (base-tecnica) and modified only the two documentation files: `docs/roadmap.md` and `docs/base-tecnica.md`.  
- Changes were made on branch `docs/abc-landing-page-research-resolution` and committed (`docs: update landing page research docs`).

### Testing

- Ran `git diff --check` which succeeded with no whitespace errors.  
- Verified working tree with `git status --short` and `git diff --name-only` which show only `docs/roadmap.md` and `docs/base-tecnica.md` were modified.  
- Attempted `git diff main..HEAD` and `git diff main...HEAD` but these commands could not run due to the local checkout lacking a `main` reference.  
- Attempted to push the branch with `git push -u origin docs/abc-landing-page-research-resolution` which failed because the local checkout has no `origin` remote configured; `npm ci` and `npm run check` were not applicable for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a568bfdc4b48329a9ae2d51a6dd79bb)