### PR TITLE
docs: corrigir encerramento da E10.8 e clarificar redações em 10.8

### DIFF
--- a/docs/lousa-plano-base-e10-8.md
+++ b/docs/lousa-plano-base-e10-8.md
@@ -1,8 +1,8 @@
 # Plano-base E10.8 — Resolução de pesquisas estruturadas para landing_page
 
-- Versão: v2
+- Versão: v3
 - Data: 14/07/2026
-- Status: fase executada e validada na branch; aguarda revisão humana e merge
+- Status: plano encerrado; fase concluída e mergeada pelo PR 571 em 14/07/2026.
 - Recorte previsto para roadmap: `10.8 — Resolução de pesquisas estruturadas para landing_page`
 - Path canônico: `docs/lousa-plano-base-e10-8.md`
 - Fontes obrigatórias: `README.md`, `AGENTS.md`, `docs/prompt-estrategista.md`, `docs/template-roadmap.md`, `docs/template-briefing-codex.md`, `docs/prompt-executor.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/schema.md`, `docs/lp-planejamento.md`, `docs/supa-up.md`, `supabase/snippets/e10_5_5_nicho_carregamento.sql`, implementação e documentação atuais da E10.5.5, E10.5.6 e E10.7.
@@ -188,7 +188,7 @@
 
 ### 3.1. E10.8.3–10.8.5 — Resolver server-side completo para landing_page
 
-- Status: implementada e validada em 14/07/2026 na branch `feat/e10-8-research-resolution`; aguarda revisão humana e merge.
+- Status: concluída e mergeada em 14/07/2026 pelo PR 571, commit `2c577ee96569f27ae05ab88055e5f14d453cfc08`.
 - Objetivo: implementar o resolver compartilhado de elegibilidade, precedência, proveniência, falha fechada e consumo tipado definido na seção 2.
 - Automação: não.
 - Escopo executável:
@@ -237,8 +237,8 @@
   - inspeção read-only real no Supabase confirmou o taxon atendido ativo, o pai direto ativo, quatro blocos `business_buyer` próprios na versão 1 com 49 itens ativos e quatro blocos `business_buyer` no pai direto na versão 1 com 54 itens ativos, sem item ativo estruturalmente inválido;
   - validação read-only real do DTO no resolver retornou `business_buyer.sourceRelation = own`, 49 itens próprios e 74 itens `end_customer` próprios, ambos na versão 1;
   - nenhum registro, estrutura de banco, rota, UI, consumidor, parametrização raiz da E18.4 ou contrato da E10.7 foi alterado.
-- Decisão da fase: encerrar a única fase executável após revisão humana e merge do PR.
-- Próxima ação: revisar e fazer merge humano do PR; após o merge, habilitar o relatório final ao Gestor de Docs conforme `docs/prompt-estrategista.md`.
+- Decisão da fase: encerrar.
+- Próxima ação: N/A — plano encerrado.
 
 ## 4. Escopo negativo e critérios de parada
 
@@ -270,5 +270,6 @@
 
 ### 4.3. Decisão ao fim da fase
 
-- Registrar neste plano somente uma das decisões: avançar, ajustar, bloquear ou encerrar.
-- Como existe uma única fase executável, aprovação integral encerra o plano e habilita o relatório final ao Gestor de Docs conforme `docs/prompt-estrategista.md`.
+- Decisão: encerrar.
+- Resultado: fase concluída e mergeada pelo PR 571 em 14/07/2026.
+- Próxima ação: N/A — plano encerrado.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1121,7 +1121,7 @@ Repositório — Ajustados
 
   * Entrada por `taxon_id` do taxon atendido, já resolvido pelo fluxo responsável.
   * Execução server-side e read-only, sem persistência nova.
-  * Cada conjunto exige `strategic_core`, `lp_overview`, `lp_sections` e `seo`, com pesquisas-pai ativas e uma versão comum aos quatro blocos.
+  * Cada `audience_scope` deve resultar em um único conjunto completo e elegível, formado por `strategic_core`, `lp_overview`, `lp_sections` e `seo`, com pesquisas-pai ativas e uma versão comum aos quatro blocos.
   * Saída tipada e rastreável para consumo futuro pela E20 e pela E19.
 
 10.8.4 Precedência, proveniência e falha fechada
@@ -1130,7 +1130,7 @@ Repositório — Ajustados
 * Conteúdo:
 
   * `end_customer` é resolvido exclusivamente no taxon atendido.
-  * O conjunto próprio completo de `business_buyer` vence sempre.
+  * O conjunto próprio completo e elegível de `business_buyer` vence sempre.
   * O pai direto só pode ser usado quando o conjunto próprio estiver ausente ou incompleto.
   * Conjunto próprio inválido ou ambíguo falha fechado e não pode ser mascarado pelo pai.
   * Cada `audience_scope` usa um conjunto atômico, sem mistura de blocos, taxons de origem ou versões dentro do próprio público; `end_customer` e `business_buyer` podem usar versões diferentes.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 0.1 Cabeçalho
 • Data: 14/07/2026
-• Versão: v1.5.92
+• Versão: v1.5.93
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -1121,7 +1121,7 @@ Repositório — Ajustados
 
   * Entrada por `taxon_id` do taxon atendido, já resolvido pelo fluxo responsável.
   * Execução server-side e read-only, sem persistência nova.
-  * Cada público deve resultar em um único conjunto completo e elegível.
+  * Cada conjunto exige `strategic_core`, `lp_overview`, `lp_sections` e `seo`, com pesquisas-pai ativas e uma versão comum aos quatro blocos.
   * Saída tipada e rastreável para consumo futuro pela E20 e pela E19.
 
 10.8.4 Precedência, proveniência e falha fechada
@@ -1133,7 +1133,8 @@ Repositório — Ajustados
   * O conjunto próprio completo de `business_buyer` vence sempre.
   * O pai direto só pode ser usado quando o conjunto próprio estiver ausente ou incompleto.
   * Conjunto próprio inválido ou ambíguo falha fechado e não pode ser mascarado pelo pai.
-  * Não há mistura de blocos, fontes ou versões, nem consulta além do pai direto.
+  * Cada `audience_scope` usa um conjunto atômico, sem mistura de blocos, taxons de origem ou versões dentro do próprio público; `end_customer` e `business_buyer` podem usar versões diferentes.
+  * A resolução não consulta além do pai direto.
   * O resultado preserva taxons, relação de origem, pesquisas, itens e versões usados.
 
 10.8.5 Validação e limites do recorte
@@ -1924,6 +1925,8 @@ Repositório — Ajustados
   - Esta referência não cria obrigação de nova implementação agora.
 
 99. Changelog
+v1.5.93 — 14/07/2026 — Ajustada a E10.8 para explicitar os quatro blocos obrigatórios, a versão comum dentro de cada `audience_scope` e a independência de versões entre `end_customer` e `business_buyer`.
+
 v1.5.92 — 14/07/2026 — E10.8 concluída com resolução server-side, read-only, tipada e fail-closed das pesquisas estruturadas de `landing_page`, preservando precedência, atomicidade e proveniência sem alteração de banco ou implementação dos consumidores futuros.
 
 v1.5.91 — 13/07/2026 — E18.4 consolidada como parametrização raiz versionada da família `landing_page`; removida a implementação anterior de composição e separado o recorte futuro 18.5 para módulos e variantes.


### PR DESCRIPTION
### Motivation
- Tornar explícitos os requisitos de blocos e a regra de versões na seção E10.8 do Roadmap para evitar ambiguidade operacional. 
- Registrar formalmente o encerramento do plano-base da E10.8 após o merge do PR 571 para refletir o estado final do caso.

### Description
- Atualiza o cabeçalho do `docs/roadmap.md` para `• Versão: v1.5.93` e mantém a data `14/07/2026`.
- Substitui o bullet em `10.8.3` para explicitar que cada conjunto exige `strategic_core`, `lp_overview`, `lp_sections` e `seo`, com pesquisas-pai ativas e uma versão comum aos quatro blocos.
- Substitui e expande os bullets em `10.8.4` para declarar que cada `audience_scope` usa um conjunto atômico, proibir mistura de blocos/taxons/versões dentro do público e permitir que `end_customer` e `business_buyer` usem versões diferentes, mantendo que a resolução não consulta além do pai direto.
- Insere no início de `99. Changelog` uma entrada `v1.5.93 — 14/07/2026 — Ajustada a E10.8 ...` descrevendo as correções.
- Atualiza `docs/lousa-plano-base-e10-8.md` alterando `Versão: v2` → `v3`, definindo `Status` como plano encerrado após merge do PR 571, ajustando o status da fase 3.1 para indicar conclusão e merge, substituindo decisão/próxima ação por encerramento e substituindo integralmente a seção `### 4.3. Decisão ao fim da fase` para registrar o encerramento.
- Alterações limitadas a `docs/roadmap.md` e `docs/lousa-plano-base-e10-8.md` apenas.

### Testing
- Executed `git diff --check` with zero issues reported.
- Verified only the two authorized files were changed via `git diff --name-only` and a sorted diff check, which passed.
- Confirmed presence of new header/version and inserted phrases with `rg`/`sed` checks: Roadmap at `v1.5.93`, plan-base at `v3`, presence of the four blocks in `10.8.3`, and the phrase about differing versions in `10.8.4`.
- Confirmed forbidden phrases (`aguarda revisão humana e merge`, `Próxima ação: revisar`, `revisar e fazer merge humano do PR`) no conjunto de documents are absent and `docs/base-tecnica.md` remains unchanged via `git diff --quiet`.
- `npm ci` / `npm run check` not applicable (document-only change).
- `git push` failed due to missing remote configuration in the environment, so the branch/commit are available locally but were not published to a remote in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a568fbde50083298651bb73a1446562)