### PR TITLE
E20.2: implementa catálogo de entradas por taxon

### DIFF
--- a/docs/lousa-plano-base-e20-2.md
+++ b/docs/lousa-plano-base-e20-2.md
@@ -3,7 +3,7 @@
 Fontes: chat, `README.md`, `AGENTS.md`, `docs/prompt-estrategista.md`, `docs/template-roadmap.md`, `docs/template-briefing-codex.md`, `docs/prompt-executor.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/schema.md`, `docs/lp-planejamento.md`, `docs/lousa-plano-base-e10-8.md`, `docs/supa-up.md`, `docs/prod-up.md`, contratos atuais de planos, contas, taxons e landing pages, `Pesquisa bruta para corretor de imóveis de médio padrão.pdf`, `Projeto Piloto Imobiliário.pdf`, avaliações do Analista, do Gestor Estrutural e do Gestor de Updates e decisões humanas de 14/07/2026.
 
 - Versão: v2.
-- Status: plano-base v2 consolidado no PR #573; merge humano pendente; Executor não autorizado.
+- Status: plano-base v2 mergeado no PR #573; E20.2.3–E20.2.6 executada e validada na branch material `codex-app/e20-2-3-input-catalog-v1`, aguardando PR e merge humanos.
 - Recorte previsto para roadmap: `20.2 — Catálogo de entradas por taxon`.
 - Path canônico: `docs/lousa-plano-base-e20-2.md`.
 
@@ -698,7 +698,7 @@ O snippet não pode:
 
 ### 3.1. E20.2.3–E20.2.6 — Contrato, catálogo imobiliário v1 e resolver repo-only
 
-- Status: planejada; bloqueada até merge humano deste plano-base v2.
+- Status: implementada e validada; aguarda PR material e merge humanos.
 - Automação: não.
 - Fontes obrigatórias de execução:
   - `README.md`;
@@ -735,6 +735,16 @@ O snippet não pode:
   - ajustar `lib/conversion-content/index.ts`;
   - ajustar `package.json`;
   - ajustar somente este plano-base para registrar execução.
+- Evidências da execução em 14/07/2026:
+  - inspeção read-only no projeto Supabase `LP-Factory-10` confirmou a cadeia ativa `imobiliario` (`segment`) → `corretor-imoveis` (`niche`) → `corretor-de-imoveis-de-medio-padrao` (`ultra_niche`), com relações pai-filho coerentes;
+  - `supabase/snippets/e20_2_taxon_chain_verify.sql` foi criado e executado sem escrita;
+  - registry v1 implementado com 19 campos efetivos, sem camada própria para o ultranicho de médio padrão;
+  - `npm ci`: aprovado; o audit da árvore instalada reportou 13 vulnerabilidades preexistentes, sem mudança de dependências;
+  - `npm run check`: aprovado, com 24 warnings preexistentes e nenhum erro;
+  - `npm run validate:landing-page-input-catalog`: aprovado em 26 casos executáveis;
+  - `git diff --check`: aprovado.
+- Decisão da fase: avançar.
+- Próxima ação real: submeter o PR material contra `main`, aguardar merge humano e então encaminhar o estado final ao Gestor de Docs.
 - Critérios de aceite:
   - snippet confirma a cadeia real sem escrita;
   - matriz completa aprovada;

--- a/docs/lousa-plano-base-e20-2.md
+++ b/docs/lousa-plano-base-e20-2.md
@@ -3,7 +3,7 @@
 Fontes: chat, `README.md`, `AGENTS.md`, `docs/prompt-estrategista.md`, `docs/template-roadmap.md`, `docs/template-briefing-codex.md`, `docs/prompt-executor.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/schema.md`, `docs/lp-planejamento.md`, `docs/lousa-plano-base-e10-8.md`, `docs/supa-up.md`, `docs/prod-up.md`, contratos atuais de planos, contas, taxons e landing pages, `Pesquisa bruta para corretor de imóveis de médio padrão.pdf`, `Projeto Piloto Imobiliário.pdf`, avaliações do Analista, do Gestor Estrutural e do Gestor de Updates e decisões humanas de 14/07/2026.
 
 - Versão: v2.
-- Status: plano-base v2 mergeado no PR #573; E20.2.3–E20.2.6 executada e validada na branch material `codex-app/e20-2-3-input-catalog-v1`, aguardando PR e merge humanos.
+- Status: plano-base v2 mergeado no PR #573; PR #576 aberto; correção da E20.2.3–E20.2.6 em andamento na branch material `codex-app/e20-2-3-input-catalog-v1`.
 - Recorte previsto para roadmap: `20.2 — Catálogo de entradas por taxon`.
 - Path canônico: `docs/lousa-plano-base-e20-2.md`.
 
@@ -214,7 +214,7 @@ Validações-base:
 
 - `string`:
   - texto normalizado, sem apenas espaços e com pelo menos um caractere;
-  - sem validação adicional quando o campo declarar `type_only`.
+  - usa `type_only` quando não houver validação adicional.
 - `phone`:
   - valor canônico em formato E.164, com `+` e de 8 a 15 dígitos;
   - não aceitar texto livre, ramal ou URL.
@@ -228,9 +228,11 @@ Validações-base:
   - valor pertencente ao conjunto fechado declarado pelo campo.
 - `string_list`:
   - lista de textos não vazios, normalizados e sem duplicidade após comparação case-insensitive;
-  - quando não houver limites adicionais, declarar `type_only`.
+  - sempre usa validação `kind: string_list`;
+  - ausência de limites adicionais exige ausência de `allowed_values`, `min_items` e `max_items`.
 - `boolean`:
-  - somente `true` ou `false`.
+  - somente `true` ou `false`;
+  - usa `type_only`.
 - `number_range`:
   - limite mínimo e máximo finitos e não negativos;
   - mínimo menor ou igual ao máximo;
@@ -350,6 +352,8 @@ O valor futuro se vinculará conceitualmente a:
 Limites:
 
 - a E20.2 não define tabela, coluna, JSON persistido, rota, action ou formulário;
+- o resolver retorna todos os campos permitidos pelo plano e preserva `required_when` e `applicable_when` sem receber nem avaliar valores operacionais;
+- aplicabilidade operacional e completude dos valores pertencem à E19.4;
 - a E19.4 decidirá a persistência operacional;
 - a E19.4 deverá preservar no snapshot a versão do catálogo e os valores efetivamente usados;
 - todos os campos v1 usam `include_if_used`;
@@ -391,7 +395,7 @@ Limites:
   - usam snapshot `include_if_used`;
   - possuem consumidor futuro E19.4;
   - não definem estrutura, copy ou composição.
-- Quando a validação declarar `type_only`, nenhuma regra adicional além da validação-base do tipo pode ser inventada.
+- `type_only` é permitido somente para `string` e `boolean`; `string_list` sempre declara `kind: string_list` e omite `allowed_values`, `min_items` e `max_items` quando não houver restrições adicionais.
 - As evidências abaixo são suficientes para implementação do registry; os PDFs permanecem fontes empíricas externas, não dependências de runtime.
 
 #### 2.10.2. Camada universal
@@ -698,7 +702,7 @@ O snippet não pode:
 
 ### 3.1. E20.2.3–E20.2.6 — Contrato, catálogo imobiliário v1 e resolver repo-only
 
-- Status: implementada e validada; aguarda PR material e merge humanos.
+- Status: PR #576 aberto; correção em andamento após parecer do Analista e decisão do Estrategista.
 - Automação: não.
 - Fontes obrigatórias de execução:
   - `README.md`;
@@ -739,12 +743,13 @@ O snippet não pode:
   - inspeção read-only no projeto Supabase `LP-Factory-10` confirmou a cadeia ativa `imobiliario` (`segment`) → `corretor-imoveis` (`niche`) → `corretor-de-imoveis-de-medio-padrao` (`ultra_niche`), com relações pai-filho coerentes;
   - `supabase/snippets/e20_2_taxon_chain_verify.sql` foi criado e executado sem escrita;
   - registry v1 implementado com 19 campos efetivos, sem camada própria para o ultranicho de médio padrão;
+  - correção do PR #576 removeu contexto operacional do resolver, preservou as condições declarativas na saída completa e endureceu identidade de origem e precedência das especializações;
   - `npm ci`: aprovado; o audit da árvore instalada reportou 13 vulnerabilidades preexistentes, sem mudança de dependências;
   - `npm run check`: aprovado, com 24 warnings preexistentes e nenhum erro;
-  - `npm run validate:landing-page-input-catalog`: aprovado em 26 casos executáveis;
+  - `npm run validate:landing-page-input-catalog`: aprovado em 30 casos executáveis;
   - `git diff --check`: aprovado.
-- Decisão da fase: avançar.
-- Próxima ação real: submeter o PR material contra `main`, aguardar merge humano e então encaminhar o estado final ao Gestor de Docs.
+- Decisão da fase: ajustar.
+- Próxima ação real: concluir a correção no PR #576, submetê-la à nova análise e aguardar merge humano.
 - Critérios de aceite:
   - snippet confirma a cadeia real sem escrita;
   - matriz completa aprovada;

--- a/docs/lousa-plano-base-e20-2.md
+++ b/docs/lousa-plano-base-e20-2.md
@@ -250,7 +250,9 @@ Condições v1:
 - o valor comparado deve ser compatível com o tipo do campo referenciado;
 - não haverá expressão livre, código executável, árvore arbitrária ou engine de regras;
 - condição não pode referenciar o próprio campo;
-- referências circulares, ausentes ou incompatíveis bloqueiam a resolução.
+- referências circulares, ausentes ou incompatíveis bloqueiam a resolução;
+- `allowed_plans` do campo condicionado deve ser subconjunto de `allowed_plans` do campo referenciado;
+- após o filtro pelo plano solicitado, as condições dos campos efetivos são validadas novamente e qualquer referência removida bloqueia a resolução.
 
 ### 2.5. Especialização entre camadas
 
@@ -687,12 +689,12 @@ O snippet não pode:
 - especialização textual, regex ou formato customizado: falhar;
 - referência de condição ausente ou incompatível: falhar;
 - condição circular: falhar;
-- cada destino de conversão deve aparecer somente no canal correspondente;
-- canal `form` exige `privacy_policy_url`;
-- `paid_search_keyword_map` ausente com busca paga: aceitar;
-- mapa presente sem busca paga: falhar;
-- mapa inválido: falhar;
-- mapa válido com busca paga: resolver;
+- planos do campo condicionado fora dos planos do campo referenciado: falhar;
+- após o filtro por plano, condição restante apontando para campo removido: falhar;
+- todos os destinos de conversão permanecem no catálogo com suas condições declarativas;
+- `privacy_policy_url` permanece no catálogo com condição declarativa de `form`;
+- `paid_search_keyword_map` permanece opcional com condição declarativa de `paid_search`;
+- avaliação concreta das condições de canal e origem de tráfego pertence à E19.4;
 - catálogo imobiliário nos quatro planos: resultado funcionalmente equivalente;
 - taxon de médio padrão: ausência de camada própria e herança integral;
 - saída: sem valores operacionais, entitlement ou snapshot;
@@ -746,7 +748,7 @@ O snippet não pode:
   - correção do PR #576 removeu contexto operacional do resolver, preservou as condições declarativas na saída completa e endureceu identidade de origem e precedência das especializações;
   - `npm ci`: aprovado; o audit da árvore instalada reportou 13 vulnerabilidades preexistentes, sem mudança de dependências;
   - `npm run check`: aprovado, com 24 warnings preexistentes e nenhum erro;
-  - `npm run validate:landing-page-input-catalog`: aprovado em 30 casos executáveis;
+  - `npm run validate:landing-page-input-catalog`: aprovado em 32 casos executáveis;
   - `git diff --check`: aprovado.
 - Decisão da fase: ajustar.
 - Próxima ação real: concluir a correção no PR #576, submetê-la à nova análise e aguardar merge humano.

--- a/lib/conversion-content/index.ts
+++ b/lib/conversion-content/index.ts
@@ -3,6 +3,7 @@ export * from "./validation";
 export * from "./commercial-activation";
 export * as landingPageRoot from "./landing-page";
 export * as landingPageResearch from "./landing-page/research-resolution";
+export * as landingPageInputCatalog from "./landing-page/input-catalog";
 export {
   getCommercialActivationBundle,
   getCommercialActivationHierarchicalBundle,

--- a/lib/conversion-content/landing-page/input-catalog/contracts.ts
+++ b/lib/conversion-content/landing-page/input-catalog/contracts.ts
@@ -1,0 +1,212 @@
+export const landingPageInputCatalogPlans = [
+  "starter",
+  "lite",
+  "pro",
+  "ultra",
+] as const;
+
+export const landingPageInputCatalogEvidenceReferences = [
+  "decision:lp-planning",
+  "decision:e20-2-human",
+  "technical:current-contracts",
+  "empirical:real-estate-research",
+  "context:real-estate-pilot",
+] as const;
+
+export type LandingPageInputCatalogPlan =
+  (typeof landingPageInputCatalogPlans)[number];
+export type LandingPageInputCatalogEvidenceReference =
+  (typeof landingPageInputCatalogEvidenceReferences)[number];
+export type LandingPageInputCatalogLayerLevel =
+  | "universal"
+  | "segment"
+  | "niche"
+  | "ultra_niche";
+export type LandingPageInputValueType =
+  | "string"
+  | "phone"
+  | "email"
+  | "url"
+  | "enum"
+  | "string_list"
+  | "boolean"
+  | "number_range"
+  | "keyword_map";
+export type LandingPageInputValueScope =
+  | "account"
+  | "business"
+  | "offer"
+  | "campaign"
+  | "landing_page";
+export type LandingPageInputExpectedValueOrigin =
+  | "account_provided"
+  | "business_provided"
+  | "offer_provided"
+  | "campaign_provided"
+  | "landing_page_provided";
+export type LandingPageInputObligation =
+  | "required"
+  | "optional"
+  | "conditional";
+
+export type LandingPageInputCondition = Readonly<{
+  fieldKey: string;
+  operator: "equals" | "in";
+  value: string | boolean | readonly string[];
+}>;
+
+export type LandingPageInputValidation =
+  | Readonly<{ kind: "type_only" }>
+  | Readonly<{ kind: "enum"; allowedValues: readonly string[] }>
+  | Readonly<{
+      kind: "string_list";
+      allowedValues?: readonly string[];
+      minItems?: number;
+      maxItems?: number;
+    }>
+  | Readonly<{
+      kind: "number_range";
+      currency: "BRL";
+      minimum?: number;
+      maximum?: number;
+    }>
+  | Readonly<{ kind: "e164" }>
+  | Readonly<{ kind: "email" }>
+  | Readonly<{ kind: "https_url" }>
+  | Readonly<{ kind: "keyword_map" }>;
+
+export type LandingPageInputEvidence = Readonly<{
+  summary: string;
+  references: readonly LandingPageInputCatalogEvidenceReference[];
+}>;
+
+export type LandingPageInputFieldDefinition = Readonly<{
+  kind: "field";
+  fieldKey: string;
+  purpose: string;
+  originLayer: LandingPageInputCatalogLayerLevel;
+  originTaxon?: LandingPageInputCatalogTaxonIdentity;
+  valueType: LandingPageInputValueType;
+  valueScope: LandingPageInputValueScope;
+  expectedValueOrigin: LandingPageInputExpectedValueOrigin;
+  obligation: LandingPageInputObligation;
+  requiredWhen?: LandingPageInputCondition;
+  applicableWhen?: LandingPageInputCondition;
+  validation: LandingPageInputValidation;
+  allowedPlans: readonly LandingPageInputCatalogPlan[];
+  snapshotPolicy: "include_if_used";
+  evidence: LandingPageInputEvidence;
+  createdInVersion: number;
+}>;
+
+export type LandingPageInputFieldSpecialization = Readonly<{
+  kind: "specialization";
+  fieldKey: string;
+  changes: Readonly<Partial<Omit<LandingPageInputFieldDefinition, "kind" | "fieldKey">>>;
+}>;
+
+export type LandingPageInputCatalogLayerEntry =
+  | LandingPageInputFieldDefinition
+  | LandingPageInputFieldSpecialization;
+
+export type LandingPageInputCatalogTaxonIdentity = Readonly<{
+  id: string;
+  name: string;
+  slug: string;
+  level: Exclude<LandingPageInputCatalogLayerLevel, "universal">;
+  isActive: boolean;
+  parentId: string | null;
+}>;
+
+export type LandingPageInputCatalogLayer = Readonly<{
+  level: LandingPageInputCatalogLayerLevel;
+  taxon?: LandingPageInputCatalogTaxonIdentity;
+  entries: readonly LandingPageInputCatalogLayerEntry[];
+}>;
+
+export type LandingPageInputCatalogRegistryEntry = Readonly<{
+  version: number;
+  universal: LandingPageInputCatalogLayer;
+  taxonLayers: Readonly<Record<string, LandingPageInputCatalogLayer>>;
+}>;
+
+export type LandingPageInputCatalogRegistry = Readonly<
+  Record<number, LandingPageInputCatalogRegistryEntry>
+>;
+
+export type LandingPageInputCatalogTaxonChain = Readonly<{
+  segment: LandingPageInputCatalogTaxonIdentity;
+  niche?: LandingPageInputCatalogTaxonIdentity;
+  ultraNiche?: LandingPageInputCatalogTaxonIdentity;
+}>;
+
+export type ResolveLandingPageInputCatalogInput = Readonly<{
+  version: number;
+  plan: LandingPageInputCatalogPlan | string;
+  taxonChain: LandingPageInputCatalogTaxonChain;
+  ultraNicheLayerAuthorized?: boolean;
+  applicabilityContext?: Readonly<Record<string, string | boolean>>;
+}>;
+
+export type LandingPageInputFieldProvenance = Readonly<{
+  property: "definition" | "obligation" | "allowedPlans" | "validation";
+  layer: LandingPageInputCatalogLayerLevel;
+  taxon?: LandingPageInputCatalogTaxonIdentity;
+}>;
+
+export type ResolvedLandingPageInputField = LandingPageInputFieldDefinition &
+  Readonly<{
+    provenance: readonly LandingPageInputFieldProvenance[];
+  }>;
+
+export type ResolvedLandingPageInputCatalog = Readonly<{
+  version: number;
+  servedTaxon: LandingPageInputCatalogTaxonIdentity;
+  plan: LandingPageInputCatalogPlan;
+  appliedLayers: readonly Readonly<{
+    level: LandingPageInputCatalogLayerLevel;
+    taxon?: LandingPageInputCatalogTaxonIdentity;
+  }>[];
+  fields: readonly ResolvedLandingPageInputField[];
+  valid: true;
+}>;
+
+export type LandingPageInputCatalogErrorCode =
+  | "UNKNOWN_VERSION"
+  | "INVALID_PLAN"
+  | "INVALID_TAXON_CHAIN"
+  | "INVALID_LAYER"
+  | "UNAUTHORIZED_ULTRA_NICHE_LAYER"
+  | "DUPLICATE_FIELD"
+  | "IMMUTABLE_PROPERTY_CONFLICT"
+  | "INVALID_SPECIALIZATION"
+  | "INVALID_CONDITION"
+  | "INVALID_VALIDATION"
+  | "MISSING_EVIDENCE_ORIGIN"
+  | "INVALID_PAID_SEARCH_KEYWORD_MAP";
+
+export type ResolveLandingPageInputCatalogResult =
+  | Readonly<{ ok: true; value: ResolvedLandingPageInputCatalog }>
+  | Readonly<{
+      ok: false;
+      error: Readonly<{
+        code: LandingPageInputCatalogErrorCode;
+        message: string;
+      }>;
+    }>;
+
+export type LandingPageInputValueValidationResult =
+  | Readonly<{ ok: true }>
+  | Readonly<{
+      ok: false;
+      error: Readonly<{
+        code: "NOT_APPLICABLE" | "INVALID_VALUE";
+        message: string;
+      }>;
+    }>;
+
+export type LandingPageKeywordMapItem = Readonly<{
+  keyword_or_cluster: string;
+  message_anchor: string;
+  ad_context?: string;
+}>;

--- a/lib/conversion-content/landing-page/input-catalog/contracts.ts
+++ b/lib/conversion-content/landing-page/input-catalog/contracts.ts
@@ -75,29 +75,64 @@ export type LandingPageInputValidation =
   | Readonly<{ kind: "https_url" }>
   | Readonly<{ kind: "keyword_map" }>;
 
+export type LandingPageInputTypeValidationContract =
+  | Readonly<{
+      valueType: "string" | "boolean";
+      validation: Extract<LandingPageInputValidation, { kind: "type_only" }>;
+    }>
+  | Readonly<{
+      valueType: "phone";
+      validation: Extract<LandingPageInputValidation, { kind: "e164" }>;
+    }>
+  | Readonly<{
+      valueType: "email";
+      validation: Extract<LandingPageInputValidation, { kind: "email" }>;
+    }>
+  | Readonly<{
+      valueType: "url";
+      validation: Extract<LandingPageInputValidation, { kind: "https_url" }>;
+    }>
+  | Readonly<{
+      valueType: "enum";
+      validation: Extract<LandingPageInputValidation, { kind: "enum" }>;
+    }>
+  | Readonly<{
+      valueType: "string_list";
+      validation: Extract<LandingPageInputValidation, { kind: "string_list" }>;
+    }>
+  | Readonly<{
+      valueType: "number_range";
+      validation: Extract<LandingPageInputValidation, { kind: "number_range" }>;
+    }>
+  | Readonly<{
+      valueType: "keyword_map";
+      validation: Extract<LandingPageInputValidation, { kind: "keyword_map" }>;
+    }>;
+
 export type LandingPageInputEvidence = Readonly<{
   summary: string;
   references: readonly LandingPageInputCatalogEvidenceReference[];
 }>;
 
-export type LandingPageInputFieldDefinition = Readonly<{
+type LandingPageInputFieldDefinitionBase = Readonly<{
   kind: "field";
   fieldKey: string;
   purpose: string;
   originLayer: LandingPageInputCatalogLayerLevel;
   originTaxon?: LandingPageInputCatalogTaxonIdentity;
-  valueType: LandingPageInputValueType;
   valueScope: LandingPageInputValueScope;
   expectedValueOrigin: LandingPageInputExpectedValueOrigin;
   obligation: LandingPageInputObligation;
   requiredWhen?: LandingPageInputCondition;
   applicableWhen?: LandingPageInputCondition;
-  validation: LandingPageInputValidation;
   allowedPlans: readonly LandingPageInputCatalogPlan[];
   snapshotPolicy: "include_if_used";
   evidence: LandingPageInputEvidence;
   createdInVersion: number;
 }>;
+
+export type LandingPageInputFieldDefinition =
+  LandingPageInputFieldDefinitionBase & LandingPageInputTypeValidationContract;
 
 export type LandingPageInputFieldSpecialization = Readonly<{
   kind: "specialization";
@@ -145,7 +180,6 @@ export type ResolveLandingPageInputCatalogInput = Readonly<{
   plan: LandingPageInputCatalogPlan | string;
   taxonChain: LandingPageInputCatalogTaxonChain;
   ultraNicheLayerAuthorized?: boolean;
-  applicabilityContext?: Readonly<Record<string, string | boolean>>;
 }>;
 
 export type LandingPageInputFieldProvenance = Readonly<{
@@ -200,7 +234,7 @@ export type LandingPageInputValueValidationResult =
   | Readonly<{
       ok: false;
       error: Readonly<{
-        code: "NOT_APPLICABLE" | "INVALID_VALUE";
+        code: "INVALID_VALUE";
         message: string;
       }>;
     }>;

--- a/lib/conversion-content/landing-page/input-catalog/index.ts
+++ b/lib/conversion-content/landing-page/input-catalog/index.ts
@@ -1,0 +1,4 @@
+export * from "./contracts";
+export * from "./registry";
+export * from "./resolver";
+export * from "./schema";

--- a/lib/conversion-content/landing-page/input-catalog/registry.ts
+++ b/lib/conversion-content/landing-page/input-catalog/registry.ts
@@ -1,0 +1,317 @@
+import type {
+  LandingPageInputCatalogPlan,
+  LandingPageInputCatalogRegistry,
+  LandingPageInputCatalogTaxonIdentity,
+  LandingPageInputEvidence,
+  LandingPageInputFieldDefinition,
+  LandingPageInputValidation,
+} from "./contracts";
+
+const allPlans = ["starter", "lite", "pro", "ultra"] as const;
+
+export const realEstateSegmentTaxon = taxon({
+  id: "f9ba36cd-fcd9-478b-9823-c2f003cf037a",
+  name: "Imobiliário",
+  slug: "imobiliario",
+  level: "segment",
+  isActive: true,
+  parentId: null,
+});
+
+export const realEstateBrokerNicheTaxon = taxon({
+  id: "c7952d16-678c-4615-9483-a003e57d94aa",
+  name: "Corretor Imóveis",
+  slug: "corretor-imoveis",
+  level: "niche",
+  isActive: true,
+  parentId: realEstateSegmentTaxon.id,
+});
+
+export const mediumStandardRealEstateBrokerTaxon = taxon({
+  id: "a8e986cc-070f-4ab4-9857-e6b1ce9fdb75",
+  name: "Corretor de imóveis de médio padrão",
+  slug: "corretor-de-imoveis-de-medio-padrao",
+  level: "ultra_niche",
+  isActive: true,
+  parentId: realEstateBrokerNicheTaxon.id,
+});
+
+const conversionChannelCondition = (value: string) => ({
+  fieldKey: "primary_conversion_channel",
+  operator: "equals" as const,
+  value,
+});
+
+export const landingPageInputCatalogRegistry = deepFreeze({
+  1: {
+    version: 1,
+    universal: {
+      level: "universal",
+      entries: [
+        field({
+          fieldKey: "business_display_name",
+          purpose: "Identificar factual e publicamente o negócio ou profissional atendido.",
+          valueType: "string",
+          valueScope: "business",
+          expectedValueOrigin: "business_provided",
+          obligation: "required",
+          validation: { kind: "type_only" },
+          evidence: evidence("Toda landing page precisa identificar o negócio ou profissional atendido.", "decision:lp-planning", "technical:current-contracts"),
+        }),
+        field({
+          fieldKey: "funnel_stage",
+          purpose: "Informar a intenção de funil da landing page sem confundi-la com o canal.",
+          valueType: "enum",
+          valueScope: "landing_page",
+          expectedValueOrigin: "landing_page_provided",
+          obligation: "required",
+          validation: { kind: "enum", allowedValues: ["bofu", "mofu", "tofu"] },
+          evidence: evidence("O planejamento separa BOFU, MOFU e TOFU do canal landing_page.", "decision:lp-planning"),
+        }),
+        field({
+          fieldKey: "traffic_source",
+          purpose: "Identificar a origem de tráfego separadamente da intenção da landing page.",
+          valueType: "enum",
+          valueScope: "campaign",
+          expectedValueOrigin: "campaign_provided",
+          obligation: "optional",
+          validation: { kind: "enum", allowedValues: ["paid_search", "paid_social", "organic", "whatsapp", "qr_code", "other"] },
+          evidence: evidence("O planejamento separa origem de tráfego da intenção da landing page.", "decision:lp-planning"),
+        }),
+        field({
+          fieldKey: "primary_conversion_channel",
+          purpose: "Selecionar o destino operacional principal de conversão da landing page.",
+          valueType: "enum",
+          valueScope: "landing_page",
+          expectedValueOrigin: "landing_page_provided",
+          obligation: "required",
+          validation: { kind: "enum", allowedValues: ["whatsapp", "form", "phone", "email", "external_url"] },
+          evidence: evidence("Pesquisa, piloto e decisão humana confirmam os destinos operacionais explícitos.", "empirical:real-estate-research", "context:real-estate-pilot", "decision:e20-2-human"),
+        }),
+        field({
+          fieldKey: "whatsapp_destination",
+          purpose: "Fornecer o destino E.164 quando WhatsApp for o canal principal.",
+          valueType: "phone",
+          valueScope: "landing_page",
+          expectedValueOrigin: "landing_page_provided",
+          obligation: "conditional",
+          requiredWhen: conversionChannelCondition("whatsapp"),
+          applicableWhen: conversionChannelCondition("whatsapp"),
+          validation: { kind: "e164" },
+          evidence: evidence("WhatsApp é CTA recorrente na pesquisa e canal real do piloto.", "empirical:real-estate-research", "context:real-estate-pilot"),
+        }),
+        field({
+          fieldKey: "phone_destination",
+          purpose: "Fornecer o telefone E.164 quando telefone for o canal principal.",
+          valueType: "phone",
+          valueScope: "landing_page",
+          expectedValueOrigin: "landing_page_provided",
+          obligation: "conditional",
+          requiredWhen: conversionChannelCondition("phone"),
+          applicableWhen: conversionChannelCondition("phone"),
+          validation: { kind: "e164" },
+          evidence: evidence("O telefone foi mantido como destino operacional explícito.", "decision:e20-2-human"),
+        }),
+        field({
+          fieldKey: "email_destination",
+          purpose: "Fornecer um e-mail único quando e-mail for o canal principal.",
+          valueType: "email",
+          valueScope: "landing_page",
+          expectedValueOrigin: "landing_page_provided",
+          obligation: "conditional",
+          requiredWhen: conversionChannelCondition("email"),
+          applicableWhen: conversionChannelCondition("email"),
+          validation: { kind: "email" },
+          evidence: evidence("E-mail é canal previsto no produto e no piloto.", "technical:current-contracts", "context:real-estate-pilot"),
+        }),
+        field({
+          fieldKey: "external_url_destination",
+          purpose: "Fornecer URL HTTPS quando URL externa for o canal principal.",
+          valueType: "url",
+          valueScope: "landing_page",
+          expectedValueOrigin: "landing_page_provided",
+          obligation: "conditional",
+          requiredWhen: conversionChannelCondition("external_url"),
+          applicableWhen: conversionChannelCondition("external_url"),
+          validation: { kind: "https_url" },
+          evidence: evidence("URL externa foi mantida como destino operacional explícito.", "decision:e20-2-human"),
+        }),
+        field({
+          fieldKey: "privacy_policy_url",
+          purpose: "Fornecer a política de privacidade HTTPS quando formulário for o canal principal.",
+          valueType: "url",
+          valueScope: "business",
+          expectedValueOrigin: "business_provided",
+          obligation: "conditional",
+          requiredWhen: conversionChannelCondition("form"),
+          applicableWhen: conversionChannelCondition("form"),
+          validation: { kind: "https_url" },
+          evidence: evidence("A pesquisa exige política e consentimento quando existe formulário.", "empirical:real-estate-research"),
+        }),
+        field({
+          fieldKey: "paid_search_keyword_map",
+          purpose: "Alinhar cluster de busca, contexto do anúncio e âncora factual sem produzir copy.",
+          valueType: "keyword_map",
+          valueScope: "campaign",
+          expectedValueOrigin: "campaign_provided",
+          obligation: "optional",
+          applicableWhen: { fieldKey: "traffic_source", operator: "equals", value: "paid_search" },
+          validation: { kind: "keyword_map" },
+          evidence: evidence("O planejamento autoriza message match opcional e a pesquisa confirma busca por localização, tipologia e intenção.", "decision:lp-planning", "empirical:real-estate-research"),
+        }),
+      ],
+    },
+    taxonLayers: {
+      [realEstateSegmentTaxon.slug]: {
+        level: "segment",
+        taxon: realEstateSegmentTaxon,
+        entries: [
+          field({
+            fieldKey: "service_locations",
+            purpose: "Declarar cidades, bairros ou regiões reais de atendimento.",
+            originTaxon: realEstateSegmentTaxon,
+            valueType: "string_list",
+            valueScope: "business",
+            expectedValueOrigin: "business_provided",
+            obligation: "required",
+            validation: { kind: "string_list" },
+            evidence: evidence("A descoberta imobiliária e o piloto são orientados por localização e região.", "empirical:real-estate-research", "context:real-estate-pilot"),
+          }),
+          field({
+            fieldKey: "property_types",
+            purpose: "Declarar as tipologias reais abrangidas pela oferta.",
+            originTaxon: realEstateSegmentTaxon,
+            valueType: "string_list",
+            valueScope: "offer",
+            expectedValueOrigin: "offer_provided",
+            obligation: "optional",
+            validation: { kind: "string_list" },
+            evidence: evidence("Portais e pesquisa estruturam descoberta por tipologia, dependente da oferta real.", "empirical:real-estate-research"),
+          }),
+          field({
+            fieldKey: "property_price_range",
+            purpose: "Declarar a faixa real de preço da oferta em BRL.",
+            originTaxon: realEstateSegmentTaxon,
+            valueType: "number_range",
+            valueScope: "offer",
+            expectedValueOrigin: "offer_provided",
+            obligation: "optional",
+            validation: { kind: "number_range", currency: "BRL", minimum: 0 },
+            evidence: evidence("Preço e capacidade financeira são filtros e insumos recorrentes.", "empirical:real-estate-research", "context:real-estate-pilot"),
+          }),
+          field({
+            fieldKey: "property_stage",
+            purpose: "Declarar o estágio real dos imóveis abrangidos pela oferta.",
+            originTaxon: realEstateSegmentTaxon,
+            valueType: "enum",
+            valueScope: "offer",
+            expectedValueOrigin: "offer_provided",
+            obligation: "optional",
+            validation: { kind: "enum", allowedValues: ["launch", "under_construction", "ready", "used", "mixed"] },
+            evidence: evidence("Pesquisa e piloto distinguem lançamentos, construção, prontos e usados.", "empirical:real-estate-research", "context:real-estate-pilot"),
+          }),
+        ],
+      },
+      [realEstateBrokerNicheTaxon.slug]: {
+        level: "niche",
+        taxon: realEstateBrokerNicheTaxon,
+        entries: [
+          field({
+            fieldKey: "transaction_intent",
+            purpose: "Declarar a intenção comercial específica da landing page do corretor.",
+            originTaxon: realEstateBrokerNicheTaxon,
+            valueType: "enum",
+            valueScope: "landing_page",
+            expectedValueOrigin: "landing_page_provided",
+            obligation: "required",
+            validation: { kind: "enum", allowedValues: ["buy", "sell", "valuation", "mixed"] },
+            evidence: evidence("A pesquisa diferencia compra, venda, avaliação e fluxo híbrido.", "empirical:real-estate-research"),
+          }),
+          field({
+            fieldKey: "financing_support_available",
+            purpose: "Informar se o corretor oferece apoio em financiamento.",
+            originTaxon: realEstateBrokerNicheTaxon,
+            valueType: "boolean",
+            valueScope: "business",
+            expectedValueOrigin: "business_provided",
+            obligation: "optional",
+            validation: { kind: "type_only" },
+            evidence: evidence("Financiamento é apoio possível do corretor, não propriedade universal do segmento.", "empirical:real-estate-research", "context:real-estate-pilot"),
+          }),
+          field({
+            fieldKey: "document_support_available",
+            purpose: "Informar se o corretor oferece orientação documental.",
+            originTaxon: realEstateBrokerNicheTaxon,
+            valueType: "boolean",
+            valueScope: "business",
+            expectedValueOrigin: "business_provided",
+            obligation: "optional",
+            validation: { kind: "type_only" },
+            evidence: evidence("Orientação documental é apoio possível do corretor.", "empirical:real-estate-research", "context:real-estate-pilot"),
+          }),
+          field({
+            fieldKey: "creci_registration",
+            purpose: "Declarar a credencial CRECI a ser confirmada por fonte oficial antes do uso como prova.",
+            originTaxon: realEstateBrokerNicheTaxon,
+            valueType: "string",
+            valueScope: "business",
+            expectedValueOrigin: "business_provided",
+            obligation: "required",
+            validation: { kind: "type_only" },
+            evidence: evidence("CRECI é credencial verificável e o piloto trata atuação profissional.", "empirical:real-estate-research", "context:real-estate-pilot"),
+          }),
+          field({
+            fieldKey: "attendance_modes",
+            purpose: "Declarar modos reais de atendimento do corretor.",
+            originTaxon: realEstateBrokerNicheTaxon,
+            valueType: "string_list",
+            valueScope: "business",
+            expectedValueOrigin: "business_provided",
+            obligation: "optional",
+            validation: { kind: "string_list", allowedValues: ["in_person", "remote"] },
+            evidence: evidence("O processo comercial pode combinar atendimento presencial e remoto.", "empirical:real-estate-research", "context:real-estate-pilot"),
+          }),
+        ],
+      },
+    },
+  },
+} satisfies LandingPageInputCatalogRegistry);
+
+function field(
+  input: Omit<LandingPageInputFieldDefinition, "kind" | "originLayer" | "allowedPlans" | "snapshotPolicy" | "createdInVersion"> & {
+    originTaxon?: LandingPageInputCatalogTaxonIdentity;
+    allowedPlans?: readonly LandingPageInputCatalogPlan[];
+    validation: LandingPageInputValidation;
+  },
+): LandingPageInputFieldDefinition {
+  return {
+    kind: "field",
+    ...input,
+    originLayer: input.originTaxon?.level ?? "universal",
+    allowedPlans: input.allowedPlans ?? allPlans,
+    snapshotPolicy: "include_if_used",
+    createdInVersion: 1,
+  };
+}
+
+function evidence(
+  summary: string,
+  ...references: LandingPageInputEvidence["references"]
+): LandingPageInputEvidence {
+  return { summary, references };
+}
+
+function taxon<T extends LandingPageInputCatalogTaxonIdentity>(value: T): T {
+  return value;
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === "object") {
+    for (const property of Object.getOwnPropertyNames(value)) {
+      const nested = value[property as keyof T];
+      if (nested && typeof nested === "object" && !Object.isFrozen(nested)) deepFreeze(nested);
+    }
+    Object.freeze(value);
+  }
+  return value;
+}

--- a/lib/conversion-content/landing-page/input-catalog/registry.ts
+++ b/lib/conversion-content/landing-page/input-catalog/registry.ts
@@ -4,7 +4,7 @@ import type {
   LandingPageInputCatalogTaxonIdentity,
   LandingPageInputEvidence,
   LandingPageInputFieldDefinition,
-  LandingPageInputValidation,
+  LandingPageInputTypeValidationContract,
 } from "./contracts";
 
 const allPlans = ["starter", "lite", "pro", "ultra"] as const;
@@ -278,10 +278,10 @@ export const landingPageInputCatalogRegistry = deepFreeze({
 } satisfies LandingPageInputCatalogRegistry);
 
 function field(
-  input: Omit<LandingPageInputFieldDefinition, "kind" | "originLayer" | "allowedPlans" | "snapshotPolicy" | "createdInVersion"> & {
+  input: Omit<LandingPageInputFieldDefinition, "kind" | "originLayer" | "allowedPlans" | "snapshotPolicy" | "createdInVersion" | "valueType" | "validation"> &
+    LandingPageInputTypeValidationContract & {
     originTaxon?: LandingPageInputCatalogTaxonIdentity;
     allowedPlans?: readonly LandingPageInputCatalogPlan[];
-    validation: LandingPageInputValidation;
   },
 ): LandingPageInputFieldDefinition {
   return {
@@ -291,7 +291,7 @@ function field(
     allowedPlans: input.allowedPlans ?? allPlans,
     snapshotPolicy: "include_if_used",
     createdInVersion: 1,
-  };
+  } as LandingPageInputFieldDefinition;
 }
 
 function evidence(

--- a/lib/conversion-content/landing-page/input-catalog/resolver.ts
+++ b/lib/conversion-content/landing-page/input-catalog/resolver.ts
@@ -1,0 +1,325 @@
+import type {
+  LandingPageInputCatalogErrorCode,
+  LandingPageInputCatalogLayer,
+  LandingPageInputCatalogLayerLevel,
+  LandingPageInputCatalogPlan,
+  LandingPageInputCatalogRegistry,
+  LandingPageInputCatalogTaxonChain,
+  LandingPageInputFieldDefinition,
+  LandingPageInputFieldProvenance,
+  LandingPageInputFieldSpecialization,
+  LandingPageInputValidation,
+  ResolveLandingPageInputCatalogInput,
+  ResolveLandingPageInputCatalogResult,
+  ResolvedLandingPageInputField,
+} from "./contracts";
+import { landingPageInputCatalogRegistry } from "./registry";
+import {
+  evaluateLandingPageInputCondition,
+  landingPageInputCatalogLayerSchema,
+  landingPageInputCatalogTaxonIdentitySchema,
+  landingPageInputFieldDefinitionSchema,
+} from "./schema";
+
+const validPlans = new Set<LandingPageInputCatalogPlan>([
+  "starter",
+  "lite",
+  "pro",
+  "ultra",
+]);
+const mutableSpecializationProperties = new Set([
+  "obligation",
+  "allowedPlans",
+  "validation",
+]);
+
+export function resolveLandingPageInputCatalog(
+  input: ResolveLandingPageInputCatalogInput,
+): ResolveLandingPageInputCatalogResult {
+  return resolveLandingPageInputCatalogFromRegistry(
+    input,
+    landingPageInputCatalogRegistry,
+  );
+}
+
+export function resolveLandingPageInputCatalogFromRegistry(
+  input: ResolveLandingPageInputCatalogInput,
+  registry: LandingPageInputCatalogRegistry,
+): ResolveLandingPageInputCatalogResult {
+  const entry = registry[input.version];
+  if (!entry || entry.version !== input.version) {
+    return invalid("UNKNOWN_VERSION", `Unknown input catalog version: ${input.version}`);
+  }
+  if (!validPlans.has(input.plan as LandingPageInputCatalogPlan)) {
+    return invalid("INVALID_PLAN", `Unknown input catalog plan: ${input.plan}`);
+  }
+  const chainError = validateTaxonChain(input.taxonChain);
+  if (chainError) return chainError;
+
+  const selectedLayers: LandingPageInputCatalogLayer[] = [entry.universal];
+  const chainTaxons = [
+    input.taxonChain.segment,
+    input.taxonChain.niche,
+    input.taxonChain.ultraNiche,
+  ].filter((taxon) => taxon !== undefined);
+
+  for (const taxon of chainTaxons) {
+    const layer = entry.taxonLayers[taxon.slug];
+    if (!layer) continue;
+    if (layer.level === "ultra_niche" && !input.ultraNicheLayerAuthorized) {
+      return invalid(
+        "UNAUTHORIZED_ULTRA_NICHE_LAYER",
+        `Ultra-niche layer is not authorized: ${taxon.slug}`,
+      );
+    }
+    if (!sameTaxon(layer.taxon, taxon)) {
+      return invalid("INVALID_LAYER", `Layer identity does not match taxon chain: ${taxon.slug}`);
+    }
+    selectedLayers.push(layer);
+  }
+
+  const fields: ResolvedLandingPageInputField[] = [];
+  for (const layer of selectedLayers) {
+    for (const layerEntry of layer.entries) {
+      if (layerEntry.kind === "field") {
+        const fieldError = classifyFieldError(layerEntry);
+        if (fieldError) return fieldError;
+      }
+    }
+    if (!landingPageInputCatalogLayerSchema.safeParse(layer).success) {
+      return invalid("INVALID_LAYER", `Invalid ${layer.level} input catalog layer`);
+    }
+    for (const layerEntry of layer.entries) {
+      if (layerEntry.kind === "field") {
+        if (fields.some((field) => field.fieldKey === layerEntry.fieldKey)) {
+          return invalid("DUPLICATE_FIELD", `Duplicate field without specialization: ${layerEntry.fieldKey}`);
+        }
+        fields.push({
+          ...cloneJson(layerEntry),
+          provenance: [provenance("definition", layer)],
+        });
+        continue;
+      }
+
+      const specializationResult = applySpecialization(fields, layerEntry, layer);
+      if (!specializationResult.ok) return specializationResult;
+    }
+  }
+
+  const conditionError = validateConditions(fields);
+  if (conditionError) return conditionError;
+
+  const plan = input.plan as LandingPageInputCatalogPlan;
+  const effectiveFields = fields.filter((field) => {
+    if (!field.allowedPlans.includes(plan)) return false;
+    if (!field.applicableWhen) return true;
+    const context = input.applicabilityContext ?? {};
+    return !(field.applicableWhen.fieldKey in context) || evaluateLandingPageInputCondition(field.applicableWhen, context);
+  });
+
+  const servedTaxon = input.taxonChain.ultraNiche ?? input.taxonChain.niche ?? input.taxonChain.segment;
+  return {
+    ok: true,
+    value: deepFreeze(cloneJson({
+      version: input.version,
+      servedTaxon,
+      plan,
+      appliedLayers: selectedLayers.map((layer) => ({ level: layer.level, taxon: layer.taxon })),
+      fields: effectiveFields,
+      valid: true as const,
+    })),
+  };
+}
+
+function applySpecialization(
+  fields: ResolvedLandingPageInputField[],
+  specialization: LandingPageInputFieldSpecialization,
+  layer: LandingPageInputCatalogLayer,
+): ResolveLandingPageInputCatalogResult | { ok: true } {
+  const index = fields.findIndex((field) => field.fieldKey === specialization.fieldKey);
+  if (index < 0) {
+    return invalid("INVALID_SPECIALIZATION", `Specialization target does not exist: ${specialization.fieldKey}`);
+  }
+  const changeKeys = Object.keys(specialization.changes);
+  const immutableChange = changeKeys.find((key) => !mutableSpecializationProperties.has(key));
+  if (immutableChange) {
+    return invalid(
+      "IMMUTABLE_PROPERTY_CONFLICT",
+      `Immutable property cannot be specialized: ${specialization.fieldKey}.${immutableChange}`,
+    );
+  }
+  if (changeKeys.length === 0) {
+    return invalid("INVALID_SPECIALIZATION", `Empty specialization: ${specialization.fieldKey}`);
+  }
+
+  const inherited = fields[index];
+  const provenanceItems = [...inherited.provenance];
+  if (specialization.changes.obligation !== undefined) {
+    const ranks = { optional: 0, conditional: 1, required: 2 } as const;
+    if (
+      !Object.hasOwn(ranks, specialization.changes.obligation) ||
+      ranks[specialization.changes.obligation] <= ranks[inherited.obligation]
+    ) {
+      return invalid("INVALID_SPECIALIZATION", `Obligation is not more restrictive: ${specialization.fieldKey}`);
+    }
+    provenanceItems.push(provenance("obligation", layer));
+  }
+  if (specialization.changes.allowedPlans !== undefined) {
+    const plans = specialization.changes.allowedPlans;
+    if (!Array.isArray(plans) || plans.length === 0 || plans.some((plan) => !inherited.allowedPlans.includes(plan))) {
+      return invalid("INVALID_SPECIALIZATION", `Plans must be a non-empty inherited subset: ${specialization.fieldKey}`);
+    }
+    if (new Set(plans).size !== plans.length) {
+      return invalid("INVALID_SPECIALIZATION", `Specialized plans must be unique: ${specialization.fieldKey}`);
+    }
+    provenanceItems.push(provenance("allowedPlans", layer));
+  }
+  if (specialization.changes.validation !== undefined) {
+    if (!isRestrictiveValidation(inherited.validation, specialization.changes.validation)) {
+      return invalid("INVALID_SPECIALIZATION", `Validation is not a comparable restriction: ${specialization.fieldKey}`);
+    }
+    provenanceItems.push(provenance("validation", layer));
+  }
+
+  const specialized = {
+    ...inherited,
+    ...cloneJson(specialization.changes),
+    provenance: provenanceItems,
+  } as ResolvedLandingPageInputField;
+  if (!landingPageInputFieldDefinitionSchema.safeParse(specializedWithoutProvenance(specialized)).success) {
+    return invalid("INVALID_SPECIALIZATION", `Specialization produced an invalid field: ${specialization.fieldKey}`);
+  }
+  fields[index] = specialized;
+  return { ok: true };
+}
+
+function isRestrictiveValidation(inherited: LandingPageInputValidation, next: LandingPageInputValidation): boolean {
+  if (inherited.kind !== next.kind) return false;
+  if (inherited.kind === "enum" && next.kind === "enum") {
+    return next.allowedValues.length > 0 && next.allowedValues.every((value) => inherited.allowedValues.includes(value));
+  }
+  if (inherited.kind === "string_list" && next.kind === "string_list") {
+    if (JSON.stringify(inherited.allowedValues ?? null) !== JSON.stringify(next.allowedValues ?? null)) return false;
+    const inheritedMin = inherited.minItems ?? 1;
+    const inheritedMax = inherited.maxItems ?? Number.POSITIVE_INFINITY;
+    const nextMin = next.minItems ?? 1;
+    const nextMax = next.maxItems ?? Number.POSITIVE_INFINITY;
+    return nextMin >= inheritedMin && nextMax <= inheritedMax && nextMin <= nextMax;
+  }
+  if (inherited.kind === "number_range" && next.kind === "number_range") {
+    const inheritedMin = inherited.minimum ?? 0;
+    const inheritedMax = inherited.maximum ?? Number.POSITIVE_INFINITY;
+    const nextMin = next.minimum ?? 0;
+    const nextMax = next.maximum ?? Number.POSITIVE_INFINITY;
+    return next.currency === inherited.currency && nextMin >= inheritedMin && nextMax <= inheritedMax && nextMin <= nextMax;
+  }
+  return false;
+}
+
+function validateConditions(fields: readonly LandingPageInputFieldDefinition[]): ResolveLandingPageInputCatalogResult | null {
+  const byKey = new Map(fields.map((field) => [field.fieldKey, field]));
+  const edges = new Map<string, string[]>();
+  for (const field of fields) {
+    const conditions = [field.requiredWhen, field.applicableWhen].filter((condition) => condition !== undefined);
+    for (const condition of conditions) {
+      const referenced = byKey.get(condition.fieldKey);
+      if (!referenced || !conditionIsCompatible(referenced, condition)) {
+        return invalid("INVALID_CONDITION", `Invalid condition on ${field.fieldKey}`);
+      }
+      edges.set(field.fieldKey, [...(edges.get(field.fieldKey) ?? []), condition.fieldKey]);
+    }
+  }
+  if (hasCycle(edges)) return invalid("INVALID_CONDITION", "Circular field condition detected");
+  return null;
+}
+
+function conditionIsCompatible(field: LandingPageInputFieldDefinition, condition: NonNullable<LandingPageInputFieldDefinition["requiredWhen"]>): boolean {
+  const values = Array.isArray(condition.value) ? condition.value : [condition.value];
+  if (condition.operator === "in" && !Array.isArray(condition.value)) return false;
+  if (condition.operator === "equals" && Array.isArray(condition.value)) return false;
+  if (field.valueType === "boolean") return values.every((value) => typeof value === "boolean");
+  if (field.valueType === "enum" && field.validation.kind === "enum") {
+    return values.every((value) => typeof value === "string" && field.validation.kind === "enum" && field.validation.allowedValues.includes(value));
+  }
+  return field.valueType === "string" && values.every((value) => typeof value === "string");
+}
+
+function hasCycle(edges: ReadonlyMap<string, readonly string[]>): boolean {
+  const active = new Set<string>();
+  const done = new Set<string>();
+  const visit = (node: string): boolean => {
+    if (active.has(node)) return true;
+    if (done.has(node)) return false;
+    active.add(node);
+    for (const next of edges.get(node) ?? []) if (visit(next)) return true;
+    active.delete(node);
+    done.add(node);
+    return false;
+  };
+  return [...edges.keys()].some(visit);
+}
+
+function classifyFieldError(field: LandingPageInputFieldDefinition): ResolveLandingPageInputCatalogResult | null {
+  if (!field.expectedValueOrigin || !field.evidence?.summary || !field.evidence.references.length) {
+    return invalid("MISSING_EVIDENCE_ORIGIN", `Missing origin or evidence: ${field.fieldKey}`);
+  }
+  const parsed = landingPageInputFieldDefinitionSchema.safeParse(field);
+  if (parsed.success) return null;
+  if (field.fieldKey === "paid_search_keyword_map") {
+    return invalid("INVALID_PAID_SEARCH_KEYWORD_MAP", "Invalid paid_search_keyword_map contract");
+  }
+  const validationIssue = parsed.error.issues.some((issue) => issue.path[0] === "validation");
+  return invalid(validationIssue ? "INVALID_VALIDATION" : "INVALID_LAYER", `Invalid field contract: ${field.fieldKey}`);
+}
+
+function validateTaxonChain(chain: LandingPageInputCatalogTaxonChain): ResolveLandingPageInputCatalogResult | null {
+  const taxons = [chain.segment, chain.niche, chain.ultraNiche].filter((taxon) => taxon !== undefined);
+  if (chain.segment.level !== "segment" || chain.segment.parentId !== null || (chain.niche && chain.niche.level !== "niche") || (chain.ultraNiche && chain.ultraNiche.level !== "ultra_niche") || (chain.ultraNiche && !chain.niche)) {
+    return invalid("INVALID_TAXON_CHAIN", "Taxon chain levels are invalid");
+  }
+  if (taxons.some((taxon) => !taxon.isActive || !landingPageInputCatalogTaxonIdentitySchema.safeParse(taxon).success)) {
+    return invalid("INVALID_TAXON_CHAIN", "Taxon chain contains an inactive or invalid taxon");
+  }
+  if ((chain.niche && chain.niche.parentId !== chain.segment.id) || (chain.ultraNiche && chain.ultraNiche.parentId !== chain.niche?.id)) {
+    return invalid("INVALID_TAXON_CHAIN", "Taxon chain parent-child relation is invalid");
+  }
+  if (new Set(taxons.map((taxon) => taxon.id)).size !== taxons.length) {
+    return invalid("INVALID_TAXON_CHAIN", "Taxon chain contains duplicate identities");
+  }
+  return null;
+}
+
+function provenance(
+  property: LandingPageInputFieldProvenance["property"],
+  layer: LandingPageInputCatalogLayer,
+): LandingPageInputFieldProvenance {
+  return { property, layer: layer.level, taxon: layer.taxon };
+}
+
+function sameTaxon(left: LandingPageInputCatalogLayer["taxon"], right: NonNullable<LandingPageInputCatalogLayer["taxon"]>): boolean {
+  return !!left && left.id === right.id && left.slug === right.slug && left.level === right.level && left.parentId === right.parentId && left.isActive === right.isActive;
+}
+
+function specializedWithoutProvenance(field: ResolvedLandingPageInputField): LandingPageInputFieldDefinition {
+  const { provenance: _provenance, ...definition } = field;
+  return definition;
+}
+
+function invalid(code: LandingPageInputCatalogErrorCode, message: string): ResolveLandingPageInputCatalogResult {
+  return { ok: false, error: { code, message } };
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === "object") {
+    for (const property of Object.getOwnPropertyNames(value)) {
+      const nested = value[property as keyof T];
+      if (nested && typeof nested === "object" && !Object.isFrozen(nested)) deepFreeze(nested);
+    }
+    Object.freeze(value);
+  }
+  return value;
+}

--- a/lib/conversion-content/landing-page/input-catalog/resolver.ts
+++ b/lib/conversion-content/landing-page/input-catalog/resolver.ts
@@ -15,7 +15,6 @@ import type {
 } from "./contracts";
 import { landingPageInputCatalogRegistry } from "./registry";
 import {
-  evaluateLandingPageInputCondition,
   landingPageInputCatalogLayerSchema,
   landingPageInputCatalogTaxonIdentitySchema,
   landingPageInputFieldDefinitionSchema,
@@ -82,6 +81,8 @@ export function resolveLandingPageInputCatalogFromRegistry(
   for (const layer of selectedLayers) {
     for (const layerEntry of layer.entries) {
       if (layerEntry.kind === "field") {
+        const originError = validateFieldOriginForLayer(layerEntry, layer);
+        if (originError) return originError;
         const fieldError = classifyFieldError(layerEntry);
         if (fieldError) return fieldError;
       }
@@ -110,12 +111,7 @@ export function resolveLandingPageInputCatalogFromRegistry(
   if (conditionError) return conditionError;
 
   const plan = input.plan as LandingPageInputCatalogPlan;
-  const effectiveFields = fields.filter((field) => {
-    if (!field.allowedPlans.includes(plan)) return false;
-    if (!field.applicableWhen) return true;
-    const context = input.applicabilityContext ?? {};
-    return !(field.applicableWhen.fieldKey in context) || evaluateLandingPageInputCondition(field.applicableWhen, context);
-  });
+  const effectiveFields = fields.filter((field) => field.allowedPlans.includes(plan));
 
   const servedTaxon = input.taxonChain.ultraNiche ?? input.taxonChain.niche ?? input.taxonChain.segment;
   return {
@@ -153,6 +149,16 @@ function applySpecialization(
   }
 
   const inherited = fields[index];
+  const latestAppliedLevel = inherited.provenance.reduce(
+    (latest, item) => Math.max(latest, layerRank(item.layer)),
+    -1,
+  );
+  if (layerRank(layer.level) <= latestAppliedLevel) {
+    return invalid(
+      "INVALID_SPECIALIZATION",
+      `Specialization must be in a strictly more specific layer: ${specialization.fieldKey}`,
+    );
+  }
   const provenanceItems = [...inherited.provenance];
   if (specialization.changes.obligation !== undefined) {
     const ranks = { optional: 0, conditional: 1, required: 2 } as const;
@@ -272,6 +278,24 @@ function classifyFieldError(field: LandingPageInputFieldDefinition): ResolveLand
   return invalid(validationIssue ? "INVALID_VALIDATION" : "INVALID_LAYER", `Invalid field contract: ${field.fieldKey}`);
 }
 
+function validateFieldOriginForLayer(
+  field: LandingPageInputFieldDefinition,
+  layer: LandingPageInputCatalogLayer,
+): ResolveLandingPageInputCatalogResult | null {
+  if (field.originLayer !== layer.level) {
+    return invalid("INVALID_LAYER", `Field origin layer mismatch: ${field.fieldKey}`);
+  }
+  if (layer.level === "universal") {
+    return field.originTaxon
+      ? invalid("INVALID_LAYER", `Universal field cannot declare origin taxon: ${field.fieldKey}`)
+      : null;
+  }
+  if (!layer.taxon || !sameTaxon(field.originTaxon, layer.taxon)) {
+    return invalid("INVALID_LAYER", `Field origin taxon mismatch: ${field.fieldKey}`);
+  }
+  return null;
+}
+
 function validateTaxonChain(chain: LandingPageInputCatalogTaxonChain): ResolveLandingPageInputCatalogResult | null {
   const taxons = [chain.segment, chain.niche, chain.ultraNiche].filter((taxon) => taxon !== undefined);
   if (chain.segment.level !== "segment" || chain.segment.parentId !== null || (chain.niche && chain.niche.level !== "niche") || (chain.ultraNiche && chain.ultraNiche.level !== "ultra_niche") || (chain.ultraNiche && !chain.niche)) {
@@ -297,7 +321,11 @@ function provenance(
 }
 
 function sameTaxon(left: LandingPageInputCatalogLayer["taxon"], right: NonNullable<LandingPageInputCatalogLayer["taxon"]>): boolean {
-  return !!left && left.id === right.id && left.slug === right.slug && left.level === right.level && left.parentId === right.parentId && left.isActive === right.isActive;
+  return !!left && left.id === right.id && left.name === right.name && left.slug === right.slug && left.level === right.level && left.parentId === right.parentId && left.isActive === right.isActive;
+}
+
+function layerRank(level: LandingPageInputCatalogLayerLevel): number {
+  return { universal: 0, segment: 1, niche: 2, ultra_niche: 3 }[level];
 }
 
 function specializedWithoutProvenance(field: ResolvedLandingPageInputField): LandingPageInputFieldDefinition {

--- a/lib/conversion-content/landing-page/input-catalog/resolver.ts
+++ b/lib/conversion-content/landing-page/input-catalog/resolver.ts
@@ -112,6 +112,8 @@ export function resolveLandingPageInputCatalogFromRegistry(
 
   const plan = input.plan as LandingPageInputCatalogPlan;
   const effectiveFields = fields.filter((field) => field.allowedPlans.includes(plan));
+  const effectiveConditionError = validateConditions(effectiveFields);
+  if (effectiveConditionError) return effectiveConditionError;
 
   const servedTaxon = input.taxonChain.ultraNiche ?? input.taxonChain.niche ?? input.taxonChain.segment;
   return {
@@ -231,6 +233,12 @@ function validateConditions(fields: readonly LandingPageInputFieldDefinition[]):
       const referenced = byKey.get(condition.fieldKey);
       if (!referenced || !conditionIsCompatible(referenced, condition)) {
         return invalid("INVALID_CONDITION", `Invalid condition on ${field.fieldKey}`);
+      }
+      if (field.allowedPlans.some((plan) => !referenced.allowedPlans.includes(plan))) {
+        return invalid(
+          "INVALID_CONDITION",
+          `Conditioned field plans must be a subset of referenced field plans: ${field.fieldKey}`,
+        );
       }
       edges.set(field.fieldKey, [...(edges.get(field.fieldKey) ?? []), condition.fieldKey]);
     }

--- a/lib/conversion-content/landing-page/input-catalog/schema.ts
+++ b/lib/conversion-content/landing-page/input-catalog/schema.ts
@@ -1,0 +1,326 @@
+import { z } from "zod";
+
+import {
+  landingPageInputCatalogEvidenceReferences,
+  landingPageInputCatalogPlans,
+  type LandingPageInputCondition,
+  type LandingPageInputFieldDefinition,
+  type LandingPageInputValueValidationResult,
+} from "./contracts";
+
+const nonEmptyText = z.string().trim().min(1);
+const fieldKeySchema = z.string().regex(/^[a-z][a-z0-9_]*$/);
+const planSchema = z.enum(landingPageInputCatalogPlans);
+const layerLevelSchema = z.enum([
+  "universal",
+  "segment",
+  "niche",
+  "ultra_niche",
+]);
+const taxonLevelSchema = z.enum(["segment", "niche", "ultra_niche"]);
+
+export const landingPageInputCatalogTaxonIdentitySchema = z
+  .object({
+    id: z.uuid(),
+    name: nonEmptyText,
+    slug: z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
+    level: taxonLevelSchema,
+    isActive: z.boolean(),
+    parentId: z.uuid().nullable(),
+  })
+  .strict();
+
+export const landingPageInputConditionSchema = z
+  .object({
+    fieldKey: fieldKeySchema,
+    operator: z.enum(["equals", "in"]),
+    value: z.union([
+      nonEmptyText,
+      z.boolean(),
+      z.array(nonEmptyText).min(1),
+    ]),
+  })
+  .strict()
+  .superRefine((condition, context) => {
+    if (condition.operator === "in" && !Array.isArray(condition.value)) {
+      context.addIssue({
+        code: "custom",
+        path: ["value"],
+        message: "in requires an array value",
+      });
+    }
+    if (condition.operator === "equals" && Array.isArray(condition.value)) {
+      context.addIssue({
+        code: "custom",
+        path: ["value"],
+        message: "equals requires a scalar value",
+      });
+    }
+  });
+
+const validationSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("type_only") }).strict(),
+  z
+    .object({
+      kind: z.literal("enum"),
+      allowedValues: z.array(nonEmptyText).min(1),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("string_list"),
+      allowedValues: z.array(nonEmptyText).min(1).optional(),
+      minItems: z.number().int().min(1).optional(),
+      maxItems: z.number().int().min(1).optional(),
+    })
+    .strict()
+    .superRefine((validation, context) => {
+      if (
+        validation.minItems !== undefined &&
+        validation.maxItems !== undefined &&
+        validation.minItems > validation.maxItems
+      ) {
+        context.addIssue({ code: "custom", message: "list limits are inverted" });
+      }
+    }),
+  z
+    .object({
+      kind: z.literal("number_range"),
+      currency: z.literal("BRL"),
+      minimum: z.number().finite().min(0).optional(),
+      maximum: z.number().finite().min(0).optional(),
+    })
+    .strict()
+    .superRefine((validation, context) => {
+      if (
+        validation.minimum !== undefined &&
+        validation.maximum !== undefined &&
+        validation.minimum > validation.maximum
+      ) {
+        context.addIssue({ code: "custom", message: "range limits are inverted" });
+      }
+    }),
+  z.object({ kind: z.literal("e164") }).strict(),
+  z.object({ kind: z.literal("email") }).strict(),
+  z.object({ kind: z.literal("https_url") }).strict(),
+  z.object({ kind: z.literal("keyword_map") }).strict(),
+]);
+
+const evidenceSchema = z
+  .object({
+    summary: nonEmptyText,
+    references: z
+      .array(z.enum(landingPageInputCatalogEvidenceReferences))
+      .min(1),
+  })
+  .strict();
+
+export const landingPageInputFieldDefinitionSchema = z
+  .object({
+    kind: z.literal("field"),
+    fieldKey: fieldKeySchema,
+    purpose: nonEmptyText,
+    originLayer: layerLevelSchema,
+    originTaxon: landingPageInputCatalogTaxonIdentitySchema.optional(),
+    valueType: z.enum([
+      "string",
+      "phone",
+      "email",
+      "url",
+      "enum",
+      "string_list",
+      "boolean",
+      "number_range",
+      "keyword_map",
+    ]),
+    valueScope: z.enum([
+      "account",
+      "business",
+      "offer",
+      "campaign",
+      "landing_page",
+    ]),
+    expectedValueOrigin: z.enum([
+      "account_provided",
+      "business_provided",
+      "offer_provided",
+      "campaign_provided",
+      "landing_page_provided",
+    ]),
+    obligation: z.enum(["required", "optional", "conditional"]),
+    requiredWhen: landingPageInputConditionSchema.optional(),
+    applicableWhen: landingPageInputConditionSchema.optional(),
+    validation: validationSchema,
+    allowedPlans: z.array(planSchema).min(1),
+    snapshotPolicy: z.literal("include_if_used"),
+    evidence: evidenceSchema,
+    createdInVersion: z.number().int().min(1),
+  })
+  .strict()
+  .superRefine((field, context) => {
+    if (field.originLayer === "universal" && field.originTaxon) {
+      context.addIssue({ code: "custom", path: ["originTaxon"], message: "universal field cannot have a taxon" });
+    }
+    if (field.originLayer !== "universal" && !field.originTaxon) {
+      context.addIssue({ code: "custom", path: ["originTaxon"], message: "taxon layer requires a taxon" });
+    }
+    if (field.originTaxon && field.originTaxon.level !== field.originLayer) {
+      context.addIssue({ code: "custom", path: ["originTaxon", "level"], message: "origin taxon level mismatch" });
+    }
+    if (field.obligation === "conditional" && !field.requiredWhen) {
+      context.addIssue({ code: "custom", path: ["requiredWhen"], message: "conditional field requires requiredWhen" });
+    }
+    if (field.obligation !== "conditional" && field.requiredWhen) {
+      context.addIssue({ code: "custom", path: ["requiredWhen"], message: "non-conditional field cannot declare requiredWhen" });
+    }
+    if (field.requiredWhen?.fieldKey === field.fieldKey || field.applicableWhen?.fieldKey === field.fieldKey) {
+      context.addIssue({ code: "custom", message: "field condition cannot reference itself" });
+    }
+    if (new Set(field.allowedPlans).size !== field.allowedPlans.length) {
+      context.addIssue({ code: "custom", path: ["allowedPlans"], message: "plans must be unique" });
+    }
+    validateValueTypeAndValidation(field, context);
+  });
+
+export const landingPageInputFieldSpecializationSchema = z
+  .object({
+    kind: z.literal("specialization"),
+    fieldKey: fieldKeySchema,
+    changes: z.record(z.string(), z.unknown()),
+  })
+  .strict();
+
+export const landingPageInputCatalogLayerSchema = z
+  .object({
+    level: layerLevelSchema,
+    taxon: landingPageInputCatalogTaxonIdentitySchema.optional(),
+    entries: z.array(
+      z.union([
+        landingPageInputFieldDefinitionSchema,
+        landingPageInputFieldSpecializationSchema,
+      ]),
+    ),
+  })
+  .strict()
+  .superRefine((layer, context) => {
+    if (layer.level === "universal" && layer.taxon) {
+      context.addIssue({ code: "custom", path: ["taxon"], message: "universal layer cannot have a taxon" });
+    }
+    if (layer.level !== "universal" && !layer.taxon) {
+      context.addIssue({ code: "custom", path: ["taxon"], message: "taxon layer requires identity" });
+    }
+    if (layer.taxon && layer.taxon.level !== layer.level) {
+      context.addIssue({ code: "custom", path: ["taxon", "level"], message: "layer and taxon level mismatch" });
+    }
+  });
+
+export function evaluateLandingPageInputCondition(
+  condition: LandingPageInputCondition,
+  context: Readonly<Record<string, unknown>>,
+): boolean {
+  const actual = context[condition.fieldKey];
+  return condition.operator === "equals"
+    ? actual === condition.value
+    : Array.isArray(condition.value) && condition.value.includes(actual as never);
+}
+
+export function validateLandingPageInputValue(
+  field: LandingPageInputFieldDefinition,
+  value: unknown,
+  context: Readonly<Record<string, unknown>> = {},
+): LandingPageInputValueValidationResult {
+  if (field.applicableWhen && !evaluateLandingPageInputCondition(field.applicableWhen, context)) {
+    return { ok: false, error: { code: "NOT_APPLICABLE", message: `${field.fieldKey} is not applicable` } };
+  }
+
+  const valid = validateValue(field, value);
+  return valid
+    ? { ok: true }
+    : { ok: false, error: { code: "INVALID_VALUE", message: `Invalid value for ${field.fieldKey}` } };
+}
+
+function validateValue(field: LandingPageInputFieldDefinition, value: unknown): boolean {
+  switch (field.valueType) {
+    case "string":
+      return typeof value === "string" && value.trim().length > 0;
+    case "phone":
+      return typeof value === "string" && /^\+[1-9]\d{7,14}$/.test(value);
+    case "email":
+      return typeof value === "string" && z.string().trim().email().safeParse(value).success;
+    case "url": {
+      if (typeof value !== "string") return false;
+      try {
+        return new URL(value).protocol === "https:";
+      } catch {
+        return false;
+      }
+    }
+    case "enum":
+      return typeof value === "string" && field.validation.kind === "enum" && field.validation.allowedValues.includes(value);
+    case "boolean":
+      return typeof value === "boolean";
+    case "string_list":
+      return validateStringList(field, value);
+    case "number_range":
+      return validateNumberRange(field, value);
+    case "keyword_map":
+      return validateKeywordMap(value);
+  }
+}
+
+function validateStringList(field: LandingPageInputFieldDefinition, value: unknown): boolean {
+  if (!Array.isArray(value) || value.length === 0 || !value.every((item) => typeof item === "string" && item.trim())) return false;
+  const normalized = value.map((item) => item.trim().toLocaleLowerCase("pt-BR"));
+  if (new Set(normalized).size !== normalized.length) return false;
+  if (field.validation.kind !== "string_list") return false;
+  if (field.validation.minItems !== undefined && value.length < field.validation.minItems) return false;
+  if (field.validation.maxItems !== undefined && value.length > field.validation.maxItems) return false;
+  return !field.validation.allowedValues || normalized.every((item) => field.validation.kind === "string_list" && field.validation.allowedValues?.some((allowed) => allowed.toLocaleLowerCase("pt-BR") === item));
+}
+
+function validateNumberRange(field: LandingPageInputFieldDefinition, value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const range = value as Record<string, unknown>;
+  if (Object.keys(range).some((key) => !["minimum", "maximum", "currency"].includes(key))) return false;
+  if (typeof range.minimum !== "number" || typeof range.maximum !== "number" || range.currency !== "BRL") return false;
+  if (!Number.isFinite(range.minimum) || !Number.isFinite(range.maximum) || range.minimum < 0 || range.minimum > range.maximum) return false;
+  if (field.validation.kind !== "number_range") return false;
+  if (field.validation.minimum !== undefined && range.minimum < field.validation.minimum) return false;
+  return field.validation.maximum === undefined || range.maximum <= field.validation.maximum;
+}
+
+function validateKeywordMap(value: unknown): boolean {
+  if (!Array.isArray(value) || value.length === 0) return false;
+  const seen = new Set<string>();
+  for (const item of value) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) return false;
+    const mapItem = item as Record<string, unknown>;
+    if (Object.keys(mapItem).some((key) => !["keyword_or_cluster", "message_anchor", "ad_context"].includes(key))) return false;
+    if (typeof mapItem.keyword_or_cluster !== "string" || !mapItem.keyword_or_cluster.trim()) return false;
+    if (typeof mapItem.message_anchor !== "string" || !mapItem.message_anchor.trim()) return false;
+    if (mapItem.ad_context !== undefined && (typeof mapItem.ad_context !== "string" || !mapItem.ad_context.trim())) return false;
+    const normalized = mapItem.keyword_or_cluster.trim().toLocaleLowerCase("pt-BR");
+    if (seen.has(normalized)) return false;
+    seen.add(normalized);
+  }
+  return true;
+}
+
+function validateValueTypeAndValidation(field: z.infer<typeof landingPageInputFieldDefinitionSchema>, context: z.RefinementCtx) {
+  const expectedKind: Partial<Record<typeof field.valueType, typeof field.validation.kind>> = {
+    phone: "e164",
+    email: "email",
+    url: "https_url",
+    enum: "enum",
+    string_list: "string_list",
+    number_range: "number_range",
+    keyword_map: "keyword_map",
+  };
+  const expected = expectedKind[field.valueType];
+  if (expected && field.validation.kind !== expected) {
+    context.addIssue({ code: "custom", path: ["validation"], message: "validation is incompatible with value type" });
+  }
+  if ((field.valueType === "string" || field.valueType === "boolean") && field.validation.kind !== "type_only") {
+    context.addIssue({ code: "custom", path: ["validation"], message: "type-only field has incompatible validation" });
+  }
+}

--- a/lib/conversion-content/landing-page/input-catalog/schema.ts
+++ b/lib/conversion-content/landing-page/input-catalog/schema.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 import {
   landingPageInputCatalogEvidenceReferences,
   landingPageInputCatalogPlans,
-  type LandingPageInputCondition,
   type LandingPageInputFieldDefinition,
   type LandingPageInputValueValidationResult,
 } from "./contracts";
@@ -75,6 +74,15 @@ const validationSchema = z.discriminatedUnion("kind", [
     })
     .strict()
     .superRefine((validation, context) => {
+      for (const key of ["allowedValues", "minItems", "maxItems"] as const) {
+        if (Object.hasOwn(validation, key) && validation[key] === undefined) {
+          context.addIssue({
+            code: "custom",
+            path: [key],
+            message: "unset string-list constraints must be omitted",
+          });
+        }
+      }
       if (
         validation.minItems !== undefined &&
         validation.maxItems !== undefined &&
@@ -214,25 +222,10 @@ export const landingPageInputCatalogLayerSchema = z
     }
   });
 
-export function evaluateLandingPageInputCondition(
-  condition: LandingPageInputCondition,
-  context: Readonly<Record<string, unknown>>,
-): boolean {
-  const actual = context[condition.fieldKey];
-  return condition.operator === "equals"
-    ? actual === condition.value
-    : Array.isArray(condition.value) && condition.value.includes(actual as never);
-}
-
 export function validateLandingPageInputValue(
   field: LandingPageInputFieldDefinition,
   value: unknown,
-  context: Readonly<Record<string, unknown>> = {},
 ): LandingPageInputValueValidationResult {
-  if (field.applicableWhen && !evaluateLandingPageInputCondition(field.applicableWhen, context)) {
-    return { ok: false, error: { code: "NOT_APPLICABLE", message: `${field.fieldKey} is not applicable` } };
-  }
-
   const valid = validateValue(field, value);
   return valid
     ? { ok: true }

--- a/lib/conversion-content/landing-page/input-catalog/validation-cases.ts
+++ b/lib/conversion-content/landing-page/input-catalog/validation-cases.ts
@@ -1,0 +1,414 @@
+import assert from "node:assert/strict";
+
+import type {
+  LandingPageInputCatalogLayer,
+  LandingPageInputCatalogLayerEntry,
+  LandingPageInputCatalogRegistry,
+  LandingPageInputFieldDefinition,
+  LandingPageInputFieldSpecialization,
+  ResolveLandingPageInputCatalogInput,
+} from "./contracts";
+import {
+  landingPageInputCatalogRegistry,
+  mediumStandardRealEstateBrokerTaxon,
+  realEstateBrokerNicheTaxon,
+  realEstateSegmentTaxon,
+} from "./registry";
+import {
+  resolveLandingPageInputCatalog,
+  resolveLandingPageInputCatalogFromRegistry,
+} from "./resolver";
+import {
+  landingPageInputFieldDefinitionSchema,
+  validateLandingPageInputValue,
+} from "./schema";
+
+type Case = Readonly<{ name: string; run: () => void }>;
+
+const baseInput: ResolveLandingPageInputCatalogInput = {
+  version: 1,
+  plan: "starter",
+  taxonChain: {
+    segment: realEstateSegmentTaxon,
+    niche: realEstateBrokerNicheTaxon,
+    ultraNiche: mediumStandardRealEstateBrokerTaxon,
+  },
+};
+
+const cases: Case[] = [
+  {
+    name: "registry v1 resolves the ordered real-estate catalog",
+    run: () => {
+      const result = resolveLandingPageInputCatalog(baseInput);
+      assert.equal(result.ok, true);
+      assert.equal(result.value.valid, true);
+      assert.equal(result.value.fields.length, 19);
+      assert.deepEqual(result.value.fields.map((field) => field.fieldKey), [
+        "business_display_name", "funnel_stage", "traffic_source", "primary_conversion_channel",
+        "whatsapp_destination", "phone_destination", "email_destination", "external_url_destination",
+        "privacy_policy_url", "paid_search_keyword_map", "service_locations", "property_types",
+        "property_price_range", "property_stage", "transaction_intent", "financing_support_available",
+        "document_support_available", "creci_registration", "attendance_modes",
+      ]);
+    },
+  },
+  {
+    name: "unknown version fails closed",
+    run: () => assertError({ ...baseInput, version: 999 }, "UNKNOWN_VERSION"),
+  },
+  {
+    name: "unknown plan fails closed",
+    run: () => assertError({ ...baseInput, plan: "enterprise" }, "INVALID_PLAN"),
+  },
+  {
+    name: "inactive or out-of-order taxon chain fails closed",
+    run: () => {
+      assertError({
+        ...baseInput,
+        taxonChain: {
+          ...baseInput.taxonChain,
+          niche: { ...realEstateBrokerNicheTaxon, isActive: false },
+        },
+      }, "INVALID_TAXON_CHAIN");
+      assertError({
+        ...baseInput,
+        taxonChain: {
+          ...baseInput.taxonChain,
+          niche: { ...realEstateBrokerNicheTaxon, parentId: mediumStandardRealEstateBrokerTaxon.id },
+        },
+      }, "INVALID_TAXON_CHAIN");
+    },
+  },
+  {
+    name: "valid universal catalog resolves without a registered taxon layer",
+    run: () => {
+      const result = resolveLandingPageInputCatalog({
+        version: 1,
+        plan: "starter",
+        taxonChain: {
+          segment: { ...realEstateSegmentTaxon, id: "11111111-1111-4111-8111-111111111111", slug: "outro-segmento", name: "Outro segmento" },
+        },
+      });
+      assert.equal(result.ok, true);
+      assert.equal(result.value.fields.length, 10);
+    },
+  },
+  {
+    name: "segment and niche layers append fields deterministically",
+    run: () => {
+      const result = resolveLandingPageInputCatalog({ ...baseInput, taxonChain: { segment: realEstateSegmentTaxon, niche: realEstateBrokerNicheTaxon } });
+      assert.equal(result.ok, true);
+      assert.equal(result.value.fields[9].fieldKey, "paid_search_keyword_map");
+      assert.equal(result.value.fields[10].fieldKey, "service_locations");
+      assert.equal(result.value.fields[14].fieldKey, "transaction_intent");
+    },
+  },
+  {
+    name: "ultra-niche without its own layer inherits completely",
+    run: () => {
+      const result = resolveLandingPageInputCatalog(baseInput);
+      assert.equal(result.ok, true);
+      assert.equal(result.value.servedTaxon.slug, "corretor-de-imoveis-de-medio-padrao");
+      assert.deepEqual(result.value.appliedLayers.map((layer) => layer.level), ["universal", "segment", "niche"]);
+    },
+  },
+  {
+    name: "authorized ultra-niche layer resolves and unauthorized layer fails",
+    run: () => {
+      const registry = cloneRegistry();
+      mutableTaxonLayers(registry)[mediumStandardRealEstateBrokerTaxon.slug] = ultraLayer();
+      assertRegistryError(baseInput, registry, "UNAUTHORIZED_ULTRA_NICHE_LAYER");
+      const result = resolveLandingPageInputCatalogFromRegistry({ ...baseInput, ultraNicheLayerAuthorized: true }, registry);
+      assert.equal(result.ok, true);
+      assert.equal(result.value.fields.at(-1)?.fieldKey, "authorized_ultra_fixture");
+    },
+  },
+  {
+    name: "new lower-layer field appends at the end of that layer",
+    run: () => {
+      const registry = cloneRegistry();
+      mutableEntries(segmentLayer(registry)).push(fixtureField("segment_fixture", "segment", realEstateSegmentTaxon));
+      const result = resolveLandingPageInputCatalogFromRegistry(baseInput, registry);
+      assert.equal(result.ok, true);
+      assert.equal(result.value.fields[14].fieldKey, "segment_fixture");
+      assert.equal(result.value.fields[15].fieldKey, "transaction_intent");
+    },
+  },
+  {
+    name: "duplicate field without specialization fails closed",
+    run: () => {
+      const registry = cloneRegistry();
+      mutableEntries(segmentLayer(registry)).push({
+        ...fixtureField("business_display_name", "segment", realEstateSegmentTaxon),
+      });
+      assertRegistryError(baseInput, registry, "DUPLICATE_FIELD");
+    },
+  },
+  {
+    name: "valid specialization preserves position and inherited properties",
+    run: () => {
+      const registry = withNicheSpecialization("traffic_source", { obligation: "required" });
+      const result = resolveLandingPageInputCatalogFromRegistry(baseInput, registry);
+      assert.equal(result.ok, true);
+      const field = result.value.fields[2];
+      assert.equal(field.fieldKey, "traffic_source");
+      assert.equal(field.valueType, "enum");
+      assert.equal(field.obligation, "required");
+      assert.deepEqual(field.provenance.map((item) => item.property), ["definition", "obligation"]);
+    },
+  },
+  {
+    name: "immutable identity type scope origin condition snapshot and evidence changes fail",
+    run: () => {
+      for (const changes of [
+        { purpose: "changed" }, { valueType: "string" }, { valueScope: "account" },
+        { expectedValueOrigin: "account_provided" }, { applicableWhen: { fieldKey: "funnel_stage", operator: "equals", value: "bofu" } },
+        { snapshotPolicy: "other" }, { evidence: { summary: "changed", references: ["decision:lp-planning"] } },
+      ]) {
+        assertRegistryError(baseInput, withNicheSpecialization("traffic_source", changes), "IMMUTABLE_PROPERTY_CONFLICT");
+      }
+    },
+  },
+  {
+    name: "more restrictive obligation is accepted and relaxation fails",
+    run: () => {
+      assert.equal(resolveLandingPageInputCatalogFromRegistry(baseInput, withNicheSpecialization("traffic_source", { obligation: "required" })).ok, true);
+      assertRegistryError(baseInput, withNicheSpecialization("business_display_name", { obligation: "optional" }), "INVALID_SPECIALIZATION");
+    },
+  },
+  {
+    name: "enum subset is accepted and expansion fails",
+    run: () => {
+      const reduced = withNicheSpecialization("traffic_source", { validation: { kind: "enum", allowedValues: ["paid_search", "organic"] } });
+      assert.equal(resolveLandingPageInputCatalogFromRegistry(baseInput, reduced).ok, true);
+      const expanded = withNicheSpecialization("traffic_source", { validation: { kind: "enum", allowedValues: ["paid_search", "paid_social", "organic", "whatsapp", "qr_code", "other", "partner"] } });
+      assertRegistryError(baseInput, expanded, "INVALID_SPECIALIZATION");
+    },
+  },
+  {
+    name: "plan subset is accepted and expansion fails",
+    run: () => {
+      const reduced = withNicheSpecialization("traffic_source", { allowedPlans: ["starter", "lite"] });
+      assert.equal(resolveLandingPageInputCatalogFromRegistry(baseInput, reduced).ok, true);
+      const inheritedSubset = withNicheSpecialization("traffic_source", { allowedPlans: ["starter", "lite"] });
+      mutableEntries(nicheLayer(inheritedSubset)).push(specialization("traffic_source", { allowedPlans: ["starter", "lite", "pro"] }));
+      assertRegistryError(baseInput, inheritedSubset, "INVALID_SPECIALIZATION");
+    },
+  },
+  {
+    name: "string-list limits can only restrict coherently",
+    run: () => {
+      const restricted = withNicheSpecialization("service_locations", { validation: { kind: "string_list", minItems: 2, maxItems: 5 } });
+      assert.equal(resolveLandingPageInputCatalogFromRegistry(baseInput, restricted).ok, true);
+      assertRegistryError(baseInput, withNicheSpecialization("service_locations", { validation: { kind: "string_list", minItems: 0 } }), "INVALID_SPECIALIZATION");
+      assertRegistryError(baseInput, withNicheSpecialization("service_locations", { validation: { kind: "string_list", minItems: 5, maxItems: 2 } }), "INVALID_SPECIALIZATION");
+    },
+  },
+  {
+    name: "number-range limits can only restrict coherently",
+    run: () => {
+      const restricted = withNicheSpecialization("property_price_range", { validation: { kind: "number_range", currency: "BRL", minimum: 100000, maximum: 900000 } });
+      assert.equal(resolveLandingPageInputCatalogFromRegistry(baseInput, restricted).ok, true);
+      assertRegistryError(baseInput, withNicheSpecialization("property_price_range", { validation: { kind: "number_range", currency: "BRL", minimum: -1 } }), "INVALID_SPECIALIZATION");
+      assertRegistryError(baseInput, withNicheSpecialization("property_price_range", { validation: { kind: "number_range", currency: "BRL", minimum: 10, maximum: 5 } }), "INVALID_SPECIALIZATION");
+    },
+  },
+  {
+    name: "text regex and custom format specialization fail",
+    run: () => {
+      assertRegistryError(baseInput, withNicheSpecialization("business_display_name", { regex: ".+" }), "IMMUTABLE_PROPERTY_CONFLICT");
+      assertRegistryError(baseInput, withNicheSpecialization("business_display_name", { format: "custom" }), "IMMUTABLE_PROPERTY_CONFLICT");
+    },
+  },
+  {
+    name: "missing incompatible and circular conditions fail",
+    run: () => {
+      assertRegistryError(baseInput, mutateUniversalField("whatsapp_destination", (field) => {
+        field.requiredWhen = { fieldKey: "missing", operator: "equals", value: "whatsapp" };
+        field.applicableWhen = field.requiredWhen;
+      }), "INVALID_CONDITION");
+      assertRegistryError(baseInput, mutateUniversalField("whatsapp_destination", (field) => {
+        field.requiredWhen = { fieldKey: "financing_support_available", operator: "equals", value: "yes" };
+        field.applicableWhen = field.requiredWhen;
+      }), "INVALID_CONDITION");
+      const circular = mutateUniversalField("traffic_source", (field) => {
+        field.applicableWhen = { fieldKey: "paid_search_keyword_map", operator: "equals", value: "x" };
+      });
+      mutableUniversalField(circular, "paid_search_keyword_map").applicableWhen = { fieldKey: "traffic_source", operator: "equals", value: "paid_search" };
+      assertRegistryError(baseInput, circular, "INVALID_CONDITION");
+    },
+  },
+  {
+    name: "conversion destinations appear only for the selected channel",
+    run: () => {
+      const destinations: Record<string, string> = {
+        whatsapp: "whatsapp_destination", phone: "phone_destination", email: "email_destination", external_url: "external_url_destination",
+      };
+      for (const [channel, expected] of Object.entries(destinations)) {
+        const result = resolveLandingPageInputCatalog({ ...baseInput, applicabilityContext: { primary_conversion_channel: channel } });
+        assert.equal(result.ok, true);
+        const present = result.value.fields.map((field) => field.fieldKey).filter((key) => key.endsWith("_destination"));
+        assert.deepEqual(present, [expected]);
+      }
+    },
+  },
+  {
+    name: "form channel exposes privacy policy and no channel destination",
+    run: () => {
+      const result = resolveLandingPageInputCatalog({ ...baseInput, applicabilityContext: { primary_conversion_channel: "form" } });
+      assert.equal(result.ok, true);
+      assert.equal(result.value.fields.some((field) => field.fieldKey === "privacy_policy_url"), true);
+      assert.equal(result.value.fields.some((field) => field.fieldKey.endsWith("_destination")), false);
+    },
+  },
+  {
+    name: "paid-search keyword map is optional applicable and strictly validated",
+    run: () => {
+      const paid = resolveLandingPageInputCatalog({ ...baseInput, applicabilityContext: { traffic_source: "paid_search" } });
+      assert.equal(paid.ok, true);
+      const field = paid.value.fields.find((candidate) => candidate.fieldKey === "paid_search_keyword_map");
+      assert.ok(field);
+      assert.equal(validateLandingPageInputValue(field, [], { traffic_source: "paid_search" }).ok, false);
+      assert.equal(validateLandingPageInputValue(field, [{ keyword_or_cluster: "apartamento centro", message_anchor: "Atendimento na região" }], { traffic_source: "paid_search" }).ok, true);
+      assert.equal(validateLandingPageInputValue(field, [{ keyword_or_cluster: "apartamento", message_anchor: "A" }, { keyword_or_cluster: "APARTAMENTO", message_anchor: "B" }], { traffic_source: "paid_search" }).ok, false);
+      const notPaid = validateLandingPageInputValue(field, [{ keyword_or_cluster: "apartamento", message_anchor: "A" }], { traffic_source: "organic" });
+      assert.equal(notPaid.ok, false);
+      assert.equal(notPaid.error.code, "NOT_APPLICABLE");
+    },
+  },
+  {
+    name: "starter lite pro and ultra are functionally equivalent",
+    run: () => {
+      const snapshots = ["starter", "lite", "pro", "ultra"].map((plan) => {
+        const result = resolveLandingPageInputCatalog({ ...baseInput, plan });
+        assert.equal(result.ok, true);
+        return result.value.fields;
+      });
+      for (const snapshot of snapshots.slice(1)) assert.deepEqual(snapshot, snapshots[0]);
+    },
+  },
+  {
+    name: "result and registry contain no operational values entitlement or generation snapshot",
+    run: () => {
+      const result = resolveLandingPageInputCatalog(baseInput);
+      assert.equal(result.ok, true);
+      const serialized = JSON.stringify(result.value);
+      assert.equal(/providedValues|operationalValues|entitlement|subscription|stripe|generationSnapshot/i.test(serialized), false);
+      assert.equal(serialized.includes("include_if_used"), true);
+    },
+  },
+  {
+    name: "registry and resolved result are deeply immutable",
+    run: () => {
+      assert.equal(Object.isFrozen(landingPageInputCatalogRegistry), true);
+      assert.equal(Object.isFrozen(landingPageInputCatalogRegistry[1].universal.entries), true);
+      assert.throws(() => {
+        (landingPageInputCatalogRegistry[1].universal.entries as LandingPageInputCatalogLayerEntry[]).push(fixtureField("forbidden"));
+      }, TypeError);
+      const result = resolveLandingPageInputCatalog(baseInput);
+      assert.equal(result.ok, true);
+      assert.equal(Object.isFrozen(result.value.fields[0].evidence.references), true);
+      assert.throws(() => {
+        (result.value.fields[0].allowedPlans as string[]).push("other");
+      }, TypeError);
+    },
+  },
+  {
+    name: "invalid validation and missing evidence fail closed",
+    run: () => {
+      assert.equal(landingPageInputFieldDefinitionSchema.safeParse({ ...fixtureField("bad_validation"), valueType: "email", validation: { kind: "type_only" } }).success, false);
+      const missingEvidence = mutateUniversalField("business_display_name", (field) => {
+        field.evidence = { summary: "", references: [] };
+      });
+      assertRegistryError(baseInput, missingEvidence, "MISSING_EVIDENCE_ORIGIN");
+      const invalidKeywordMap = mutateUniversalField("paid_search_keyword_map", (field) => {
+        field.validation = { kind: "type_only" };
+      });
+      assertRegistryError(baseInput, invalidKeywordMap, "INVALID_PAID_SEARCH_KEYWORD_MAP");
+    },
+  },
+];
+
+for (const validationCase of cases) {
+  validationCase.run();
+  console.log(`ok - ${validationCase.name}`);
+}
+
+function assertError(input: ResolveLandingPageInputCatalogInput, code: string) {
+  const result = resolveLandingPageInputCatalog(input);
+  assert.equal(result.ok, false);
+  assert.equal(result.error.code, code);
+}
+
+function assertRegistryError(input: ResolveLandingPageInputCatalogInput, registry: LandingPageInputCatalogRegistry, code: string) {
+  const result = resolveLandingPageInputCatalogFromRegistry(input, registry);
+  assert.equal(result.ok, false);
+  assert.equal(result.error.code, code);
+}
+
+function cloneRegistry(): LandingPageInputCatalogRegistry {
+  return JSON.parse(JSON.stringify(landingPageInputCatalogRegistry)) as LandingPageInputCatalogRegistry;
+}
+
+function mutableTaxonLayers(registry: LandingPageInputCatalogRegistry): Record<string, LandingPageInputCatalogLayer> {
+  return registry[1].taxonLayers as Record<string, LandingPageInputCatalogLayer>;
+}
+
+function segmentLayer(registry: LandingPageInputCatalogRegistry) {
+  return registry[1].taxonLayers[realEstateSegmentTaxon.slug];
+}
+
+function nicheLayer(registry: LandingPageInputCatalogRegistry) {
+  return registry[1].taxonLayers[realEstateBrokerNicheTaxon.slug];
+}
+
+function mutableEntries(layer: LandingPageInputCatalogLayer): LandingPageInputCatalogLayerEntry[] {
+  return layer.entries as LandingPageInputCatalogLayerEntry[];
+}
+
+function mutableUniversalField(registry: LandingPageInputCatalogRegistry, fieldKey: string): MutableField {
+  const field = registry[1].universal.entries.find((entry) => entry.fieldKey === fieldKey && entry.kind === "field");
+  assert.ok(field && field.kind === "field");
+  return field as MutableField;
+}
+
+function mutateUniversalField(fieldKey: string, mutate: (field: MutableField) => void) {
+  const registry = cloneRegistry();
+  mutate(mutableUniversalField(registry, fieldKey));
+  return registry;
+}
+
+function withNicheSpecialization(fieldKey: string, changes: Record<string, unknown>) {
+  const registry = cloneRegistry();
+  mutableEntries(nicheLayer(registry)).push(specialization(fieldKey, changes));
+  return registry;
+}
+
+function specialization(fieldKey: string, changes: Record<string, unknown>): LandingPageInputFieldSpecialization {
+  return { kind: "specialization", fieldKey, changes } as LandingPageInputFieldSpecialization;
+}
+
+function fixtureField(
+  fieldKey: string,
+  originLayer: LandingPageInputFieldDefinition["originLayer"] = "universal",
+  originTaxon?: LandingPageInputFieldDefinition["originTaxon"],
+): LandingPageInputFieldDefinition {
+  return {
+    kind: "field", fieldKey, purpose: "Executable structural fixture.", originLayer, originTaxon,
+    valueType: "string", valueScope: "business", expectedValueOrigin: "business_provided",
+    obligation: "optional", validation: { kind: "type_only" }, allowedPlans: ["starter", "lite", "pro", "ultra"],
+    snapshotPolicy: "include_if_used", evidence: { summary: "Fixture backed by the approved human decision.", references: ["decision:e20-2-human"] }, createdInVersion: 1,
+  };
+}
+
+function ultraLayer(): LandingPageInputCatalogLayer {
+  return {
+    level: "ultra_niche",
+    taxon: mediumStandardRealEstateBrokerTaxon,
+    entries: [fixtureField("authorized_ultra_fixture", "ultra_niche", mediumStandardRealEstateBrokerTaxon)],
+  };
+}
+
+type MutableField = {
+  -readonly [Key in keyof LandingPageInputFieldDefinition]: LandingPageInputFieldDefinition[Key];
+};

--- a/lib/conversion-content/landing-page/input-catalog/validation-cases.ts
+++ b/lib/conversion-content/landing-page/input-catalog/validation-cases.ts
@@ -247,14 +247,47 @@ const cases: Case[] = [
   {
     name: "plan subset is accepted and expansion fails",
     run: () => {
-      const reduced = withNicheSpecialization("traffic_source", { allowedPlans: ["starter", "lite"] });
+      const reduced = withNicheSpecialization("business_display_name", { allowedPlans: ["starter", "lite"] });
       assert.equal(resolveLandingPageInputCatalogFromRegistry(baseInput, reduced).ok, true);
       const inheritedSubset = cloneRegistry();
       mutableEntries(segmentLayer(inheritedSubset)).push(
+        specialization("business_display_name", { allowedPlans: ["starter", "lite"] }),
+      );
+      mutableEntries(nicheLayer(inheritedSubset)).push(specialization("business_display_name", { allowedPlans: ["starter", "lite", "pro"] }));
+      assertRegistryError(baseInput, inheritedSubset, "INVALID_SPECIALIZATION");
+    },
+  },
+  {
+    name: "conditioned field plans cannot exceed referenced field plans",
+    run: () => {
+      const registry = cloneRegistry();
+      mutableEntries(segmentLayer(registry)).push(
         specialization("traffic_source", { allowedPlans: ["starter", "lite"] }),
       );
-      mutableEntries(nicheLayer(inheritedSubset)).push(specialization("traffic_source", { allowedPlans: ["starter", "lite", "pro"] }));
-      assertRegistryError(baseInput, inheritedSubset, "INVALID_SPECIALIZATION");
+      assertRegistryError(baseInput, registry, "INVALID_CONDITION");
+    },
+  },
+  {
+    name: "joint plan restriction keeps or removes conditioned fields coherently",
+    run: () => {
+      const registry = cloneRegistry();
+      mutableEntries(segmentLayer(registry)).push(
+        specialization("traffic_source", { allowedPlans: ["starter", "lite"] }),
+        specialization("paid_search_keyword_map", { allowedPlans: ["starter", "lite"] }),
+      );
+
+      const starter = resolveLandingPageInputCatalogFromRegistry(baseInput, registry);
+      assert.equal(starter.ok, true);
+      assert.equal(starter.value.fields.some((field) => field.fieldKey === "traffic_source"), true);
+      assert.equal(starter.value.fields.some((field) => field.fieldKey === "paid_search_keyword_map"), true);
+
+      const pro = resolveLandingPageInputCatalogFromRegistry(
+        { ...baseInput, plan: "pro" },
+        registry,
+      );
+      assert.equal(pro.ok, true);
+      assert.equal(pro.value.fields.some((field) => field.fieldKey === "traffic_source"), false);
+      assert.equal(pro.value.fields.some((field) => field.fieldKey === "paid_search_keyword_map"), false);
     },
   },
   {

--- a/lib/conversion-content/landing-page/input-catalog/validation-cases.ts
+++ b/lib/conversion-content/landing-page/input-catalog/validation-cases.ts
@@ -7,6 +7,7 @@ import type {
   LandingPageInputFieldDefinition,
   LandingPageInputFieldSpecialization,
   ResolveLandingPageInputCatalogInput,
+  ResolvedLandingPageInputField,
 } from "./contracts";
 import {
   landingPageInputCatalogRegistry,
@@ -37,7 +38,7 @@ const baseInput: ResolveLandingPageInputCatalogInput = {
 
 const cases: Case[] = [
   {
-    name: "registry v1 resolves the ordered real-estate catalog",
+    name: "registry v1 resolves all 19 ordered fields without operational context",
     run: () => {
       const result = resolveLandingPageInputCatalog(baseInput);
       assert.equal(result.ok, true);
@@ -77,6 +78,18 @@ const cases: Case[] = [
           niche: { ...realEstateBrokerNicheTaxon, parentId: mediumStandardRealEstateBrokerTaxon.id },
         },
       }, "INVALID_TAXON_CHAIN");
+    },
+  },
+  {
+    name: "taxon name mismatch between chain and registered layer fails closed",
+    run: () => {
+      assertError({
+        ...baseInput,
+        taxonChain: {
+          ...baseInput.taxonChain,
+          niche: { ...realEstateBrokerNicheTaxon, name: "Nome divergente" },
+        },
+      }, "INVALID_LAYER");
     },
   },
   {
@@ -135,6 +148,29 @@ const cases: Case[] = [
     },
   },
   {
+    name: "field origin layer must match its containing layer",
+    run: () => {
+      const registry = cloneRegistry();
+      mutableLayerField(segmentLayer(registry), "service_locations").originLayer = "niche";
+      assertRegistryError(baseInput, registry, "INVALID_LAYER");
+    },
+  },
+  {
+    name: "field origin taxon must exactly match its containing layer taxon",
+    run: () => {
+      const registry = cloneRegistry();
+      mutableLayerField(segmentLayer(registry), "service_locations").originTaxon = {
+        ...realEstateSegmentTaxon,
+        name: "Imobiliário divergente",
+      };
+      assertRegistryError(baseInput, registry, "INVALID_LAYER");
+
+      const universalRegistry = cloneRegistry();
+      mutableUniversalField(universalRegistry, "business_display_name").originTaxon = realEstateSegmentTaxon;
+      assertRegistryError(baseInput, universalRegistry, "INVALID_LAYER");
+    },
+  },
+  {
     name: "duplicate field without specialization fails closed",
     run: () => {
       const registry = cloneRegistry();
@@ -145,7 +181,7 @@ const cases: Case[] = [
     },
   },
   {
-    name: "valid specialization preserves position and inherited properties",
+    name: "valid specialization in a lower layer preserves position and inherited properties",
     run: () => {
       const registry = withNicheSpecialization("traffic_source", { obligation: "required" });
       const result = resolveLandingPageInputCatalogFromRegistry(baseInput, registry);
@@ -155,6 +191,29 @@ const cases: Case[] = [
       assert.equal(field.valueType, "enum");
       assert.equal(field.obligation, "required");
       assert.deepEqual(field.provenance.map((item) => item.property), ["definition", "obligation"]);
+    },
+  },
+  {
+    name: "field followed by specialization in the same layer fails closed",
+    run: () => {
+      const registry = cloneRegistry();
+      mutableEntries(segmentLayer(registry)).push(
+        specialization("service_locations", { obligation: "required" }),
+      );
+      assertRegistryError(baseInput, registry, "INVALID_SPECIALIZATION");
+    },
+  },
+  {
+    name: "two specializations of the same field in one layer fail closed",
+    run: () => {
+      const registry = cloneRegistry();
+      mutableEntries(segmentLayer(registry)).push(
+        specialization("traffic_source", { obligation: "required" }),
+        specialization("traffic_source", {
+          validation: { kind: "enum", allowedValues: ["paid_search", "organic"] },
+        }),
+      );
+      assertRegistryError(baseInput, registry, "INVALID_SPECIALIZATION");
     },
   },
   {
@@ -190,7 +249,10 @@ const cases: Case[] = [
     run: () => {
       const reduced = withNicheSpecialization("traffic_source", { allowedPlans: ["starter", "lite"] });
       assert.equal(resolveLandingPageInputCatalogFromRegistry(baseInput, reduced).ok, true);
-      const inheritedSubset = withNicheSpecialization("traffic_source", { allowedPlans: ["starter", "lite"] });
+      const inheritedSubset = cloneRegistry();
+      mutableEntries(segmentLayer(inheritedSubset)).push(
+        specialization("traffic_source", { allowedPlans: ["starter", "lite"] }),
+      );
       mutableEntries(nicheLayer(inheritedSubset)).push(specialization("traffic_source", { allowedPlans: ["starter", "lite", "pro"] }));
       assertRegistryError(baseInput, inheritedSubset, "INVALID_SPECIALIZATION");
     },
@@ -239,41 +301,43 @@ const cases: Case[] = [
     },
   },
   {
-    name: "conversion destinations appear only for the selected channel",
+    name: "conversion destination conditions remain declarative in the complete result",
     run: () => {
-      const destinations: Record<string, string> = {
-        whatsapp: "whatsapp_destination", phone: "phone_destination", email: "email_destination", external_url: "external_url_destination",
+      const result = resolveLandingPageInputCatalog(baseInput);
+      assert.equal(result.ok, true);
+      const conditions: Record<string, string> = {
+        whatsapp_destination: "whatsapp",
+        phone_destination: "phone",
+        email_destination: "email",
+        external_url_destination: "external_url",
       };
-      for (const [channel, expected] of Object.entries(destinations)) {
-        const result = resolveLandingPageInputCatalog({ ...baseInput, applicabilityContext: { primary_conversion_channel: channel } });
-        assert.equal(result.ok, true);
-        const present = result.value.fields.map((field) => field.fieldKey).filter((key) => key.endsWith("_destination"));
-        assert.deepEqual(present, [expected]);
+      for (const [fieldKey, channel] of Object.entries(conditions)) {
+        const resolvedField: ResolvedLandingPageInputField | undefined =
+          result.value.fields.find((candidate) => candidate.fieldKey === fieldKey);
+        assert.ok(resolvedField);
+        const expected = { fieldKey: "primary_conversion_channel", operator: "equals", value: channel };
+        assert.deepEqual(resolvedField.requiredWhen, expected);
+        assert.deepEqual(resolvedField.applicableWhen, expected);
       }
     },
   },
   {
-    name: "form channel exposes privacy policy and no channel destination",
+    name: "form and paid-search conditions remain declarative",
     run: () => {
-      const result = resolveLandingPageInputCatalog({ ...baseInput, applicabilityContext: { primary_conversion_channel: "form" } });
+      const result = resolveLandingPageInputCatalog(baseInput);
       assert.equal(result.ok, true);
-      assert.equal(result.value.fields.some((field) => field.fieldKey === "privacy_policy_url"), true);
-      assert.equal(result.value.fields.some((field) => field.fieldKey.endsWith("_destination")), false);
-    },
-  },
-  {
-    name: "paid-search keyword map is optional applicable and strictly validated",
-    run: () => {
-      const paid = resolveLandingPageInputCatalog({ ...baseInput, applicabilityContext: { traffic_source: "paid_search" } });
-      assert.equal(paid.ok, true);
-      const field = paid.value.fields.find((candidate) => candidate.fieldKey === "paid_search_keyword_map");
-      assert.ok(field);
-      assert.equal(validateLandingPageInputValue(field, [], { traffic_source: "paid_search" }).ok, false);
-      assert.equal(validateLandingPageInputValue(field, [{ keyword_or_cluster: "apartamento centro", message_anchor: "Atendimento na região" }], { traffic_source: "paid_search" }).ok, true);
-      assert.equal(validateLandingPageInputValue(field, [{ keyword_or_cluster: "apartamento", message_anchor: "A" }, { keyword_or_cluster: "APARTAMENTO", message_anchor: "B" }], { traffic_source: "paid_search" }).ok, false);
-      const notPaid = validateLandingPageInputValue(field, [{ keyword_or_cluster: "apartamento", message_anchor: "A" }], { traffic_source: "organic" });
-      assert.equal(notPaid.ok, false);
-      assert.equal(notPaid.error.code, "NOT_APPLICABLE");
+      const privacy = result.value.fields.find((field) => field.fieldKey === "privacy_policy_url");
+      const keywordMap = result.value.fields.find((field) => field.fieldKey === "paid_search_keyword_map");
+      assert.ok(privacy);
+      assert.ok(keywordMap);
+      const formCondition = { fieldKey: "primary_conversion_channel", operator: "equals", value: "form" };
+      assert.deepEqual(privacy.requiredWhen, formCondition);
+      assert.deepEqual(privacy.applicableWhen, formCondition);
+      assert.equal(keywordMap.obligation, "optional");
+      assert.deepEqual(keywordMap.applicableWhen, { fieldKey: "traffic_source", operator: "equals", value: "paid_search" });
+      assert.equal(validateLandingPageInputValue(keywordMap, []).ok, false);
+      assert.equal(validateLandingPageInputValue(keywordMap, [{ keyword_or_cluster: "apartamento centro", message_anchor: "Atendimento na região" }]).ok, true);
+      assert.equal(validateLandingPageInputValue(keywordMap, [{ keyword_or_cluster: "apartamento", message_anchor: "A" }, { keyword_or_cluster: "APARTAMENTO", message_anchor: "B" }]).ok, false);
     },
   },
   {
@@ -317,6 +381,8 @@ const cases: Case[] = [
     name: "invalid validation and missing evidence fail closed",
     run: () => {
       assert.equal(landingPageInputFieldDefinitionSchema.safeParse({ ...fixtureField("bad_validation"), valueType: "email", validation: { kind: "type_only" } }).success, false);
+      assert.equal(landingPageInputFieldDefinitionSchema.safeParse({ ...fixtureField("bad_string_list"), valueType: "string_list", validation: { kind: "type_only" } }).success, false);
+      assert.equal(landingPageInputFieldDefinitionSchema.safeParse({ ...fixtureField("undefined_string_list_limits"), valueType: "string_list", validation: { kind: "string_list", allowedValues: undefined } }).success, false);
       const missingEvidence = mutateUniversalField("business_display_name", (field) => {
         field.evidence = { summary: "", references: [] };
       });
@@ -367,7 +433,11 @@ function mutableEntries(layer: LandingPageInputCatalogLayer): LandingPageInputCa
 }
 
 function mutableUniversalField(registry: LandingPageInputCatalogRegistry, fieldKey: string): MutableField {
-  const field = registry[1].universal.entries.find((entry) => entry.fieldKey === fieldKey && entry.kind === "field");
+  return mutableLayerField(registry[1].universal, fieldKey);
+}
+
+function mutableLayerField(layer: LandingPageInputCatalogLayer, fieldKey: string): MutableField {
+  const field = layer.entries.find((entry) => entry.fieldKey === fieldKey && entry.kind === "field");
   assert.ok(field && field.kind === "field");
   return field as MutableField;
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "validate:commercial-activation": "tsx lib/conversion-content/commercial-activation/validation-cases.ts",
     "validate:landing-page-root": "tsx lib/conversion-content/landing-page/root-validation-cases.ts",
-    "validate:landing-page-research": "tsx lib/conversion-content/landing-page/research-resolution/validation-cases.ts"
+    "validate:landing-page-research": "tsx lib/conversion-content/landing-page/research-resolution/validation-cases.ts",
+    "validate:landing-page-input-catalog": "tsx lib/conversion-content/landing-page/input-catalog/validation-cases.ts"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "1.1.7",

--- a/supabase/snippets/e20_2_taxon_chain_verify.sql
+++ b/supabase/snippets/e20_2_taxon_chain_verify.sql
@@ -1,0 +1,46 @@
+with recursive
+  params as (
+    select 'corretor-de-imoveis-de-medio-padrao'::text as requested_taxon_slug
+  ),
+  taxon_chain as (
+    select
+      taxon.id,
+      taxon.name,
+      taxon.slug,
+      taxon.level,
+      taxon.is_active,
+      taxon.parent_id,
+      0::integer as depth,
+      array[taxon.id]::uuid[] as visited_ids
+    from public.business_taxons as taxon
+    cross join params
+    where taxon.slug = params.requested_taxon_slug
+
+    union all
+
+    select
+      parent.id,
+      parent.name,
+      parent.slug,
+      parent.level,
+      parent.is_active,
+      parent.parent_id,
+      child.depth + 1,
+      child.visited_ids || parent.id
+    from taxon_chain as child
+    join public.business_taxons as parent
+      on parent.id = child.parent_id
+    where not (parent.id = any(child.visited_ids))
+      and child.depth < 2
+  )
+select
+  id,
+  name,
+  slug,
+  level,
+  is_active,
+  parent_id,
+  depth
+from taxon_chain
+order by depth desc
+limit 3


### PR DESCRIPTION
## O que mudou

- adiciona contratos tipados, registry v1, schema estrito e resolver puro para o catálogo de entradas de `landing_page`;
- implementa herança `universal → segmento → nicho → ultranicho autorizado`, especializações restritivas, proveniência e imutabilidade profunda;
- adiciona o primeiro catálogo imobiliário com 19 campos, sem camada própria para o ultranicho de médio padrão;
- adiciona snippet SQL read-only para comprovação da cadeia taxonômica e matriz executável com 32 casos;
- atualiza somente o export agregado, o script npm e o registro factual do plano-base.

## Ajustes após análise

- remove `applicabilityContext`: o resolver retorna todos os campos permitidos pelo plano e preserva `requiredWhen`/`applicableWhen` sem avaliar valores operacionais;
- exige correspondência integral entre definição, camada de origem e taxon, incluindo nome e relações;
- exige que cada especialização esteja em nível estritamente mais específico que a definição e especializações anteriores;
- rejeita definição seguida de especialização na mesma camada e especializações duplicadas na mesma camada;
- restringe `type_only` a `string` e `boolean`; `string_list` usa sempre `kind: string_list`;
- exige que os planos do campo condicionado sejam subconjunto dos planos do campo referenciado;
- revalida condições após o filtro pelo plano solicitado, rejeitando referências a campos removidos.

## Por quê

Materializa e corrige a fase E20.2.3–E20.2.6 após o merge do plano-base v2 no PR #573, mantendo separados catálogo declarativo, aplicabilidade/completude de valores da E19.4, snapshot e entitlement comercial.

## Evidência read-only

A consulta executada no projeto Supabase `LP-Factory-10` confirmou a cadeia ativa `imobiliario` → `corretor-imoveis` → `corretor-de-imoveis-de-medio-padrao`, com níveis e relações pai-filho coerentes. Nenhuma escrita ou migration foi executada.

## Validações

- `npm ci` — aprovado na implementação original; audit reportou 13 vulnerabilidades na árvore instalada, sem mudança de dependências
- `npm run check` — aprovado, com 24 warnings preexistentes e nenhum erro
- `npm run validate:landing-page-input-catalog` — aprovado em 32 casos
- `git diff --check` — aprovado

## Impacto

Consumidores futuros podem resolver um catálogo versionado e fail-closed por taxon e plano, recebendo todas as condições declarativas sem consulta a banco, Stripe ou dados operacionais e sem concessão de acesso comercial. A avaliação concreta das condições permanece sob responsabilidade da E19.4.