### PR TITLE
docs: exige merge antes do relatório final

### DIFF
--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -117,7 +117,7 @@ Regra:
 • se o teste reprovar, voltar ao item 7.
 
 10. Relatório final ao Gestor de Docs
-      Emitir relatório ao Gestor de Docs apenas ao final do plano, após aprovação da última fase ou decisão explícita de encerramento.
+   Emitir o relatório somente após o PR final da execução estar mergeado e o plano encerrado por aprovação da última fase ou decisão explícita de encerramento.
 
 Registrar apenas o que ocorreu, informar a decisão documental do roadmap e marcar N/A quando não se aplicar.
 


### PR DESCRIPTION
### Motivation
- Garantir que o relatório final ao Gestor de Docs só seja emitido após o PR final da execução estar mergeado e o plano estar oficialmente encerrado.

### Description
- Substituí a frase inicial do item 10 em `docs/prompt-estrategista.md` para: “Emitir o relatório somente após o PR final da execução estar mergeado e o plano encerrado por aprovação da última fase ou decisão explícita de encerramento.”, preservando `Versão: v21` e todo o restante do item e do arquivo; nenhuma outra alteração foi feita.

### Testing
- Executei `git diff --check`, `git diff --name-only` e `rg` para confirmar que apenas `docs/prompt-estrategista.md` foi alterado e que apenas a abertura do item 10 foi modificada; commit criado `b91efdd` na branch `docs/exige-merge-relatorio-final`; `git push -u origin docs/exige-merge-relatorio-final` falhou porque não há remote `origin` configurado; `npm ci` e `npm run check` não se aplicam por se tratar de alteração exclusivamente documental.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56969ec2d48329afbc779156a591ec)