### PR TITLE
Adiciona orquestração integrada de planos-base

### DIFF
--- a/.agents/skills/lp-factory-orquestrar-plano/SKILL.md
+++ b/.agents/skills/lp-factory-orquestrar-plano/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: lp-factory-orquestrar-plano
+description: Orquestrar a produção e o gate de um plano-base v2 do LP Factory 10 a partir de um PR de plano-base v1, usando uma worktree de automação já preparada, o Gestor Estrutural e o Analista. Usar quando o humano informar o número ou a URL do PR e pedir para executar, orquestrar ou automatizar a revisão do plano.
+---
+
+# Orquestrar plano-base v2
+
+Conduzir o primeiro fluxo integrado de revisão do plano-base. Manter o task principal como orquestrador e executor; usar os custom agents somente para avaliações read-only.
+
+## Entrada humana
+
+Aceitar como comando suficiente o número ou a URL do PR que contém o plano-base v1, por exemplo:
+
+`Use $lp-factory-orquestrar-plano no PR #577.`
+
+Não exigir do humano nomes de agentes, paths, branches, matriz ou etapas internas. Pedir informação adicional somente diante de ambiguidade que impeça selecionar com segurança o plano ou a worktree de destino.
+
+## Fontes obrigatórias
+
+Antes de executar:
+
+1. Ler `docs/orquestracao-plano-base.md`.
+2. Ler `docs/analista.md`.
+3. Ler e seguir `.agents/skills/lp-factory-avaliar-plano-estrutura/SKILL.md` na delegação estrutural.
+4. Ler e seguir `.agents/skills/lp-factory-avaliar-plano-analista/SKILL.md` no gate do Analista.
+
+Não copiar nem reinterpretar os contratos canônicos desses arquivos.
+
+## 1. Congelar a fonte v1
+
+1. Confirmar repositório, número, URL, estado, base, head e head SHA do PR informado.
+2. Listar os arquivos do PR e selecionar automaticamente o plano somente quando houver exatamente um path compatível com `docs/lousa-plano-base-*.md`.
+3. Se nenhum plano ou mais de um plano for encontrado, pedir somente o path exato.
+4. Obter o conteúdo integral do plano pelo head SHA do PR.
+5. Registrar head SHA, blob SHA, path e caso ou recorte como referência imutável da v1.
+6. Não editar a branch head do PR nem alterar o PR de origem.
+
+## 2. Selecionar a worktree de automação
+
+O task principal pode estar aberto no projeto local padrão. Direcionar todas as mutações ao checkout de automação selecionado, sem trocar ou editar a `main`.
+
+1. Listar as worktrees Git já registradas.
+2. Considerar candidatas somente worktrees:
+   - limpas;
+   - fora da `main`;
+   - em branch compatível com `codex-app/*-v2-orquestracao`;
+   - cujo histórico contenha o head SHA da v1;
+   - cujo plano, antes das alterações, corresponda ao blob SHA congelado.
+3. Selecionar automaticamente somente quando existir exatamente uma candidata.
+4. Se não houver candidata ou houver mais de uma, parar e pedir apenas o path da worktree de automação.
+5. Recusar worktree ou branch destinada ao processo atual/manual, incluindo branches compatíveis com `*-v2-processo-atual`.
+
+Neste primeiro recorte, não criar worktree nem branch automaticamente.
+
+## 3. Preparar as fontes do caso
+
+1. Confirmar o caso e a seção competente de `docs/roadmap.md`.
+2. Identificar casos adjacentes, dependências e consumidores relevantes.
+3. Identificar `docs/base-tecnica.md` e outras fontes técnicas necessárias ao recorte.
+4. Obter o plano conceitual somente quando houver referência competente ou vínculo inequívoco com o caso.
+5. Registrar `N/A` quando a inexistência de plano conceitual for confirmada; não escolher documento por semelhança.
+6. Identificar decisões humanas registradas que sejam fontes do plano.
+
+Parar quando faltar uma decisão material que altere produto, escopo ou arquitetura.
+
+## 4. Obter o parecer estrutural
+
+1. Executar o workflow de `lp-factory-avaliar-plano-estrutura` para a v1 congelada.
+2. Acionar exatamente um custom agent `gestor-estrutural` e preservar integralmente seu parecer.
+3. Não realizar avaliação estrutural paralela no task principal.
+4. Parar antes da v2 se o handoff estiver incompleto ou se a conclusão for `requer investigação` ou `rejeitado por conflito com fonte competente`.
+5. Permitir consolidação quando a conclusão for `aprovado`, `aprovado com condicionantes` ou `requer patch estrutural`, mantendo condicionantes e patches rastreáveis.
+
+Não acionar Gestor de Updates nem Gestor de Automações neste recorte.
+
+## 5. Produzir a v2 e a matriz
+
+1. Editar somente o plano correspondente dentro da worktree de automação.
+2. Preservar objetivo, decisões válidas e limites da v1; incorporar apenas tratamentos sustentados pelo parecer e pelas fontes competentes.
+3. Não implementar fases nem ampliar silenciosamente o escopo.
+4. Preparar uma matriz com uma linha por achado, usando o contrato de `docs/analista.md`.
+5. Manter a matriz fora do alcance do Analista até ele concluir a Passagem 1:
+   - não incluí-la no prompt ou nos turnos herdados;
+   - não gravá-la na worktree antes da conclusão independente;
+   - iniciar o Analista com `fork_turns=none`.
+6. Validar a v2 com `git diff --check` e criar um commit de checkpoint somente com o plano-base v2.
+7. Usar esse commit como referência imutável da v2 na Passagem 1.
+
+## 6. Executar o gate do Analista
+
+1. Executar a Passagem 1 de `lp-factory-avaliar-plano-analista` com v1, v2, plano conceitual ou `N/A`, decisões registradas e fontes do caso, sem parecer estrutural ou matriz.
+2. Preservar integralmente a resposta independente.
+3. Depois da Passagem 1, gravar a matriz em `docs/matriz-consolidacao-<caso>.md`, validar e criar novo checkpoint.
+4. Continuar no mesmo Analista e entregar o parecer estrutural completo e a matriz para a Passagem 2.
+5. Preservar integralmente a auditoria e a conclusão formal.
+
+## 7. Tratar a conclusão
+
+- `aprovado para merge do plano-base v2`: avançar para publicação.
+- `aprovado com correções obrigatórias`: corrigir a v2 e a matriz, criar nova referência imutável e solicitar `revisao_delta` ao mesmo Analista.
+- `requer nova rodada especializada`: devolver o delta ao Gestor Estrutural antes de retornar ao Analista.
+- `bloqueado por decisão humana`: parar e apresentar somente a decisão necessária, sem escolher pelo humano.
+
+Repetir o ciclo somente enquanto houver correções objetivas dentro do escopo. Não converter uma decisão material ausente em correção editorial.
+
+## 8. Publicar para decisão humana
+
+Somente após `aprovado para merge do plano-base v2`:
+
+1. Confirmar que o diff contém apenas o plano v2 e sua matriz.
+2. Verificar alterações acidentais, secrets, `.env`, banco e workflows.
+3. Executar `git diff --check`; tratar `npm ci` e `npm run check` como não aplicáveis quando o diff for exclusivamente documental.
+4. Commitar a versão final e publicar a branch de automação.
+5. Abrir um PR draft tendo como base a branch head do PR da v1; se a criação automática não estiver disponível, entregar o link de comparação com base e head preenchidos.
+6. Não fazer merge. O humano compara, decide e realiza o merge pelo GitHub Web.
+
+## Devolução ao humano
+
+Apresentar:
+
+- v1 avaliada e sua referência imutável;
+- worktree e branch de automação usadas;
+- conclusão integral do Gestor Estrutural;
+- Passagens 1 e 2 do Analista;
+- arquivos alterados;
+- commits e validações;
+- PR draft ou link de criação;
+- eventual decisão ou bloqueio pendente.
+
+## Limites
+
+- Não alterar a v1 nem o PR de origem.
+- Não editar ou commitar na `main`.
+- Não criar worktree ou branch neste primeiro recorte.
+- Não acionar especialistas fora do recorte.
+- Não permitir que custom agents editem arquivos.
+- Não executar fases do plano.
+- Não avaliar implementação ou PR de código.
+- Não fazer merge nem substituir decisão humana.

--- a/.agents/skills/lp-factory-orquestrar-plano/agents/openai.yaml
+++ b/.agents/skills/lp-factory-orquestrar-plano/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Orquestrar plano-base"
+  short_description: "Produz e valida a v2 com especialistas"
+  default_prompt: "Use $lp-factory-orquestrar-plano no PR #577."
+
+policy:
+  allow_implicit_invocation: false

--- a/docs/orquestracao-plano-base.md
+++ b/docs/orquestracao-plano-base.md
@@ -1,8 +1,8 @@
 # Orquestração de planos-base no Codex
 
 Data: 18/07/2026
-Versão: v0.2
-Status: planejamento em construção; teste do Gestor Estrutural validado; primeiro recorte do Analista implementado e pendente de teste real.
+Versão: v0.3
+Status: primeiro fluxo integrado implementado e pendente de teste real com Gestor Estrutural e Analista.
 
 ## 1. Objetivo e função deste documento
 
@@ -193,3 +193,48 @@ Este passo não inclui:
 - revisão do PR de implementação;
 - alteração do fluxo operacional vigente de `docs/prompt-estrategista.md` antes da aprovação do workflow completo;
 - merge automático ou decisão humana delegada ao Codex.
+
+## 4. Terceiro passo: skill de orquestração integrada
+
+O terceiro passo reúne os dois testes anteriores em uma única entrada humana. Foi criada a skill `lp-factory-orquestrar-plano`, localizada em `.agents/skills/lp-factory-orquestrar-plano/`.
+
+Ela não cria um novo custom agent. O task comum permanece como orquestrador e executor, enquanto `gestor-estrutural` e `analista` permanecem read-only e aplicam seus contratos existentes.
+
+### 4.1 Entrada mínima
+
+O humano informa somente o PR que contém o plano-base v1 e invoca explicitamente a skill:
+
+`Use $lp-factory-orquestrar-plano no PR #577.`
+
+Paths, branches, agentes e etapas internas são resolvidos pela skill. Informação adicional só pode ser solicitada quando houver ambiguidade real que impeça selecionar o plano ou a worktree correta.
+
+### 4.2 Destino das alterações
+
+A skill usa uma worktree de automação previamente criada e nunca altera a `main`, a branch do processo atual ou a branch head do PR da v1.
+
+Uma worktree só pode ser selecionada automaticamente quando estiver limpa, usar branch `codex-app/*-v2-orquestracao`, contiver o head SHA da v1 e ainda possuir o mesmo blob do plano congelado. Se não houver exatamente uma candidata, o fluxo pede somente o path correto e para.
+
+No primeiro teste E18.5, o destino esperado é:
+
+- worktree: `C:\Dev\GitHub\LP-Factory-10-e18-5-automacao`;
+- branch: `codex-app/e18-5-v2-orquestracao`;
+- fonte congelada: plano-base v1 do PR #577.
+
+### 4.3 Sequência integrada
+
+1. Congelar a v1 pelo head SHA e blob do PR informado.
+2. Selecionar e validar a worktree de automação já existente.
+3. Acionar o Gestor Estrutural e preservar o parecer integral.
+4. Produzir a v2 e preparar a matriz de consolidação.
+5. Criar referência imutável da v2 e acionar o Analista sem parecer ou matriz.
+6. Depois da Passagem 1, gravar a matriz e entregá-la com o parecer ao mesmo Analista.
+7. Corrigir ou encaminhar pendências conforme a conclusão formal.
+8. Publicar um PR draft empilhado contra a branch da v1 somente após aprovação do Analista.
+
+A matriz não é gravada antes da Passagem 1. Isso impede que a avaliação independente seja contaminada por um arquivo acessível na própria worktree.
+
+### 4.4 Limites do primeiro fluxo integrado
+
+Este recorte inclui somente Gestor Estrutural, consolidação pelo orquestrador e gate do Analista. Gestor de Updates, Gestor de Automações, execução das fases e revisão do PR de implementação continuam fora do fluxo até testes próprios.
+
+O teste será considerado válido quando uma instrução humana curta produzir uma v2 rastreável, duas passagens não contaminadas do Analista e um PR filho comparável, sem alteração da v1 e sem edição feita pelos custom agents.


### PR DESCRIPTION
## O que mudou

- adiciona a skill explícita `$lp-factory-orquestrar-plano`;
- coordena Gestor Estrutural, produção da v2/matriz e gate do Analista;
- seleciona uma worktree de automação já preparada, sem criar novo projeto, worktree ou custom agent;
- atualiza o planejamento canônico do fluxo integrado.

## Limites

O primeiro recorte não inclui Gestor de Updates, Gestor de Automações, execução do plano ou revisão de implementação. O merge permanece exclusivamente humano pelo GitHub Web.

## Validação

- validador oficial `quick_validate.py`: aprovado;
- `git diff --cached --check`: aprovado;
- `main..HEAD` e `main...HEAD`: somente os três arquivos previstos;
- `npm ci`: não aplicável (documentação/configuração de skill);
- `npm run check`: não aplicável (documentação/configuração de skill).