### PR TITLE
Corrige modelo dos agentes de orquestração

### DIFF
--- a/.codex/agents/analista.toml
+++ b/.codex/agents/analista.toml
@@ -1,6 +1,6 @@
 name = "analista"
 description = "Avalia a coerência e a suficiência de planos-base v2 e audita a incorporação dos pareceres especializados antes do merge do plano."
-model = "gpt-5.6"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/.codex/agents/gestor-estrutural.toml
+++ b/.codex/agents/gestor-estrutural.toml
@@ -1,6 +1,6 @@
 name = "gestor-estrutural"
 description = "Avalia planos-base do LP Factory 10 quanto a estrutura, boundaries, reuso, adapters, acoplamento, regressão e impacto em repositório ou banco."
-model = "gpt-5.6"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """


### PR DESCRIPTION
## O que mudou

- altera `gestor-estrutural` de `gpt-5.6` para `gpt-5.6-sol`;
- altera `analista` de `gpt-5.6` para `gpt-5.6-sol`;
- preserva `model_reasoning_effort = "high"` e o modo read-only.

## Motivo

O primeiro teste da orquestração parou corretamente porque o Codex App com conta ChatGPT rejeitou o identificador `gpt-5.6`. O slug explícito disponível nesta conta é `gpt-5.6-sol`.

## Validação

- ambos os arquivos TOML foram parseados com sucesso;
- `git diff --cached --check`: aprovado;
- `main..HEAD` e `main...HEAD`: somente os dois TOML previstos;
- worktree experimental permaneceu limpa;
- `npm ci`: não aplicável;
- `npm run check`: não aplicável.