### PR TITLE
docs: consolida plano-base v2 da E18.5

### DIFF
--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -4,7 +4,7 @@ Fontes: chat, `README.md`, `AGENTS.md`, `docs/roadmap.md`, `docs/base-tecnica.md
 
 Versão: v1 em ajuste.
 
-Status: plano simplificado; nove módulos mantidos no escopo; `hero`, `hero.standard@v1`, `trust_bar`, `trust_bar.standard@v1`, `problem_solution`, `problem_solution.standard@v1`, `offer`, `offer.standard@v1`, `process`, `process.standard@v1`, `technical_assurance`, `technical_assurance.standard@v1`, `social_proof` e `social_proof.standard@v1` conceitualmente fechados; dois módulos pendentes; nenhuma implementação autorizada neste PR.
+Status: plano simplificado; nove módulos mantidos no escopo; `hero`, `hero.standard@v1`, `trust_bar`, `trust_bar.standard@v1`, `problem_solution`, `problem_solution.standard@v1`, `offer`, `offer.standard@v1`, `process`, `process.standard@v1`, `technical_assurance`, `technical_assurance.standard@v1`, `social_proof`, `social_proof.standard@v1`, `faq` e `faq.standard@v1` conceitualmente fechados; um módulo pendente; nenhuma implementação autorizada neste PR.
 
 Path: `docs/lousa-plano-base-e18-5.md`.
 
@@ -48,7 +48,7 @@ Regras:
 - `item_key` é evidência de pesquisa, não identidade canônica do módulo.
 - Os módulos são transversais e não recebem identidade de taxon.
 - Formatos curto, médio e longo pertencem à composição e à extensão da LP.
-- O próximo módulo para análise é `faq`.
+- O próximo módulo para análise é `final_cta`.
 
 ### 1.4. Escopo positivo
 
@@ -844,16 +844,44 @@ Estado:
 - contrato conceitualmente fechado; lifecycle `experimental`; propósito `controlled_test`;
 - implementação ainda não autorizada por este ajuste documental.
 
+### 3.15. Módulo `faq`
+
+- `moduleKey = faq`; `moduleVersion = 1`.
+- Função: responder dúvidas e objeções recorrentes em pares claros de pergunta e resposta, apoiando compreensão e decisão.
+- Invariantes: cada pergunta é relevante e possui resposta direta; fatos e condições reais exigem sustentação; não há aconselhamento individualizado, promessa ou resposta enganosa.
+- Fronteiras: não substitui oferta, processo ou prova técnica; não contém CTA, mídia, formulário, ação ou interação na execução inicial.
+- Evidências: `faq_objeções` de `lp_sections`, `faq_questions` e `search_intent` de `seo`, `objection`, `fear`, `belief` e `awareness_level` de `strategic_core` e Blueprint do corretor.
+- Variantes futuras podem usar outra execução estrutural sem alterar `faq.standard@v1`.
+
+### 3.16. Variante `faq.standard@v1`
+
+- Identidade: `variantKey = faq.standard`; `variantVersion = 1`; compatível com `faq@v1` e com a versão vigente da raiz; única variante inicial.
+- Campos:
+  - `title`: texto, papel `h2`, `1..1`, policy `research_guided`;
+  - `items`: coleção `2..6`, policy `not_copy`, com `question` (`faq_question`, `1..1`, `research_guided`) e `answer` (`faq_answer`, `1..1`, `hybrid`, suporte `when_factual`).
+- Copy:
+  - `title`: primárias `objection` e `awareness_level`; auxiliar `search_intent`;
+  - `question`: primárias `objection` e `fear`; auxiliar `faq_questions`;
+  - `answer`: primárias `belief` e `positioning_opportunity`; auxiliar `desire`.
+- Regras e validações:
+  - exigir de dois a seis pares completos, sem perguntas vazias ou duplicadas;
+  - cada resposta deve tratar diretamente sua pergunta e fatos operacionais, legais, técnicos ou financeiros exigem suporte real;
+  - usar `h2`, `faq_question` e `faq_answer` da raiz sem especialização;
+  - rejeitar coleção aninhada, campos extras, CTA, mídia, formulário, ação, interação ou aconselhamento individualizado;
+  - funil altera seleção, ordem e profundidade, sem alterar campos, cardinalidades ou variante;
+  - ausência de pares válidos depende da obrigatoriedade da E20 e será tratada pela E19;
+  - resolver de forma fail-closed e imutável.
+- Estado: contrato conceitualmente fechado; lifecycle `experimental`; propósito `controlled_test`; implementação ainda não autorizada.
+
 ## 4. Módulos pendentes
 
 ### 4.1. Estado
 
-Permanecem pendentes:
+Permanece pendente:
 
-- `faq`;
 - `final_cta`.
 
-Cada um receberá:
+Ele receberá:
 
 - contrato permanente do módulo;
 - variante `standard@v1`;
@@ -874,8 +902,8 @@ A etapa seguinte só deve reproduzir o contrato compartilhado após ele estar va
 
 ### 4.3. Próxima ação
 
-- Analisar `faq` pelo checklist mínimo da seção 2.9.
-- Separar `faq` de `faq.standard@v1`.
+- Analisar `final_cta` pelo checklist mínimo da seção 2.9.
+- Separar `final_cta` de `final_cta.standard@v1`.
 - Não alterar o arquivo novamente sem decisão humana sobre o contrato proposto.
 - Não implementar código durante o fechamento conceitual.
 

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -4,7 +4,7 @@ Fontes: chat; `README.md`; `AGENTS.md`; `docs/prompt-estrategista.md`; `docs/pro
 
 Versão: v2 consolidada com patch final do Analista.
 
-Status: plano-base aprovado humanamente em 19/07/2026 para implementação manual comparativa da fase 3.1 em branch filha própria; PR #585 permanece documental, draft e sem merge durante o experimento.
+Status: plano-base aprovado humanamente em 19/07/2026 para implementação manual comparativa, fase a fase, das subseções 18.5.3 a 18.5.9 em branch filha própria; PR #585 permanece documental, draft e sem merge durante o experimento.
 
 Path: `docs/lousa-plano-base-e18-5.md`.
 
@@ -14,7 +14,7 @@ Branches:
 - v2 somente em `codex-app/e18-5-v2-processo-atual`;
 - não alterar diretamente o PR #577;
 - PR #585 compara a v2 manual contra a branch congelada do PR #577;
-- aprovação humana deste patch autoriza somente a criação da branch de implementação manual comparativa;
+- aprovação humana deste patch autoriza somente a criação da branch de implementação manual comparativa e o início da fase 18.5.3;
 - nenhum PR experimental deve ser mergeado antes da comparação com o workflow automatizado.
 
 ## 1. Estado e decisões fixas
@@ -65,7 +65,8 @@ Aceito:
 - aplicação obrigatória do `absoluteMax` da raiz com os helpers canônicos de normalização e contagem;
 - assinatura pública inequívoca do resolver e exposição dos três lifecycles mais o lifecycle efetivo;
 - paths literais em `copySourceMap` e teste de compatibilidade dos canais com o catálogo de entradas;
-- fluxo experimental sem merge, com duas entregas irmãs comparadas a partir do mesmo baseline.
+- fluxo experimental sem merge, com duas entregas irmãs comparadas a partir do mesmo baseline;
+- execução dividida nas fases 18.5.3 a 18.5.9, alinhadas às subseções futuras previstas em `docs/lp-planejamento.md`.
 
 Rejeitado:
 
@@ -537,83 +538,243 @@ Depois da comparação:
 
 ### 3.2. Regras comuns
 
-- Todos: `lifecycleStatus=hypothesis`, `purpose=controlled_test` e `rootDelta={}`.
+- Todos: lifecycle hypothesis, purpose controlled_test e `rootDelta={}`.
 - Suporte real conforme fields; Problem Solution sem alarmismo.
 - Social Proof sem fabricação/alteração material.
 - FAQ sem duplicidade ou fato sem suporte.
-- Hero e Final CTA excluem `form`.
+- Hero/Final CTA excluem form.
 - Accordion valida contrato declarativo, não comportamento.
 - Nenhum contrato armazena destino concreto ou taxon.
 
-## 4. Fase e próxima ação
+## 4. Fases e próxima ação
 
-### 4.1. Fase 3.1 — E18.5.3–E18.5.9 — Catálogo repo-only
+Regra geral:
+
+- o plano contém todas as fases executáveis necessárias ao recorte aprovado;
+- o Executor recebe somente a fase atual, uma por vez, na ordem abaixo;
+- cada avanço depende de avaliação do Analista e decisão do Estrategista;
+- as sete fases usam os identificadores das futuras subseções do roadmap previstos em `docs/lp-planejamento.md`;
+- todas as fases têm `Automação: não`;
+- `18.5.10 — Limites do recorte` não é fase executável e será materializada pelas regras de escopo negativo e parada deste plano;
+- as fases usam a mesma branch e o mesmo PR draft de implementação manual comparativa, sem merge durante o experimento.
+
+### 4.1. Fase 1 — E18.5.3 — Módulos e funções estruturais
 
 - Automação: não.
 
-Sequência:
-
-1. contracts, schemas, registry, API e raiz;
-2. FAQ Standard/Accordion;
-3. prova das duas variantes;
-4. demais módulos;
-5. integração e não regressão.
-
 Entregas:
 
-- somente arquivos da seção 2.7;
-- registry imutável, resolver/validator fail-closed, namespace e script;
-- sem banco, rede ou renderer.
+- criar a base interna de `contracts.ts`, `schema.ts`, `registry.ts`, `validation-cases.ts` e o script `validate:landing-page-module-catalog`;
+- registrar `family=landing_page`, `moduleCatalogVersion=1`, `compatibleRootVersions=[1]` e os nove módulos;
+- definir para cada módulo `moduleKey`, `moduleVersion`, função, fronteiras, invariantes, lifecycle inicial e purpose;
+- manter o catálogo parcial sem export público para consumidores até a fase 18.5.9.
 
 Critérios:
 
-- `landingPageRoot` preserva o contrato da raiz e reexporta somente os dois helpers canônicos de texto; resolver usa exclusivamente a API pública da raiz;
-- versões, identidades, fields, policies, supports, maps, treatments, `ctaMode`, capabilities, lifecycle e compatibilidade usam somente valores literais fechados;
-- rootDelta vazio, form rejeitado, FAQs independentes;
-- Accordion somente declarativo WCAG 2.2;
-- payload cobre todos os `fieldKind`, aplica normalização e `absoluteMax` da raiz e rejeita aliases, desconhecidos e combinações inválidas;
-- erros sem copy, pesquisa, PII, credenciais ou secrets;
-- output profundamente imutável;
-- nenhum consumidor ou família preservada é alterado, salvo o reexport aditivo dos helpers da raiz e a verificação test-only contra o catálogo de entradas.
+- nove identidades de módulo exatas e sem colisão com `commercial_activation`;
+- nenhum módulo contém taxon, campanha, plano, copy, ativo, ordem ou conteúdo concreto;
+- funções, fronteiras e invariantes são imutáveis e fail-closed;
+- nenhuma variante, field, map ou profile é antecipado como contrato público.
 
 Validações:
 
 - `npm ci`;
+- `npm run validate:landing-page-module-catalog` com os casos desta fase;
+- `npm run check`;
+- `git diff --check`.
+
+### 4.2. Fase 2 — E18.5.4 — Campos, estruturas e cardinalidades
+
+- Automação: não.
+
+Entregas:
+
+- implementar a gramática fechada de `fieldKind`, policies, supports e cardinalidades;
+- implementar os shapes de `text`, `collection`, `action`, `image` e `reference`;
+- definir os paths e contratos de fields previstos para os nove módulos, ainda sem publicar variantes;
+- criar a base do `payload-validator.ts` para keys, tipos, cardinalidades e shapes.
+
+Critérios:
+
+- somente literais aprovados são aceitos;
+- coleção aninhada, path desconhecido, combinação inválida ou field adicional falha fechado;
+- ação não armazena destino concreto;
+- imagem informativa/decorativa e `evidenceRef` seguem os shapes fechados;
+- o catálogo continua sem API pública consumível.
+
+Validações:
+
+- casos positivos e negativos de todos os `fieldKind`;
+- cardinalidades mínimas e máximas;
+- `npm run validate:landing-page-module-catalog`;
+- `npm run check`;
+- `git diff --check`.
+
+### 4.3. Fase 3 — E18.5.5 — Variantes e critérios de criação
+
+- Automação: não.
+
+Entregas:
+
+- registrar as nove variantes `standard@v1` e `faq.accordion@v1`;
+- vincular os fields definidos na fase anterior às dez variantes;
+- implementar `primary_action`, `image_asset` e `accordion_interaction`;
+- usar FAQ Standard e Accordion como prova inicial de duas variantes do mesmo módulo.
+
+Critérios:
+
+- cada variante pertence a um único módulo e versão compatível;
+- FAQ Accordion possui contrato próprio, sem herança semântica da FAQ Standard;
+- diferenças de taxon, copy, plano, campanha, ativo, ordem ou quantidade não criam variante;
+- `form` permanece incompatível com Hero e Final CTA;
+- capability desconhecida falha fechado.
+
+Validações:
+
+- resolução interna das dez identidades;
+- independência das duas FAQs;
+- contrato declarativo WCAG 2.2 do Accordion;
+- `npm run validate:landing-page-module-catalog`;
+- `npm run check`;
+- `git diff --check`.
+
+### 4.4. Fase 4 — E18.5.6 — Especializações sobre a parametrização raiz
+
+- Automação: não.
+
+Entregas:
+
+- integrar internamente `resolveLandingPageRootParameters` pelo boundary público;
+- reexportar de forma aditiva `normalizeLandingPageRootText` e `countLandingPageRootTextCharacters` no namespace da raiz;
+- manter `rootDelta={}` em todos os módulos e variantes da v1;
+- aplicar no payload validator o `absoluteMax` do `semanticRole` resolvido.
+
+Critérios:
+
+- nenhuma importação direta de `root-registry.ts`;
+- nenhuma duplicação de roles, ranges, limits, spacing, presets ou algoritmos de texto;
+- texto vazio após normalização ou acima de `absoluteMax` falha fechado;
+- faixas recomendadas não causam rejeição automática;
+- qualquer chave em `rootDelta` é inválida na v1.
+
+Validações:
+
+- valor exatamente em `absoluteMax` aceito;
+- valor acima de `absoluteMax` rejeitado;
+- intervalos recomendados não bloqueiam;
+- erro da raiz convertido em `ROOT_RESOLUTION_FAILED`;
+- `npm run validate:landing-page-module-catalog`;
+- validação existente da raiz;
+- `npm run check`;
+- `git diff --check`.
+
+### 4.5. Fase 5 — E18.5.7 — Mapa de fontes de copy
+
+- Automação: não.
+
+Entregas:
+
+- implementar os `copySourceMap` literais da seção 2.4;
+- usar paths exatos de fields, 1–2 `primaryItemKeys` e até 1 `auxiliaryItemKey`;
+- separar `sourceMode=research` de `sourceMode=operational_evidence`.
+
+Critérios:
+
+- todos os paths existem na variante correspondente;
+- todos os `item_key` pertencem aos conjuntos estruturados permitidos;
+- Social Proof preserva quote e attribution como evidência operacional;
+- path, source mode, item key ou quantidade desconhecida falha fechado.
+
+Validações:
+
+- casos de todos os paths mapeados;
+- excesso de fontes, item key inválido e map órfão rejeitados;
+- `npm run validate:landing-page-module-catalog`;
+- `npm run check`;
+- `git diff --check`.
+
+### 4.6. Fase 6 — E18.5.8 — Perfis de copy por intenção e funil
+
+- Automação: não.
+
+Entregas:
+
+- implementar os profiles BOFU, MOFU e TOFU com treatments e `ctaMode` literais;
+- implementar os deltas aprovados por módulo e o mesmo delta para as duas FAQs;
+- impedir categorias ou aliases como valores de registry.
+
+Critérios:
+
+- cada treatment aparece exatamente uma vez entre `allowed`, `restricted` e `prohibited`;
+- `ctaMode` corresponde ao action treatment definido;
+- deltas somente restringem, proíbem ou enfatizam tratamentos conhecidos;
+- suporte factual continua obrigatório quando aplicável;
+- alias, treatment ou `ctaMode` desconhecido falha fechado.
+
+Validações:
+
+- profiles completos dos três estágios;
+- deltas dos nove módulos e dez variantes;
+- conflitos e treatments ausentes/duplicados rejeitados;
+- `npm run validate:landing-page-module-catalog`;
+- `npm run check`;
+- `git diff --check`.
+
+### 4.7. Fase 7 — E18.5.9 — Ciclo de vida, compatibilidade e validação
+
+- Automação: não.
+
+Entregas:
+
+- finalizar `resolver.ts`, `payload-validator.ts` e `index.ts`;
+- implementar as assinaturas públicas da seção 2.6;
+- retornar os lifecycles de raiz, módulo, variante e o lifecycle efetivo;
+- adicionar o namespace público `landingPageModuleCatalog` em `lib/conversion-content/index.ts`;
+- fechar compatibilidade, erros, imutabilidade e matriz integrada de não regressão.
+
+Critérios:
+
+- resolver usa registries canônicos internamente, sem injeção pública e sem fallback;
+- versões, identidades, root compatibility e lifecycles inválidos falham fechado;
+- resultado e registry são profundamente imutáveis;
+- `primary_action.allowedValues` é subconjunto do enum público `primary_conversion_channel` em teste;
+- nenhum consumidor ou família preservada é alterado além dos exports aditivos aprovados;
+- o namespace público somente é liberado nesta fase, após o catálogo completo ser válido.
+
+Validações:
+
+- resolução pública das dez variantes;
+- matriz completa de erros, payloads, lifecycles, compatibilidade, imutabilidade e canais;
 - validações existentes de root, pesquisa, input catalog e commercial activation;
 - `npm run validate:landing-page-module-catalog`;
 - `npm run check`;
 - `git diff --check`.
 
-Matriz mínima:
+Parada comum a todas as fases:
 
-- resolve dez variantes;
-- rejeita versões, identidades, roles, fields, policies, supports, capabilities, maps, treatments, `ctaMode`, aliases, deltas e payloads inválidos;
-- rejeita form;
-- valida alt text, cardinalidade, texto vazio após normalização, valor exatamente em `absoluteMax`, valor acima de `absoluteMax` e ausência de bloqueio pelos intervalos recomendados;
-- comprova imutabilidade, independência das FAQs, cálculo dos quatro estados de lifecycle, ausência de colisão, preservação dos exports e subconjunto de canais frente a `primary_conversion_channel`.
-
-Parada:
-
-- arquivo/export/dependency/regra não listado retorna ao Estrategista;
+- arquivo, export, dependência ou regra não listado retorna ao Estrategista;
 - banco, rota, renderer, composição, persistência, tracking ou mudança destrutiva bloqueia;
-- sem merge ou fase futura automática.
+- o Executor não inicia a fase seguinte sem avaliação do Analista e decisão do Estrategista;
+- sem merge ou avanço automático durante a comparação.
 
-### 4.2. Próxima ação
+### 4.8. Próxima ação
 
-- Plano v2 aprovado humanamente neste patch final.
+- Plano v2 permanece aprovado humanamente, agora com a execução corrigida para sete fases.
 - Criar branch de implementação manual comparativa a partir do head atualizado de `codex-app/e18-5-v2-processo-atual`.
 - Abrir PR draft dessa branch com base `codex-app/e18-5-v2-processo-atual`.
-- Orientar o Executor a executar exclusivamente a fase 3.1 nessa nova branch.
-- Manter PR #577, PR #585 e o novo PR sem merge durante a comparação com o workflow automatizado.
-- Após as duas entregas, comparar aderência, qualidade, escopo, testes, retrabalho e decisões implícitas antes de escolher ou reconciliar a solução final.
+- Orientar o Executor somente para a fase 18.5.3.
+- Após a entrega, submeter a fase ao Analista e decidir entre avançar para 18.5.4, ajustar ou bloquear.
+- Repetir o fluxo, uma fase por vez, até 18.5.9.
+- Manter PR #577, PR #585 e o PR de implementação sem merge durante a comparação com o workflow automatizado.
+- Após as duas entregas completas, comparar aderência, qualidade, escopo, testes, retrabalho e decisões implícitas antes de escolher ou reconciliar a solução final.
 
 ## 5. Validação e encerramento
 
 ### 5.1. Validação documental
 
 - três pareceres iniciais e reavaliação final do Analista consolidados;
-- única fase, `Automação: não`;
-- topologia, API, copy, funil, limites, lifecycle efetivo, erros, testes e fluxo experimental definidos;
+- sete fases executáveis, todas com `Automação: não`;
+- fases 18.5.3 a 18.5.9, topologia, API, copy, funil, limites, lifecycle efetivo, erros, testes e fluxo experimental definidos;
 - sem fase administrativa.
 
 Nesta consolidação:

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -553,21 +553,21 @@ Campos:
   - texto, papel `h2`, cardinalidade `1..1`, policy `research_guided`.
 - `items`:
   - coleção, cardinalidade `1..4`, policy `not_copy`;
-  - item fechado com `title` e `description`;
-  - `title`: texto, papel `card_title`, cardinalidade `1..1`, policy `hybrid`, suporte `when_present`;
+  - item fechado com `itemTitle` e `description`;
+  - `itemTitle`: texto, papel `card_title`, cardinalidade `1..1`, policy `hybrid`, suporte `when_present`;
   - `description`: texto, papel `card_body`, cardinalidade `1..1`, policy `hybrid`, suporte `when_present`.
 
 Copy:
 
 - `title`: primárias `desire` e `trigger`; auxiliar `positioning_opportunity`.
-- `items.title`: primárias `trigger` e `desire`; auxiliar `search_intent`.
-- `items.description`: primárias `positioning_opportunity` e `belief`; auxiliar `objection`.
+- `itemTitle`: primárias `trigger` e `desire`; auxiliar `search_intent`.
+- `description`: primárias `positioning_opportunity` e `belief`; auxiliar `objection`.
 
 Regras específicas:
 
 - uma ocorrência válida contém de um a quatro itens completos;
 - o mínimo de um item permite LPs de intenção única sem forçar ofertas irrelevantes;
-- cada item contém exatamente `title` e `description`;
+- cada item contém exatamente `itemTitle` e `description`;
 - título e descrição representam uma oferta, escopo ou caso de uso efetivamente disponível;
 - todo item exige suporte por entradas operacionais aplicáveis ao taxon, negócio ou oferta;
 - o contrato transversal não fixa chaves de um taxon específico;
@@ -590,10 +590,10 @@ Validações estruturais:
 
 - exigir `title` e `items`;
 - exigir cardinalidade `1..4` em `items`;
-- exigir exatamente `title` e `description` em cada item;
+- exigir exatamente `itemTitle` e `description` em cada item;
 - rejeitar coleção aninhada e campos extras;
 - validar os papéis semânticos e as policies declaradas;
-- exigir suporte `when_present` em `items.title` e `items.description`;
+- exigir suporte `when_present` em `itemTitle` e `description`;
 - rejeitar CTA, mídia, ação, prova, preço, condição comercial, processo ou referência técnica na variante;
 - resolver de forma fail-closed e imutável.
 

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -72,6 +72,7 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 - `hero.standard` é a única variante inicial e pode ter delta vazio.
 - Canal e destino concretos de CTA permanecem fora do registry do módulo.
 - Nenhum `actionRole` está aprovado sem contrato fechado.
+- `moduleCatalogVersion` possui versão e compatibilidade; lifecycle próprio do catálogo não está aprovado.
 
 ### 1.6. Estado técnico confirmado
 
@@ -83,8 +84,8 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 
 ### 1.7. Pontos ainda em debate
 
-- Contrato da ação secundária e eventual necessidade de `actionRole`.
-- Acessibilidade de vídeo no campo `media`.
+- Destinação do campo candidato `secondaryCta` na v1.
+- Contrato exato de acessibilidade para vídeo.
 - Confirmação dos oito candidatos restantes.
 - Evolução da raiz e divisão final em fases.
 
@@ -94,8 +95,9 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 
 - Faltam contratos aprovados para todos os módulos e variantes.
 - O catálogo deve generalizar funções sem carregar identidade imobiliária.
-- CTA não pode duplicar canal/destino da E20.2.
-- Mídia deve separar contrato estrutural de schema concreto da E19.
+- CTA não pode duplicar canal ou destino da E20.2.
+- Campos híbridos precisam representar declarativamente quando suporte operacional é exigido.
+- Mídia deve separar contrato estrutural e acessibilidade do schema concreto da E19.
 - Policies devem impedir invenção de fatos e fallback deve permanecer proibido.
 
 ### 2.2. Resultado esperado
@@ -152,7 +154,7 @@ Todos os módulos devem analisar:
 4. campos, `fieldKind` e cardinalidades;
 5. herança, capabilities e policies;
 6. fontes e funil quando aplicáveis;
-7. responsividade e acessibilidade quando aplicáveis;
+7. suporte operacional, responsividade e acessibilidade quando aplicáveis;
 8. variante, versões, lifecycle e compatibilidades;
 9. fronteiras E20/E19/renderer;
 10. casos E18.5, invariantes E19 e critérios de fechamento.
@@ -166,9 +168,17 @@ O Hero é referência metodológica, não molde rígido de conteúdo.
 - `family = landing_page`.
 - `moduleCatalogVersion = 1` no primeiro catálogo.
 - Módulo declara `moduleKey`, `moduleVersion`, lifecycle, função, evidências e campos.
-- Evidência de pesquisa registra taxon, `taxonId`, público, bloco, `researchId`, versão, status, `itemKey`, estado ativo, função observada, função transversal e equivalência.
+- Evidência de pesquisa registra:
+  - taxon e `taxonId`;
+  - público e bloco;
+  - `researchId` e `itemId`;
+  - versão e status da pesquisa;
+  - `itemKey` e estado ativo do item;
+  - função observada;
+  - função transversal;
+  - justificativa da equivalência.
 - Variante declara identidade, versão, módulo compatível, lifecycle e deltas fechados.
-- Catálogo declara compatibilidade explícita com `rootVersion`.
+- Catálogo declara versão e compatibilidade explícita com `rootVersion`, sem lifecycle próprio presumido.
 
 ### 2.5. Contrato-base de campo
 
@@ -186,7 +196,7 @@ Todo campo declara `fieldKey`, `fieldKind`, cardinalidade e policy.
 Regras:
 
 - texto visível exige `semanticRole` da raiz;
-- ação possui label textual e vínculo operacional futuro, sem canal/destino no registry;
+- ação possui label textual e dependência operacional declarativa, sem canal ou destino concreto no registry;
 - mídia declara tipos e requisitos abstratos de ativo e acessibilidade;
 - coleção declara contrato fechado do item;
 - valor operacional não pode ser inferido como fato;
@@ -199,23 +209,59 @@ Regras:
 - `research_generated_non_factual`: copy não factual gerada da pesquisa.
 - `research_guided`: pesquisa orienta, mas não fornece o valor final completo.
 - `operational_required`: valor deve vir de fonte operacional autorizada.
-- `hybrid`: orientação editorial com suporte operacional obrigatório para fato ou ação concreta.
+- `hybrid`: orientação editorial combinada com suporte operacional conforme exigência declarada pelo campo.
 - `technical_reference`: mídia, link, identificador ou vínculo técnico.
 - `not_copy`: objeto estrutural ou técnico.
 
 E18.5 declara; E19 aplica na instância concreta.
 
-#### 2.5.2. Matriz de compatibilidade das policies
+#### 2.5.2. Exigência declarativa de suporte operacional
+
+Campos que geram ou exibem texto podem declarar `operationalSupportRequirement` como união fechada:
+
+- `none`:
+  - o campo não exige entrada operacional para existir;
+  - continua proibido inventar alegação factual.
+- `when_factual`:
+  - suporte operacional é obrigatório somente quando o texto contiver fato, condição, capacidade, credencial, métrica ou ação concreta.
+- `when_present`:
+  - o campo só pode estar presente quando existir suporte operacional resolvido aplicável.
+
+Regras:
+
+- policy `hybrid` exige `operationalSupportRequirement` explícito.
+- policy `operational_required` equivale materialmente a `when_present`.
+- `technical_reference` e `not_copy` não usam essa propriedade.
+- E18.5 valida a declaração abstrata; E19 valida o suporte concreto.
+
+#### 2.5.3. Matriz de compatibilidade das policies
 
 - `research_generated_non_factual` e `research_guided` admitem `copySourceMap` em texto.
-- `hybrid` pode admitir `copySourceMap`, mas fato, canal, ação ou prova exigem suporte operacional.
+- `hybrid` admite `copySourceMap`, mas deve declarar `operationalSupportRequirement`.
 - `operational_required` não pode ser preenchida somente por pesquisa.
 - `technical_reference` e `not_copy` não admitem `copySourceMap`.
-- Falham: policy incompatível com `fieldKind`, mídia com policy textual, `not_copy` com fontes, `hybrid` factual sem suporte e valor operacional gerado apenas da pesquisa.
+- Falham:
+  - policy incompatível com `fieldKind`;
+  - mídia com policy textual;
+  - `not_copy` com fontes;
+  - `hybrid` sem exigência de suporte;
+  - suporte exigido sem vínculo operacional aplicável;
+  - valor operacional gerado apenas da pesquisa.
+
+#### 2.5.4. Dependência operacional de ações
+
+Ação pode declarar `operationalBindingRequirement`:
+
+- referencia somente `fieldKey` estável do catálogo operacional;
+- não armazena valor, canal, URL, telefone, e-mail ou destino;
+- declara se o vínculo é obrigatório quando a ação estiver presente;
+- E19 resolve o campo e valida seus condicionais e destinos aplicáveis.
+
+Nova chave operacional não pode ser criada implicitamente pela E18.5.
 
 ### 2.6. Contrato de variante
 
-- Deltas permitidos: cardinalidade, remoção/ativação de campo previsto, restrição de faixa/tratamento e comportamento enumerado.
+- Deltas permitidos: cardinalidade, remoção ou ativação de campo previsto, restrição de faixa ou tratamento e comportamento enumerado.
 - Deltas proibidos: campo livre, papel desconhecido, ampliação de limite, taxon, conteúdo, valor operacional, URL, classe ou componente concreto.
 - `standard` pode ter delta vazio; outra variante vazia e redundante falha.
 
@@ -234,46 +280,68 @@ E18.5 declara; E19 aplica na instância concreta.
 - público `end_customer`;
 - bloco `lp_sections`;
 - `researchId = 31e4c229-1582-4d2c-8e4a-7b74e6e07681`;
+- `itemId = ee178af8-294c-403c-8c53-d0baef42ee8c`;
 - versão 1, pesquisa ativa;
 - `itemKey = hero_segmentado`, item ativo, ordem 1;
 - função observada: apresentar valor central e segmentar por intenção;
+- interpretação v1:
+  - a intenção já está resolvida para a LP concreta;
+  - a segmentação ocorre na mensagem e no recorte editorial;
+  - não existe seletor, coleção de intenções ou escolha interativa dentro de `hero.standard`;
 - função transversal: apresentar recorte, proposta e ação principal.
+
+Escolha interativa entre intenções exigiria análise estrutural futura e não é autorizada por esta evidência.
 
 #### 2.7.3. Fronteiras
 
-Pertencem: enquadramento, título, explicação curta, CTA principal, CTA secundário opcional, microprova opcional e uma mídia opcional.
+Pertencem: enquadramento, título, explicação curta, CTA principal, candidato a CTA secundário, microprova opcional e uma mídia opcional.
 
-Não pertencem: trust bar completa, oferta, processo, prova extensa, depoimentos, FAQ, formulário completo, galeria, carrossel, tour, CTA final, navegação e ordem global.
+Não pertencem: trust bar completa, oferta, processo, prova extensa, depoimentos, FAQ, formulário completo, seletor interativo de intenção, galeria, carrossel, tour, CTA final, navegação e ordem global.
 
 #### 2.7.4. Catálogo de campos proposto
 
-- `eyebrow`: texto/`eyebrow`, `0..1`, `research_guided`.
-- `title`: texto/`h1`, `1..1`, `hybrid`.
-- `subtitle`: texto/`paragraph`, `1..1`, `hybrid`; padrão `body.editorialEmphasis`, alternativa `body.base`.
-- `primaryCta`: ação `1..1`, `not_copy`:
+- `eyebrow`:
+  - texto/`eyebrow`, `0..1`, `research_guided`;
+  - `operationalSupportRequirement = none`.
+- `title`:
+  - texto/`h1`, `1..1`, `hybrid`;
+  - `operationalSupportRequirement = when_factual`.
+- `subtitle`:
+  - texto/`paragraph`, `1..1`, `hybrid`;
+  - `operationalSupportRequirement = when_factual`;
+  - padrão `body.editorialEmphasis`, alternativa `body.base`.
+- `primaryCta`:
+  - ação `1..1`, `not_copy`;
   - label `cta_label`, `1..1`, `hybrid`;
-  - compatível com `primary_conversion_channel`;
-  - canal e destino concretos fora do registry;
-  - E19 realiza o vínculo operacional.
-- `secondaryCta`: ação `0..1`, `not_copy`:
-  - label `cta_label`, `hybrid`;
-  - ação complementar;
-  - contrato estrutural permitido ainda pendente;
-  - canal e destino fora do registry.
-- `proofShort`: texto/`paragraph`, `0..1`, `hybrid`:
+  - label usa `operationalSupportRequirement = when_present`;
+  - `operationalBindingRequirement.catalogFieldKey = primary_conversion_channel`;
+  - vínculo obrigatório quando a ação estiver presente;
+  - canal e destino concretos ficam fora do registry;
+  - E19 resolve o canal e os destinos condicionais aplicáveis.
+- `secondaryCta`:
+  - candidato a ação `0..1`, ainda não aprovado para publicação;
+  - não existe `secondary_conversion_channel` ou vínculo operacional equivalente aprovado;
+  - E18.5 não criará nova entrada operacional;
+  - deve ser removido da v1 ou receber decisão explícita sobre reutilização de fonte existente ou navegação interna.
+- `proofShort`:
+  - texto/`paragraph`, `0..1`, `hybrid`;
+  - `operationalSupportRequirement = when_present`;
   - microprova, credencial ou sinal curto de confiança;
-  - suporte factual operacional obrigatório quando presente;
   - não recebe genericamente preço, prazo, disponibilidade ou condição comercial.
-- `media`: mídia `0..1`, `technical_reference`:
+- `media`:
+  - mídia `0..1`, `technical_reference`;
   - `mediaKind = image | video`;
   - referência do ativo pertence à instância futura;
   - `accessibilityMode = informative | decorative`;
-  - imagem informativa exige `altText` não vazio;
-  - imagem decorativa normaliza `altText = ""`;
-  - `altText` é `hybrid` e depende do ativo/contexto real;
-  - legenda é separada de `altText`;
+  - acessibilidade usa contrato próprio de mídia, não `operationalValuePolicy` textual;
+  - imagem informativa exige alternativa acessível não vazia;
+  - imagem decorativa exige ausência de descrição semântica, normalizada pelo contrato final;
+  - conteúdo da alternativa acessível deriva do ativo, função e contexto reais;
+  - legenda não integra o contrato inicial e não se confunde com alternativa acessível;
   - vídeo exige alternativa acessível própria; contrato exato ainda pendente;
   - mídia decorativa não transporta informação essencial.
+
+O conjunto candidato contém sete campos, mas `secondaryCta` não entra no `fieldCatalog` publicável enquanto seu contrato não for decidido.
 
 #### 2.7.5. Herança e exceção tipográfica
 
@@ -303,9 +371,9 @@ Não pertencem: trust bar completa, oferta, processo, prova extensa, depoimentos
 - `eyebrow`: `positioning_opportunity`; auxiliar `search_intent`.
 - `title`: `positioning_opportunity` e `desire`; auxiliar `commercial_keywords`.
 - `subtitle`: `pain` e `desire`; auxiliar `belief`.
-- labels: `trigger`; auxiliar `search_intent`; ação concreta exige entrada operacional.
-- `proofShort`: `proof_type`; auxiliar `objection`; fato sempre operacional.
-- `altText` depende do ativo/contexto real, não da pesquisa isolada.
+- labels: `trigger`; auxiliar `search_intent`; ação concreta exige vínculo operacional.
+- `proofShort`: `proof_type`; auxiliar `objection`; suporte operacional obrigatório quando presente.
+- Alternativa acessível de mídia não usa `copySourceMap` nem `operationalValuePolicy`; E19 a produz a partir do ativo e contexto sob o contrato de acessibilidade.
 - Ativo, tipo de mídia, modo de acessibilidade, visibilidade, canal e destino não recebem `copySourceMap`.
 
 #### 2.7.9. Perfis de funil do Hero
@@ -319,28 +387,38 @@ Não pertencem: trust bar completa, oferta, processo, prova extensa, depoimentos
 
 - `variantVersion = 1`, compatível com `moduleVersion = 1`.
 - Execução-base com delta vazio.
-- Mídia e CTA secundário permanecem opcionais.
+- Mídia permanece opcional.
+- O estado do CTA secundário depende da decisão final do campo candidato.
 - Imagem, vídeo, funil, visibilidade e troca para `body.base` não criam variante.
 - `hero.media_split` permanece rejeitada.
 
 #### 2.7.11. Lifecycle e compatibilidade do Hero
 
 - `moduleCatalogVersion`, `moduleVersion` e `variantVersion` iniciais: 1 propostos.
+- `moduleCatalogVersion` não possui lifecycle próprio aprovado; declara apenas versão e compatibilidade com a raiz.
 - `rootVersion` depende das capabilities tipográfica e responsiva.
 - Raiz `hypothesis`: somente `controlled_test`; `validated`: conforme demais camadas; `deprecated`: somente `historical_read`.
 - Módulo e variante começam `experimental`; propósito inicial `controlled_test`.
-- Elegibilidade cruza raiz, compatibilidade raiz–catálogo, catálogo, módulo, variante e propósito.
+- Elegibilidade cruza:
+  - lifecycle da raiz;
+  - compatibilidade raiz–catálogo;
+  - lifecycle do módulo;
+  - lifecycle da variante;
+  - propósito solicitado.
 - Promoção exige LP real, revisão e decisão humanas.
 
 #### 2.7.12. Casos executáveis da E18.5 para o Hero
 
-- Aceitar exatamente os sete campos e `hero.standard` com delta vazio.
+- Validar identidade, evidência, proveniência e interpretação editorial de `hero_segmentado`.
+- Rejeitar publicação enquanto campo candidato não possuir contrato fechado.
 - Rejeitar campo, cardinalidade, policy, fonte, tratamento ou variante inválidos.
-- Falhar sem capabilities exigidas e sem fallback.
-- Garantir que CTA não armazene canal/destino.
-- Garantir labels e `proofShort` como `hybrid`.
+- Validar `operationalSupportRequirement` e sua compatibilidade com policy e campo.
+- Validar vínculo abstrato do CTA principal com `primary_conversion_channel`.
+- Garantir que CTA não armazene canal ou destino concreto.
 - Validar contrato abstrato de mídia, acessibilidade e responsividade.
-- Incluir raiz na elegibilidade e retornar resultado imutável.
+- Falhar sem capabilities exigidas e sem fallback.
+- Incluir raiz na elegibilidade sem exigir lifecycle do catálogo.
+- Retornar resultado imutável.
 
 #### 2.7.13. Invariantes futuras de conteúdo para E19
 
@@ -348,20 +426,22 @@ Não criam agora schema ou validador de conteúdo na E18.5:
 
 - título, subtítulo e CTA principal concretos conforme cardinalidade;
 - label compatível com canal, ação e destino resolvidos;
+- suporte operacional exigido disponível;
 - prova concreta sustentada;
 - ativo de mídia válido;
-- imagem informativa com `altText` e decorativa com `altText = ""`;
+- imagem informativa com alternativa acessível e decorativa sem descrição semântica;
 - vídeo com alternativa acessível;
 - `desktop_only` sem ocultar informação essencial;
-- ausência de formulário completo, galeria, carrossel ou tour dentro de `hero.standard`.
+- ausência de formulário completo, seletor interativo, galeria, carrossel ou tour dentro de `hero.standard`.
 
 #### 2.7.14. Critérios de fechamento do Hero
 
 Fechar após aprovação de:
 
-- identidade, evidência, fronteiras, sete campos e cardinalidades;
-- matriz de policies e fontes;
-- CTA sem destino concreto e contrato da ação secundária;
+- identidade, evidência, interpretação da segmentação e fronteiras;
+- campos publicáveis e cardinalidades;
+- matriz de policies e `operationalSupportRequirement`;
+- vínculo do CTA principal e decisão sobre `secondaryCta`;
 - mídia e acessibilidade, inclusive vídeo;
 - visibilidade responsiva e nova raiz;
 - variante, versões, lifecycle e compatibilidades;
@@ -369,11 +449,14 @@ Fechar após aprovação de:
 
 Estado:
 
-- `hero_segmentado` comprovado e rastreável;
-- labels e `proofShort` corrigidos para `hybrid`;
-- destino removido do registry;
-- acessibilidade de imagem registrada;
-- ação secundária e acessibilidade de vídeo ainda pendentes;
+- `hero_segmentado` comprovado com `researchId` e `itemId`;
+- segmentação v1 definida como editorial, não interativa;
+- labels e `proofShort` usam `hybrid` com suporte declarativo;
+- CTA principal referencia somente a chave operacional aprovada;
+- destino concreto permanece fora do registry;
+- alternativa acessível saiu de `operationalValuePolicy`;
+- lifecycle próprio do catálogo foi retirado;
+- `secondaryCta` e acessibilidade de vídeo ainda pendentes;
 - Hero ainda não fechado e implementação bloqueada.
 
 ### 2.8. `copy_source_map`
@@ -381,7 +464,7 @@ Estado:
 - Até duas fontes primárias e uma auxiliar por campo.
 - `end_customer` é fonte primária; `business_buyer` só auxilia autoridade, processo, posicionamento ou prova institucional.
 - `lp_sections` comprova função, não vira fonte fixa de copy.
-- Policies controlam quando `copySourceMap` é permitido.
+- Policies e exigência de suporte controlam quando `copySourceMap` é permitido.
 
 ### 2.9. `funnel_copy_profile`
 
@@ -397,9 +480,10 @@ Estado:
 ### 2.11. Lifecycle e compatibilidade
 
 - Raiz: `hypothesis | validated | deprecated`.
-- Catálogo, módulo e variante: `candidate | experimental | validated | deprecated`.
+- Módulo e variante: `candidate | experimental | validated | deprecated`.
+- `moduleCatalogVersion` possui versão e compatibilidade, sem lifecycle próprio na v1.
 - Propósitos: `controlled_test | new_use | historical_read`.
-- Elegibilidade é interseção de raiz, compatibilidade, catálogo, módulo, variante e propósito.
+- Elegibilidade é interseção de lifecycle da raiz, compatibilidade raiz–catálogo, lifecycle do módulo, lifecycle da variante e propósito.
 - `candidate` bloqueia uso; `experimental` permite teste; `deprecated` só permite histórico.
 
 ### 2.12. Contrato de resolução previsto
@@ -409,15 +493,15 @@ Entrada: `rootVersion`, `moduleCatalogVersion`, `moduleKey`, `variantKey`, `purp
 Processamento:
 
 1. resolver raiz, lifecycle e propósito;
-2. validar compatibilidade do catálogo;
-3. resolver módulo;
-4. validar evidências, campos, policies e matriz;
-5. resolver variante e compatibilidade;
+2. validar compatibilidade do catálogo com a raiz;
+3. resolver módulo e lifecycle;
+4. validar evidências, campos, policies, suporte e vínculos abstratos;
+5. resolver variante, lifecycle e compatibilidade;
 6. aplicar delta válido;
 7. calcular contrato e elegibilidade;
 8. retornar resultado imutável.
 
-A saída não contém deltas, canal, destino concreto ou fallback.
+A saída não contém deltas, canal, destino concreto, lifecycle de catálogo ou fallback.
 
 ### 2.13. Artefatos previstos
 
@@ -443,20 +527,23 @@ Interface: `landingPageModules`. Script: `validate:landing-page-modules`.
 
 Validações E18.5:
 
-- versões, evidências, compatibilidades e lifecycle válidos;
+- versões, evidências, compatibilidades e lifecycle de raiz, módulo e variante válidos;
+- ausência de lifecycle próprio não aprovado no catálogo;
 - campos, cardinalidades, policies, fontes e tratamentos válidos;
-- matriz de policy respeitada;
+- matriz de policy e suporte operacional respeitada;
+- vínculo de ação referencia apenas `fieldKey` aprovado do catálogo operacional;
 - nenhum destino concreto de CTA no registry;
 - capabilities exigidas sem fallback;
 - delta vazio somente na base autorizada;
 - contrato abstrato de mídia e acessibilidade válido;
-- formulário completo não adicionado ao Hero;
+- formulário ou seletor interativo não adicionados ao Hero;
 - resultado imutável, versões históricas preservadas e sem imports fora do boundary.
 
 #### 2.14.1. Invariantes futuras para E19
 
 - presença e consistência do conteúdo concreto;
 - CTA vinculado à operação real;
+- suporte operacional exigido resolvido;
 - prova sustentada;
 - ativo e acessibilidade válidos;
 - ocultação responsiva sem perda de informação;
@@ -466,8 +553,8 @@ Validações E18.5:
 
 - Gatilho: raiz e plano v2 mergeados, fase instruída.
 - Entrada: raiz compatível, catálogo aprovado, itens oficiais e decisões humanas.
-- Processamento: contratos, registry, resolver, policies, mapas, lifecycle e casos E18.5.
-- Validação: `npm ci`, validações da raiz/módulos/commercial activation, `npm run check`, `git diff --check` e checks do PR.
+- Processamento: contratos, registry, resolver, policies, suporte, mapas, lifecycle e casos E18.5.
+- Validação: `npm ci`, validações da raiz, módulos e commercial activation, `npm run check`, `git diff --check` e checks do PR.
 - Persistência: repositório; consumo futuro: E20 e E19; fallback: falha fechada.
 
 ## 3. Fases e próxima ação
@@ -476,9 +563,9 @@ Validações E18.5:
 
 - Status pendente e bloqueado até grade fechada, raiz evoluída e v2 consolidada.
 - Automação: não. Risco: médio controlado.
-- Aceite: módulos aprovados, sem duplicação da raiz/E20.2, compatibilidade validada, Hero conforme contrato, resolver fail-closed e separação E18.5/E19.
+- Aceite: módulos aprovados, sem duplicação da raiz ou E20.2, compatibilidade validada, Hero conforme contrato, resolver fail-closed e separação E18.5/E19.
 - Próxima ação:
-  - fechar ação secundária;
+  - decidir `secondaryCta`;
   - fechar acessibilidade de vídeo;
   - reavaliar Hero;
   - depois iniciar `trust_bar` e seguir a grade;
@@ -490,30 +577,37 @@ Validações E18.5:
 
 - Implementação da raiz no PR #577.
 - Banco, composição, geração, renderer, Admin, Builder, tracking, automação ou nova infraestrutura.
-- Módulo de formulário, galeria, carrossel ou tour neste recorte.
+- Nova entrada operacional para sustentar `secondaryCta`.
+- Módulo de formulário, seletor interativo, galeria, carrossel ou tour neste recorte.
 - Persistência nova para justificativa da composição.
 
 ### 4.2. Critérios de parada
 
 Parar se:
 
-- raiz/capability/lifecycle não estiverem resolvidos;
+- raiz, capability ou lifecycle aplicável não estiverem resolvidos;
+- surgir lifecycle próprio de catálogo sem decisão explícita;
 - surgir fallback, dependência de taxon ou ampliação de limite;
 - faltar evidência oficial;
 - destino concreto entrar no registry;
-- formulário ou mídia essencial forem tratados incorretamente;
+- campo híbrido depender de regra hardcoded por `fieldKey`;
+- formulário, seletor interativo ou mídia essencial forem tratados incorretamente;
 - validação de conteúdo for antecipada na E18.5;
 - houver conflito de fronteiras ou perda histórica.
 
 ### 4.3. Decisão atual
 
 - PR #577 permanece em v1 e sem implementação autorizada.
-- `hero_segmentado` está comprovado e rastreável.
+- `hero_segmentado` está comprovado com `itemId` e interpretado editorialmente na v1.
 - Grade comum e nove candidatos permanecem.
-- Hero conserva sete campos e `hero.standard` com delta vazio.
-- Labels e `proofShort` usam `hybrid`; canal/destino ficam fora do registry.
-- Imagem/vídeo e visibilidade responsiva não criam variante.
-- Formulário completo fica fora do Hero.
-- Elegibilidade inclui a raiz; E18.5 e E19 estão separadas.
-- Hero ainda não está fechado por ação secundária e acessibilidade de vídeo.
+- Hero mantém seis campos com contrato interno fechado e `secondaryCta` como candidato pendente.
+- `hero.standard` permanece a única variante inicial, com delta vazio.
+- Labels e `proofShort` usam `hybrid` com exigência declarativa de suporte.
+- CTA principal referencia `primary_conversion_channel`, sem canal ou destino concreto no registry.
+- Alternativa acessível da mídia usa contrato próprio, não policy textual.
+- Imagem, vídeo e visibilidade responsiva não criam variante.
+- Formulário completo e seletor interativo ficam fora do Hero.
+- Elegibilidade inclui a raiz e não presume lifecycle do catálogo.
+- E18.5 e E19 permanecem separadas.
+- Hero ainda não está fechado por `secondaryCta`, acessibilidade de vídeo e evolução da raiz.
 - Próxima decisão humana: fechar esses pontos e reavaliar antes de `trust_bar`.

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -1,10 +1,10 @@
 19/07/2026 — Plano-base E18.5 — Parametrização de módulos e variantes `landing_page`
 
-Fontes: chat; `README.md`; `AGENTS.md`; `docs/prompt-estrategista.md`; `docs/prompt-executor.md`; `docs/gestor-estrutural.md`; `docs/roadmap.md`; `docs/base-tecnica.md`; `docs/schema.md`; `docs/lp-planejamento.md`; planos E18.4 e E20.2; Blueprint; prompt de itens estruturados; catálogos de updates; boundary `landing_page`; pareceres do Analista, Gestor Estrutural e Gestor de Updates de 19/07/2026.
+Fontes: chat; `README.md`; `AGENTS.md`; `docs/prompt-estrategista.md`; `docs/prompt-executor.md`; `docs/gestor-estrutural.md`; `docs/roadmap.md`; `docs/base-tecnica.md`; `docs/schema.md`; `docs/lp-planejamento.md`; planos E18.4 e E20.2; Blueprint; prompt de itens estruturados; catálogos de updates; `lib/conversion-content/landing-page/index.ts`; `lib/conversion-content/landing-page/root-schema.ts`; pareceres do Analista, Gestor Estrutural e Gestor de Updates e reavaliação final do Analista de 19/07/2026.
 
-Versão: v2 consolidada.
+Versão: v2 consolidada com patch final do Analista.
 
-Status: nove módulos, nove `standard@v1`, `faq.accordion@v1`, contrato compartilhado e fase executável fechados; implementação não autorizada.
+Status: plano-base aprovado humanamente em 19/07/2026 para implementação manual comparativa da fase 3.1 em branch filha própria; PR #585 permanece documental, draft e sem merge durante o experimento.
 
 Path: `docs/lousa-plano-base-e18-5.md`.
 
@@ -13,7 +13,9 @@ Branches:
 - v1 e PR #577 congelados em `docs/e18-5-modules-variants`;
 - v2 somente em `codex-app/e18-5-v2-processo-atual`;
 - não alterar diretamente o PR #577;
-- merge e execução exigem decisão humana.
+- PR #585 compara a v2 manual contra a branch congelada do PR #577;
+- aprovação humana deste patch autoriza somente a criação da branch de implementação manual comparativa;
+- nenhum PR experimental deve ser mergeado antes da comparação com o workflow automatizado.
 
 ## 1. Estado e decisões fixas
 
@@ -58,16 +60,29 @@ Aceito:
 - consumo obrigatório de `resolveLandingPageRootParameters`;
 - gramática, maps, profiles, capabilities e lifecycle fechados;
 - ausência de especializações v1, incompatibilidade com `form` e FAQ validada primeiro;
-- `prod#17` apenas como referência declarativa.
+- `prod#17` apenas como referência declarativa;
+- eliminação de aliases em policies, treatments, `ctaMode` e contratos de fields;
+- aplicação obrigatória do `absoluteMax` da raiz com os helpers canônicos de normalização e contagem;
+- assinatura pública inequívoca do resolver e exposição dos três lifecycles mais o lifecycle efetivo;
+- paths literais em `copySourceMap` e teste de compatibilidade dos canais com o catálogo de entradas;
+- fluxo experimental sem merge, com duas entregas irmãs comparadas a partir do mesmo baseline.
 
 Rejeitado:
 
 - novas fases/variantes, banco, renderer, tracking, automação e updates de Supabase/Vercel/GitHub;
-- conformidade WCAG integral e validação comportamental real.
+- conformidade WCAG integral e validação comportamental real;
+- aliases aceitos pelo registry ou resolução pública por injeção de objetos de catálogo/raiz.
 
 Pendente sem bloquear:
 
 - planos técnicos futuros de E20, E19.4 e renderer.
+
+Decisão humana de 19/07/2026:
+
+- este patch final está aprovado;
+- a implementação manual comparativa da fase 3.1 pode começar em branch filha criada do head atualizado do PR #585;
+- a aprovação não autoriza merge do PR #585, do PR #577 ou de qualquer entrega experimental;
+- a integração na `main` será decidida somente após a comparação manual versus automatizada.
 
 ## 2. Contrato compartilhado
 
@@ -130,12 +145,23 @@ Suporte:
 
 Combinações:
 
-- text aceita research/hybrid/operational;
-- collection/action usam `not_copy`;
-- image/reference usam `technical_reference`;
-- operational exige `when_present`;
-- texto visível exige semantic role da raiz;
-- desconhecido ou combinação inválida falha fechado.
+- `text` aceita somente `research_guided`, `hybrid` ou `operational_required`;
+- `collection` e `action` usam somente `not_copy`;
+- `image` e `reference` usam somente `technical_reference`;
+- `operational_required` exige `when_present`;
+- todo texto visível exige `semanticRole` existente na raiz resolvida;
+- aliases, valores desconhecidos ou combinação inválida falham fechado.
+
+Limites de texto herdados:
+
+- `validateLandingPageVariantPayload` calcula uma forma normalizada de cada valor textual com `normalizeLandingPageRootText`, somente para validação;
+- o validator conta caracteres com `countLandingPageRootTextCharacters` e consulta `rootParameters.semanticRoles[semanticRole].textRange.absoluteMax`;
+- texto vazio após normalização ou acima de `absoluteMax` produz `INVALID_VARIANT_PAYLOAD`;
+- o validator não reescreve nem persiste o payload original;
+- `recommended.min` e `recommended.max` permanecem orientação editorial e não causam rejeição automática;
+- a normalização e a contagem não podem ser duplicadas no catálogo de módulos;
+- `landing-page/index.ts` deve reexportar de forma aditiva `normalizeLandingPageRootText` e `countLandingPageRootTextCharacters`, já implementadas em `root-schema.ts`;
+- nenhuma faixa ou algoritmo da E18.4 é alterado por esta fase.
 
 ### 2.3. Shapes e capabilities
 
@@ -159,20 +185,28 @@ Referência:
 Capabilities:
 
 - `primary_action`:
-  - Hero e Final CTA;
-  - binding `primary_conversion_channel`;
-  - allowed `whatsapp|phone|email|external_url`;
-  - `form` incompatível.
+  - consumidores: Hero e Final CTA;
+  - `bindingFieldKey=primary_conversion_channel`;
+  - `allowedValues=[whatsapp, phone, email, external_url]`;
+  - `form` é incompatível.
 - `image_asset`:
-  - somente Hero;
-  - modes/alt conforme imagem.
+  - consumidor: Hero;
+  - `modes=[informative, decorative]`;
+  - `visibility=all_viewports`;
+  - `informative` exige `altText` não vazio e `decorative` exige `altText` vazio.
 - `accordion_interaction`:
-  - somente FAQ Accordion;
-  - all closed, single expansion, toggle próprio, teclado, estado exposto, associação e foco preservado;
-  - foco visível e baseline herdados da raiz;
-  - validação somente declarativa.
+  - consumidor: FAQ Accordion;
+  - `initialState=all_closed`;
+  - `expansionMode=single`;
+  - `toggleMode=own_control`;
+  - `keyboardRequired=true`;
+  - `stateExposed=true`;
+  - `controlContentAssociationRequired=true`;
+  - `focusPreserved=true`;
+  - foco visível e baseline WCAG 2.2 são herdados da raiz;
+  - a E18.5 valida somente esse contrato declarativo.
 
-Nenhuma outra capability integra v1.
+Nenhuma outra capability ou valor de payload integra a v1.
 
 ### 2.4. `copySourceMap`
 
@@ -180,45 +214,46 @@ Shape:
 
 - pesquisa: `sourceMode=research`, 1–2 `primaryItemKeys`, 0–1 `auxiliaryItemKey`;
 - operacional: `sourceMode=operational_evidence`, sem item key;
-- desconhecido ou excesso falha fechado.
+- as chaves do map são paths literais de fields da variante;
+- path, item key, source mode desconhecido ou excesso falha fechado.
 
 Mappings:
 
 - Hero:
-  - eyebrow `[positioning_opportunity]` + `search_intent`;
-  - title `[positioning_opportunity, desire]` + `commercial_keywords`;
-  - subtitle `[pain, desire]` + `belief`;
-  - CTA label `[trigger]` + `search_intent`;
-  - proofShort `[proof_type]` + `objection`.
+  - `eyebrow`: `[positioning_opportunity]` + `search_intent`;
+  - `title`: `[positioning_opportunity, desire]` + `commercial_keywords`;
+  - `subtitle`: `[pain, desire]` + `belief`;
+  - `primaryCta.label`: `[trigger]` + `search_intent`;
+  - `proofShort`: `[proof_type]` + `objection`.
 - Trust Bar:
-  - item text `[proof_type, belief]` + `objection`.
+  - `items[].text`: `[proof_type, belief]` + `objection`.
 - Problem Solution:
-  - title `[pain, desire]` + `positioning_opportunity`;
-  - problem `[pain, fear]` + `objection`;
-  - solution `[positioning_opportunity, desire]` + `belief`.
+  - `title`: `[pain, desire]` + `positioning_opportunity`;
+  - `items[].problem`: `[pain, fear]` + `objection`;
+  - `items[].solution`: `[positioning_opportunity, desire]` + `belief`.
 - Offer:
-  - title `[desire, trigger]` + `positioning_opportunity`;
-  - itemTitle `[trigger, desire]`;
-  - description `[positioning_opportunity, belief]` + `objection`.
+  - `title`: `[desire, trigger]` + `positioning_opportunity`;
+  - `items[].itemTitle`: `[trigger, desire]`;
+  - `items[].description`: `[positioning_opportunity, belief]` + `objection`.
 - Process:
-  - title `[belief, desire]` + `positioning_opportunity`;
-  - stepTitle `[trigger, positioning_opportunity]` + `desire`;
-  - stepBody `[belief, desire]` + `objection`.
+  - `title`: `[belief, desire]` + `positioning_opportunity`;
+  - `steps[].stepTitle`: `[trigger, positioning_opportunity]` + `desire`;
+  - `steps[].stepBody`: `[belief, desire]` + `objection`.
 - Technical Assurance:
-  - title `[proof_type, belief]` + `objection`;
-  - assuranceTitle `[proof_type]` + `belief`;
-  - assuranceBody `[proof_type, positioning_opportunity]` + `objection`.
+  - `title`: `[proof_type, belief]` + `objection`;
+  - `items[].assuranceTitle`: `[proof_type]` + `belief`;
+  - `items[].assuranceBody`: `[proof_type, positioning_opportunity]` + `objection`.
 - Social Proof:
-  - title `[proof_type, belief]` + `objection`;
-  - quote/attribution operacionais.
-- FAQ Standard/Accordion:
-  - title `[objection, awareness_level]` + `search_intent`;
-  - question `[objection, fear]` + `faq_questions`;
-  - answer `[belief, positioning_opportunity]` + `desire`.
+  - `title`: `[proof_type, belief]` + `objection`;
+  - `items[].quote` e `items[].attribution`: `sourceMode=operational_evidence`.
+- FAQ Standard e Accordion:
+  - `title`: `[objection, awareness_level]` + `search_intent`;
+  - `items[].question`: `[objection, fear]` + `faq_questions`;
+  - `items[].answer`: `[belief, positioning_opportunity]` + `desire`.
 - Final CTA:
-  - title `[trigger, desire]` + `positioning_opportunity`;
-  - body `[desire, objection]` + `belief`;
-  - CTA label `[trigger]` + `search_intent`.
+  - `title`: `[trigger, desire]` + `positioning_opportunity`;
+  - `body`: `[desire, objection]` + `belief`;
+  - `primaryCta.label`: `[trigger]` + `search_intent`.
 
 ### 2.5. `funnelCopyProfile`
 
@@ -226,78 +261,147 @@ Stages:
 
 - `bofu`, `mofu`, `tofu`.
 
-Treatments:
+Treatments fechados:
 
-- actions: `direct_action`, `qualified_action`, `low_friction_action`;
-- content: `educational_context`, `problem_emphasis`, `offer_specificity`;
-- factual: `proof`, `comparison`, `price`, `promise`, `credential`, `authority`, `urgency`, `scarcity`, `guarantee`.
+- `direct_action`;
+- `qualified_action`;
+- `low_friction_action`;
+- `educational_context`;
+- `problem_emphasis`;
+- `offer_specificity`;
+- `proof`;
+- `comparison`;
+- `price`;
+- `promise`;
+- `credential`;
+- `authority`;
+- `urgency`;
+- `scarcity`;
+- `guarantee`.
+
+`ctaMode` fechado:
+
+- `direct`;
+- `qualified`;
+- `low_friction`.
+
+Mapeamento obrigatório:
+
+- `direct` → `direct_action`;
+- `qualified` → `qualified_action`;
+- `low_friction` → `low_friction_action`.
 
 Regras:
 
-- profile contém allowed/restricted/prohibited e `ctaMode`;
-- prohibited vence restricted; restricted vence allowed;
-- restricted exige field compatível e suporte;
-- módulo só restringe ou enfatiza algo permitido;
-- treatment desconhecido falha fechado.
+- cada profile contém arrays de treatment literals em `allowed`, `restricted` e `prohibited`, além de `ctaMode`;
+- cada treatment aparece exatamente uma vez entre `allowed`, `restricted` e `prohibited`;
+- `prohibited` prevalece sobre `restricted`, e `restricted` sobre `allowed`;
+- `restricted` exige field compatível e suporte;
+- módulo ou variante somente restringe, proíbe ou enfatiza treatment já conhecido;
+- categorias auxiliares podem existir como constantes internas, mas nunca são valores aceitos no registry;
+- alias, treatment ou `ctaMode` desconhecido falha fechado.
 
-Padrão:
+Padrão da família:
 
 - BOFU:
-  - allowed actions, context, problem, offer;
-  - factual restricted;
+  - `allowed`: `direct_action`, `qualified_action`, `low_friction_action`, `educational_context`, `problem_emphasis`, `offer_specificity`;
+  - `restricted`: `proof`, `comparison`, `price`, `promise`, `credential`, `authority`, `urgency`, `scarcity`, `guarantee`;
+  - `prohibited`: vazio;
   - `ctaMode=direct`.
 - MOFU:
-  - allowed qualified/low-friction, context, problem, offer;
-  - direct e factual restricted;
+  - `allowed`: `qualified_action`, `low_friction_action`, `educational_context`, `problem_emphasis`, `offer_specificity`;
+  - `restricted`: `direct_action`, `proof`, `comparison`, `price`, `promise`, `credential`, `authority`, `urgency`, `scarcity`, `guarantee`;
+  - `prohibited`: vazio;
   - `ctaMode=qualified`.
 - TOFU:
-  - allowed low-friction, context, problem;
-  - qualified/offer/proof/credential/authority restricted;
-  - direct/comparison/price/promise/urgency/scarcity/guarantee prohibited;
+  - `allowed`: `low_friction_action`, `educational_context`, `problem_emphasis`;
+  - `restricted`: `qualified_action`, `offer_specificity`, `proof`, `credential`, `authority`;
+  - `prohibited`: `direct_action`, `comparison`, `price`, `promise`, `urgency`, `scarcity`, `guarantee`;
   - `ctaMode=low_friction`.
 
-Deltas:
+Deltas por módulo:
 
-- Hero: CTA do stage; proof só em `proofShort`; preço/comparação/garantia/urgência/escassez proibidos.
-- Trust Bar: somente proof/credential/authority com suporte; ação e demais tratamentos comerciais proibidos.
-- Problem Solution: problem/context; sem ação, prova comercial, preço, urgência, escassez, garantia ou alarmismo.
-- Offer: oferta real; sem ação, preço, comparação, promessa, urgência, escassez ou garantia.
-- Process: context; sem ação, prova, preço, comparação, promessa, urgência, escassez ou garantia.
-- Technical Assurance: context; proof/credential/authority restritos a suporte; demais tratamentos comerciais proibidos.
-- Social Proof: somente prova operacional; quote/attribution gerada ou alterada é inválida.
-- FAQ: context/objection; sem ação, oferta, preço, comparação, promessa, urgência, escassez ou garantia; Accordion usa o mesmo delta.
-- Final CTA: somente ação do stage; treatments factuais e de oferta proibidos.
+- Hero:
+  - a ação permitida é somente `direct_action`, `qualified_action` ou `low_friction_action`, conforme o mapeamento literal do `ctaMode` efetivo;
+  - `proof` permanece restrito e só pode aparecer em `proofShort`;
+  - `comparison`, `price`, `guarantee`, `urgency` e `scarcity` são proibidos.
+- Trust Bar:
+  - `proof`, `credential` e `authority` permanecem restritos a suporte real;
+  - `direct_action`, `qualified_action`, `low_friction_action`, `educational_context`, `problem_emphasis`, `offer_specificity`, `comparison`, `price`, `promise`, `urgency`, `scarcity` e `guarantee` são proibidos.
+- Problem Solution:
+  - `educational_context` e `problem_emphasis` são permitidos;
+  - `direct_action`, `qualified_action`, `low_friction_action`, `offer_specificity`, `proof`, `comparison`, `price`, `promise`, `credential`, `authority`, `urgency`, `scarcity` e `guarantee` são proibidos.
+- Offer:
+  - `offer_specificity` é permitido somente com capacidade operacional real;
+  - `direct_action`, `qualified_action`, `low_friction_action`, `proof`, `comparison`, `price`, `promise`, `credential`, `authority`, `urgency`, `scarcity` e `guarantee` são proibidos.
+- Process:
+  - `educational_context` é permitido;
+  - `direct_action`, `qualified_action`, `low_friction_action`, `problem_emphasis`, `offer_specificity`, `proof`, `comparison`, `price`, `promise`, `credential`, `authority`, `urgency`, `scarcity` e `guarantee` são proibidos.
+- Technical Assurance:
+  - `educational_context` é permitido;
+  - `proof`, `credential` e `authority` permanecem restritos a suporte rastreável;
+  - `direct_action`, `qualified_action`, `low_friction_action`, `problem_emphasis`, `offer_specificity`, `comparison`, `price`, `promise`, `urgency`, `scarcity` e `guarantee` são proibidos.
+- Social Proof:
+  - somente `proof` é admitido e exige `operational_required`;
+  - `direct_action`, `qualified_action`, `low_friction_action`, `educational_context`, `problem_emphasis`, `offer_specificity`, `comparison`, `price`, `promise`, `credential`, `authority`, `urgency`, `scarcity` e `guarantee` são proibidos.
+- FAQ Standard e Accordion:
+  - `educational_context` e `problem_emphasis` são permitidos;
+  - `direct_action`, `qualified_action`, `low_friction_action`, `offer_specificity`, `proof`, `comparison`, `price`, `promise`, `credential`, `authority`, `urgency`, `scarcity` e `guarantee` são proibidos;
+  - as duas variantes usam o mesmo delta.
+- Final CTA:
+  - somente `direct_action`, `qualified_action` ou `low_friction_action` é permitido, conforme o mapeamento literal do `ctaMode` efetivo;
+  - `educational_context`, `problem_emphasis`, `offer_specificity`, `proof`, `comparison`, `price`, `promise`, `credential`, `authority`, `urgency`, `scarcity` e `guarantee` são proibidos.
 
 ### 2.6. Lifecycle, compatibilidade, API e erros
 
 Lifecycle:
 
-- `hypothesis`, `validated`, `deprecated`;
-- módulo/variante começam hypothesis, `purpose=controlled_test`;
-- não avançam além da raiz;
-- validated exige raiz validada, LP real, revisão e decisão humanas;
-- deprecated bloqueia nova composição e preserva histórico;
-- raiz depreciada torna cadeia inelegível sem mutar filhos.
+- valores: `hypothesis`, `validated`, `deprecated`;
+- módulo e variante começam `hypothesis`, com `purpose=controlled_test`;
+- promoção para `validated` exige raiz validada, LP real, revisão e decisão humanas;
+- `deprecated` bloqueia nova composição e preserva histórico;
+- raiz depreciada torna a cadeia inelegível sem mutar módulo ou variante.
+
+Lifecycle efetivo:
+
+- o resultado retorna `rootLifecycleStatus`, `moduleLifecycleStatus`, `variantLifecycleStatus` e `effectiveLifecycleStatus`;
+- `effectiveLifecycleStatus=deprecated` quando qualquer um dos três estados for `deprecated`;
+- sem `deprecated`, `effectiveLifecycleStatus=hypothesis` quando qualquer um dos três estados for `hypothesis`;
+- `effectiveLifecycleStatus=validated` somente quando raiz, módulo e variante forem `validated`.
 
 Referência completa:
 
 - `family`, `moduleCatalogVersion`, `rootVersion`, `moduleKey`, `moduleVersion`, `variantKey`, `variantVersion`;
 - incompatibilidade falha fechado.
 
-Resolver:
+Resolver público:
 
-- `resolveLandingPageModuleVariant`;
-- input: catálogo, raiz, preset opcional e referência completa;
-- resolve raiz, valida catálogo/compatibilidade e seleciona sem fallback;
-- output: identidade, root parameters, módulo, variante, fields, capabilities, map, profile, lifecycle e purpose;
-- profundamente imutável.
+```ts
+resolveLandingPageModuleVariant(
+  reference: LandingPageModuleVariantReference,
+  options?: Readonly<{ presetKey?: string }>,
+): ResolveLandingPageModuleVariantResult
+```
 
-Payload validator:
+- o consumidor não fornece objetos de catálogo, raiz ou registry;
+- o resolver usa internamente o registry canônico do catálogo e chama `resolveLandingPageRootParameters({ rootVersion, presetKey })` pelo boundary público;
+- valida catálogo, versões, identidade, compatibilidade e seleciona módulo/variante sem fallback;
+- sucesso retorna referência, `rootParameters`, módulo, variante, fields, capabilities, `copySourceMap`, `funnelCopyProfile`, `rootLifecycleStatus`, `moduleLifecycleStatus`, `variantLifecycleStatus`, `effectiveLifecycleStatus`, `modulePurpose` e `variantPurpose`;
+- erro retorna somente código e mensagem segura;
+- resultado é profundamente imutável.
 
-- `validateLandingPageVariantPayload`;
-- referência mais `payload: unknown`;
-- valida keys, tipos, cardinalidade, collection, action, image e reference;
-- não valida qualidade, verdade factual, destino, renderer, composição, persistência ou snapshot.
+Payload validator público:
+
+```ts
+validateLandingPageVariantPayload(
+  reference: LandingPageModuleVariantReference,
+  payload: unknown,
+  options?: Readonly<{ presetKey?: string }>,
+): ValidateLandingPageVariantPayloadResult
+```
+
+- chama o resolver público e valida keys, tipos, cardinalidade, collection, action, image, reference e limites textuais da raiz;
+- não valida qualidade editorial, verdade factual, destino concreto, renderer, composição, persistência ou snapshot.
 
 Erros:
 
@@ -326,93 +430,118 @@ Novos em `lib/conversion-content/landing-page/module-catalog/`:
 
 Ajustados:
 
+- `lib/conversion-content/landing-page/index.ts`:
+  - reexportar `normalizeLandingPageRootText` e `countLandingPageRootTextCharacters` de `root-schema.ts`;
+  - preservar todos os exports atuais e o significado do namespace `landingPageRoot`.
 - `lib/conversion-content/index.ts`:
   - adicionar namespace `landingPageModuleCatalog`;
   - preservar namespaces existentes.
 - `package.json`:
-  - script `validate:landing-page-module-catalog`.
+  - adicionar script `validate:landing-page-module-catalog`.
 - este plano:
-  - somente estado/evidências/decisão da fase.
+  - registrar somente estado, evidências e decisão da fase.
 
 Preservados:
 
-- `landing-page/index.ts` e arquivos root;
+- contratos, registry, resolver, schema e valores da raiz E18.4, exceto o reexport aditivo dos dois helpers já existentes;
 - `research-resolution/*`, `input-catalog/*`, `commercial-activation/*`.
 
 API:
 
-- `landingPageRoot` continua somente raiz;
-- novo `landingPageModuleCatalog`;
-- exporta types, registry, schemas necessários, resolver e validator;
-- “público” é boundary TypeScript, não client/rota/API HTTP.
+- `landingPageRoot` continua exclusivamente relacionado à raiz e passa a expor também seus helpers canônicos de texto;
+- novo namespace `landingPageModuleCatalog` exporta types, registry, schemas necessários, resolver e validator;
+- “público” significa boundary TypeScript, não client, rota ou API HTTP;
+- o resolver não expõe API pública de injeção de registry.
 
 ### 2.8. Update e fronteiras
 
 - Aplicar `prod#17` somente como referência declarativa WCAG 2.2 no Accordion.
 - Rejeitar todos os updates de Supabase, Vercel, GitHub e demais de Produto.
 - E18.5 define estrutura; E20 futura escolhe composição; E19 futura produz copy/valores e snapshot; renderer futuro executa payload e acessibilidade concreta.
+- A matriz de validação deve confirmar, em teste apenas, que `primary_action.allowedValues` é subconjunto do enum público de `primary_conversion_channel` do catálogo de entradas v1.
+- Essa verificação usa o boundary público do catálogo de entradas e não cria dependência runtime no resolver.
+
+### 2.9. Estratégia experimental de branches e merge
+
+Durante a comparação:
+
+- baseline comum e imutável: commit `83d0048678c3139b82075380c4e1bcbb1dac0043` da branch `docs/e18-5-modules-variants`;
+- PR #585 permanece draft, com base nessa branch e head `codex-app/e18-5-v2-processo-atual`;
+- a implementação manual usa nova branch filha criada do head aprovado do PR #585 e novo PR draft com base `codex-app/e18-5-v2-processo-atual`;
+- o workflow automatizado deve usar pilha irmã originada do mesmo baseline;
+- nenhum PR documental ou de implementação é mergeado durante a comparação.
+
+Depois da comparação:
+
+- escolher a melhor entrega ou criar branch de reconciliação a partir do head selecionado;
+- a branch final deve conter v1, v2 escolhida e implementação validada;
+- abrir ou retargetar somente o PR final de integração contra `main`;
+- fechar PR #577, PR #585 e PRs experimentais substituídos sem merge, quando aplicável;
+- merge na `main` continua dependente de decisão humana explícita após a comparação.
 
 ## 3. Contratos fechados
 
 ### 3.1. Fields por variante
 
 - Hero:
-  - eyebrow text/eyebrow `0..1`, research, none;
-  - title text/h1 `1..1`, hybrid, when_factual;
-  - subtitle text/paragraph `1..1`, hybrid, when_factual;
-  - CTA action `1..1`, not_copy, primary_action; label text/cta_label `1..1`, hybrid, when_present;
-  - proofShort text/paragraph `0..1`, hybrid, when_present;
-  - media image `0..1`, technical_reference, image_asset.
+  - `eyebrow`: `fieldKind=text`, `semanticRole=eyebrow`, `cardinality=0..1`, `policy=research_guided`, `support=none`;
+  - `title`: `fieldKind=text`, `semanticRole=h1`, `cardinality=1..1`, `policy=hybrid`, `support=when_factual`;
+  - `subtitle`: `fieldKind=text`, `semanticRole=paragraph`, `cardinality=1..1`, `policy=hybrid`, `support=when_factual`;
+  - `primaryCta`: `fieldKind=action`, `cardinality=1..1`, `policy=not_copy`, `capability=primary_action`;
+  - `primaryCta.label`: `fieldKind=text`, `semanticRole=cta_label`, `cardinality=1..1`, `policy=hybrid`, `support=when_present`;
+  - `proofShort`: `fieldKind=text`, `semanticRole=paragraph`, `cardinality=0..1`, `policy=hybrid`, `support=when_present`;
+  - `media`: `fieldKind=image`, `cardinality=0..1`, `policy=technical_reference`, `capability=image_asset`.
 - Trust Bar:
-  - items collection `2..4`, not_copy;
-  - text text/benefit_item `1..1`, hybrid, when_present.
+  - `items`: `fieldKind=collection`, `cardinality=2..4`, `policy=not_copy`;
+  - `items[].text`: `fieldKind=text`, `semanticRole=benefit_item`, `cardinality=1..1`, `policy=hybrid`, `support=when_present`.
 - Problem Solution:
-  - title text/h2 `1..1`, research, none;
-  - items collection `2..4`, not_copy;
-  - problem text/card_title `1..1`, research, none;
-  - solution text/card_body `1..1`, hybrid, when_present.
+  - `title`: `fieldKind=text`, `semanticRole=h2`, `cardinality=1..1`, `policy=research_guided`, `support=none`;
+  - `items`: `fieldKind=collection`, `cardinality=2..4`, `policy=not_copy`;
+  - `items[].problem`: `fieldKind=text`, `semanticRole=card_title`, `cardinality=1..1`, `policy=research_guided`, `support=none`;
+  - `items[].solution`: `fieldKind=text`, `semanticRole=card_body`, `cardinality=1..1`, `policy=hybrid`, `support=when_present`.
 - Offer:
-  - title text/h2 `1..1`, research, none;
-  - items collection `1..4`, not_copy;
-  - itemTitle text/card_title `1..1`, hybrid, when_present;
-  - description text/card_body `1..1`, hybrid, when_present.
+  - `title`: `fieldKind=text`, `semanticRole=h2`, `cardinality=1..1`, `policy=research_guided`, `support=none`;
+  - `items`: `fieldKind=collection`, `cardinality=1..4`, `policy=not_copy`;
+  - `items[].itemTitle`: `fieldKind=text`, `semanticRole=card_title`, `cardinality=1..1`, `policy=hybrid`, `support=when_present`;
+  - `items[].description`: `fieldKind=text`, `semanticRole=card_body`, `cardinality=1..1`, `policy=hybrid`, `support=when_present`.
 - Process:
-  - title text/h2 `1..1`, research, none;
-  - steps ordered collection `2..6`, not_copy;
-  - stepTitle text/step_title `1..1`, hybrid, when_present;
-  - stepBody text/step_body `1..1`, hybrid, when_present.
+  - `title`: `fieldKind=text`, `semanticRole=h2`, `cardinality=1..1`, `policy=research_guided`, `support=none`;
+  - `steps`: `fieldKind=collection`, `ordered=true`, `cardinality=2..6`, `policy=not_copy`;
+  - `steps[].stepTitle`: `fieldKind=text`, `semanticRole=step_title`, `cardinality=1..1`, `policy=hybrid`, `support=when_present`;
+  - `steps[].stepBody`: `fieldKind=text`, `semanticRole=step_body`, `cardinality=1..1`, `policy=hybrid`, `support=when_present`.
 - Technical Assurance:
-  - title text/h2 `1..1`, research, none;
-  - items collection `1..4`, not_copy;
-  - assuranceTitle text/card_title `1..1`, hybrid, when_present;
-  - assuranceBody text/card_body `1..1`, hybrid, when_present.
+  - `title`: `fieldKind=text`, `semanticRole=h2`, `cardinality=1..1`, `policy=research_guided`, `support=none`;
+  - `items`: `fieldKind=collection`, `cardinality=1..4`, `policy=not_copy`;
+  - `items[].assuranceTitle`: `fieldKind=text`, `semanticRole=card_title`, `cardinality=1..1`, `policy=hybrid`, `support=when_present`;
+  - `items[].assuranceBody`: `fieldKind=text`, `semanticRole=card_body`, `cardinality=1..1`, `policy=hybrid`, `support=when_present`.
 - Social Proof:
-  - title text/h2 `1..1`, research, none;
-  - items collection `1..3`, not_copy;
-  - quote text/card_body `1..1`, operational, when_present;
-  - attribution text/card_title `1..1`, operational, when_present;
-  - evidenceRef reference `1..1`, technical_reference, operational_evidence.
+  - `title`: `fieldKind=text`, `semanticRole=h2`, `cardinality=1..1`, `policy=research_guided`, `support=none`;
+  - `items`: `fieldKind=collection`, `cardinality=1..3`, `policy=not_copy`;
+  - `items[].quote`: `fieldKind=text`, `semanticRole=card_body`, `cardinality=1..1`, `policy=operational_required`, `support=when_present`;
+  - `items[].attribution`: `fieldKind=text`, `semanticRole=card_title`, `cardinality=1..1`, `policy=operational_required`, `support=when_present`;
+  - `items[].evidenceRef`: `fieldKind=reference`, `cardinality=1..1`, `policy=technical_reference`, `referenceKind=operational_evidence`.
 - FAQ Standard:
-  - title text/h2 `1..1`, research, none;
-  - items collection `2..6`, not_copy;
-  - question text/faq_question `1..1`, research, none;
-  - answer text/faq_answer `1..1`, hybrid, when_factual.
+  - `title`: `fieldKind=text`, `semanticRole=h2`, `cardinality=1..1`, `policy=research_guided`, `support=none`;
+  - `items`: `fieldKind=collection`, `cardinality=2..6`, `policy=not_copy`;
+  - `items[].question`: `fieldKind=text`, `semanticRole=faq_question`, `cardinality=1..1`, `policy=research_guided`, `support=none`;
+  - `items[].answer`: `fieldKind=text`, `semanticRole=faq_answer`, `cardinality=1..1`, `policy=hybrid`, `support=when_factual`.
 - FAQ Accordion:
-  - definição própria com os mesmos fields;
-  - accordion_interaction;
-  - sem herança semântica ou campo novo.
+  - possui definição própria com os mesmos paths e valores literais de fields da FAQ Standard;
+  - adiciona somente `capability=accordion_interaction`;
+  - não herda semanticamente da variante irmã e não adiciona field.
 - Final CTA:
-  - title text/h2 `1..1`, hybrid, when_factual;
-  - body text/paragraph `1..1`, hybrid, when_factual;
-  - CTA action `1..1`, not_copy, primary_action; label text/cta_label `1..1`, hybrid, when_present.
+  - `title`: `fieldKind=text`, `semanticRole=h2`, `cardinality=1..1`, `policy=hybrid`, `support=when_factual`;
+  - `body`: `fieldKind=text`, `semanticRole=paragraph`, `cardinality=1..1`, `policy=hybrid`, `support=when_factual`;
+  - `primaryCta`: `fieldKind=action`, `cardinality=1..1`, `policy=not_copy`, `capability=primary_action`;
+  - `primaryCta.label`: `fieldKind=text`, `semanticRole=cta_label`, `cardinality=1..1`, `policy=hybrid`, `support=when_present`.
 
 ### 3.2. Regras comuns
 
-- Todos: lifecycle hypothesis, purpose controlled_test e `rootDelta={}`.
+- Todos: `lifecycleStatus=hypothesis`, `purpose=controlled_test` e `rootDelta={}`.
 - Suporte real conforme fields; Problem Solution sem alarmismo.
 - Social Proof sem fabricação/alteração material.
 - FAQ sem duplicidade ou fato sem suporte.
-- Hero/Final CTA excluem form.
+- Hero e Final CTA excluem `form`.
 - Accordion valida contrato declarativo, não comportamento.
 - Nenhum contrato armazena destino concreto ou taxon.
 
@@ -438,14 +567,14 @@ Entregas:
 
 Critérios:
 
-- `landingPageRoot` somente raiz; resolver usa API raiz;
-- versões, identidades, grammar, maps, profiles, capabilities, lifecycle e compatibility estritos;
+- `landingPageRoot` preserva o contrato da raiz e reexporta somente os dois helpers canônicos de texto; resolver usa exclusivamente a API pública da raiz;
+- versões, identidades, fields, policies, supports, maps, treatments, `ctaMode`, capabilities, lifecycle e compatibilidade usam somente valores literais fechados;
 - rootDelta vazio, form rejeitado, FAQs independentes;
 - Accordion somente declarativo WCAG 2.2;
-- payload cobre todos field kinds; desconhecidos rejeitados;
+- payload cobre todos os `fieldKind`, aplica normalização e `absoluteMax` da raiz e rejeita aliases, desconhecidos e combinações inválidas;
 - erros sem copy, pesquisa, PII, credenciais ou secrets;
 - output profundamente imutável;
-- nenhum consumidor/família preservada alterado.
+- nenhum consumidor ou família preservada é alterado, salvo o reexport aditivo dos helpers da raiz e a verificação test-only contra o catálogo de entradas.
 
 Validações:
 
@@ -458,10 +587,10 @@ Validações:
 Matriz mínima:
 
 - resolve dez variantes;
-- rejeita versões, identidades, roles, fields, policies, supports, capabilities, maps, treatments, deltas e payloads inválidos;
+- rejeita versões, identidades, roles, fields, policies, supports, capabilities, maps, treatments, `ctaMode`, aliases, deltas e payloads inválidos;
 - rejeita form;
-- valida alt text e cardinalidade;
-- comprova imutabilidade, independência das FAQs, ausência de colisão e preservação dos exports.
+- valida alt text, cardinalidade, texto vazio após normalização, valor exatamente em `absoluteMax`, valor acima de `absoluteMax` e ausência de bloqueio pelos intervalos recomendados;
+- comprova imutabilidade, independência das FAQs, cálculo dos quatro estados de lifecycle, ausência de colisão, preservação dos exports e subconjunto de canais frente a `primary_conversion_channel`.
 
 Parada:
 
@@ -471,18 +600,20 @@ Parada:
 
 ### 4.2. Próxima ação
 
-- Revisar esta v2 na branch filha.
-- Não alterar o PR #577.
-- Não implementar antes da aprovação humana e do ingresso da v2 na `main`.
-- Após confirmação do merge aplicável, orientar somente a fase 3.1.
+- Plano v2 aprovado humanamente neste patch final.
+- Criar branch de implementação manual comparativa a partir do head atualizado de `codex-app/e18-5-v2-processo-atual`.
+- Abrir PR draft dessa branch com base `codex-app/e18-5-v2-processo-atual`.
+- Orientar o Executor a executar exclusivamente a fase 3.1 nessa nova branch.
+- Manter PR #577, PR #585 e o novo PR sem merge durante a comparação com o workflow automatizado.
+- Após as duas entregas, comparar aderência, qualidade, escopo, testes, retrabalho e decisões implícitas antes de escolher ou reconciliar a solução final.
 
 ## 5. Validação e encerramento
 
 ### 5.1. Validação documental
 
-- três pareceres consolidados;
+- três pareceres iniciais e reavaliação final do Analista consolidados;
 - única fase, `Automação: não`;
-- topologia, API, copy, funil, lifecycle, erros e testes definidos;
+- topologia, API, copy, funil, limites, lifecycle efetivo, erros, testes e fluxo experimental definidos;
 - sem fase administrativa.
 
 Nesta consolidação:

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -106,6 +106,7 @@ A separação aplica-se aos nove módulos.
 - Cada módulo começa com uma única variante `standard@v1`.
 - Nova variante exige diferença estrutural ou comportamental reutilizável.
 - Nova variante pode adicionar ou especializar campos, mídia, interação, responsividade e validações próprias.
+- Nova variante deve constituir evolução aditiva e localizada; poderá exigir capabilities compartilhadas ou infraestrutura inerente à nova execução, tratadas nos respectivos recortes, sem alteração destrutiva do módulo, das variantes existentes ou das LPs anteriores.
 - Nova variante não altera contratos ou LPs de variantes anteriores.
 - Restrições de `standard@v1` não restringem variantes futuras.
 - Nova variante não exige nova `moduleVersion` quando preserva função, fronteiras e invariantes do módulo.

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -1,418 +1,501 @@
-14/07/2026 — Plano-base E18.5 — Parametrização de módulos e variantes `landing_page`
+19/07/2026 — Plano-base E18.5 — Parametrização de módulos e variantes `landing_page`
 
-Fontes: chat, `README.md`, `AGENTS.md`, `docs/prompt-estrategista.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/schema.md`, `docs/lp-planejamento.md`, `docs/lousa-plano-base-e18-4.md`, `docs/lousa-plano-base-e20-2.md`, `docs/blueprint-corretor-imoveis-end-customer.md`, `docs/prompt-nicho-itens-estruturados.md`, consulta read-only ao Supabase, `lib/conversion-content/landing-page/`, `lib/conversion-content/landing-page/input-catalog/registry.ts`, PRs #559, #563, #564, #566, #567, #577 e #581, avaliações do Analista e decisões humanas de 14 a 17/07/2026.
+Fontes: chat; `README.md`; `AGENTS.md`; `docs/prompt-estrategista.md`; `docs/prompt-executor.md`; `docs/gestor-estrutural.md`; `docs/roadmap.md`; `docs/base-tecnica.md`; `docs/schema.md`; `docs/lp-planejamento.md`; planos E18.4 e E20.2; Blueprint; prompt de itens estruturados; catálogos de updates; boundary `landing_page`; pareceres do Analista, Gestor Estrutural e Gestor de Updates de 19/07/2026.
 
-Versão: v1 conceitualmente fechada.
+Versão: v2 consolidada.
 
-Status: nove módulos e nove variantes `standard@v1` conceitualmente fechados; `faq.accordion@v1` aprovada como única variante adicional para validação controlada; uma fase executável definida; nenhuma implementação de código autorizada neste PR.
+Status: nove módulos, nove `standard@v1`, `faq.accordion@v1`, contrato compartilhado e fase executável fechados; implementação não autorizada.
 
 Path: `docs/lousa-plano-base-e18-5.md`.
 
-Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_page`.
+Branches:
+
+- v1 e PR #577 congelados em `docs/e18-5-modules-variants`;
+- v2 somente em `codex-app/e18-5-v2-processo-atual`;
+- não alterar diretamente o PR #577;
+- merge e execução exigem decisão humana.
 
 ## 1. Estado e decisões fixas
 
-### 1.1. Objetivo da E18.5
+### 1.1. Objetivo e escopo
 
-- Implementar no repositório o catálogo versionado dos nove módulos `landing_page`, suas variantes `standard@v1` e `faq.accordion@v1`.
-- Entregar contratos pequenos, estritos, imutáveis e suficientes para consumo posterior pela E20 e pela E19.
-- Preservar extensibilidade sem antecipar campos, capabilities ou variantes sem uso aprovado.
+- Implementar catálogo repo-only versionado, reutilizando a raiz v1 pela API pública.
+- Entregar contrato estrito e imutável para futuros E20, E19 e renderer.
+- Incluir identidade, lifecycle, fields, cardinalidades, policies, suporte, capabilities, copy, funil, schemas, registry, resolver, payload validator e testes.
+- Excluir banco, rota, UI, composição, geração, persistência, snapshot, renderer, tracking, automação, HTML/ARIA concreto, nova variante, formulário e especialização numérica da raiz.
 
 ### 1.2. Estado confirmado
 
-- A E18.4 está concluída e a raiz versionada existe em `lib/conversion-content/landing-page/`.
-- A precedência permanece `raiz → módulo → variante`.
-- A E18.5 é repo-only; ainda não existem composição, renderer ou render model deste recorte.
-- O catálogo operacional já define `primary_conversion_channel` e destinos condicionais.
-- `commercial_activation`, E18.2 e E18.3 permanecem preservados.
-- O trabalho documental ocorre no PR #577 e na branch `docs/e18-5-modules-variants`.
-- O PR não deve ser mergeado sem confirmação humana explícita.
+- Raiz `landing_page@1` implementada; precedência `raiz → módulo → variante`.
+- Raiz usa `hypothesis` e baseline WCAG 2.2 sem conformidade integral.
+- Catálogo de entradas conhece `form`; variantes v1 não o aceitam.
+- `commercial_activation`, pesquisa e catálogo de entradas permanecem inalterados.
+- Contratos próprios de E20, E19.4 e renderer ainda não existem; a E18.5 não define decisões internas desses consumidores.
 
-### 1.3. Grade fechada de módulos
+### 1.3. Grade fechada
 
-- `hero` ← `hero_segmentado`.
-- `trust_bar` ← `barra_de_confianca`.
-- `problem_solution` ← `dores_e_solucoes`.
-- `offer` ← `servicos_por_intencao`.
-- `process` ← `processo_de_atendimento`.
-- `technical_assurance` ← `prova_tecnica_documental`.
-- `social_proof` ← `prova_social`.
-- `faq` ← `faq_objeções`.
-- `final_cta` ← `cta_final_qualificado`.
+- `hero@v1` → `hero.standard@v1`.
+- `trust_bar@v1` → `trust_bar.standard@v1`.
+- `problem_solution@v1` → `problem_solution.standard@v1`.
+- `offer@v1` → `offer.standard@v1`.
+- `process@v1` → `process.standard@v1`.
+- `technical_assurance@v1` → `technical_assurance.standard@v1`.
+- `social_proof@v1` → `social_proof.standard@v1`.
+- `faq@v1` → `faq.standard@v1`, `faq.accordion@v1`.
+- `final_cta@v1` → `final_cta.standard@v1`.
 
 Regras:
 
-- `item_key` é evidência de pesquisa, não identidade canônica do módulo.
-- Os módulos são transversais e não recebem identidade de taxon.
-- Formatos curto, médio e longo pertencem à composição e à extensão da LP.
-- Não há módulo conceitual pendente.
+- identidade escopada por `family = landing_page`, sem colisão com `commercial_activation`;
+- taxon, funil, campanha, plano, copy, ativo, ordem ou quantidade não criam variante;
+- não há parametrização aprovada pendente.
 
-### 1.4. Escopo positivo
+### 1.4. Consolidação dos pareceres
 
-- identidade e versão do catálogo, módulos e variantes;
-- função, invariantes, fronteiras, campos, cardinalidades e capabilities;
-- especializações sobre a raiz, fontes de copy e perfis de funil;
-- exigências factuais e operacionais;
-- tipos, schemas, registry, resolver, validadores, testes e exportação pública;
-- lifecycle, compatibilidade e descontinuação.
+Aceito:
 
-### 1.5. Escopo negativo
+- topologia, namespace, API, script, erros e responsabilidades exatas;
+- consumo obrigatório de `resolveLandingPageRootParameters`;
+- gramática, maps, profiles, capabilities e lifecycle fechados;
+- ausência de especializações v1, incompatibilidade com `form` e FAQ validada primeiro;
+- `prod#17` apenas como referência declarativa.
 
-- banco, migrations, Admin, Builder, composição concreta, LP real, renderer ou componente visual;
-- persistência, snapshot, tracking ou conteúdo operacional concreto;
-- variantes além de `standard@v1`, exceto `faq.accordion@v1`;
-- capabilities sem consumidor aprovado.
+Rejeitado:
+
+- novas fases/variantes, banco, renderer, tracking, automação e updates de Supabase/Vercel/GitHub;
+- conformidade WCAG integral e validação comportamental real.
+
+Pendente sem bloquear:
+
+- planos técnicos futuros de E20, E19.4 e renderer.
 
 ## 2. Contrato compartilhado
 
-### 2.1. Separação entre módulo e variante
+### 2.1. Registry, versões e raiz
 
-Módulo define:
+Catálogo v1:
 
-- função estrutural reutilizável;
-- fronteiras, invariantes permanentes e integração comum;
-- compatibilidade compartilhada.
+- `family = landing_page`;
+- `moduleCatalogVersion = 1`;
+- `compatibleRootVersions = [1]`;
+- nove módulos e dez variantes;
+- catálogo sem lifecycle.
 
-Variante define:
+Shape:
 
-- execução estrutural ou comportamental concreta;
-- campos, cardinalidades, capabilities e deltas sobre a raiz;
-- validações e requisitos técnicos, factuais, operacionais ou de acessibilidade.
+- catálogo: `family`, `moduleCatalogVersion`, `compatibleRootVersions`, `modules`;
+- módulo: `moduleKey`, `moduleVersion`, `lifecycleStatus`, `purpose`, `function`, `boundaries`, `invariants`, `rootDelta`, `variants`;
+- variante: `variantKey`, `variantVersion`, `lifecycleStatus`, `purpose`, `compatibleModuleVersion`, `fields`, `copySourceMap`, `funnelProfileDelta`, `capabilities`, `rootDelta`;
+- chave externa e identidade interna devem coincidir.
 
-### 2.2. Extensibilidade das variantes
+Versão:
 
-- Cada módulo começa com `standard@v1`; `faq.accordion@v1` é a única exceção antes da primeira LP.
-- Nova variante exige diferença estrutural ou comportamental reutilizável.
-- A evolução deve ser aditiva e localizada, sem alteração destrutiva do módulo, das variantes existentes ou das LPs anteriores.
-- Capability compartilhada ou infraestrutura inerente à nova execução pertence ao respectivo recorte e deve ser versionada quando necessário.
-- Nova `moduleVersion` é exigida quando mudam função, fronteiras, invariantes ou integração comum.
-- Nova `variantVersion` é exigida quando muda o contrato da variante.
-- Toda referência identifica `moduleKey`, `moduleVersion`, `variantKey` e `variantVersion`.
+- toda entrada é imutável e sem fallback;
+- mudança no conjunto/gramática/maps/profiles/capabilities/compatibilidade/resolução exige nova `moduleCatalogVersion`;
+- mudança de função/fronteira/invariante comum exige nova `moduleVersion`;
+- mudança de fields/cardinalidade/behavior/capability/copy/validação exige nova `variantVersion`;
+- mudança comum da família ou ampliação absoluta pertence à raiz.
 
-Não criam variante isoladamente:
+Reuso:
 
-- taxon, plano, campanha, funil ou copy;
-- troca de ativo, canal ou destino concreto;
-- ordem na LP, quantidade já permitida ou ajuste visual/responsivo normal.
+- resolver chama `resolveLandingPageRootParameters` pelo boundary;
+- proibido importar `root-registry.ts` ou duplicar roles, ranges, limits, spacing, presets e visual criteria;
+- erro raiz vira causa de `ROOT_RESOLUTION_FAILED`;
+- todos herdam integralmente a raiz v1;
+- `rootDelta = {}` em todos; qualquer chave é inválida.
 
-### 2.3. Herança, limites e resolução
+### 2.2. Gramática de fields
 
-- A raiz contém regras comuns; módulo e variante registram somente deltas necessários.
-- Módulo ou variante pode restringir a raiz, mas não ampliar seu limite absoluto.
-- Ampliação exige nova versão da raiz.
-- Variante declara compatibilidade explícita com a versão da raiz utilizada.
-- Variante imutável não muda pela disponibilidade posterior de nova capability.
-- Contrato ausente, incompatível ou inválido falha fechado, sem fallback silencioso.
-- Resultado resolvido é completo, profundamente imutável e sem referência mutável compartilhada.
+`fieldKind`:
 
-### 2.4. Contrato mínimo de campo
+- `text`, `collection`, `action`, `image`, `reference`.
+
+Cardinalidade:
+
+- `{ min, max }`, inteiros válidos;
+- notação `0..1` é abreviação;
+- coleção tem item fechado; coleção aninhada é inválida.
+
+Policies:
+
+- `research_guided`: texto somente pelos item keys do map;
+- `hybrid`: pesquisa e suporte quando factual;
+- `operational_required`: evidência real, sem geração/alteração material;
+- `technical_reference`: ativo/evidência/vínculo não gerado;
+- `not_copy`: container estrutural.
+
+Suporte:
+
+- `none`, `when_factual`, `when_present`.
+
+Combinações:
+
+- text aceita research/hybrid/operational;
+- collection/action usam `not_copy`;
+- image/reference usam `technical_reference`;
+- operational exige `when_present`;
+- texto visível exige semantic role da raiz;
+- desconhecido ou combinação inválida falha fechado.
+
+### 2.3. Shapes e capabilities
+
+Ação:
+
+- payload somente `label`, role `cta_label`;
+- sem canal ou destino concreto.
 
-Cada campo declara:
-
-- `fieldKey`, `fieldKind`, cardinalidade e policy;
-- `semanticRole`, quando textual;
-- suporte operacional e capability específica, quando aplicáveis.
-
-Notação da seção 3:
-
-- texto: `fieldKey: semanticRole, cardinalidade, policy[, suporte]`; nessa notação `fieldKind = text` fica implícito;
-- coleção, ação, mídia e referência técnica declaram o tipo explicitamente;
-- campos internos de coleção declaram cardinalidade própria;
-- coleção aninhada não integra a v1;
-- ação não armazena canal ou destino concreto.
-
-### 2.5. Copy e sustentação factual
-
-- `copySourceMap` define até duas fontes primárias e uma auxiliar por campo textual.
-- `funnelCopyProfile` adapta seleção e redação para BOFU, MOFU e TOFU, sem redefinir sozinho estrutura ou ordem.
-- Pesquisa orienta copy, mas não comprova fatos da operação.
-- Credencial, capacidade, condição, preço, prazo, parceria, resultado, garantia ou ação concreta exige suporte operacional real.
-- A E19 resolve valores e valida a instância concreta.
-- Policies aprovadas: `research_guided`, `hybrid`, `operational_required`, `technical_reference` e `not_copy`.
-
-### 2.6. Ações e vínculos operacionais
-
-- Ação possui label e vínculo abstrato com campo estável do catálogo operacional.
-- O registry não armazena valor, canal ou destino concreto.
-- A E19 resolve o campo operacional, condicionais e destino.
-- Nova chave operacional não pode ser criada implicitamente pela E18.5.
-
-### 2.7. Lifecycle e compatibilidade
-
-- `moduleCatalogVersion` declara versão e compatibilidade com a raiz.
-- Módulo e variante usam `experimental`, `active` ou `deprecated`.
-- Todos começam `experimental`, com propósito `controlled_test`.
-- Promoção para `active` exige LP real, revisão e decisão humanas.
-- `deprecated` bloqueia novas composições, mas preserva leitura histórica.
-
-### 2.8. Fronteiras entre etapas
-
-- E18.5 define validade estrutural e implementa contratos repo-only.
-- E20 escolhe módulos, variantes, versões, ordem, obrigatoriedade e opções por ocorrência.
-- E19 resolve conteúdo, ativos e vínculos, trata ausência conforme E20 e preserva versões e payload.
-- Renderer executa o contrato resolvido; não escolhe variante, conteúdo ou fallback.
-
-### 2.9. Checklist de fechamento
-
-Obrigatório:
-
-- identidade, função, evidência, fronteiras e invariantes;
-- `standard@v1`, campos, cardinalidades, copy, suporte factual, lifecycle e compatibilidade.
-
-Condicional:
-
-- ação, mídia, interação, responsividade, acessibilidade, fallback técnico ou referência técnica.
-
-### 2.10. Significado de implementação
-
-Um módulo está implementado quando existem:
-
-- identidade versionada do módulo e variantes aprovadas;
-- tipos, schemas, fields, cardinalidades e capabilities;
-- registry, resolver, validadores, casos executáveis e testes;
-- lifecycle, compatibilidade e exportação pelo boundary existente.
-
-Compatibilidade comum da seção 3:
-
-- cada `standard@v1` é compatível somente com o respectivo módulo `@v1` e com a raiz inicial;
-- `faq.accordion@v1` é compatível com `faq@v1` e com a mesma raiz;
-- definições compartilhadas podem ser reutilizadas, mas variantes irmãs não herdam semanticamente entre si.
-
-## 3. Contratos conceitualmente fechados
-
-### 3.1. Módulo `hero`
-
-- Identidade: `hero@v1`.
-- Função: apresentar a proposta principal e conduzir à rota prioritária.
-- Invariantes: proposta identificável, hierarquia coerente e ação abstrata quando usada.
-- Fronteiras: sem formulário completo, galeria, carrossel, tour, navegação global, oferta detalhada ou prova extensa.
-- Evidência: `hero_segmentado` e Blueprint.
-
-### 3.2. Variante `hero.standard@v1`
-
-- Campos: `eyebrow` (`eyebrow`, `0..1`, `research_guided`); `title` (`h1`, `1..1`, `hybrid`, `when_factual`); `subtitle` (`paragraph`, `1..1`, `hybrid`, `when_factual`); `primaryCta` (ação `1..1`, label `cta_label`, `hybrid`, `when_present`, vínculo com `primary_conversion_channel`); `proofShort` (`paragraph`, `0..1`, `hybrid`, `when_present`); `media` (imagem `0..1`, `technical_reference`).
-- Copy: posicionamento/desejo no título; dor/desejo no subtítulo; trigger no CTA; prova/objeção em `proofShort`.
-- Regras: canais `whatsapp`, `phone`, `email`, `external_url`; mídia informativa exige alternativa; `all_viewports`; sem CTA secundário, vídeo, formulário ou interação.
-- Estado: `experimental`, `controlled_test`.
-
-### 3.3. Módulo `trust_bar`
-
-- Identidade: `trust_bar@v1`.
-- Função: sinais curtos e verificáveis de confiança.
-- Invariantes: brevidade, relevância e suporte real.
-- Fronteiras: sem depoimento, prova extensa, CTA, formulário ou mídia.
-- Evidência: `barra_de_confianca`.
-
-### 3.4. Variante `trust_bar.standard@v1`
-
-- `items`: coleção `2..4`, `not_copy`; `text`: `benefit_item`, `1..1`, `hybrid`, `when_present`.
-- Copy: `proof_type`, `belief`; auxiliar `objection`.
-- Regras: cada item exige suporte; sem título, CTA, ícone ou mídia; responsividade pertence ao renderer.
-- Estado: `experimental`, `controlled_test`.
-
-### 3.5. Módulo `problem_solution`
-
-- Identidade: `problem_solution@v1`.
-- Função: relacionar problema ou risco a resposta prática.
-- Invariantes: correspondência direta, distinção clara, sem alarmismo.
-- Fronteiras: sem oferta detalhada, processo, prova, FAQ, CTA, mídia ou interação.
-- Evidência: `dores_e_solucoes`, `pain`, `fear`, `objection`, `desire`, `belief`, `positioning_opportunity`.
-
-### 3.6. Variante `problem_solution.standard@v1`
-
-- `title`: `h2`, `1..1`, `research_guided`.
-- `items`: coleção `2..4`, com `problem` (`card_title`, `1..1`, `research_guided`) e `solution` (`card_body`, `1..1`, `hybrid`, `when_present`).
-- Copy: dor/desejo no título; dor/medo no problema; posicionamento/desejo na solução.
-- Regras: solução responde ao problema do item; sem CTA, mídia, prova, preço, oferta ou processo.
-- Estado: `experimental`, `controlled_test`.
-
-### 3.7. Módulo `offer`
-
-- Identidade: `offer@v1`.
-- Função: apresentar ofertas ou casos de uso disponíveis.
-- Invariantes: item real, coerente e operacionalmente sustentado.
-- Fronteiras: sem preço, condição comercial, CTA, mídia, prova, processo ou FAQ.
-- Evidência: `servicos_por_intencao`, `trigger`, `desire`, `positioning_opportunity`, `belief`, `objection`, Blueprint e catálogo de entradas.
-
-### 3.8. Variante `offer.standard@v1`
-
-- `title`: `h2`, `1..1`, `research_guided`.
-- `items`: coleção `1..4`, com `itemTitle` (`card_title`, `1..1`, `hybrid`, `when_present`) e `description` (`card_body`, `1..1`, `hybrid`, `when_present`).
-- Copy: desejo/trigger no título e item; posicionamento/belief na descrição.
-- Regras: cada item exige capacidade real; pesquisa não comprova preço, prazo, parceria, garantia ou disponibilidade.
-- Estado: `experimental`, `controlled_test`.
-
-### 3.9. Módulo `process`
-
-- Identidade: `process@v1`.
-- Função: explicar progressão real por etapas.
-- Invariantes: ordem, etapas distintas e ausência de prazo ou resultado inventado.
-- Fronteiras: sem oferta, prova, FAQ, CTA, preço, mídia ou interação.
-- Evidência: `processo_de_atendimento`, `belief`, `desire`, `positioning_opportunity`, `trigger`, `objection`, Blueprint e catálogo.
-
-### 3.10. Variante `process.standard@v1`
-
-- `title`: `h2`, `1..1`, `research_guided`.
-- `steps`: coleção ordenada `2..6`, com `stepTitle` (`step_title`, `1..1`, `hybrid`, `when_present`) e `stepBody` (`step_body`, `1..1`, `hybrid`, `when_present`).
-- Copy: belief/desejo no título e corpo no título da etapa.
-- Regras: ordem reflete progressão real; numeração é do renderer; sem CTA, mídia, prova, preço ou formulário.
-- Estado: `experimental`, `controlled_test`.
-
-### 3.11. Módulo `technical_assurance`
-
-- Identidade: `technical_assurance@v1`.
-- Função: explicar salvaguardas, critérios, documentos, credenciais ou verificações.
-- Invariantes: item real e verificável, sem implicar risco zero, aprovação ou resultado.
-- Fronteiras: sem trust bar, depoimento, processo, oferta, FAQ, CTA, mídia, download ou link.
-- Evidência: `prova_tecnica_documental`, `proof_type`, `belief`, `fear`, `objection`, `positioning_opportunity`, narrativa e Blueprint.
-
-### 3.12. Variante `technical_assurance.standard@v1`
-
-- `title`: `h2`, `1..1`, `research_guided`.
-- `items`: coleção `1..4`, com `assuranceTitle` (`card_title`, `1..1`, `hybrid`, `when_present`) e `assuranceBody` (`card_body`, `1..1`, `hybrid`, `when_present`).
-- Copy: prova/belief no título; prova/posicionamento no corpo.
-- Regras: todo item exige suporte rastreável; sem aconselhamento individualizado, CTA, mídia, link, depoimento, preço, processo ou FAQ.
-- Estado: `experimental`, `controlled_test`.
-
-### 3.13. Módulo `social_proof`
-
-- Identidade: `social_proof@v1`.
-- Função: apresentar experiências reais de terceiros.
-- Invariantes: prova real, rastreável, autorizada e sem alteração material.
-- Fronteiras: sem trust bar, prova técnica, oferta, processo, FAQ, CTA, rating, métrica, logo, caso detalhado ou mídia.
-- Evidência: `prova_social`, `proof_type`, `belief`, `objection`, narrativa e Blueprint.
-
-### 3.14. Variante `social_proof.standard@v1`
-
-- `title`: `h2`, `1..1`, `research_guided`.
-- `items`: coleção `1..3`, com `quote` (`card_body`, `1..1`, `operational_required`), `attribution` (`card_title`, `1..1`, `operational_required`) e `evidenceRef` (referência técnica `1..1`, `technical_reference`).
-- Copy: título por prova/belief; quote e atribuição exclusivamente da evidência.
-- Regras: impedir fabricação ou alteração; atribuição pública depende de autorização.
-- Estado: `experimental`, `controlled_test`.
-
-### 3.15. Módulo `faq`
-
-- Identidade: `faq@v1`.
-- Função: responder dúvidas e objeções em pares de pergunta e resposta.
-- Invariantes: pergunta relevante, resposta direta, suporte factual e ausência de aconselhamento ou promessa enganosa.
-- Fronteiras: sem oferta, processo, prova técnica, CTA, mídia, formulário ou ação; interação pertence à variante.
-- Evidência: `faq_objeções`, `faq_questions`, `search_intent`, `objection`, `fear`, `belief`, `awareness_level` e Blueprint.
-
-### 3.16. Variante `faq.standard@v1`
-
-- `title`: `h2`, `1..1`, `research_guided`.
-- `items`: coleção `2..6`, com `question` (`faq_question`, `1..1`, `research_guided`) e `answer` (`faq_answer`, `1..1`, `hybrid`, `when_factual`).
-- Copy: objeção/awareness no título; objeção/medo na pergunta; belief/posicionamento na resposta.
-- Regras: sem duplicidade; resposta direta; fatos legais, técnicos, financeiros ou operacionais exigem suporte; sem interação.
-- Estado: `experimental`, `controlled_test`.
-
-### 3.17. Variante `faq.accordion@v1`
-
-- Identidade: compatível com `faq@v1` e a raiz inicial.
-- Declara o mesmo contrato de campos da variante standard, sem herança semântica; não adiciona conteúdo.
-- Capability: interação de acordeão e acessibilidade.
-- Comportamento: todos fechados inicialmente; abre/fecha pelo controle; somente um aberto; teclado; estado e associação acessíveis; foco preservado.
-- Limites: não define HTML, componente, ícone, animação ou visual.
-- Estado: `experimental`, `controlled_test`, candidata à primeira composição controlada.
-
-### 3.18. Módulo `final_cta`
-
-- Identidade: `final_cta@v1`.
-- Função: encerrar a jornada com próximo passo claro e qualificado.
-- Invariantes: uma ação principal, linguagem não coercitiva, vínculo abstrato e suporte factual.
-- Fronteiras: sem repetição de oferta, processo, FAQ ou prova; sem formulário, mídia, ação secundária ou destino concreto.
-- Evidência: `cta_final_qualificado`, `narrative_arc`, `mobile_priority`, `trigger`, `desire`, `objection`, `belief`, `positioning_opportunity`, `search_intent` e catálogo operacional.
-
-### 3.19. Variante `final_cta.standard@v1`
-
-- `title`: `h2`, `1..1`, `hybrid`, `when_factual`.
-- `body`: `paragraph`, `1..1`, `hybrid`, `when_factual`.
-- `primaryCta`: ação `1..1`, label `cta_label`, `hybrid`, `when_present`, vínculo obrigatório com `primary_conversion_channel`.
-- Copy: trigger/desejo no título; desejo/objeção no body; trigger no label.
-- Regras: canais `whatsapp`, `phone`, `email`, `external_url`; uma ação; sem destino no registry; sem CTA secundário, formulário, mídia, preço ou condição.
-- Estado: `experimental`, `controlled_test`.
-
-## 4. Fases e próxima ação
-
-### 4.1. Estado
-
-- Os nove módulos, as nove variantes `standard@v1` e `faq.accordion@v1` estão conceitualmente fechados.
-- Não há parametrização aprovada pendente.
-
-### 4.2. Fase executável
-
-#### 4.2.1. Fase 3.1 — E18.5.3–E18.5.9 — Catálogo repo-only de módulos e variantes
+Imagem:
+
+- `assetRef`, `mode`, `altText`;
+- mode `informative|decorative`;
+- informative exige alt; decorative exige alt vazio;
+- visibility `all_viewports`.
+
+Referência:
+
+- `referenceKind = operational_evidence`;
+- `evidenceRef` interno e rastreável.
+
+Capabilities:
+
+- `primary_action`:
+  - Hero e Final CTA;
+  - binding `primary_conversion_channel`;
+  - allowed `whatsapp|phone|email|external_url`;
+  - `form` incompatível.
+- `image_asset`:
+  - somente Hero;
+  - modes/alt conforme imagem.
+- `accordion_interaction`:
+  - somente FAQ Accordion;
+  - all closed, single expansion, toggle próprio, teclado, estado exposto, associação e foco preservado;
+  - foco visível e baseline herdados da raiz;
+  - validação somente declarativa.
+
+Nenhuma outra capability integra v1.
+
+### 2.4. `copySourceMap`
+
+Shape:
+
+- pesquisa: `sourceMode=research`, 1–2 `primaryItemKeys`, 0–1 `auxiliaryItemKey`;
+- operacional: `sourceMode=operational_evidence`, sem item key;
+- desconhecido ou excesso falha fechado.
+
+Mappings:
+
+- Hero:
+  - eyebrow `[positioning_opportunity]` + `search_intent`;
+  - title `[positioning_opportunity, desire]` + `commercial_keywords`;
+  - subtitle `[pain, desire]` + `belief`;
+  - CTA label `[trigger]` + `search_intent`;
+  - proofShort `[proof_type]` + `objection`.
+- Trust Bar:
+  - item text `[proof_type, belief]` + `objection`.
+- Problem Solution:
+  - title `[pain, desire]` + `positioning_opportunity`;
+  - problem `[pain, fear]` + `objection`;
+  - solution `[positioning_opportunity, desire]` + `belief`.
+- Offer:
+  - title `[desire, trigger]` + `positioning_opportunity`;
+  - itemTitle `[trigger, desire]`;
+  - description `[positioning_opportunity, belief]` + `objection`.
+- Process:
+  - title `[belief, desire]` + `positioning_opportunity`;
+  - stepTitle `[trigger, positioning_opportunity]` + `desire`;
+  - stepBody `[belief, desire]` + `objection`.
+- Technical Assurance:
+  - title `[proof_type, belief]` + `objection`;
+  - assuranceTitle `[proof_type]` + `belief`;
+  - assuranceBody `[proof_type, positioning_opportunity]` + `objection`.
+- Social Proof:
+  - title `[proof_type, belief]` + `objection`;
+  - quote/attribution operacionais.
+- FAQ Standard/Accordion:
+  - title `[objection, awareness_level]` + `search_intent`;
+  - question `[objection, fear]` + `faq_questions`;
+  - answer `[belief, positioning_opportunity]` + `desire`.
+- Final CTA:
+  - title `[trigger, desire]` + `positioning_opportunity`;
+  - body `[desire, objection]` + `belief`;
+  - CTA label `[trigger]` + `search_intent`.
+
+### 2.5. `funnelCopyProfile`
+
+Stages:
+
+- `bofu`, `mofu`, `tofu`.
+
+Treatments:
+
+- actions: `direct_action`, `qualified_action`, `low_friction_action`;
+- content: `educational_context`, `problem_emphasis`, `offer_specificity`;
+- factual: `proof`, `comparison`, `price`, `promise`, `credential`, `authority`, `urgency`, `scarcity`, `guarantee`.
+
+Regras:
+
+- profile contém allowed/restricted/prohibited e `ctaMode`;
+- prohibited vence restricted; restricted vence allowed;
+- restricted exige field compatível e suporte;
+- módulo só restringe ou enfatiza algo permitido;
+- treatment desconhecido falha fechado.
+
+Padrão:
+
+- BOFU:
+  - allowed actions, context, problem, offer;
+  - factual restricted;
+  - `ctaMode=direct`.
+- MOFU:
+  - allowed qualified/low-friction, context, problem, offer;
+  - direct e factual restricted;
+  - `ctaMode=qualified`.
+- TOFU:
+  - allowed low-friction, context, problem;
+  - qualified/offer/proof/credential/authority restricted;
+  - direct/comparison/price/promise/urgency/scarcity/guarantee prohibited;
+  - `ctaMode=low_friction`.
+
+Deltas:
+
+- Hero: CTA do stage; proof só em `proofShort`; preço/comparação/garantia/urgência/escassez proibidos.
+- Trust Bar: somente proof/credential/authority com suporte; ação e demais tratamentos comerciais proibidos.
+- Problem Solution: problem/context; sem ação, prova comercial, preço, urgência, escassez, garantia ou alarmismo.
+- Offer: oferta real; sem ação, preço, comparação, promessa, urgência, escassez ou garantia.
+- Process: context; sem ação, prova, preço, comparação, promessa, urgência, escassez ou garantia.
+- Technical Assurance: context; proof/credential/authority restritos a suporte; demais tratamentos comerciais proibidos.
+- Social Proof: somente prova operacional; quote/attribution gerada ou alterada é inválida.
+- FAQ: context/objection; sem ação, oferta, preço, comparação, promessa, urgência, escassez ou garantia; Accordion usa o mesmo delta.
+- Final CTA: somente ação do stage; treatments factuais e de oferta proibidos.
+
+### 2.6. Lifecycle, compatibilidade, API e erros
+
+Lifecycle:
+
+- `hypothesis`, `validated`, `deprecated`;
+- módulo/variante começam hypothesis, `purpose=controlled_test`;
+- não avançam além da raiz;
+- validated exige raiz validada, LP real, revisão e decisão humanas;
+- deprecated bloqueia nova composição e preserva histórico;
+- raiz depreciada torna cadeia inelegível sem mutar filhos.
+
+Referência completa:
+
+- `family`, `moduleCatalogVersion`, `rootVersion`, `moduleKey`, `moduleVersion`, `variantKey`, `variantVersion`;
+- incompatibilidade falha fechado.
+
+Resolver:
+
+- `resolveLandingPageModuleVariant`;
+- input: catálogo, raiz, preset opcional e referência completa;
+- resolve raiz, valida catálogo/compatibilidade e seleciona sem fallback;
+- output: identidade, root parameters, módulo, variante, fields, capabilities, map, profile, lifecycle e purpose;
+- profundamente imutável.
+
+Payload validator:
+
+- `validateLandingPageVariantPayload`;
+- referência mais `payload: unknown`;
+- valida keys, tipos, cardinalidade, collection, action, image e reference;
+- não valida qualidade, verdade factual, destino, renderer, composição, persistência ou snapshot.
+
+Erros:
+
+- `UNKNOWN_MODULE_CATALOG_VERSION`;
+- `INVALID_MODULE_CATALOG_CONTRACT`;
+- `ROOT_RESOLUTION_FAILED`;
+- `INCOMPATIBLE_ROOT_VERSION`;
+- `UNKNOWN_MODULE`;
+- `UNKNOWN_MODULE_VERSION`;
+- `UNKNOWN_VARIANT`;
+- `UNKNOWN_VARIANT_VERSION`;
+- `INCOMPATIBLE_REFERENCE`;
+- `INVALID_VARIANT_PAYLOAD`.
+
+### 2.7. Topologia e API pública
+
+Novos em `lib/conversion-content/landing-page/module-catalog/`:
+
+- `contracts.ts`;
+- `schema.ts`;
+- `registry.ts`;
+- `resolver.ts`;
+- `payload-validator.ts`;
+- `validation-cases.ts`;
+- `index.ts`.
+
+Ajustados:
+
+- `lib/conversion-content/index.ts`:
+  - adicionar namespace `landingPageModuleCatalog`;
+  - preservar namespaces existentes.
+- `package.json`:
+  - script `validate:landing-page-module-catalog`.
+- este plano:
+  - somente estado/evidências/decisão da fase.
+
+Preservados:
+
+- `landing-page/index.ts` e arquivos root;
+- `research-resolution/*`, `input-catalog/*`, `commercial-activation/*`.
+
+API:
+
+- `landingPageRoot` continua somente raiz;
+- novo `landingPageModuleCatalog`;
+- exporta types, registry, schemas necessários, resolver e validator;
+- “público” é boundary TypeScript, não client/rota/API HTTP.
+
+### 2.8. Update e fronteiras
+
+- Aplicar `prod#17` somente como referência declarativa WCAG 2.2 no Accordion.
+- Rejeitar todos os updates de Supabase, Vercel, GitHub e demais de Produto.
+- E18.5 define estrutura; E20 futura escolhe composição; E19 futura produz copy/valores e snapshot; renderer futuro executa payload e acessibilidade concreta.
+
+## 3. Contratos fechados
+
+### 3.1. Fields por variante
+
+- Hero:
+  - eyebrow text/eyebrow `0..1`, research, none;
+  - title text/h1 `1..1`, hybrid, when_factual;
+  - subtitle text/paragraph `1..1`, hybrid, when_factual;
+  - CTA action `1..1`, not_copy, primary_action; label text/cta_label `1..1`, hybrid, when_present;
+  - proofShort text/paragraph `0..1`, hybrid, when_present;
+  - media image `0..1`, technical_reference, image_asset.
+- Trust Bar:
+  - items collection `2..4`, not_copy;
+  - text text/benefit_item `1..1`, hybrid, when_present.
+- Problem Solution:
+  - title text/h2 `1..1`, research, none;
+  - items collection `2..4`, not_copy;
+  - problem text/card_title `1..1`, research, none;
+  - solution text/card_body `1..1`, hybrid, when_present.
+- Offer:
+  - title text/h2 `1..1`, research, none;
+  - items collection `1..4`, not_copy;
+  - itemTitle text/card_title `1..1`, hybrid, when_present;
+  - description text/card_body `1..1`, hybrid, when_present.
+- Process:
+  - title text/h2 `1..1`, research, none;
+  - steps ordered collection `2..6`, not_copy;
+  - stepTitle text/step_title `1..1`, hybrid, when_present;
+  - stepBody text/step_body `1..1`, hybrid, when_present.
+- Technical Assurance:
+  - title text/h2 `1..1`, research, none;
+  - items collection `1..4`, not_copy;
+  - assuranceTitle text/card_title `1..1`, hybrid, when_present;
+  - assuranceBody text/card_body `1..1`, hybrid, when_present.
+- Social Proof:
+  - title text/h2 `1..1`, research, none;
+  - items collection `1..3`, not_copy;
+  - quote text/card_body `1..1`, operational, when_present;
+  - attribution text/card_title `1..1`, operational, when_present;
+  - evidenceRef reference `1..1`, technical_reference, operational_evidence.
+- FAQ Standard:
+  - title text/h2 `1..1`, research, none;
+  - items collection `2..6`, not_copy;
+  - question text/faq_question `1..1`, research, none;
+  - answer text/faq_answer `1..1`, hybrid, when_factual.
+- FAQ Accordion:
+  - definição própria com os mesmos fields;
+  - accordion_interaction;
+  - sem herança semântica ou campo novo.
+- Final CTA:
+  - title text/h2 `1..1`, hybrid, when_factual;
+  - body text/paragraph `1..1`, hybrid, when_factual;
+  - CTA action `1..1`, not_copy, primary_action; label text/cta_label `1..1`, hybrid, when_present.
+
+### 3.2. Regras comuns
+
+- Todos: lifecycle hypothesis, purpose controlled_test e `rootDelta={}`.
+- Suporte real conforme fields; Problem Solution sem alarmismo.
+- Social Proof sem fabricação/alteração material.
+- FAQ sem duplicidade ou fato sem suporte.
+- Hero/Final CTA excluem form.
+- Accordion valida contrato declarativo, não comportamento.
+- Nenhum contrato armazena destino concreto ou taxon.
+
+## 4. Fase e próxima ação
+
+### 4.1. Fase 3.1 — E18.5.3–E18.5.9 — Catálogo repo-only
 
 - Automação: não.
-- Objetivo:
-  - implementar no boundary existente o contrato compartilhado, os nove módulos, as nove variantes `standard@v1` e `faq.accordion@v1`.
-- Entregas:
-  - contratos e tipos públicos profundamente `readonly`;
-  - schemas estritos, registry versionado, resolver fail-closed, validadores e casos executáveis;
-  - exportação pública e script próprio de validação no `package.json`;
-  - fixtures somente quando úteis ao padrão de teste.
-- Critérios de aceite:
-  - identidade e compatibilidade completas;
-  - lifecycle `experimental` e propósito `controlled_test`;
-  - todos os módulos e variantes aprovados resolvidos e validados;
-  - `faq.accordion@v1` preserva `faq.standard@v1` e valida interaction sem herança entre variantes;
-  - rejeição de campos, policies, capabilities, versões e deltas desconhecidos;
-  - resultado profundamente imutável, sem fallback ou referência mutável compartilhada;
-  - nenhuma regra específica de E19, E20, renderer, Admin, Builder ou banco;
-  - `npm ci`, validação própria da E18.5, `npm run check` e `git diff --check` aprovados.
-- Parada:
-  - necessidade de banco, migration, rota, renderer, composição, persistência, tracking, infraestrutura ou mudança destrutiva retorna ao Estrategista.
 
-### 4.3. Próxima ação
+Sequência:
 
-- Executar o item 5 de `docs/prompt-estrategista.md`.
-- Solicitar avaliação única do plano completo pelo Analista, Gestor Estrutural e Gestor de Updates.
-- Não chamar Gestor de Automação, pois a fase está marcada como `Automação: não`.
-- Consolidar os pareceres no mesmo PR como plano-base v2 antes de solicitar o merge humano.
-- Não autorizar a fase 3.1 antes da consolidação e do merge do plano-base v2 na `main`.
+1. contracts, schemas, registry, API e raiz;
+2. FAQ Standard/Accordion;
+3. prova das duas variantes;
+4. demais módulos;
+5. integração e não regressão.
+
+Entregas:
+
+- somente arquivos da seção 2.7;
+- registry imutável, resolver/validator fail-closed, namespace e script;
+- sem banco, rede ou renderer.
+
+Critérios:
+
+- `landingPageRoot` somente raiz; resolver usa API raiz;
+- versões, identidades, grammar, maps, profiles, capabilities, lifecycle e compatibility estritos;
+- rootDelta vazio, form rejeitado, FAQs independentes;
+- Accordion somente declarativo WCAG 2.2;
+- payload cobre todos field kinds; desconhecidos rejeitados;
+- erros sem copy, pesquisa, PII, credenciais ou secrets;
+- output profundamente imutável;
+- nenhum consumidor/família preservada alterado.
+
+Validações:
+
+- `npm ci`;
+- validações existentes de root, pesquisa, input catalog e commercial activation;
+- `npm run validate:landing-page-module-catalog`;
+- `npm run check`;
+- `git diff --check`.
+
+Matriz mínima:
+
+- resolve dez variantes;
+- rejeita versões, identidades, roles, fields, policies, supports, capabilities, maps, treatments, deltas e payloads inválidos;
+- rejeita form;
+- valida alt text e cardinalidade;
+- comprova imutabilidade, independência das FAQs, ausência de colisão e preservação dos exports.
+
+Parada:
+
+- arquivo/export/dependency/regra não listado retorna ao Estrategista;
+- banco, rota, renderer, composição, persistência, tracking ou mudança destrutiva bloqueia;
+- sem merge ou fase futura automática.
+
+### 4.2. Próxima ação
+
+- Revisar esta v2 na branch filha.
+- Não alterar o PR #577.
+- Não implementar antes da aprovação humana e do ingresso da v2 na `main`.
+- Após confirmação do merge aplicável, orientar somente a fase 3.1.
 
 ## 5. Validação e encerramento
 
-### 5.1. Validação do plano v1
+### 5.1. Validação documental
 
-- Existe uma única fase executável e necessária ao recorte.
-- A fase usa identificadores implementáveis da E18.5 e declara `Automação: não`.
-- Validações técnicas integram os critérios de aceite, sem fase administrativa separada.
-- Não existe fase própria de governança, handoff, revisão, documentação final ou encerramento.
-- Os identificadores previstos não atualizam `docs/roadmap.md` automaticamente.
+- três pareceres consolidados;
+- única fase, `Automação: não`;
+- topologia, API, copy, funil, lifecycle, erros e testes definidos;
+- sem fase administrativa.
 
-Alteração exclusivamente documental:
+Nesta consolidação:
 
-- `npm ci`: não aplicável;
-- `npm run check`: não aplicável;
-- `git diff --check`: obrigatório quando houver ambiente local disponível.
+- `npm ci`: N/A;
+- `npm run check`: N/A;
+- `git diff --check`: obrigatório no ambiente local antes da entrega final.
 
-### 5.2. Regra de parada
+### 5.2. Regras de parada
 
-- encerrar a E18.5 após a implementação aprovada;
-- não criar outra variante antes da primeira LP;
-- não adicionar campo para cenário futuro;
-- não criar policy ou capability sem consumidor;
-- não antecipar renderer, composição ou geração;
-- avançar para E20 e depois E19.
-
-### 5.3. Estado de validação
-
-- Implementação técnica significa contrato executável no repositório.
-- Os módulos permanecem hipóteses até validação por LP real.
-- Promoção de lifecycle exige evidência e decisão humana.
-
-### 5.4. Critérios de parada imediata
-
-Parar e informar se:
-
-- surgir banco, rota, job, agente, automação ou infraestrutura sem fonte e recorte próprios;
-- módulo receber identidade de taxon;
-- variante representar apenas copy, campanha, plano ou ativo;
-- regra de `standard@v1` for tratada como limite permanente do módulo;
-- variante não aprovada for antecipada;
-- destino concreto entrar no registry;
-- conteúdo factual puder ser inventado;
-- E19, E20 ou renderer forem implementados implicitamente;
-- alteração sair do arquivo ou branch autorizados;
-- houver tentativa de merge na `main`.
+- encerrar E18.5 após implementação aprovada;
+- não criar variante, field, treatment, policy, capability ou delta sem consumidor;
+- não antecipar renderer, composição, geração, persistência ou tracking;
+- implementação técnica não equivale a validação comercial;
+- `prod#17` é referência, não certificação;
+- parar se alteração sair dos arquivos, branch ou fase ou houver merge sem decisão humana.

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -560,7 +560,7 @@ Campos:
 Copy:
 
 - `title`: primárias `desire` e `trigger`; auxiliar `positioning_opportunity`.
-- `itemTitle`: primárias `trigger` e `desire`; auxiliar `search_intent`.
+- `itemTitle`: primárias `trigger` e `desire`; sem fonte auxiliar na v1.
 - `description`: primárias `positioning_opportunity` e `belief`; auxiliar `objection`.
 
 Regras específicas:

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -1,10 +1,10 @@
 14/07/2026 — Plano-base E18.5 — Parametrização de módulos e variantes `landing_page`
 
-Fontes: chat, `README.md`, `AGENTS.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/schema.md`, `docs/lp-planejamento.md`, `docs/lousa-plano-base-e18-4.md`, `docs/lousa-plano-base-e20-2.md`, `docs/blueprint-corretor-imoveis-end-customer.md`, `docs/prompt-nicho-itens-estruturados.md`, consulta read-only ao Supabase, `lib/conversion-content/landing-page/`, `lib/conversion-content/landing-page/input-catalog/registry.ts`, PRs #559, #563, #564, #566, #567 e #577, avaliações do Analista e decisões humanas de 14, 15 e 16/07/2026.
+Fontes: chat, `README.md`, `AGENTS.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/schema.md`, `docs/lp-planejamento.md`, `docs/lousa-plano-base-e18-4.md`, `docs/lousa-plano-base-e20-2.md`, `docs/blueprint-corretor-imoveis-end-customer.md`, `docs/prompt-nicho-itens-estruturados.md`, consulta read-only ao Supabase, `lib/conversion-content/landing-page/`, `lib/conversion-content/landing-page/input-catalog/registry.ts`, PRs #559, #563, #564, #566, #567, #577 e #581, avaliações do Analista e decisões humanas de 14 a 17/07/2026.
 
 Versão: v1 em ajuste.
 
-Status: PR vivo para debate; grade metodológica comum registrada; `hero`, `hero.standard`, `trust_bar` e `trust_bar.standard` conceitualmente fechados na v1; sete módulos candidatos ainda pendentes; nenhuma implementação autorizada.
+Status: plano simplificado; nove módulos mantidos no escopo; `hero`, `hero.standard@v1`, `trust_bar` e `trust_bar.standard@v1` conceitualmente fechados; sete módulos pendentes; nenhuma implementação autorizada neste PR.
 
 Path: `docs/lousa-plano-base-e18-5.md`.
 
@@ -12,1024 +12,499 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 
 ## 1. Estado e decisões fixas
 
-### 1.1. Pré-requisitos confirmados
+### 1.1. Objetivo da E18.5
+
+- Definir e implementar, no repositório, o catálogo versionado dos nove módulos `landing_page` e de suas variantes `standard@v1`.
+- Entregar contratos pequenos, estritos, imutáveis e suficientes para consumo posterior pela E20 e pela E19.
+- Preservar extensibilidade sem antecipar variantes, campos ou capacidades sem uso aprovado.
+- Encerrar a E18.5 após os nove módulos, suas variantes `standard@v1` e a validação integrada dos contratos.
+
+### 1.2. Estado confirmado
 
 - A E18.4 está concluída e a raiz versionada existe em `lib/conversion-content/landing-page/`.
-- A raiz v1 não garante `body.editorialEmphasis` em todos os presets nem possui capability fechada de visibilidade responsiva por campo.
-- Ambas as necessidades exigem evolução versionada própria, preservando `rootVersion 1`.
-- Essas necessidades bloqueiam implementação, não o fechamento conceitual do módulo.
-- Fonte estrutural principal confirmada:
-  - taxon `Corretor Imóveis`;
-  - `taxonId = c7952d16-678c-4615-9483-a003e57d94aa`;
-  - nível `niche`;
-  - público `end_customer`;
-  - bloco `lp_sections`;
-  - versão 1 ativa.
-- O ultranicho de médio padrão permanece evidência complementar.
-- Os módulos serão transversais; a precedência permanece `raiz → módulo → variante`.
-- `commercial_activation`, E18.2 e E18.3 permanecem preservados.
-
-### 1.2. Estado processual
-
-- O debate permanece no PR #577; não criar arquivo paralelo.
-- Cada candidato será analisado individualmente; existência na grade não equivale a aprovação.
-- Rejeição, fusão ou substituição exige justificativa e decisão humana.
-- A grade comum é obrigatória, com blocos condicionais conforme a função.
-- Cada módulo deve fechar:
-  - identidade e evidência;
-  - fronteiras;
-  - campos e cardinalidades;
-  - policies e suporte operacional;
-  - fontes e perfis de funil;
-  - responsividade e acessibilidade aplicáveis;
-  - variante, versões, lifecycle e compatibilidades;
-  - casos da E18.5 e invariantes futuras da E19.
-- O Hero permanece como piloto metodológico e está conceitualmente fechado na v1.
-- `trust_bar` e `trust_bar.standard` estão conceitualmente fechados na v1.
-- O próximo candidato é `problem_solution`.
-- Implementação somente após evolução da raiz, v2 estável, pareceres e merge humano.
-
-### 1.3. Princípio canônico de herança
-
-- A raiz contém regras comuns; módulo e variante registram apenas especializações justificadas.
-- A E18.5 autoriza opções; a E20 seleciona por ocorrência; a E19 gera e vincula valores; o renderer apenas executa.
-- Escolha excepcional na E20 exige decisão humana documentada, sem pressupor campo, coluna ou persistência nova.
-- O resolver entrega contrato efetivo, completo, imutável e sem fallback.
-
-### 1.4. Regras de exceção
-
-- Escolha já autorizada por ocorrência não cria variante.
-- Tipo de mídia, ativo, taxon, campanha, funil, conteúdo ou visibilidade responsiva autorizada não criam variante isoladamente.
-- Módulo e variante não ampliam limite absoluto da raiz.
-- Campo novo exige nova versão do módulo.
-- Reintrodução de vídeo, formulário ou CTA secundário no Hero exige nova `moduleVersion`.
-
-### 1.5. Decisões técnicas incorporadas
-
-- Cardinalidade substitui `required`.
-- Não haverá regras abertas nem delta livre.
-- Grade candidata:
-  - `hero` ← `hero_segmentado`;
-  - `trust_bar` ← `barra_de_confianca`;
-  - `problem_solution` ← `dores_e_solucoes`;
-  - `offer` ← `servicos_por_intencao`;
-  - `process` ← `processo_de_atendimento`;
-  - `technical_assurance` ← `prova_tecnica_documental`;
-  - `social_proof` ← `prova_social`;
-  - `faq` ← `faq_objeções`;
-  - `final_cta` ← `cta_final_qualificado`.
-- `item_key` é evidência, não identidade canônica.
-- Formatos curto, médio e longo pertencem à composição e à extensão.
-- `hero.subtitle`:
-  - `semanticRole = paragraph`;
-  - padrão `body.editorialEmphasis`;
-  - alternativa `body.base`;
-  - sem fallback.
-- `hero.standard` é a única variante inicial e possui delta vazio.
-- Canal e destino concretos de CTA permanecem fora do registry do módulo.
-- Nenhum `actionRole` está aprovado sem contrato fechado.
-- `moduleCatalogVersion` possui versão e compatibilidade; lifecycle próprio do catálogo não está aprovado.
-- Decisão humana de 16/07/2026 sobre `desktop_only`:
-  - autorizar conceitualmente a opção para `hero.media`;
-  - condicionar sua implementação à evolução versionada da raiz;
-  - proibir a ocultação de informação essencial.
-- A relação entre lifecycle da raiz e propósito é política nova da E18.5; não é comportamento já implementado pelo resolver da raiz.
-- Decisão humana de 16/07/2026 sobre `secondaryCta`:
-  - retirar o campo da v1 de `hero` e de `hero.standard`;
-  - não criar entrada operacional para sustentá-lo;
-  - permitir reavaliação futura somente com evidência real, contrato fechado e nova `moduleVersion`.
-- Decisão humana de 16/07/2026 sobre mídia:
-  - restringir `hero.media` da v1 a imagem;
-  - retirar vídeo da v1;
-  - permitir vídeo futuramente somente com contrato de acessibilidade fechado e nova `moduleVersion`.
-- Decisão humana de 16/07/2026 sobre CTA para formulário:
-  - restringir a v1 a `whatsapp`, `phone`, `email` e `external_url`;
-  - retirar `form` do contrato do Hero v1;
-  - permitir suporte futuro somente após contrato de composição E20/E19 e nova `moduleVersion`.
-- Decisão humana de 16/07/2026 sobre `trust_bar`:
-  - aprovar coleção de dois a quatro sinais curtos de confiança;
-  - exigir suporte operacional real para cada sinal;
-  - manter TOFU, MOFU e BOFU como perfis de seleção e redação, sem alterar estrutura ou variante;
-  - aprovar `trust_bar.standard` como única variante inicial, com delta vazio.
-
-### 1.6. Estado técnico confirmado
-
-- Boundary: `lib/conversion-content/landing-page/`; namespace atual: `landingPageRoot`.
-- Ainda não existem catálogo de módulos, composição, renderer ou render model.
-- A E18.5 é repo-only e não altera banco.
+- A precedência permanece `raiz → módulo → variante`.
+- A E18.5 permanece repo-only.
+- Ainda não existem composição, renderer ou render model.
 - O catálogo operacional já define `primary_conversion_channel` e destinos condicionais.
-- A E20 seleciona composição; a E19 vincula valores, gera e preserva snapshot.
+- `commercial_activation`, E18.2 e E18.3 permanecem preservados.
+- O trabalho documental continua no PR #577 e na branch `docs/e18-5-modules-variants`.
+- O PR #577 não deve ser mergeado sem confirmação humana explícita.
 
-### 1.7. Pontos ainda em debate
+### 1.3. Grade fechada de módulos
 
-- Confirmação dos sete candidatos restantes.
-- Evolução tipográfica e responsiva da raiz.
-- Divisão final em fases.
+- `hero` ← `hero_segmentado`.
+- `trust_bar` ← `barra_de_confianca`.
+- `problem_solution` ← `dores_e_solucoes`.
+- `offer` ← `servicos_por_intencao`.
+- `process` ← `processo_de_atendimento`.
+- `technical_assurance` ← `prova_tecnica_documental`.
+- `social_proof` ← `prova_social`.
+- `faq` ← `faq_objeções`.
+- `final_cta` ← `cta_final_qualificado`.
 
-## 2. Contrato do caso
+Regras:
 
-### 2.1. Problema
+- Os nove módulos serão fechados e implementados na E18.5.
+- `item_key` é evidência de pesquisa, não identidade canônica do módulo.
+- Os módulos são transversais e não recebem identidade de taxon.
+- Formatos curto, médio e longo pertencem à composição e à extensão da LP.
+- O próximo módulo para análise é `problem_solution`.
 
-- Faltam contratos aprovados para sete módulos e suas variantes.
-- O catálogo deve generalizar funções sem carregar identidade imobiliária.
-- CTA não pode duplicar canal ou destino da E20.2.
-- Campos híbridos precisam representar declarativamente quando suporte operacional é exigido.
-- A combinação entre `fieldKind` e `operationalValuePolicy` precisa ser fechada por allowlist.
-- Mídia deve separar contrato estrutural e acessibilidade do schema concreto da E19.
-- Policies devem impedir invenção de fatos e fallback deve permanecer proibido.
+### 1.4. Escopo positivo
 
-### 2.2. Resultado esperado
+A E18.5 define e implementa:
 
-- Catálogo repo-only, versionado e imutável.
-- Grade única, com módulos aprovados individualmente.
-- Separação entre pesquisa, contrato estrutural, entrada operacional, composição e conteúdo.
-- BOFU, MOFU e TOFU como perfis, não variantes.
-- Sem banco, composição, geração ou renderer neste recorte.
+- identidade e versão do catálogo;
+- identidade, versão, função e invariantes dos módulos;
+- identidade, versão, campos, cardinalidades e capacidades das variantes `standard@v1`;
+- especializações necessárias sobre a raiz;
+- fontes de copy e perfis de funil;
+- exigências factuais ou operacionais;
+- schemas, tipos, registry, resolver, validadores e testes de contrato;
+- lifecycle, compatibilidade e descontinuação.
 
-### 2.3. Hierarquia para parametrização
+### 1.5. Escopo negativo
 
-#### 2.3.1. Restrições normativas
+Ficam fora:
 
-- raiz vigente;
-- `docs/lp-planejamento.md`;
-- contratos de pesquisas e catálogo operacional;
-- fronteiras E18.5/E20/E19;
-- decisões humanas e versionamento histórico.
+- banco e migrations;
+- Admin e Builder;
+- composição concreta por taxon;
+- geração ou edição de LP real;
+- renderer e componentes visuais;
+- persistência e snapshot;
+- tracking;
+- conteúdo operacional concreto;
+- variantes além de `standard@v1`;
+- capacidades sem consumidor aprovado.
 
-#### 2.3.2. Evidências
+## 2. Contrato compartilhado
 
-- pesquisas estruturadas;
-- Blueprints e LPs reais;
-- contrastes entre taxons;
-- evidência executável existente.
+### 2.1. Separação entre módulo e variante
 
-#### 2.3.3. Decisão humana de produto
+Módulo define somente:
 
-- resolve hipóteses e ambiguidades;
-- pode rejeitar evidência insuficiente;
-- pode aprovar padrão funcional do produto;
-- pode reduzir a v1 para preservar fechamento e avanço seguro;
-- não viola contrato vigente sem evolução versionada.
+- função estrutural reutilizável;
+- fronteiras com outros módulos;
+- invariantes realmente permanentes;
+- requisitos mínimos de integração;
+- compatibilidade comum.
 
-#### 2.3.4. Validação posterior
+Variante define:
 
-- casos executáveis da parametrização;
-- LP real em conta de teste;
-- invariantes de conteúdo na E19;
-- revisão e promoção humanas.
+- execução estrutural ou comportamental concreta;
+- campos e cardinalidades;
+- capacidades utilizadas;
+- especializações da raiz;
+- validações próprias;
+- requisitos técnicos, factuais, operacionais e de acessibilidade aplicáveis.
 
-#### 2.3.5. Regras específicas
+A separação aplica-se aos nove módulos.
 
-- Item de `lp_sections` não cria módulo automaticamente.
-- Módulo exige função reutilizável nova; variante exige execução reutilizável diferente.
-- Taxon, entrada, copy, funil e composição não criam variante.
+### 2.2. Extensibilidade das variantes
 
-#### 2.3.6. Grade metodológica comum
+- Cada módulo começa com uma única variante `standard@v1`.
+- Nova variante exige diferença estrutural ou comportamental reutilizável.
+- Nova variante pode adicionar ou especializar campos, mídia, interação, responsividade e validações próprias.
+- Nova variante não altera contratos ou LPs de variantes anteriores.
+- Restrições de `standard@v1` não restringem variantes futuras.
+- Nova variante não exige nova `moduleVersion` quando preserva função, fronteiras e invariantes do módulo.
+- Nova `moduleVersion` é exigida quando mudam função, fronteiras, invariantes permanentes ou integração comum.
+- Nova `variantVersion` é exigida quando muda o contrato de uma variante existente.
+- Cada referência futura deve identificar `moduleKey`, `moduleVersion`, `variantKey` e `variantVersion`.
 
-Todos os módulos devem analisar:
+Não criam variante isoladamente:
 
-1. identidade e função;
-2. evidências e equivalência;
-3. fronteiras;
-4. campos, `fieldKind` e cardinalidades;
-5. herança, capabilities e policies;
-6. fontes e funil quando aplicáveis;
-7. suporte operacional, responsividade e acessibilidade quando aplicáveis;
-8. variante, versões, lifecycle e compatibilidades;
-9. fronteiras E20/E19/renderer;
-10. casos E18.5, invariantes E19 e critérios de fechamento.
+- taxon;
+- plano;
+- campanha ou origem de tráfego;
+- funil;
+- copy;
+- troca de ativo;
+- canal ou destino concreto;
+- ordem na LP;
+- quantidade já permitida;
+- ajuste responsivo normal do renderer.
 
-Blocos condicionais:
+### 2.3. Herança e limites
 
-- CTA;
-- mídia;
-- coleção;
-- valor operacional;
-- referência técnica;
-- interação;
-- acessibilidade;
-- visibilidade responsiva;
-- variante adicional.
+- A raiz contém regras comuns.
+- Módulo e variante registram apenas deltas necessários.
+- Módulo ou variante pode restringir a raiz, mas não ampliar limite absoluto vigente.
+- Necessidade acima do limite da raiz exige evolução versionada da raiz.
+- Capability da raiz só bloqueia a implementação quando for indispensável à variante `standard@v1` em implementação.
+- Capability opcional ou destinada a variante futura permanece evolução posterior.
+- Não existe fallback silencioso.
+- Contrato ausente, incompatível ou inválido falha fechado.
+- Resultado resolvido deve ser completo e imutável.
 
-O Hero é referência metodológica, não molde rígido de conteúdo.
+### 2.4. Contrato mínimo de campo
 
-### 2.4. Identidade, evidência e versionamento previstos
-
-- `family = landing_page`.
-- `moduleCatalogVersion = 1` no primeiro catálogo.
-- Módulo declara `moduleKey`, `moduleVersion`, lifecycle, função, evidências e campos.
-- Evidência de pesquisa registra:
-  - taxon e `taxonId`;
-  - público e bloco;
-  - `researchId` e `itemId`;
-  - versão e status da pesquisa;
-  - `itemKey` e estado ativo do item;
-  - função observada;
-  - função transversal;
-  - justificativa da equivalência.
-- Variante declara identidade, versão, módulo compatível, lifecycle e deltas fechados.
-- Catálogo declara versão e compatibilidade explícita com `rootVersion`, sem lifecycle próprio presumido.
-
-### 2.5. Contrato-base de campo
-
-Todo campo declara:
+Cada campo usado por uma variante declara:
 
 - `fieldKey`;
 - `fieldKind`;
 - cardinalidade;
-- `operationalValuePolicy`.
-
-`fieldKind` fechado:
-
-- `text`;
-- `action`;
-- `media`;
-- `collection`;
-- `operational_value`;
-- `technical_reference`.
+- `semanticRole`, quando textual;
+- policy de origem do valor;
+- suporte operacional, quando aplicável;
+- capability específica, quando aplicável.
 
 Regras:
 
-- texto visível exige `semanticRole` da raiz;
-- ação possui label textual e dependência operacional declarativa, sem canal ou destino concreto no registry;
-- mídia declara tipos e requisitos abstratos de ativo e acessibilidade;
-- coleção declara contrato fechado do item;
-- valor operacional não pode ser inferido como fato;
-- referência técnica não é copy;
-- somente cardinalidade representa obrigatoriedade;
-- capability ausente falha fechado na implementação.
+- cardinalidade representa obrigatoriedade;
+- texto visível usa papel semântico existente na raiz;
+- coleção possui contrato fechado do item;
+- coleção aninhada não integra a v1;
+- ação não armazena canal, URL, telefone, e-mail ou destino concreto;
+- mídia referencia ativo futuro e declara apenas requisitos necessários à variante;
+- tipos, policies e matrizes só são adicionados quando um dos nove módulos realmente precisar.
 
-#### 2.5.1. Política fechada de origem do valor
+### 2.5. Copy e sustentação factual
 
-- `research_generated_non_factual`:
-  - copy não factual gerada da pesquisa.
-- `research_guided`:
-  - pesquisa orienta, mas não fornece o valor final completo.
-- `operational_required`:
-  - valor deve vir de fonte operacional autorizada.
-- `hybrid`:
-  - orientação editorial combinada com suporte operacional conforme exigência declarada pelo campo.
-- `technical_reference`:
-  - mídia, link, identificador ou vínculo técnico.
-- `not_copy`:
-  - objeto estrutural ou técnico.
+- `copySourceMap` define até duas fontes primárias e uma auxiliar por campo textual, salvo decisão humana registrada.
+- `funnelCopyProfile` adapta seleção e redação para BOFU, MOFU e TOFU.
+- Funil altera copy, seleção e ordem permitida; não cria módulo ou variante.
+- Pesquisa orienta copy, mas não comprova fatos sobre a operação.
+- Credencial, capacidade, condição, preço, prazo, parceria, resultado, garantia ou ação concreta exige suporte operacional real.
+- A E18.5 declara a exigência estrutural.
+- A E19 resolve valores, omissões e validação final da instância concreta.
+- Nenhum módulo pode inventar prova, certificação, garantia ou resultado.
 
-A E18.5 declara; a E19 aplica na instância concreta.
+Policies iniciais devem ser limitadas às efetivamente consumidas pelas variantes aprovadas:
 
-#### 2.5.2. Exigência declarativa de suporte operacional
+- `research_guided`;
+- `hybrid`;
+- `technical_reference`;
+- `not_copy`.
 
-Campos que geram ou exibem texto podem declarar `operationalSupportRequirement` como união fechada:
+Novas policies somente entram quando outro módulo aprovado exigir comportamento não representável pelas existentes.
 
-- `none`:
-  - o campo não exige entrada operacional para existir;
-  - continua proibido inventar alegação factual.
-- `when_factual`:
-  - suporte operacional é obrigatório somente quando o texto contiver fato, condição, capacidade, credencial, métrica ou ação concreta.
-- `when_present`:
-  - o campo só pode estar presente quando existir suporte operacional resolvido aplicável.
+### 2.6. Ações e vínculos operacionais
 
-Regras:
+- Ação possui label textual e vínculo abstrato com campo estável do catálogo operacional.
+- O registry não armazena valor, canal ou destino concreto.
+- O vínculo declara se o campo operacional é obrigatório quando a ação estiver presente.
+- A E19 resolve o campo operacional, seus condicionais e o destino.
+- Nova chave operacional não pode ser criada implicitamente pela E18.5.
 
-- policy `hybrid` exige `operationalSupportRequirement` explícito.
-- policy `operational_required` equivale materialmente a `when_present`.
-- `technical_reference` e `not_copy` não usam essa propriedade.
-- A E18.5 valida a declaração abstrata; a E19 valida o suporte concreto.
+### 2.7. Lifecycle e compatibilidade
 
-#### 2.5.3. Allowlist de `fieldKind × operationalValuePolicy`
+- `moduleCatalogVersion` declara versão e compatibilidade com a raiz; não possui lifecycle próprio.
+- Módulo e variante usam lifecycle:
+  - `experimental`;
+  - `active`;
+  - `deprecated`.
+- Todos começam `experimental` e com propósito `controlled_test`.
+- Promoção para `active` exige uso em LP real, revisão e decisão humanas.
+- `deprecated` impede novas composições, mas preserva leitura e renderização histórica.
+- Remoção física exige inexistência de dependentes ou migração aprovada.
+- Implementação técnica não equivale a validação comercial.
 
-Combinações válidas na v1:
+### 2.8. Fronteiras entre etapas
 
-- `text`:
-  - `research_generated_non_factual`;
-  - `research_guided`;
-  - `hybrid`;
-  - `operational_required`.
-- `action`:
-  - `not_copy`.
-- `media`:
-  - `technical_reference`.
-- `technical_reference`:
-  - `technical_reference`.
-- `operational_value`:
-  - `operational_required`.
-- `collection`:
-  - `not_copy` no contêiner;
-  - cada campo do item declara sua própria combinação conforme esta allowlist;
-  - coleção aninhada não está aprovada na v1.
+E18.5:
 
-Regras adicionais:
+- define o que é estruturalmente válido;
+- implementa contratos repo-only;
+- não resolve instâncias concretas.
 
-- qualquer combinação ausente da allowlist falha fechado;
-- `research_generated_non_factual` e `research_guided` admitem `copySourceMap` somente em `text`;
-- `hybrid` admite `copySourceMap` somente em `text` e exige `operationalSupportRequirement`;
-- `operational_required` não pode ser preenchida somente por pesquisa;
-- `technical_reference` e `not_copy` não admitem `copySourceMap`;
-- contêiner `collection` não gera copy; seus campos internos seguem seus próprios contratos.
+E20:
 
-Falham:
+- escolhe módulos, variantes, versões, ordem, obrigatoriedade e opções por ocorrência;
+- define a composição aplicável ao taxon.
 
-- policy não listada para o `fieldKind`;
-- mídia com policy textual;
-- ação com policy diferente de `not_copy`;
-- `not_copy` com fontes;
-- `hybrid` sem exigência de suporte;
-- suporte exigido sem vínculo operacional aplicável;
-- valor operacional gerado apenas da pesquisa;
-- item de coleção sem contrato fechado.
+E19:
 
-#### 2.5.4. Dependência operacional de ações
+- recebe pesquisas, composição e entradas;
+- resolve conteúdo, ativos, vínculos e omissões;
+- gera e administra a LP real;
+- preserva as versões utilizadas.
 
-Ação pode declarar `operationalBindingRequirement`:
+Renderer:
 
-- referencia somente `fieldKey` estável do catálogo operacional;
-- não armazena valor, canal, URL, telefone, e-mail ou destino;
-- declara se o vínculo é obrigatório quando a ação estiver presente;
-- a E19 resolve o campo e valida seus condicionais e destinos aplicáveis.
+- executa o contrato resolvido;
+- não escolhe variante, conteúdo ou fallback.
 
-Nova chave operacional não pode ser criada implicitamente pela E18.5.
+### 2.9. Checklist de fechamento de cada módulo
 
-### 2.6. Contrato de variante
+Obrigatório:
 
-- Deltas permitidos:
-  - cardinalidade;
-  - remoção ou ativação de campo previsto;
-  - restrição de faixa ou tratamento;
-  - comportamento enumerado.
-- Deltas proibidos:
-  - campo livre;
-  - papel desconhecido;
-  - ampliação de limite;
-  - taxon;
-  - conteúdo;
-  - valor operacional;
-  - URL;
-  - classe;
-  - componente concreto.
-- `standard` pode ter delta vazio; outra variante vazia e redundante falha.
+- identidade, função e evidência;
+- fronteiras;
+- invariantes permanentes;
+- variante `standard@v1`;
+- campos e cardinalidades necessários;
+- especializações da raiz;
+- fontes de copy;
+- requisitos factuais ou operacionais;
+- lifecycle e compatibilidade;
+- validações estruturais indispensáveis.
 
-### 2.7. Módulo-piloto `hero`
+Condicional, somente quando utilizado por `standard@v1`:
 
-#### 2.7.1. Identidade e função estrutural
+- ação;
+- mídia;
+- interação;
+- responsividade especial;
+- acessibilidade específica;
+- fallback técnico;
+- referência técnica.
+
+O fechamento conceitual não exige detalhar comportamentos de variantes futuras.
+
+### 2.10. Significado de implementação
+
+Um módulo está implementado na E18.5 quando existem, conforme o contrato técnico adotado:
+
+- identidade versionada do módulo;
+- identidade versionada de `standard@v1`;
+- tipos e schemas;
+- campos, cardinalidades e capabilities;
+- registry;
+- resolver ou mecanismo equivalente;
+- validadores;
+- fixtures somente quando úteis ao padrão de teste;
+- casos executáveis e testes de contrato;
+- regras de lifecycle e compatibilidade;
+- exportação pelo boundary `lib/conversion-content/landing-page/`.
+
+Isso não inclui seção visual funcional.
+
+## 3. Contratos conceitualmente fechados
+
+### 3.1. Módulo `hero`
 
 - `moduleKey = hero`.
 - `moduleVersion = 1`.
 - Função:
-  - apresentar recorte;
-  - comunicar proposta principal;
-  - indicar ação prioritária.
-- Não representa taxon, tráfego, funil ou composição.
+  - apresentar a proposta principal;
+  - estabelecer o recorte da LP;
+  - conduzir a uma rota prioritária de conversão ou continuidade.
+- Invariantes:
+  - uma proposta principal identificável;
+  - hierarquia semântica coerente;
+  - ausência de identidade de taxon, plano, campanha ou funil no contrato;
+  - integração abstrata com a ação principal quando a variante a utilizar.
+- Fronteiras:
+  - não contém formulário completo, galeria, carrossel, tour, navegação global, oferta detalhada ou prova extensa.
+- Evidência principal:
+  - `hero_segmentado`, pesquisa ativa de `lp_sections`, taxon `Corretor Imóveis`.
+- Variantes futuras podem possuir campos e capacidades próprias sem alterar `hero.standard@v1`.
 
-#### 2.7.2. Evidência estrutural inicial
+### 3.2. Variante `hero.standard@v1`
 
-- taxon `Corretor Imóveis`;
-- `taxonId = c7952d16-678c-4615-9483-a003e57d94aa`;
-- público `end_customer`;
-- bloco `lp_sections`;
-- `researchId = 31e4c229-1582-4d2c-8e4a-7b74e6e07681`;
-- `itemId = ee178af8-294c-403c-8c53-d0baef42ee8c`;
-- versão 1;
-- pesquisa ativa;
-- `itemKey = hero_segmentado`;
-- item ativo;
-- ordem 1;
-- função observada: apresentar valor central e segmentar por intenção;
-- interpretação v1:
-  - a intenção já está resolvida para a LP concreta;
-  - a segmentação ocorre na mensagem e no recorte editorial;
-  - não existe seletor, coleção de intenções ou escolha interativa dentro de `hero.standard`;
-- função transversal: apresentar recorte, proposta e ação principal.
+Identidade:
 
-Escolha interativa entre intenções exigiria análise estrutural futura e não é autorizada por esta evidência.
-
-#### 2.7.3. Fronteiras
-
-Pertencem:
-
-- enquadramento;
-- título;
-- explicação curta;
-- CTA principal;
-- microprova opcional;
-- uma imagem opcional.
-
-Não pertencem:
-
-- CTA secundário na v1;
-- vídeo na v1;
-- CTA para formulário na v1;
-- trust bar completa;
-- oferta;
-- processo;
-- prova extensa;
-- depoimentos;
-- FAQ;
-- formulário completo;
-- seletor interativo de intenção;
-- galeria;
-- carrossel;
-- tour;
-- CTA final;
-- navegação;
-- ordem global.
-
-#### 2.7.4. Catálogo de campos v1
-
-- `eyebrow`:
-  - `fieldKind = text`;
-  - `semanticRole = eyebrow`;
-  - cardinalidade `0..1`;
-  - policy `research_guided`;
-  - `operationalSupportRequirement = none`.
-- `title`:
-  - `fieldKind = text`;
-  - `semanticRole = h1`;
-  - cardinalidade `1..1`;
-  - policy `hybrid`;
-  - `operationalSupportRequirement = when_factual`.
-- `subtitle`:
-  - `fieldKind = text`;
-  - `semanticRole = paragraph`;
-  - cardinalidade `1..1`;
-  - policy `hybrid`;
-  - `operationalSupportRequirement = when_factual`;
-  - padrão `body.editorialEmphasis`;
-  - alternativa `body.base`.
-- `primaryCta`:
-  - `fieldKind = action`;
-  - cardinalidade `1..1`;
-  - policy `not_copy`;
-  - label:
-    - `fieldKind = text`;
-    - `semanticRole = cta_label`;
-    - cardinalidade `1..1`;
-    - policy `hybrid`;
-    - `operationalSupportRequirement = when_present`;
-  - `operationalBindingRequirement.catalogFieldKey = primary_conversion_channel`;
-  - canais admitidos na v1:
-    - `whatsapp`;
-    - `phone`;
-    - `email`;
-    - `external_url`;
-  - vínculo obrigatório quando a ação estiver presente;
-  - canal e destino concretos ficam fora do registry.
-- `proofShort`:
-  - `fieldKind = text`;
-  - `semanticRole = paragraph`;
-  - cardinalidade `0..1`;
-  - policy `hybrid`;
-  - `operationalSupportRequirement = when_present`;
-  - finalidade limitada a microprova, credencial ou sinal curto de confiança;
-  - não recebe genericamente preço, prazo, disponibilidade ou condição comercial.
-- `media`:
-  - `fieldKind = media`;
-  - cardinalidade `0..1`;
-  - policy `technical_reference`;
-  - `mediaKind = image`;
-  - referência do ativo pertence à instância futura;
-  - `accessibilityMode = informative | decorative`;
-  - acessibilidade usa contrato próprio de mídia, não policy textual;
-  - imagem informativa exige alternativa acessível não vazia;
-  - imagem decorativa exige ausência de descrição semântica, normalizada pelo contrato final;
-  - conteúdo da alternativa acessível deriva do ativo, função e contexto reais;
-  - legenda não integra o contrato inicial e não se confunde com alternativa acessível;
-  - mídia decorativa não transporta informação essencial.
-
-Estado dos campos:
-
-- a v1 do Hero contém seis campos publicáveis:
-  - `eyebrow`;
-  - `title`;
-  - `subtitle`;
-  - `primaryCta`;
-  - `proofShort`;
-  - `media`;
-- os seis possuem contrato interno conceitualmente fechado;
-- `secondaryCta`, vídeo e `form` foram retirados da v1 por decisão humana;
-- as capabilities tipográfica e responsiva da raiz são dependências externas de implementação.
-
-#### 2.7.5. Herança e exceção tipográfica
-
-- Campos textuais herdam raiz; não há tamanho ou spacing próprio aprovado.
-- A E18.5 autoriza `body.editorialEmphasis` e `body.base`; a E20 seleciona.
-- Exceção exige decisão humana documentada, sem presumir persistência nova.
-- O renderer não escolhe nem aplica fallback.
-- A capability tipográfica ainda depende de nova `rootVersion` para implementação.
-
-#### 2.7.6. Mídia e comportamento responsivo
-
-- A v1 admite apenas imagem no slot de mídia de `hero.standard`.
-- Vídeo exige nova `moduleVersion` e contrato de acessibilidade próprio.
-- Galeria, carrossel e tour ficam fora.
-- Opções conceitualmente autorizadas:
-  - `all_viewports`;
-  - `desktop_only`.
-- Decisão humana de 16/07/2026:
-  - `desktop_only` é opção responsiva aprovada para `hero.media`;
-  - pertence à escolha por ocorrência da E20;
-  - não cria variante;
-  - só pode ser usada quando a imagem for decorativa, complementar ou redundante;
-  - não pode ocultar informação essencial.
-- Aprovação conceitual não equivale a capability técnica disponível.
-- A raiz v1 não possui a capability necessária.
-- A implementação de `desktop_only` permanece bloqueada até evolução versionada da raiz.
-- A E19 valida a imagem concreta e a preservação da informação.
-
-#### 2.7.7. Fronteira com formulário
-
-- O Hero não armazena `destinationRef`, URL, identificador de formulário ou destino concreto.
-- Quando `primary_conversion_channel` for:
-  - `whatsapp`:
-    - a E19 resolve `whatsapp_destination`;
-  - `phone`:
-    - a E19 resolve `phone_destination`;
-  - `email`:
-    - a E19 resolve `email_destination`;
-  - `external_url`:
-    - a E19 resolve `external_url_destination`.
-- `primary_conversion_channel = form` é inválido para `hero` v1.
-- Suporte futuro a formulário exige:
-  - ocorrência de módulo de formulário aprovada na composição;
-  - contrato E20 para composição;
-  - contrato E19 para vínculo;
-  - nova `moduleVersion` do Hero.
-- Não criar agora:
-  - nova entrada operacional;
-  - identificador de formulário;
-  - propriedade de composição;
-  - `moduleKey` de formulário.
-- Formulário completo fica fora de `hero.standard`.
-- Variante com formulário não está aprovada.
-
-#### 2.7.8. `copySourceMap` do Hero
-
-- `eyebrow`:
-  - primária `positioning_opportunity`;
-  - auxiliar `search_intent`.
-- `title`:
-  - primárias `positioning_opportunity` e `desire`;
-  - auxiliar `commercial_keywords`.
-- `subtitle`:
-  - primárias `pain` e `desire`;
-  - auxiliar `belief`.
-- label:
-  - primária `trigger`;
-  - auxiliar `search_intent`;
-  - ação concreta exige vínculo operacional.
-- `proofShort`:
-  - primária `proof_type`;
-  - auxiliar `objection`;
-  - suporte operacional obrigatório quando presente.
-- Alternativa acessível de imagem:
-  - não usa `copySourceMap`;
-  - não usa `operationalValuePolicy`;
-  - a E19 a produz a partir do ativo e contexto sob o contrato de acessibilidade.
-- Ativo, modo de acessibilidade, visibilidade, canal e destino não recebem `copySourceMap`.
-
-#### 2.7.9. Perfis de funil do Hero
-
-- BOFU:
-  - direto;
-  - decisório;
-  - alta intenção;
-  - sem alegação não sustentada.
-- MOFU:
-  - diferenciação;
-  - explicação;
-  - pressão menor.
-- TOFU:
-  - contexto educativo;
-  - baixa fricção;
-  - sem pressão artificial.
-- Perfil altera copy, não campos, estrutura ou variante.
-
-#### 2.7.10. Variante `hero.standard`
-
+- `variantKey = hero.standard`.
 - `variantVersion = 1`.
-- Compatível com `moduleVersion = 1`.
-- Execução-base com delta vazio.
-- Imagem permanece opcional.
-- `secondaryCta`, vídeo e `form` não pertencem à v1.
-- Inclusão futura de qualquer um deles exige nova `moduleVersion`, contrato aprovado e casos próprios.
-- Funil, visibilidade e troca para `body.base` não criam variante.
-- `hero.media_split` permanece rejeitada.
-- A variante está conceitualmente fechada na v1.
+- Compatível com `hero@v1`.
+- Única variante inicial.
 
-#### 2.7.11. Lifecycle e compatibilidade do Hero
+Campos:
 
-- `moduleCatalogVersion = 1` proposto.
-- `moduleVersion = 1` fechado conceitualmente.
-- `variantVersion = 1` fechada conceitualmente.
-- `moduleCatalogVersion` não possui lifecycle próprio aprovado; declara apenas versão e compatibilidade com a raiz.
-- Lifecycle da raiz disponível no contrato atual:
-  - `hypothesis`;
-  - `validated`;
-  - `deprecated`.
-- Política nova de elegibilidade criada pela E18.5:
-  - raiz `hypothesis` permite somente `controlled_test`;
-  - raiz `validated` segue a interseção das demais camadas;
-  - raiz `deprecated` permite somente `historical_read`.
-- Essa política:
-  - interpreta o lifecycle fornecido pela raiz;
-  - não é comportamento já implementado no resolver da raiz;
-  - será aplicada pelo futuro resolver da E18.5.
-- Módulo e variante começam `experimental`.
-- Propósito inicial: `controlled_test`.
-- Elegibilidade cruza:
-  - lifecycle da raiz;
-  - compatibilidade raiz–catálogo;
-  - lifecycle do módulo;
-  - lifecycle da variante;
-  - propósito solicitado.
-- Promoção exige LP real, revisão e decisão humanas.
+- `eyebrow`:
+  - texto, papel `eyebrow`, cardinalidade `0..1`, policy `research_guided`.
+- `title`:
+  - texto, papel `h1`, cardinalidade `1..1`, policy `hybrid`, suporte `when_factual`.
+- `subtitle`:
+  - texto, papel `paragraph`, cardinalidade `1..1`, policy `hybrid`, suporte `when_factual`.
+- `primaryCta`:
+  - ação, cardinalidade `1..1`, policy `not_copy`;
+  - label textual com papel `cta_label`, cardinalidade `1..1`, policy `hybrid`, suporte `when_present`;
+  - vínculo obrigatório com `primary_conversion_channel`.
+- `proofShort`:
+  - texto, papel `paragraph`, cardinalidade `0..1`, policy `hybrid`, suporte `when_present`.
+- `media`:
+  - mídia, cardinalidade `0..1`, policy `technical_reference`;
+  - somente imagem;
+  - modo `informative` ou `decorative`.
 
-#### 2.7.12. Casos executáveis da E18.5 para o Hero
+Copy:
 
-- Validar identidade, evidência, proveniência e interpretação editorial de `hero_segmentado`.
-- Aceitar exatamente os seis campos publicáveis da v1.
-- Rejeitar `secondaryCta` em `moduleVersion = 1`.
-- Rejeitar `mediaKind = video` em `moduleVersion = 1`.
-- Rejeitar `primary_conversion_channel = form` no Hero v1.
-- Exigir nova `moduleVersion` para inclusão futura desses recursos.
-- Rejeitar campo, cardinalidade, policy, fonte, tratamento ou variante inválidos.
-- Rejeitar combinação ausente da allowlist.
-- Validar `operationalSupportRequirement` e sua compatibilidade com policy e campo.
-- Validar vínculo abstrato do CTA principal com `primary_conversion_channel`.
-- Garantir que CTA não armazene canal ou destino concreto.
-- Validar contrato abstrato de imagem, acessibilidade e responsividade.
-- Falhar na implementação sem capabilities exigidas e sem fallback.
-- Incluir raiz na elegibilidade sem exigir lifecycle do catálogo.
-- Tratar lifecycle–propósito como política da E18.5.
-- Retornar resultado imutável.
+- `eyebrow`: primária `positioning_opportunity`; auxiliar `search_intent`.
+- `title`: primárias `positioning_opportunity` e `desire`; auxiliar `commercial_keywords`.
+- `subtitle`: primárias `pain` e `desire`; auxiliar `belief`.
+- `primaryCta.label`: primária `trigger`; auxiliar `search_intent`.
+- `proofShort`: primária `proof_type`; auxiliar `objection`.
 
-#### 2.7.13. Invariantes futuras de conteúdo para E19
+Regras específicas:
 
-Não criam agora schema ou validador de conteúdo na E18.5:
+- Canais permitidos: `whatsapp`, `phone`, `email` e `external_url`.
+- Canal e destino concretos ficam fora do registry.
+- Imagem informativa exige alternativa acessível.
+- Imagem decorativa não transporta informação essencial.
+- Visibilidade `desktop_only` pode ser selecionada pela E20 somente para imagem complementar, decorativa ou redundante.
+- A capability técnica de `desktop_only` depende de evolução da raiz; sua ausência não bloqueia a implementação básica com `all_viewports`.
+- `subtitle` usa `body.editorialEmphasis` quando disponível; `body.base` é alternativa explícita, não fallback do renderer.
+- Não pertencem a `hero.standard@v1`:
+  - CTA secundário;
+  - vídeo;
+  - formulário;
+  - interação;
+  - galeria, carrossel ou tour.
+- Essas exclusões não restringem futuras variantes de `hero`.
 
-- título, subtítulo e CTA principal concretos conforme cardinalidade;
-- label compatível com canal, ação e destino resolvidos;
-- canal limitado ao conjunto autorizado pela v1;
-- suporte operacional exigido disponível;
-- prova concreta sustentada;
-- ativo de imagem válido;
-- imagem informativa com alternativa acessível;
-- imagem decorativa sem descrição semântica;
-- `desktop_only` sem ocultar informação essencial;
-- ausência de CTA secundário, vídeo, formulário completo, seletor interativo, galeria, carrossel ou tour dentro de `hero.standard` v1.
+Funil:
 
-#### 2.7.14. Fechamento do Hero
-
-Contrato conceitual aprovado na v1:
-
-- identidade, evidência, interpretação da segmentação e fronteiras;
-- seis campos publicáveis e cardinalidades;
-- allowlist de policies e `operationalSupportRequirement`;
-- vínculo do CTA principal aos quatro canais autorizados;
-- imagem e acessibilidade abstrata;
-- visibilidade responsiva conceitual;
-- variante, versões, lifecycle e compatibilidades;
-- casos E18.5 e invariantes E19.
+- BOFU: direto e decisório.
+- MOFU: diferenciação e explicação moderada.
+- TOFU: contexto educativo e baixa fricção.
+- Funil não altera campos ou variante.
 
 Estado:
 
-- `hero_segmentado` comprovado com `researchId` e `itemId`;
-- segmentação v1 definida como editorial, não interativa;
-- allowlist de policies registrada;
-- labels e `proofShort` usam `hybrid` com suporte declarativo;
-- CTA principal referencia somente a chave operacional aprovada;
-- destinos concretos permanecem fora do registry;
-- `form` foi retirado da v1;
-- mídia foi restringida a imagem;
-- alternativa acessível saiu de `operationalValuePolicy`;
-- `desktop_only` possui aprovação humana conceitual, mas capability técnica ainda não existe;
-- lifecycle próprio do catálogo foi retirado;
-- lifecycle–propósito foi identificado como política nova da E18.5;
-- `secondaryCta` e vídeo foram retirados da v1;
-- `hero` está conceitualmente fechado na v1;
-- `hero.standard` está conceitualmente fechada na v1;
-- implementação permanece bloqueada até evolução tipográfica e responsiva da raiz.
+- contrato conceitualmente fechado;
+- lifecycle `experimental`;
+- propósito `controlled_test`;
+- implementação ainda não autorizada por este ajuste documental.
 
-### 2.8. `copy_source_map`
-
-- Até duas fontes primárias e uma auxiliar por campo.
-- `end_customer` é fonte primária.
-- `business_buyer` só auxilia autoridade, processo, posicionamento ou prova institucional.
-- `lp_sections` comprova função, não vira fonte fixa de copy.
-- Policies e exigência de suporte controlam quando `copySourceMap` é permitido.
-
-### 2.9. `funnel_copy_profile`
-
-- Perfis:
-  - `bofu`;
-  - `mofu`;
-  - `tofu`.
-- Perfil altera transformação, nunca schema, cardinalidade, módulo ou variante.
-
-### 2.10. Tratamentos comerciais
-
-- Prova, credencial, preço, oferta, garantia, urgência, resultado, depoimento e métrica exigem fonte real.
-- Pesquisa não cria fato operacional.
-- Label que nomeia canal ou ação concreta exige capacidade operacional correspondente.
-
-### 2.11. Lifecycle e compatibilidade
-
-- Raiz: `hypothesis | validated | deprecated`.
-- Módulo e variante: `candidate | experimental | validated | deprecated`.
-- `moduleCatalogVersion` possui versão e compatibilidade, sem lifecycle próprio na v1.
-- Propósitos: `controlled_test | new_use | historical_read`.
-- Elegibilidade é interseção de lifecycle da raiz, compatibilidade raiz–catálogo, lifecycle do módulo, lifecycle da variante e propósito.
-- A relação lifecycle da raiz–propósito é política nova da E18.5.
-- `candidate` bloqueia uso; `experimental` permite teste; `deprecated` só permite histórico.
-
-### 2.12. Contrato de resolução previsto
-
-Entrada: `rootVersion`, `moduleCatalogVersion`, `moduleKey`, `variantKey`, `purpose`.
-
-Processamento:
-
-1. resolver raiz e ler seu lifecycle;
-2. aplicar a política lifecycle–propósito da E18.5;
-3. validar compatibilidade do catálogo com a raiz;
-4. resolver módulo e lifecycle;
-5. validar evidências, campos, policies, suporte e vínculos abstratos;
-6. resolver variante, lifecycle e compatibilidade;
-7. aplicar delta válido;
-8. calcular contrato e elegibilidade;
-9. retornar resultado imutável.
-
-A saída não contém deltas, canal, destino concreto, lifecycle de catálogo ou fallback.
-
-### 2.13. Artefatos previstos
-
-Após raiz e v2:
-
-- `module-catalog/contracts.ts`;
-- `registry.ts`;
-- `schema.ts`;
-- `resolver.ts`;
-- `validation-cases.ts`;
-- `index.ts`.
-
-Interface: `landingPageModules`. Script: `validate:landing-page-modules`.
-
-#### 2.13.1. Evolução futura do catálogo
-
-- Extensão comum ocorre por registry, casos e nova versão aplicável.
-- Campo novo exige nova `moduleVersion`; capability comum exige nova `rootVersion`.
-- Contrato, schema e resolver só mudam quando a necessidade não couber no contrato fechado.
-- Sem cadastro dinâmico, mutação runtime ou criação automática no MVP.
-
-### 2.14. Validações mínimas previstas
-
-Validações E18.5:
-
-- versões, evidências, compatibilidades e lifecycle de raiz, módulo e variante válidos;
-- ausência de lifecycle próprio não aprovado no catálogo;
-- campos, cardinalidades, policies, fontes e tratamentos válidos;
-- allowlist de policy e suporte operacional respeitada;
-- vínculo de ação referencia apenas `fieldKey` aprovado do catálogo operacional;
-- nenhum destino concreto de CTA no registry;
-- `secondaryCta`, vídeo e canal `form` rejeitados no Hero v1;
-- capabilities exigidas sem fallback na implementação;
-- delta vazio somente na base autorizada;
-- contrato abstrato de imagem e acessibilidade válido;
-- formulário ou seletor interativo não adicionados ao Hero;
-- resultado imutável, versões históricas preservadas e sem imports fora do boundary.
-
-#### 2.14.1. Invariantes futuras para E19
-
-- presença e consistência do conteúdo concreto;
-- CTA vinculado à operação real e a canal autorizado;
-- suporte operacional exigido resolvido;
-- prova sustentada;
-- ativo e acessibilidade válidos;
-- ocultação responsiva sem perda de informação;
-- ausência de estrutura não autorizada no Hero.
-
-### 2.15. Fluxo operacional
-
-- Gatilho: raiz e plano v2 mergeados, fase instruída.
-- Entrada: raiz compatível, catálogo aprovado, itens oficiais e decisões humanas.
-- Processamento: contratos, registry, resolver, policies, suporte, mapas, lifecycle e casos E18.5.
-- Validação: `npm ci`, validações da raiz, módulos e commercial activation, `npm run check`, `git diff --check` e checks do PR.
-- Persistência: repositório; consumo futuro: E20 e E19; fallback: falha fechada.
-
-### 2.16. Módulo `trust_bar`
-
-#### 2.16.1. Identidade e função estrutural
+### 3.3. Módulo `trust_bar`
 
 - `moduleKey = trust_bar`.
 - `moduleVersion = 1`.
 - Função:
   - apresentar sinais curtos e verificáveis de confiança;
-  - reduzir a insegurança inicial;
-  - sustentar a continuidade da leitura ou a aproximação do CTA.
-- O módulo é opcional na composição.
-- Sua posição mais comum é após o Hero, mas ordem e ocorrência pertencem à E20.
+  - reduzir insegurança inicial;
+  - sustentar continuidade da leitura ou aproximação da conversão.
+- Invariantes:
+  - sinais curtos;
+  - relevância para o público;
+  - sustentação factual real.
+- Fronteiras:
+  - não contém depoimento, prova social extensa, explicação institucional, política completa, prova técnica detalhada, CTA, formulário ou mídia.
+- Evidência principal:
+  - `barra_de_confianca`, pesquisa ativa de `lp_sections`, taxon `Corretor Imóveis`.
+- Variantes futuras podem usar outra execução estrutural sem alterar `trust_bar.standard@v1`.
 
-#### 2.16.2. Evidência e equivalência
+### 3.4. Variante `trust_bar.standard@v1`
 
-- Evidência estrutural:
-  - candidato `barra_de_confianca` da grade de `lp_sections`;
-  - blueprint imobiliário com prova curta imediata;
-  - exemplos documentados: especialização, registro profissional, privacidade e marca parceira.
-- Função transversal:
-  - responder rapidamente se a empresa, profissional ou oferta possui sinais reais de confiança.
-- A evidência imobiliária orienta o primeiro caso, mas o módulo não carrega identidade de taxon.
-
-#### 2.16.3. Fronteiras
-
-Pertencem:
-
-- credencial ou registro verificável;
-- especialização real;
-- capacidade operacional concreta;
-- informação curta de segurança ou privacidade;
-- parceria ou vínculo real;
-- outro sinal curto sustentado por dado operacional.
-
-Não pertencem:
-
-- depoimentos ou avaliações;
-- prova social extensa;
-- explicação institucional;
-- política de privacidade completa;
-- prova técnica detalhada;
-- CTA;
-- formulário;
-- mídia;
-- selo, certificação, parceria, experiência ou resultado inventado.
-
-#### 2.16.4. Catálogo de campos v1
-
-- `items`:
-  - `fieldKind = collection`;
-  - cardinalidade `2..4`;
-  - policy `not_copy` no contêiner;
-  - contrato fechado do item:
-    - `text`:
-      - `fieldKind = text`;
-      - `semanticRole = benefit_item`;
-      - cardinalidade `1..1`;
-      - policy `hybrid`;
-      - `operationalSupportRequirement = when_present`.
-- A coleção não admite item aninhado.
-- A v1 não possui título, subtítulo, CTA, ícone ou mídia próprios.
-- A redação herda as faixas da raiz para `benefit_item`, sem especialização própria.
-
-#### 2.16.5. Fontes de copy e suporte
-
-- `copySourceMap` de `items.text`:
-  - primárias:
-    - `proof_type`;
-    - `belief`;
-  - auxiliar:
-    - `objection`.
-- Pesquisa orienta seleção, relevância e redação.
-- Pesquisa e `copySourceMap` não comprovam o sinal exibido.
-- Cada item presente exige suporte operacional real aplicável.
-- A E19 deve omitir o módulo quando não conseguir resolver ao menos dois sinais válidos.
-
-#### 2.16.6. Perfis de funil
-
-- BOFU:
-  - prioriza credencial, parceria, capacidade concreta e segurança verificável;
-  - usa redação direta e decisória.
-- MOFU:
-  - prioriza especialização, processo, orientação e suporte oferecido;
-  - reduz risco sem pressão excessiva.
-- TOFU:
-  - prioriza identificação clara, privacidade, atendimento humano e transparência;
-  - usa confiança leve e baixa fricção.
-- O perfil altera seleção, ordem e redação dos itens.
-- O perfil não altera campos, cardinalidade, módulo ou variante.
-
-#### 2.16.7. Variante `trust_bar.standard`
+Identidade:
 
 - `variantKey = trust_bar.standard`.
 - `variantVersion = 1`.
-- Compatível com `moduleVersion = 1`.
-- Execução-base com delta vazio.
+- Compatível com `trust_bar@v1`.
 - Única variante inicial.
-- Disposição horizontal, quebra de linha ou empilhamento mobile são comportamento responsivo do renderer, não novas variantes.
-- A variante está conceitualmente fechada na v1.
 
-#### 2.16.8. Lifecycle e compatibilidade
+Campos:
 
-- `moduleCatalogVersion = 1` proposto.
-- `moduleVersion = 1` fechado conceitualmente.
-- `variantVersion = 1` fechada conceitualmente.
-- Módulo e variante começam `experimental`.
-- Propósito inicial: `controlled_test`.
-- Promoção exige uso em LP real, revisão e decisão humanas.
+- `items`:
+  - coleção, cardinalidade `2..4`, policy `not_copy`;
+  - item fechado com `text`;
+  - `text`: papel `benefit_item`, cardinalidade `1..1`, policy `hybrid`, suporte `when_present`.
 
-#### 2.16.9. Casos executáveis da E18.5
+Copy:
 
-- Validar identidade e função transversal.
-- Aceitar somente o campo `items` na v1.
-- Validar cardinalidade `2..4`.
-- Validar o contrato fechado de `items.text`.
-- Validar policy `hybrid` com `operationalSupportRequirement = when_present`.
-- Validar `copySourceMap` dentro do limite comum.
-- Rejeitar CTA, mídia, item aninhado, campo adicional ou variante não aprovada.
-- Confirmar que TOFU, MOFU e BOFU não alteram schema ou variante.
-- Retornar contrato imutável.
+- primárias `proof_type` e `belief`;
+- auxiliar `objection`.
 
-#### 2.16.10. Invariantes futuras de conteúdo para E19
+Regras específicas:
 
-- Resolver de dois a quatro itens válidos.
-- Exigir suporte operacional real para cada item.
-- Proibir credencial, parceria, experiência, certificação, capacidade ou resultado inventado.
-- Não tratar pesquisa como comprovação factual.
-- Evitar duplicidade material entre itens.
-- Manter os textos curtos, claros e relevantes para o público e o funil.
-- Omitir o módulo quando houver menos de dois sinais válidos.
-- Não inserir CTA, mídia, depoimento ou explicação extensa.
-
-#### 2.16.11. Fechamento da `trust_bar`
-
-Contrato conceitual aprovado na v1:
-
-- função e fronteiras;
-- coleção `items` com cardinalidade `2..4`;
-- contrato fechado de `items.text`;
-- fontes de copy e suporte operacional;
-- perfis BOFU, MOFU e TOFU;
-- variante única `trust_bar.standard`;
-- lifecycle inicial e propósito de teste;
-- casos E18.5 e invariantes E19.
+- cada item exige suporte operacional real;
+- a pesquisa orienta seleção e redação, mas não comprova o sinal;
+- a coleção não admite item aninhado;
+- não possui título, subtítulo, CTA, ícone ou mídia;
+- disposição horizontal, quebra e empilhamento são responsabilidade responsiva do renderer;
+- TOFU, MOFU e BOFU alteram seleção, ordem e redação, não o contrato;
+- futura E19 omite a ocorrência quando não houver ao menos dois sinais válidos.
 
 Estado:
 
-- `trust_bar` está conceitualmente fechada na v1;
-- `trust_bar.standard` está conceitualmente fechada na v1;
-- implementação permanece condicionada ao catálogo de módulos e ao fluxo futuro da E19.
+- contrato conceitualmente fechado;
+- lifecycle `experimental`;
+- propósito `controlled_test`;
+- implementação ainda não autorizada por este ajuste documental.
 
-## 3. Fases e próxima ação
+## 4. Módulos pendentes
 
-### 3.1. E18.5.3–E18.5.9 — Catálogo versionado de módulos e variantes v1
+### 4.1. Estado
 
-- Status pendente e bloqueado até grade fechada, raiz evoluída e v2 consolidada.
-- Automação: não. Risco: médio controlado.
-- Aceite: módulos aprovados, sem duplicação da raiz ou E20.2, compatibilidade validada, resolver fail-closed e separação E18.5/E19.
-- Hero:
-  - contrato conceitual fechado;
-  - implementação bloqueada pela raiz.
-- `trust_bar`:
-  - contrato conceitual fechado;
-  - variante `trust_bar.standard` fechada;
-  - implementação condicionada ao catálogo de módulos e à E19.
-- Próxima ação:
-  - iniciar análise de `problem_solution` pela grade metodológica comum;
-  - seguir os sete candidatos restantes;
-  - evoluir a raiz antes da implementação;
-  - concluir pareceres, v2 e merge humano.
+Permanecem pendentes:
 
-## 4. Escopo negativo e critérios de parada
+- `problem_solution`;
+- `offer`;
+- `process`;
+- `technical_assurance`;
+- `social_proof`;
+- `faq`;
+- `final_cta`.
 
-### 4.1. Fora do escopo
+Cada um receberá:
 
-- Implementação da raiz no PR #577.
-- Banco, composição, geração, renderer, Admin, Builder, tracking, automação ou nova infraestrutura.
-- Nova entrada operacional para sustentar `secondaryCta`.
-- `secondaryCta`, vídeo ou CTA para formulário na v1 do Hero.
-- Módulo de formulário, seletor interativo, galeria, carrossel ou tour neste recorte.
-- Persistência nova para justificativa da composição.
+- contrato permanente do módulo;
+- variante `standard@v1`;
+- somente os detalhes exigidos por sua execução atual.
 
-### 4.2. Critérios de parada
+### 4.2. Sequência incremental
 
-Parar se:
+A implementação dos nove módulos ocorrerá em etapas dentro da E18.5:
 
-- raiz, capability ou lifecycle aplicável não estiverem resolvidos na implementação;
-- surgir lifecycle próprio de catálogo sem decisão explícita;
-- surgir fallback, dependência de taxon ou ampliação de limite;
-- faltar evidência oficial;
+1. contrato compartilhado de módulos e variantes;
+2. `hero` e `trust_bar`;
+3. `problem_solution`, `offer` e `process`;
+4. `technical_assurance` e `social_proof`;
+5. `faq` e `final_cta`;
+6. validação integrada, documentação final e encerramento da E18.5.
+
+A etapa seguinte só deve reproduzir o contrato compartilhado após ele estar validado pelos módulos anteriores.
+
+### 4.3. Próxima ação
+
+- Analisar `problem_solution` pelo checklist mínimo da seção 2.9.
+- Separar `problem_solution` de `problem_solution.standard@v1`.
+- Não alterar o arquivo novamente sem decisão humana sobre o contrato proposto.
+- Não implementar código durante o fechamento conceitual.
+
+## 5. Validação e encerramento
+
+### 5.1. Validações da implementação
+
+Quando a implementação for autorizada:
+
+- validar schemas e registries;
+- validar identidade e compatibilidade de módulo e variante;
+- rejeitar campos, policies, capabilities e deltas desconhecidos;
+- garantir resolução fail-closed e resultado imutável;
+- validar apenas combinações efetivamente utilizadas;
+- executar casos próprios e integração dos nove módulos;
+- executar `npm ci`, validações aplicáveis, `npm run check` e `git diff --check`.
+
+Alteração exclusivamente documental:
+
+- `npm ci`: não aplicável;
+- `npm run check`: não aplicável;
+- `git diff --check`: obrigatório antes da entrega.
+
+### 5.2. Regra de parada
+
+Após os nove módulos e suas variantes `standard@v1`:
+
+- encerrar a E18.5;
+- não criar nova variante antes da primeira LP;
+- não adicionar campo para cenário futuro;
+- não criar policy ou capability sem consumidor;
+- não antecipar matriz especulativa;
+- não absorver renderer, composição ou geração;
+- avançar para E20 e depois E19.
+
+### 5.3. Estado de validação
+
+- Implementação técnica significa contrato executável no repositório.
+- Os módulos permanecem hipóteses de produto.
+- Validação comercial ocorrerá somente quando a E20 compuser e a E19 gerar a primeira LP real.
+- Promoção de lifecycle exige evidência dessa utilização e decisão humana.
+
+### 5.4. Critérios de parada imediata
+
+Parar e informar a divergência se:
+
+- surgir banco, rota, job, agente, automação ou infraestrutura nova;
+- módulo receber identidade de taxon;
+- variante representar somente copy, campanha, plano ou ativo;
+- regra de `standard@v1` for tratada como limite permanente do módulo;
+- nova variante for antecipada;
 - destino concreto entrar no registry;
-- campo híbrido depender de regra hardcoded por `fieldKey`;
-- `secondaryCta`, vídeo ou `form` forem reintroduzidos na v1;
-- formulário, seletor interativo ou mídia essencial forem tratados incorretamente;
-- validação de conteúdo for antecipada na E18.5;
-- houver conflito de fronteiras ou perda histórica.
-
-### 4.3. Decisão atual
-
-- PR #577 permanece em v1 e sem implementação autorizada.
-- `hero_segmentado` está comprovado com `itemId` e interpretado editorialmente na v1.
-- Grade comum e nove candidatos permanecem.
-- Hero possui seis campos publicáveis com contrato conceitualmente fechado.
-- `secondaryCta`, vídeo e canal `form` foram retirados da v1; eventual retorno exige nova `moduleVersion` e contrato aprovado.
-- `hero.standard` permanece a única variante inicial, com delta vazio, e está conceitualmente fechada.
-- Labels e `proofShort` usam `hybrid` com exigência declarativa de suporte.
-- CTA principal referencia `primary_conversion_channel`, sem canal ou destino concreto no registry.
-- Alternativa acessível da imagem usa contrato próprio, não policy textual.
-- Visibilidade responsiva não cria variante.
-- Formulário completo e seletor interativo ficam fora do Hero.
-- Elegibilidade inclui a raiz e não presume lifecycle do catálogo.
-- E18.5 e E19 permanecem separadas.
-- Hero e `hero.standard` estão finalizados conceitualmente na v1.
-- `trust_bar` possui coleção de dois a quatro sinais reais de confiança.
-- TOFU, MOFU e BOFU alteram somente seleção, ordem e redação dos itens.
-- `trust_bar.standard` é a única variante inicial, com delta vazio.
-- `trust_bar` e `trust_bar.standard` estão finalizadas conceitualmente na v1.
-- Sete módulos candidatos permanecem pendentes.
-- A implementação continua bloqueada pela evolução tipográfica e responsiva da raiz.
-- Próxima ação humana: iniciar `problem_solution`.
+- conteúdo factual puder ser inventado;
+- E19, E20 ou renderer forem implementados implicitamente;
+- alteração sair do arquivo e da branch autorizados;
+- houver tentativa de merge na `main`.

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -4,7 +4,7 @@ Fontes: chat, `README.md`, `AGENTS.md`, `docs/roadmap.md`, `docs/base-tecnica.md
 
 Versão: v1 em ajuste.
 
-Status: plano simplificado; nove módulos mantidos no escopo; `hero`, `hero.standard@v1`, `trust_bar`, `trust_bar.standard@v1`, `problem_solution`, `problem_solution.standard@v1`, `offer`, `offer.standard@v1`, `process`, `process.standard@v1`, `technical_assurance`, `technical_assurance.standard@v1`, `social_proof`, `social_proof.standard@v1`, `faq` e `faq.standard@v1` conceitualmente fechados; um módulo pendente; nenhuma implementação autorizada neste PR.
+Status: plano simplificado; nove módulos mantidos no escopo; `hero`, `hero.standard@v1`, `trust_bar`, `trust_bar.standard@v1`, `problem_solution`, `problem_solution.standard@v1`, `offer`, `offer.standard@v1`, `process`, `process.standard@v1`, `technical_assurance`, `technical_assurance.standard@v1`, `social_proof`, `social_proof.standard@v1`, `faq`, `faq.standard@v1` e `faq.accordion@v1` conceitualmente fechados; um módulo pendente; nenhuma implementação autorizada neste PR.
 
 Path: `docs/lousa-plano-base-e18-5.md`.
 
@@ -14,10 +14,10 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 
 ### 1.1. Objetivo da E18.5
 
-- Definir e implementar, no repositório, o catálogo versionado dos nove módulos `landing_page` e de suas variantes `standard@v1`.
+- Definir e implementar, no repositório, o catálogo versionado dos nove módulos `landing_page`, de suas variantes `standard@v1` e da variante controlada `faq.accordion@v1`.
 - Entregar contratos pequenos, estritos, imutáveis e suficientes para consumo posterior pela E20 e pela E19.
 - Preservar extensibilidade sem antecipar variantes, campos ou capacidades sem uso aprovado.
-- Encerrar a E18.5 após os nove módulos, suas variantes `standard@v1` e a validação integrada dos contratos.
+- Encerrar a E18.5 após os nove módulos, suas variantes `standard@v1`, `faq.accordion@v1` e a validação integrada dos contratos.
 
 ### 1.2. Estado confirmado
 
@@ -56,7 +56,7 @@ A E18.5 define e implementa:
 
 - identidade e versão do catálogo;
 - identidade, versão, função e invariantes dos módulos;
-- identidade, versão, campos, cardinalidades e capacidades das variantes `standard@v1`;
+- identidade, versão, campos, cardinalidades e capacidades das variantes `standard@v1` e de `faq.accordion@v1`;
 - especializações necessárias sobre a raiz;
 - fontes de copy e perfis de funil;
 - exigências factuais ou operacionais;
@@ -75,7 +75,7 @@ Ficam fora:
 - persistência e snapshot;
 - tracking;
 - conteúdo operacional concreto;
-- variantes além de `standard@v1`;
+- variantes além de `standard@v1`, exceto `faq.accordion@v1`, explicitamente aprovada para validação controlada;
 - capacidades sem consumidor aprovado.
 
 ## 2. Contrato compartilhado
@@ -103,7 +103,7 @@ A separação aplica-se aos nove módulos.
 
 ### 2.2. Extensibilidade das variantes
 
-- Cada módulo começa com uma única variante `standard@v1`.
+- Cada módulo começa com uma variante `standard@v1`; `faq.accordion@v1` é a única exceção adicional aprovada antes da primeira LP.
 - Nova variante exige diferença estrutural ou comportamental reutilizável.
 - Nova variante pode adicionar ou especializar campos, mídia, interação, responsividade e validações próprias.
 - Nova variante deve constituir evolução aditiva e localizada; poderá exigir capabilities compartilhadas ou infraestrutura inerente à nova execução, tratadas nos respectivos recortes, sem alteração destrutiva do módulo, das variantes existentes ou das LPs anteriores.
@@ -133,8 +133,8 @@ Não criam variante isoladamente:
 - Módulo e variante registram apenas deltas necessários.
 - Módulo ou variante pode restringir a raiz, mas não ampliar limite absoluto vigente.
 - Necessidade acima do limite da raiz exige evolução versionada da raiz.
-- Capability da raiz só bloqueia a implementação quando for indispensável à variante `standard@v1` em implementação.
-- Capability opcional ou destinada a variante futura permanece evolução posterior.
+- Capability da raiz só bloqueia a implementação quando for indispensável à variante aprovada em implementação.
+- Capability opcional ou destinada a variante não aprovada permanece evolução posterior.
 - Variante deve declarar compatibilidade explícita com a versão da raiz usada por seu contrato.
 - O comportamento de uma variante imutável não muda pela disponibilidade posterior de nova capability da raiz.
 - Não existe fallback silencioso.
@@ -248,7 +248,7 @@ Obrigatório:
 - lifecycle e compatibilidade;
 - validações estruturais indispensáveis.
 
-Condicional, somente quando utilizado por `standard@v1`:
+Condicional, somente quando utilizado por `standard@v1` ou por variante adicional aprovada:
 
 - ação;
 - mídia;
@@ -258,14 +258,14 @@ Condicional, somente quando utilizado por `standard@v1`:
 - fallback técnico;
 - referência técnica.
 
-O fechamento conceitual não exige detalhar comportamentos de variantes futuras.
+O fechamento conceitual não exige detalhar comportamentos de variantes futuras não aprovadas.
 
 ### 2.10. Significado de implementação
 
 Um módulo está implementado na E18.5 quando existem, conforme o contrato técnico adotado:
 
 - identidade versionada do módulo;
-- identidade versionada de `standard@v1`;
+- identidade versionada de `standard@v1` e de cada variante adicional aprovada;
 - tipos e schemas;
 - campos, cardinalidades e capabilities;
 - registry;
@@ -850,13 +850,13 @@ Estado:
 - `moduleKey = faq`; `moduleVersion = 1`.
 - Função: responder dúvidas e objeções recorrentes em pares claros de pergunta e resposta, apoiando compreensão e decisão.
 - Invariantes: cada pergunta é relevante e possui resposta direta; fatos e condições reais exigem sustentação; não há aconselhamento individualizado, promessa ou resposta enganosa.
-- Fronteiras: não substitui oferta, processo ou prova técnica; não contém CTA, mídia, formulário, ação ou interação na execução inicial.
+- Fronteiras: não substitui oferta, processo ou prova técnica; não contém CTA, mídia, formulário ou ação; comportamento interativo pertence à variante que o declarar.
 - Evidências: `faq_objeções` de `lp_sections`, `faq_questions` e `search_intent` de `seo`, `objection`, `fear`, `belief` e `awareness_level` de `strategic_core` e Blueprint do corretor.
-- Variantes futuras podem usar outra execução estrutural sem alterar `faq.standard@v1`.
+- Variantes podem usar execuções estruturais ou comportamentais distintas sem alterar o contrato permanente de `faq@v1`.
 
 ### 3.16. Variante `faq.standard@v1`
 
-- Identidade: `variantKey = faq.standard`; `variantVersion = 1`; compatível com `faq@v1` e com a versão vigente da raiz; única variante inicial.
+- Identidade: `variantKey = faq.standard`; `variantVersion = 1`; compatível com `faq@v1` e com a versão vigente da raiz; variante base sem interação.
 - Campos:
   - `title`: texto, papel `h2`, `1..1`, policy `research_guided`;
   - `items`: coleção `2..6`, policy `not_copy`, com `question` (`faq_question`, `1..1`, `research_guided`) e `answer` (`faq_answer`, `1..1`, `hybrid`, suporte `when_factual`).
@@ -873,6 +873,32 @@ Estado:
   - ausência de pares válidos depende da obrigatoriedade da E20 e será tratada pela E19;
   - resolver de forma fail-closed e imutável.
 - Estado: contrato conceitualmente fechado; lifecycle `experimental`; propósito `controlled_test`; implementação ainda não autorizada.
+
+### 3.17. Variante `faq.accordion@v1`
+
+- Identidade: `variantKey = faq.accordion`; `variantVersion = 1`; compatível com `faq@v1` e com a versão vigente da raiz.
+- Finalidade: validar de forma controlada duas variantes do mesmo módulo e oferecer uma apresentação compacta, especialmente no mobile.
+- Conteúdo:
+  - reutiliza integralmente `title`, `items`, `question` e `answer` de `faq.standard@v1`;
+  - mantém cardinalidades, semantic roles, policies, fontes de copy e exigências de sustentação factual;
+  - não adiciona campo de conteúdo na v1.
+- Capability:
+  - acrescenta somente interação de acordeão e requisitos de acessibilidade associados;
+  - a identificação técnica compartilhada será materializada de forma versionada na implementação, sem alterar a raiz ou variantes anteriores silenciosamente.
+- Comportamento esperado:
+  - todos os itens iniciam fechados;
+  - pergunta abre e fecha sua resposta;
+  - somente um item permanece aberto por vez;
+  - abrir outro item fecha o anteriormente aberto;
+  - pergunta é operável por teclado;
+  - estado expandido é exposto semanticamente;
+  - pergunta e resposta possuem associação acessível;
+  - alternar o estado preserva o foco no controle acionado.
+- Limites e validações:
+  - não definir agora elemento HTML, componente, ícone, animação ou implementação visual do renderer;
+  - rejeitar configuração que altere conteúdo, cardinalidade, copy ou sustentação factual herdados;
+  - resolver de forma fail-closed e imutável.
+- Estado: contrato conceitualmente fechado; lifecycle `experimental`; propósito `controlled_test`; candidata à composição da primeira LP controlada; implementação ainda não autorizada.
 
 ## 4. Módulos pendentes
 
@@ -896,7 +922,7 @@ A implementação dos nove módulos ocorrerá em etapas dentro da E18.5:
 2. `hero` e `trust_bar`;
 3. `problem_solution`, `offer` e `process`;
 4. `technical_assurance` e `social_proof`;
-5. `faq` e `final_cta`;
+5. `faq.standard@v1`, `faq.accordion@v1` e `final_cta.standard@v1`;
 6. validação integrada, documentação final e encerramento da E18.5.
 
 A etapa seguinte só deve reproduzir o contrato compartilhado após ele estar validado pelos módulos anteriores.
@@ -919,7 +945,7 @@ Quando a implementação for autorizada:
 - rejeitar campos, policies, capabilities e deltas desconhecidos;
 - garantir resolução fail-closed e resultado imutável;
 - validar apenas combinações efetivamente utilizadas;
-- executar casos próprios e integração dos nove módulos;
+- executar casos próprios e integração dos nove módulos e das duas variantes de FAQ;
 - executar `npm ci`, validações aplicáveis, `npm run check` e `git diff --check`.
 
 Alteração exclusivamente documental:
@@ -930,10 +956,10 @@ Alteração exclusivamente documental:
 
 ### 5.2. Regra de parada
 
-Após os nove módulos e suas variantes `standard@v1`:
+Após os nove módulos, suas variantes `standard@v1` e `faq.accordion@v1`:
 
 - encerrar a E18.5;
-- não criar nova variante antes da primeira LP;
+- não criar outra variante além de `faq.accordion@v1` antes da primeira LP;
 - não adicionar campo para cenário futuro;
 - não criar policy ou capability sem consumidor;
 - não antecipar matriz especulativa;
@@ -955,7 +981,7 @@ Parar e informar a divergência se:
 - módulo receber identidade de taxon;
 - variante representar somente copy, campanha, plano ou ativo;
 - regra de `standard@v1` for tratada como limite permanente do módulo;
-- nova variante for antecipada;
+- variante não aprovada for antecipada;
 - destino concreto entrar no registry;
 - conteúdo factual puder ser inventado;
 - E19, E20 ou renderer forem implementados implicitamente;

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -4,7 +4,7 @@ Fontes: chat, `README.md`, `AGENTS.md`, `docs/prompt-estrategista.md`, `docs/tem
 
 Versão: v1 em ajuste.
 
-Status: PR vivo para debate; grade inicial de nove módulos candidatos definida a partir de `Corretor Imóveis`, `audience_scope = end_customer`, `lp_sections` v1 ativa; cada candidato será analisado individualmente antes de sua aprovação material; rejeição, fusão ou substituição exige decisão humana; a grade metodológica será aplicada primeiro ao Hero; nenhuma implementação autorizada.
+Status: PR vivo para debate; grade metodológica comum registrada; módulo `hero` e variante `hero.standard` registrados para avaliação; grade inicial de nove módulos candidatos preservada; nenhuma implementação autorizada.
 
 Path: `docs/lousa-plano-base-e18-5.md`.
 
@@ -22,6 +22,8 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
   - o contrato compartilhado o mantém opcional.
 - O subtítulo do Hero deve usar maior ênfase por padrão, sem fallback automático para `body.base`.
 - A garantia exige evolução versionada da raiz em recorte e PR próprios, preservando a `rootVersion 1`.
+- A raiz atual também não possui capability fechada de visibilidade responsiva por campo.
+- A visibilidade responsiva reutilizável por vários módulos deve ser tratada como capability comum da família, em evolução versionada própria da raiz.
 - A consulta ao banco confirmou como fonte estrutural principal:
   - taxon: `Corretor Imóveis`;
   - nível: `niche`;
@@ -43,6 +45,8 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
   - justificativa estrutural;
   - atualização explícita da grade;
   - decisão humana.
+- A mesma grade metodológica será usada por todos os módulos aprovados.
+- A grade comum é obrigatória, mas seus blocos condicionais são preenchidos apenas quando aplicáveis à função do módulo.
 - Para cada módulo aprovado, fechar:
   - identidade transversal;
   - restrições normativas;
@@ -53,6 +57,8 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
   - política de origem dos valores;
   - fontes de copy;
   - perfis BOFU, MOFU e TOFU;
+  - mídia, ações, coleções ou interações quando aplicáveis;
+  - comportamento responsivo específico quando aplicável;
   - variante inicial e deltas;
   - versões e compatibilidades;
   - lifecycle e propósitos permitidos;
@@ -83,6 +89,7 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 - Módulo pode restringir ou selecionar capacidades da raiz quando sua função justificar.
 - Variante pode restringir o módulo quando houver mudança reutilizável de execução ou comportamento.
 - Escolha por ocorrência já autorizada não cria variante.
+- Tipo de mídia, ativo concreto ou visibilidade responsiva autorizada não criam variante por si só.
 - Módulo ou variante não pode ampliar limite técnico absoluto.
 - Necessidade acima do limite deve avaliar antes revisão de texto, divisão de conteúdo, mudança semântica ou nova estrutura.
 - Diferença apenas de taxon, conteúdo, campanha, conta, tráfego, funil ou composição não cria módulo nem variante.
@@ -132,25 +139,24 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 
 ### 1.7. Pontos ainda em debate
 
-- Aplicação completa da grade ao Hero.
+- Avaliação e ajustes da grade registrada do Hero.
 - Confirmação individual dos oito candidatos restantes.
-- Contratos específicos por `fieldKind`.
-- Política de origem de cada campo de cada módulo.
-- Variante inicial e deltas de cada módulo.
+- Contratos específicos por `fieldKind` ainda não exemplificados pelo Hero.
+- Variante inicial e deltas dos demais módulos.
 - Critério mínimo para nova variante e exceção estrutural.
-- Mapas de fontes de copy.
-- Perfis BOFU, MOFU e TOFU.
 - Lifecycle inicial e promoção para `validated`.
+- Evolução da raiz para `body.editorialEmphasis` e visibilidade responsiva.
 - Divisão final em fases executáveis.
 
 ## 2. Contrato do caso
 
 ### 2.1. Problema
 
-- A raiz existe, mas ainda faltam contratos aprovados para módulos, variantes, campos, fontes, perfis de funil e lifecycle.
+- A raiz existe, mas ainda faltam contratos aprovados para todos os módulos, variantes, campos, fontes, perfis de funil e lifecycle.
 - Os nove itens estruturais do primeiro recorte não podem virar módulos automaticamente.
 - O catálogo precisa generalizar funções reais sem transportar identidade imobiliária.
 - A raiz v1 não garante o tratamento editorial exigido pelo Hero.
+- A raiz v1 não oferece escolha fechada de visibilidade responsiva por campo.
 - Um contrato único de campo com `semanticRole` obrigatório não atende mídia, ação, coleção ou referência técnica.
 - A política de origem precisa impedir que pesquisa seja tratada como fonte de preço, endereço, credencial, métrica, depoimento, registro, garantia ou disponibilidade.
 - Repetição de valores da raiz ou deltas aplicados por consumidores criaria múltiplas fontes da verdade.
@@ -159,6 +165,7 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 ### 2.2. Resultado esperado
 
 - Criar catálogo repo-only versionado a partir dos nove módulos candidatos, incluindo apenas os contratos individualmente aprovados.
+- Usar grade metodológica única para todos os módulos, com blocos condicionais por função.
 - Usar `Corretor Imóveis`, `end_customer`, `lp_sections` v1 ativa como evidência estrutural principal.
 - Confirmar cada módulo e variante inicial individualmente.
 - Resolver `raiz → módulo → variante` em contrato final imutável.
@@ -215,6 +222,49 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 - Conteúdo, parâmetro herdado, escolha de ocorrência, composição, fonte, funil ou valor operacional não criam variante.
 - Identidade do módulo não pode carregar taxon, profissão ou campanha.
 - Itens de extensão de página não pertencem ao catálogo.
+
+#### 2.3.6. Grade metodológica comum
+
+Todos os módulos serão analisados pelos mesmos blocos obrigatórios:
+
+1. identidade transversal;
+2. função estrutural;
+3. evidências e equivalência semântica;
+4. fronteiras positivas e negativas;
+5. catálogo de campos;
+6. `fieldKind` e contrato condicionado pelo tipo;
+7. cardinalidades sem `required`;
+8. herança, capabilities e exceções;
+9. política fechada de origem do valor;
+10. `copySourceMap` quando aplicável;
+11. perfis BOFU, MOFU e TOFU quando houver copy;
+12. comportamento responsivo específico quando necessário;
+13. variante inicial e deltas;
+14. versões e compatibilidades;
+15. lifecycle e propósitos;
+16. fronteiras com E20, E19 e renderer;
+17. casos positivos e negativos;
+18. critérios de fechamento.
+
+Blocos condicionais serão preenchidos somente quando a função exigir:
+
+- ação ou CTA;
+- mídia;
+- coleção;
+- valor operacional;
+- referência técnica;
+- acessibilidade específica;
+- comportamento interativo;
+- visibilidade responsiva específica;
+- variante estrutural adicional.
+
+Regras da grade:
+
+- O Hero é o primeiro preenchimento, não um molde rígido de conteúdo.
+- Outros módulos podem possuir campos, coleções, interações e responsividade diferentes.
+- Nenhum módulo é obrigado a possuir CTA, mídia, copy ou segunda variante.
+- Nenhuma variante adicional será criada apenas para manter simetria entre módulos.
+- O contrato específico deve ser o mínimo suficiente para representar a função reutilizável.
 
 ### 2.4. Identidade, evidência e versionamento previstos
 
@@ -290,7 +340,8 @@ Contratos condicionais por tipo:
   - não haverá `actionRole` enquanto não existir contrato fechado e fonte aprovada.
 - `media`:
   - usa contrato abstrato de referência;
-  - deve prever política de texto alternativo e uso decorativo na parametrização específica;
+  - deve declarar tipo de mídia permitido;
+  - deve prever política de texto alternativo e uso decorativo;
   - não recebe `semanticRole` visual por padrão.
 - `collection`:
   - declara cardinalidade da coleção;
@@ -366,13 +417,18 @@ Regras adicionais:
 - Delta vazio não autoriza criar variantes redundantes.
 - Não se inventa delta para justificar a existência da variante-base.
 - Nova variante exige diferença reutilizável demonstrável dentro da mesma função estrutural.
+- Tipo de mídia, ativo concreto ou opção responsiva já autorizada não criam variante.
 
 ### 2.7. Módulo-piloto `hero`
 
 #### 2.7.1. Identidade e função estrutural
 
 - `moduleKey = hero`.
-- Apresentar o recorte da LP, a proposta de valor e a principal ação.
+- `moduleVersion = 1` proposto.
+- Função estrutural:
+  - apresentar o recorte da LP;
+  - comunicar a proposta de valor principal;
+  - indicar a ação prioritária esperada do visitante.
 - Não representa taxon, campanha, tráfego, funil ou composição.
 - A função deve permanecer transversal à família `landing_page`.
 
@@ -386,45 +442,99 @@ Regras adicionais:
 - função transversal inferida: apresentar recorte, proposta de valor e ação principal;
 - o nome da seção imobiliária não determina o `moduleKey`.
 
-#### 2.7.3. Catálogo preliminar de campos
+#### 2.7.3. Fronteiras
 
-O catálogo será fechado pela grade completa antes de avançar ao próximo módulo.
+Pertence ao Hero:
+
+- enquadramento inicial;
+- título principal;
+- explicação curta;
+- CTA principal;
+- CTA secundário opcional;
+- prova curta opcional;
+- uma mídia principal opcional.
+
+Não pertence ao Hero:
+
+- barra completa de confiança;
+- lista de serviços;
+- catálogo de ofertas;
+- processo detalhado;
+- prova técnica extensa;
+- conjunto de depoimentos;
+- FAQ;
+- formulário completo;
+- galeria, carrossel ou tour;
+- CTA final da página;
+- navegação;
+- composição ou ordem global.
+
+#### 2.7.4. Catálogo de campos proposto
 
 - `eyebrow`:
   - `fieldKind = text`;
   - `semanticRole = eyebrow`;
-  - `cardinality = { min: 0, max: 1 }`.
+  - `cardinality = { min: 0, max: 1 }`;
+  - `operationalValuePolicy = research_guided`;
+  - contextualiza categoria, intenção ou recorte sem repetir integralmente o título.
 - `title`:
   - `fieldKind = text`;
   - `semanticRole = h1`;
-  - `cardinality = { min: 1, max: 1 }`.
+  - `cardinality = { min: 1, max: 1 }`;
+  - `operationalValuePolicy = hybrid`;
+  - apresenta a principal proposta de valor;
+  - fatos concretos exigem entrada operacional.
 - `subtitle`:
   - `fieldKind = text`;
   - `semanticRole = paragraph`;
   - `cardinality = { min: 1, max: 1 }`;
-  - padrão `body.editorialEmphasis`;
-  - permitidos `body.editorialEmphasis` e `body.base`.
+  - `operationalValuePolicy = hybrid`;
+  - desenvolve promessa, benefício, contexto ou objeção principal;
+  - `defaultTypographyTreatment = body.editorialEmphasis`;
+  - `allowedTypographyTreatments = [body.editorialEmphasis, body.base]`.
 - `primaryCta`:
   - `fieldKind = action`;
   - `cardinality = { min: 1, max: 1 }`;
-  - `label` textual com `semanticRole = cta_label`.
+  - `operationalValuePolicy = not_copy`;
+  - `label`:
+    - `fieldKind = text`;
+    - `semanticRole = cta_label`;
+    - `cardinality = { min: 1, max: 1 }`;
+    - `operationalValuePolicy = research_generated_non_factual`;
+  - `destinationRef`:
+    - `fieldKind = technical_reference`;
+    - `cardinality = { min: 1, max: 1 }`;
+    - `operationalValuePolicy = technical_reference`;
+    - não contém URL concreta no catálogo.
 - `secondaryCta`:
   - `fieldKind = action`;
   - `cardinality = { min: 0, max: 1 }`;
-  - `label` textual com `semanticRole = cta_label`.
+  - `operationalValuePolicy = not_copy`;
+  - quando presente, exige `label` e `destinationRef` equivalentes ao contrato do CTA principal;
+  - representa ação complementar e não deve competir com a ação principal.
 - `proofShort`:
   - `fieldKind = text`;
   - `semanticRole = paragraph`;
-  - `cardinality = { min: 0, max: 1 }`.
+  - `cardinality = { min: 0, max: 1 }`;
+  - `operationalValuePolicy = operational_required`;
+  - pode apresentar credencial, prova ou redução curta de risco;
+  - a pesquisa pode indicar o tipo de prova, mas não fornecer prova concreta;
+  - sem entrada operacional válida, o campo é omitido.
 - `media`:
   - `fieldKind = media`;
-  - referência abstrata;
   - `cardinality = { min: 0, max: 1 }`;
-  - contrato de acessibilidade ainda deve ser fechado na análise do Hero.
+  - `operationalValuePolicy = technical_reference`;
+  - `mediaKind` permitido:
+    - `image`;
+    - `video`;
+  - `assetRef` obrigatório quando o campo estiver presente;
+  - `accessibilityMode` obrigatório:
+    - `informative`;
+    - `decorative`;
+  - mídia informativa exige texto alternativo ou alternativa acessível aplicável;
+  - mídia decorativa não transporta informação essencial.
 
-A política de origem de cada campo será decidida na aplicação completa da grade ao Hero.
-
-#### 2.7.4. Herança e exceção tipográfica
+#### 2.7.5. Herança e exceção tipográfica
 
 - Campos textuais herdam faixas, limites e valores da raiz.
 - Não há tamanho, limite ou spacing próprio aprovado.
@@ -435,28 +545,208 @@ A política de origem de cada campo será decidida na aplicação completa da gr
 - Ausência de `body.editorialEmphasis` é incompatibilidade, não fallback.
 - Mídia opcional não comprova variante.
 
-#### 2.7.5. Variante inicial definida
+#### 2.7.6. Mídia e comportamento responsivo
+
+- Imagem ou vídeo no mesmo slot estrutural usam `hero.standard`.
+- A escolha de `mediaKind` pertence à ocorrência concreta e não cria variante.
+- Galeria, carrossel, tour ou coleção de mídia representam função distinta e não entram no campo `media` do Hero.
+- Política responsiva proposta para o campo `media`:
+  - padrão: `all_viewports`;
+  - alternativa autorizada: `desktop_only`.
+- `desktop_only` significa que a mídia aparece no desktop e é omitida no mobile, sem alterar a função estrutural do Hero.
+- A seleção de `desktop_only` pertence à E20.
+- O renderer apenas executa a opção resolvida.
+- `desktop_only` só é válido quando a mídia for decorativa, complementar ou redundante em relação ao conteúdo textual.
+- Não é permitido ocultar no mobile mídia que contenha informação essencial, prova necessária, instrução, condição, preço, oferta ou conteúdo sem alternativa textual equivalente.
+- A capability comum de visibilidade responsiva ainda não existe na raiz v1 e deve ser adicionada em evolução versionada própria antes da implementação material.
+- Ativo alternativo específico para mobile não entra no contrato inicial; poderá ser avaliado em nova versão se houver evidência real.
+
+#### 2.7.7. Fronteira com formulário
+
+- CTA que leva, abre ou aciona formulário continua dentro de `hero.standard` por meio de `destinationRef`.
+- Formulário completo incorporado visualmente ao Hero não pertence ao contrato inicial de `hero.standard`.
+- A decisão padrão futura é representar captação ou qualificação como módulo próprio composto com o Hero pela E20.
+- Nenhum `moduleKey` novo para formulário é definido neste recorte.
+- Uma variante de Hero com formulário só poderá ser proposta se evidência posterior demonstrar que:
+  - a função principal continua sendo a do Hero;
+  - o formulário é subordinado e inseparável da abertura;
+  - a execução é reutilizável entre taxons;
+  - composição com módulo próprio é insuficiente;
+  - privacidade, validação, responsividade e campos possuem contrato fechado.
+- Nenhuma variante com formulário está aprovada na v1.
+
+#### 2.7.8. `copySourceMap` do Hero
+
+- `eyebrow`:
+  - primária: `end_customer.strategic_core.positioning_opportunity`;
+  - auxiliar: `end_customer.seo.search_intent`.
+- `title`:
+  - primárias: `end_customer.strategic_core.positioning_opportunity`, `end_customer.strategic_core.desire`;
+  - auxiliar: `end_customer.seo.commercial_keywords`.
+- `subtitle`:
+  - primárias: `end_customer.strategic_core.pain`, `end_customer.strategic_core.desire`;
+  - auxiliar: `end_customer.strategic_core.belief`.
+- labels de CTA:
+  - primária: `end_customer.strategic_core.trigger`;
+  - auxiliar: `end_customer.seo.search_intent`.
+- `proofShort`:
+  - orientadora primária: `end_customer.strategic_core.proof_type`;
+  - auxiliar: `end_customer.strategic_core.objection`;
+  - valor factual obrigatoriamente operacional.
+- Não recebem `copySourceMap`:
+  - `destinationRef`;
+  - `assetRef`;
+  - `mediaKind`;
+  - `accessibilityMode`;
+  - política de visibilidade responsiva.
+
+#### 2.7.9. Perfis de funil do Hero
+
+- BOFU:
+  - título direto e específico;
+  - subtítulo orientado à decisão;
+  - objeção principal tratada com clareza;
+  - CTA de alta intenção;
+  - prova curta quando houver fonte operacional real;
+  - sem promessa, urgência ou condição não sustentada.
+- MOFU:
+  - título orientado à diferenciação;
+  - subtítulo explicativo;
+  - CTA proporcional;
+  - prova contextual quando disponível;
+  - menor pressão comercial que BOFU.
+- TOFU:
+  - título orientado a contexto, problema ou desejo;
+  - subtítulo educativo;
+  - CTA de baixa fricção;
+  - sem urgência, escassez ou pressão artificial;
+  - prova curta apenas quando contribuir para confiança.
+- Os perfis usam o mesmo catálogo de campos e cardinalidades.
+- Perfil altera transformação da copy, não estrutura, identidade ou variante.
+
+#### 2.7.10. Variante `hero.standard`
 
 - `variantKey = hero.standard`.
+- `variantVersion = 1` proposta.
+- `compatibleModuleVersion = 1` proposta.
 - Representa a execução-base versionada do Hero.
 - Delta vazio é permitido.
-- Mídia permanece opcional pelo contrato do módulo.
-- É a única variante inicial aprovada do Hero.
+- Não altera campos, cardinalidades ou limites.
+- Mídia permanece opcional.
+- CTA secundário permanece opcional.
+- `mediaKind = image | video` não cria variante.
+- `responsiveVisibility = all_viewports | desktop_only` não cria variante.
 - `hero.media_split` permanece rejeitada.
 - Troca isolada para `body.base` não cria variante.
-- Variante específica de nicho é proibida.
+- Variante específica de nicho, campanha, tráfego ou funil é proibida.
 
-#### 2.7.6. Pendências para fechamento do Hero
+#### 2.7.11. Lifecycle e compatibilidade do Hero
 
-- confirmar o catálogo fechado de campos;
-- confirmar cardinalidades sem `required`;
-- classificar cada campo por `operationalValuePolicy`;
-- validar o `copySourceMap` de cada campo textual;
-- separar perfis BOFU, MOFU e TOFU da estrutura;
-- definir `moduleVersion`, `variantVersion` e compatibilidades;
-- definir lifecycle inicial do módulo e da variante;
-- criar casos positivos e negativos;
-- confirmar dependência da raiz que garanta `body.editorialEmphasis`.
+- `moduleCatalogVersion = 1` proposta para o primeiro catálogo publicado.
+- `moduleVersion = 1` proposta.
+- `variantVersion = 1` proposta.
+- `rootVersion` permanece pendente da evolução que garanta:
+  - `body.editorialEmphasis`;
+  - capability de visibilidade responsiva, caso `desktop_only` permaneça no contrato aprovado.
+- Lifecycle inicial proposto do módulo:
+  - `experimental`.
+- Lifecycle inicial proposto da variante:
+  - `experimental`.
+- Propósito permitido inicialmente:
+  - `controlled_test`.
+- `new_use` permanece proibido até promoção.
+- Promoção para `validated` exige:
+  - LP real em conta de teste;
+  - revisão humana;
+  - validação visual, responsiva e editorial;
+  - ausência de falha estrutural;
+  - decisão humana registrada.
+
+#### 2.7.12. Casos positivos do Hero
+
+- Hero mínimo válido:
+  - `title`;
+  - `subtitle`;
+  - `primaryCta`;
+  - sem eyebrow, CTA secundário, prova curta ou mídia.
+- Hero completo válido:
+  - eyebrow;
+  - title;
+  - subtitle;
+  - CTA principal;
+  - CTA secundário;
+  - prova curta sustentada operacionalmente;
+  - mídia com acessibilidade válida.
+- Hero com imagem:
+  - `hero.standard`;
+  - `mediaKind = image`;
+  - `all_viewports` ou `desktop_only` autorizado.
+- Hero com vídeo:
+  - `hero.standard`;
+  - `mediaKind = video`;
+  - mesmo slot estrutural.
+- Exceção tipográfica válida:
+  - E20 seleciona `body.base`;
+  - opção autorizada;
+  - justificativa registrada;
+  - renderer recebe tratamento resolvido.
+- CTA para formulário válido:
+  - CTA usa `destinationRef` operacional;
+  - formulário permanece fora do contrato do Hero.
+
+#### 2.7.13. Casos negativos do Hero
+
+- Estrutura inválida:
+  - ausência de `title`, `subtitle` ou `primaryCta`;
+  - mais de um título, mídia ou CTA secundário.
+- Origem inválida:
+  - prova concreta criada apenas a partir de `proof_type`;
+  - credencial, métrica ou condição inventada;
+  - destino do CTA inventado pela pesquisa;
+  - mídia sem referência operacional.
+- Tipografia inválida:
+  - raiz sem `body.editorialEmphasis`;
+  - tratamento não autorizado;
+  - fallback automático;
+  - renderer escolhendo tratamento.
+- Mídia inválida:
+  - `mediaKind` desconhecido;
+  - mídia informativa sem alternativa acessível;
+  - `desktop_only` ocultando informação essencial;
+  - galeria, carrossel ou tour tratados como mídia única do Hero.
+- Variante inválida:
+  - variante específica de corretor de imóveis;
+  - variante criada apenas por funil, imagem, vídeo ou visibilidade responsiva;
+  - variante com campo não previsto;
+  - variante redundante com delta vazio sem função de base autorizada.
+- Formulário inválido:
+  - formulário completo adicionado silenciosamente a `hero.standard`;
+  - variante de formulário criada sem análise estrutural própria.
+
+#### 2.7.14. Critérios de fechamento do Hero
+
+O Hero estará fechado para avaliação final quando forem aprovados:
+
+- identidade e função;
+- fronteiras;
+- sete campos e seus contratos internos;
+- cardinalidades;
+- políticas de origem;
+- `copySourceMap`;
+- perfis de funil;
+- contrato de mídia e acessibilidade;
+- decisão sobre `desktop_only` e sua capability de raiz;
+- fronteira com formulário;
+- `hero.standard` com delta vazio;
+- versões e compatibilidades;
+- lifecycle experimental;
+- casos positivos e negativos.
+
+Estado atual:
+
+- módulo e variante registrados como proposta consolidada para avaliação e ajustes;
+- nenhuma implementação autorizada;
+- próxima decisão humana: aprovar ou ajustar a grade do Hero antes de iniciar `trust_bar`.
 
 ### 2.8. `copy_source_map`
 
@@ -469,23 +759,12 @@ A política de origem de cada campo será decidida na aplicação completa da gr
 - `lp_sections` comprova funções estruturais, mas não vira fonte fixa de copy.
 - Chave desconhecida e fato operacional inferido falham fechado.
 
-Mapa inicial do Hero para validação:
-
-- `title`: `positioning_opportunity`, `desire`; auxiliar `commercial_keywords`.
-- `subtitle`: `pain`, `desire`; auxiliar `belief`.
-- labels de CTA: `trigger`; auxiliar `search_intent`.
-- `proofShort`: `proof_type`; auxiliar `objection`.
-
 ### 2.9. `funnel_copy_profile`
 
 - Perfis: `bofu`, `mofu`, `tofu`.
 - Perfil orienta transformação, sem alterar schema, cardinalidade, limite, identidade do módulo ou estrutura aprovada.
 - Módulo adapta o perfil à função.
 - Variante apenas restringe ou especializa tratamento permitido quando houver mudança comportamental comprovada.
-- Hero:
-  - BOFU: recorte específico, benefício sustentado, objeção direta e CTA de maior intenção;
-  - MOFU: diferenciação, explicação, prova contextual e CTA proporcional;
-  - TOFU: contexto, dor e desejo, baixa pressão e CTA de baixa fricção.
 
 ### 2.10. Tratamentos comerciais
 
@@ -596,9 +875,13 @@ Script previsto: `validate:landing-page-modules`.
 - Fato operacional originado apenas da pesquisa falha.
 - Referência, tratamento, módulo, variante ou campo desconhecido falha.
 - Tratamento padrão fora da lista permitida falha.
-- Ausência de `body.editorialEmphasis` e fallback automático falham.
+- Ausência de capability exigida e fallback automático falham.
 - Delta vazio é aceito somente para variante-base autorizada.
 - Variante redundante sem diferença nem função de base autorizada falha.
+- Tipo de mídia desconhecido falha.
+- Política responsiva desconhecida falha.
+- `desktop_only` com conteúdo essencial falha.
+- Formulário completo em `hero.standard` falha.
 - Faixa, limite e comportamento inválidos falham.
 - Valor da raiz não é duplicado.
 - Fontes excedentes ou `itemKey` desconhecido falham.
@@ -645,31 +928,27 @@ Script previsto: `validate:landing-page-modules`.
 
 - Status:
   - pendente;
-  - bloqueada até fechar individualmente os módulos aprovados, mergear a evolução da raiz e consolidar a v2.
+  - bloqueada até fechar a grade, mergear a evolução da raiz e consolidar a v2.
 - Automação: não.
 - Risco: médio controlado.
-- Objetivo: implementar o contrato repo-only dos módulos aprovados a partir dos nove candidatos e de suas variantes iniciais.
+- Objetivo: implementar o contrato repo-only dos módulos e variantes iniciais individualmente aprovados.
 - Critérios de aceite:
-  - catálogo derivado da análise individual dos nove candidatos;
-  - módulos transversais;
+  - grade metodológica comum aplicada;
+  - módulos transversais individualmente aprovados;
   - nenhuma duplicação da raiz;
-  - compatibilidades e capabilities validadas;
-  - contratos discriminados por `fieldKind`;
-  - policies de origem fechadas;
-  - variante-base com delta vazio somente quando autorizada;
-  - elegibilidade calculada por interseção;
-  - `hero.subtitle` com ênfase padrão e alternativa explícita;
+  - compatibilidade e capabilities validadas;
+  - Hero e `hero.standard` conforme contrato aprovado;
   - catálogo imutável e resolver fail-closed;
   - extensão futura comum pelo registry e casos de validação;
   - evolução de infraestrutura somente quando o contrato fechado não atender;
   - nenhum taxon, composição, banco, renderer ou geração.
 - Próxima ação:
-  - aplicar a grade completa ao Hero;
-  - fechar campos, policies, fontes, perfis, versões, lifecycle e casos do Hero;
+  - avaliar e ajustar a grade consolidada do Hero;
+  - fechar o Hero por decisão humana;
   - somente depois iniciar `trust_bar`;
   - seguir módulo por módulo na ordem da grade;
   - dividir depois em fases executáveis;
-  - concluir a evolução da raiz;
+  - concluir as evoluções necessárias da raiz;
   - realizar avaliação única dos especialistas;
   - consolidar v2 e solicitar merge humano.
 
@@ -682,7 +961,6 @@ Script previsto: `validate:landing-page-modules`.
 - Módulos identificados por corretor, imóveis, médio padrão ou outro taxon.
 - Implementação específica dos taxons usados como evidência.
 - Cadastro dinâmico de módulos ou variantes no banco ou Admin.
-- `actionRole` sem contrato fechado e fonte aprovada.
 - Catálogo de entradas, valores reais, taxonomia ou resolução de pesquisas.
 - Composição, ordem global, prontidão de taxon ou conta de teste.
 - Geração, IA, prompt, schema final, renderer, render model ou publicação.
@@ -690,6 +968,8 @@ Script previsto: `validate:landing-page-modules`.
 - Banco, migration, RPC, policy, grant, trigger, storage ou upload.
 - CRM, webhook, job, agente, automação, workflow ou nova infraestrutura.
 - Nova dependência, bundler ou alteração em `commercial_activation`.
+- Criação de módulo de formulário neste recorte.
+- Aprovação de galeria, carrossel ou tour como campo do Hero.
 
 ### 4.2. Critérios de parada
 
@@ -698,13 +978,14 @@ Parar se:
 - a raiz compatível não estiver mergeada ou não garantir a capability;
 - surgir fallback automático;
 - módulo ou variante depender do taxon usado como evidência;
-- `itemKey` for tratado como identidade automática de módulo;
 - surgir necessidade de banco, composição, geração ou renderer;
-- faltar `item_key` oficial necessário para copy;
+- faltar `item_key` oficial;
 - diferença puder ser atendida por conteúdo, parâmetro ou composição;
 - houver ampliação de limite absoluto;
 - houver tentativa de sobrescrever catálogo, módulo ou variante já publicado;
 - uma necessidade nova exigir alteração de contrato sem versionamento próprio;
+- formulário completo for incorporado silenciosamente ao Hero;
+- mídia essencial for ocultada no mobile;
 - houver conflito com E18.4, E20, E19 ou `commercial_activation`;
 - surgir nova dependência ou artefato fora do escopo;
 - preservação histórica não puder ser garantida.
@@ -714,7 +995,9 @@ Parar se:
 - PR #577 preservado e plano-base mantido em v1.
 - Fonte principal: `Corretor Imóveis`, `end_customer`, `lp_sections` v1 ativa.
 - Fonte complementar: `Corretor de imóveis de médio padrão`.
-- Grade inicial de candidatos:
+- Grade metodológica comum registrada para todos os módulos.
+- A grade comum possui núcleo obrigatório e blocos condicionais.
+- Grade inicial limitada aos candidatos:
   - `hero`;
   - `trust_bar`;
   - `problem_solution`;
@@ -724,19 +1007,18 @@ Parar se:
   - `social_proof`;
   - `faq`;
   - `final_cta`.
-- Os candidatos serão analisados individualmente; rejeição ou fusão exige decisão humana.
-- Os módulos aprovados serão transversais e reutilizáveis na família `landing_page`.
+- Os módulos serão transversais e reutilizáveis na família `landing_page`.
 - `formato_curto`, `formato_medio` e `formato_longo` não são módulos.
-- Hero e `hero.standard` possuem decisões-base aprovadas, mas a grade completa do Hero ainda deve ser fechada.
-- `hero.standard` pode possuir delta vazio como execução-base versionada.
+- Hero registrado com sete campos, mídia opcional e fronteira explícita com formulário.
+- `mediaKind = image | video` não cria variante.
+- `all_viewports | desktop_only` é escolha responsiva por ocorrência, dependente de capability futura da raiz, e não cria variante.
+- Formulário completo não pertence a `hero.standard`.
+- `hero.standard` é a única variante inicial e possui delta vazio autorizado.
 - `body.editorialEmphasis` é padrão; `body.base` é alternativa explícita; fallback é proibido.
-- A E20 controla a seleção tipográfica por ocorrência; o renderer apenas executa.
-- O contrato de campo será discriminado por `fieldKind` e não exigirá `semanticRole` para campos não textuais.
-- A política de origem será união fechada.
-- Elegibilidade será calculada pela interseção de catálogo, módulo, variante e propósito.
+- Lifecycle inicial proposto do Hero e da variante: `experimental`.
 - A criação futura comum de módulos e variantes será declarativa em `registry.ts`, acompanhada de casos em `validation-cases.ts` e nova versão aplicável.
 - `contracts.ts`, `schema.ts` e `resolver.ts` só serão alterados quando a necessidade não couber no contrato fechado existente.
 - Versões publicadas são imutáveis; campo novo exige nova `moduleVersion` e capability comum exige nova `rootVersion`.
 - Uso por taxon pertence à composição da E20.
 - A implementação permanece bloqueada.
-- Próxima decisão humana: aplicar e fechar a grade completa do Hero.
+- Próxima decisão humana: avaliar e ajustar o Hero antes de iniciar `trust_bar`.

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -1,10 +1,10 @@
 14/07/2026 — Plano-base E18.5 — Parametrização de módulos e variantes `landing_page`
 
-Fontes: chat, `README.md`, `AGENTS.md`, `docs/prompt-estrategista.md`, `docs/template-roadmap.md`, `docs/template-briefing-codex.md`, `docs/prompt-executor.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/schema.md`, `docs/lp-planejamento.md`, `docs/lousa-plano-base-e18-4.md`, `docs/template-blueprint.md`, `docs/blueprint-corretor-imoveis-end-customer.md`, `docs/prompt-nicho-itens-estruturados.md`, `lib/conversion-content/landing-page/`, contratos atuais de templates, compositions e módulos, PRs #559, #563, #564, #566, #567 e #577, avaliação do Analista e decisões humanas de 14/07/2026.
+Fontes: chat, `README.md`, `AGENTS.md`, `docs/prompt-estrategista.md`, `docs/template-roadmap.md`, `docs/template-briefing-codex.md`, `docs/prompt-executor.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/schema.md`, `docs/lp-planejamento.md`, `docs/lousa-plano-base-e18-4.md`, `docs/template-blueprint.md`, `docs/blueprint-corretor-imoveis-end-customer.md`, `docs/prompt-nicho-itens-estruturados.md`, `lib/conversion-content/landing-page/`, contratos atuais de templates, compositions e módulos, PRs #559, #563, #564, #566, #567 e #577, avaliações do Analista e decisões humanas de 14 e 15/07/2026.
 
 Versão: v1 em ajuste.
 
-Status: PR vivo para debate e avaliação; correções conceituais do Analista incorporadas nesta v1; plano-base v2 ainda não consolidado; nenhuma implementação autorizada antes da consolidação v2 e do merge humano do PR #577.
+Status: PR vivo para debate e avaliação; decisões conceituais aprovadas incorporadas nesta v1; plano-base v2 ainda não consolidado; definição material da E18.5 bloqueada até a evolução versionada da raiz que garanta o tratamento editorial requerido pelo Hero e até o merge humano da v2 do PR #577.
 
 Path: `docs/lousa-plano-base-e18-5.md`.
 
@@ -17,7 +17,13 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 - O PR #559 foi mergeado na `main` em 13/07/2026.
 - A E18.4 foi concluída, aprovada, documentada e formalmente encerrada.
 - A parametrização raiz v1 está implementada em `lib/conversion-content/landing-page/`.
-- A raiz possui registry versionado, schema estrito, resolver fail-closed, saída profundamente imutável, papéis semânticos, faixas editoriais recomendadas, limites técnicos absolutos, opções comuns de espaçamento, critérios visuais e presets.
+- A raiz v1 possui registry versionado, schema estrito, resolver fail-closed, saída profundamente imutável, papéis semânticos, faixas editoriais recomendadas, limites técnicos absolutos, opções comuns de espaçamento, critérios visuais e presets.
+- A raiz v1 não garante `body.editorialEmphasis` em todos os presets:
+  - o tratamento é opcional no contrato compartilhado;
+  - o preset `balanced` o possui;
+  - o preset `compact` não o possui.
+- A decisão de produto é que o subtítulo do Hero normalmente use maior ênfase, sem fallback automático para texto-base.
+- Essa garantia exige evolução versionada da raiz em recorte e PR próprios, preservando integralmente a `rootVersion 1`.
 - A precedência obrigatória é:
   - parametrização raiz;
   - módulo;
@@ -30,12 +36,15 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 - O debate conceitual permanece aberto para fechar o contrato da E18.5.
 - As decisões aprovadas neste debate devem ser incorporadas no mesmo PR.
 - Não reiniciar o fluxo em novo arquivo ou novo PR.
+- A evolução da raiz será planejada e implementada em recorte e PR próprios.
+- O PR #577 registra somente a dependência e o contrato esperado; não incorpora tamanhos concretos nem detalhes internos da nova raiz.
 - A versão v2 será declarada somente após:
   - conclusão do debate necessário;
   - recebimento dos pareceres aplicáveis;
   - consolidação única dos retornos;
-  - decisão humana sobre os pontos pendentes.
-- O Executor não pode ser instruído antes do merge humano da v2.
+  - decisão humana sobre os pontos pendentes;
+  - confirmação da evolução versionada da raiz necessária para o Hero.
+- O Executor da E18.5 não pode ser instruído antes do merge humano da evolução da raiz e da v2 do PR #577.
 
 ### 1.3. Princípio canônico de herança
 
@@ -48,21 +57,26 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
   - cardinalidade;
   - fontes de copy;
   - política de valor operacional;
+  - tratamento tipográfico padrão e alternativas permitidas somente quando disponibilizados pela raiz;
   - somente exceções próprias e justificadas.
 - A variante não repete o módulo.
 - A variante declara somente deltas fechados e tipados sobre campos já previstos pelo módulo.
+- A composição futura pode selecionar, por ocorrência, somente opções previamente autorizadas pelo módulo ou variante.
 - O resolver aplica:
   - raiz;
   - módulo;
-  - variante.
+  - variante;
+  - seleção válida por ocorrência quando o contrato futuro da composição a fornecer.
 - O consumidor recebe o contrato efetivo completo e profundamente imutável.
 - E20, E19, geração, validação e renderer futuros não podem reaplicar a herança por conta própria.
+- O renderer executa o tratamento resolvido; não escolhe fallback nem corrige ausência de capability.
 
 ### 1.4. Regras de exceção
 
 - Campo sem exceção herda integralmente a raiz.
-- Módulo pode restringir a raiz quando a função estrutural justificar.
+- Módulo pode restringir ou selecionar capacidades da raiz quando a função estrutural justificar.
 - Variante pode restringir o módulo quando sua execução reutilizável justificar.
+- Escolha por ocorrência não cria variante quando já estiver autorizada no contrato do módulo.
 - Módulo ou variante não pode ampliar limite técnico absoluto da raiz.
 - Necessidade acima do limite absoluto deve primeiro avaliar:
   - revisão do texto;
@@ -88,10 +102,17 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 - `structuralBehavior`, caso necessário, deverá ser união fechada, aprovada e validável.
 - Deltas de variante são internos ao registry e ao resolver.
 - O contrato público resolvido não expõe operações de delta para o consumidor aplicar.
-- A E18.5 associa campos a papéis semânticos, mas não cria agora mapeamento tipográfico como `paragraph → body.base`.
-- O Hero v1 não exige `body.editorialEmphasis`.
-- A E18.5 não altera a raiz para tornar `editorialEmphasis` obrigatório.
-- O futuro renderer deverá consumir a raiz e definir o mapeamento visual por contrato próprio, sem hardcode independente.
+- A E18.5 não cria mapeamento tipográfico geral como `paragraph → body.base` para toda a família.
+- A E18.5 pode selecionar tratamento tipográfico disponibilizado e garantido pela raiz para um campo específico do módulo.
+- O Hero define para `subtitle`:
+  - `semanticRole = paragraph`;
+  - tratamento padrão `body.editorialEmphasis`;
+  - tratamentos permitidos `body.editorialEmphasis` e `body.base`.
+- `body.base` é alternativa explícita autorizada, nunca fallback automático.
+- A E20 poderá selecionar `body.base` por ocorrência concreta do Hero quando houver justificativa.
+- A E18.5 dependerá explicitamente da versão da raiz que garanta `body.editorialEmphasis` em todos os presets compatíveis.
+- A forma concreta de preservar contratos da versão 1 e garantir a capability na versão seguinte pertence ao plano e ao PR próprios da evolução da raiz.
+- O futuro renderer deverá consumir o contrato resolvido, sem hardcode independente e sem escolher tratamento.
 - `hero.media_split` não está aprovada.
 - Mídia obrigatória, isoladamente, não comprova uma variante.
 - O catálogo inicial pode ter apenas uma variante para determinado módulo.
@@ -112,6 +133,7 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 - O banco possui estruturas transversais de templates e compositions, mas elas não autorizam registros de `landing_page` nesta fase.
 - A E18.5 será repo-only.
 - Composição concreta e registros por taxon pertencem à E20.
+- Seleção por ocorrência entre tratamentos previamente autorizados pertence à E20.
 - Geração, snapshot, persistência e ciclo das LPs por conta pertencem à E19.
 - `account_landing_pages` não será alterada neste recorte.
 
@@ -123,7 +145,6 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 - Critério mínimo de evidência para:
   - criar módulo;
   - criar variante;
-  - criar exceção editorial;
   - criar exceção estrutural.
 - Necessidade real de múltiplas variantes no primeiro catálogo.
 - Contratos fechados de comportamento estrutural que forem efetivamente necessários.
@@ -145,9 +166,11 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
   - `funnel_copy_profile`;
   - tratamentos por BOFU, MOFU e TOFU;
   - lifecycle e compatibilidade histórica.
+- A raiz v1 não garante o tratamento editorial definido como padrão do subtítulo do Hero em todos os presets.
 - Repetir parâmetros da raiz nos módulos criaria múltiplas fontes da verdade.
 - Permitir variantes abertas criaria especializações por taxon, campanha ou conteúdo.
 - Entregar deltas aos consumidores faria cada camada reimplementar a precedência.
+- Usar `body.base` como fallback ocultaria a ausência da capability e transformaria exceção deliberada em degradação silenciosa.
 
 ### 2.2. Resultado esperado
 
@@ -156,6 +179,9 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 - Fazer módulos herdarem a raiz sem repetição.
 - Fazer variantes registrarem apenas deltas.
 - Fazer o resolver retornar contrato efetivo completo e imutável.
+- Fazer a E18.5 depender somente de raiz compatível com as capabilities tipográficas que selecionar.
+- Definir no Hero a ênfase como padrão do subtítulo e `body.base` como alternativa explícita.
+- Deixar a escolha por ocorrência para a composição futura, dentro das opções autorizadas.
 - Definir fontes de copy usando apenas `item_key` oficiais.
 - Separar valores factuais operacionais de orientação de pesquisa.
 - Definir BOFU, MOFU e TOFU como perfis de transformação, não como variantes.
@@ -168,7 +194,7 @@ A decisão sobre módulo, variante ou exceção deve seguir esta ordem de evidê
 
 1. Parametrização raiz:
    - contrato comum obrigatório;
-   - fonte dos papéis, limites e opções permitidas.
+   - fonte dos papéis, limites, treatments e opções permitidas.
 2. `docs/lp-planejamento.md`:
    - fronteiras entre raiz, módulo, variante, composição, conteúdo e entradas.
 3. Itens estruturados oficiais:
@@ -179,7 +205,10 @@ A decisão sobre módulo, variante ou exceção deve seguir esta ordem de evidê
 4. Blueprints e referências reais:
    - evidência para funções, estruturas, campos e riscos;
    - recomendação sem sustentação suficiente permanece hipótese.
-5. LP real validada:
+5. Decisão interna de produto:
+   - pode definir padrão funcional próprio do LP Factory 10;
+   - não deve ser apresentada como regra universal da web.
+6. LP real validada:
    - evidência posterior para promover, restringir, substituir ou depreciar contratos.
 
 Critérios:
@@ -189,18 +218,19 @@ Critérios:
 - Não criar variante quando a diferença puder ser atendida por:
   - conteúdo;
   - parâmetro herdado;
-  - escolha de ocorrência;
+  - escolha de ocorrência autorizada;
   - composição;
   - fonte de copy;
   - perfil de funil;
   - valor operacional.
 - Não generalizar para toda a família um valor observado apenas em um nicho.
+- Não usar fallback para mascarar ausência de capability requerida pelo módulo.
 
 ### 2.4. Identidade e versionamento previstos
 
 - Identidade inicial prevista:
   - `family = landing_page`;
-  - `rootVersion = 1`;
+  - `rootVersion = versão que garanta body.editorialEmphasis em todos os presets compatíveis`, prevista como evolução da versão 1 em recorte próprio;
   - `moduleCatalogVersion = 1`.
 - O registry deve ser explícito:
   - `moduleCatalogVersion → catálogo imutável`.
@@ -219,10 +249,12 @@ Critérios:
 - Regras:
   - `rootVersion` e `moduleCatalogVersion` obrigatórios;
   - compatibilidade explícita entre catálogo e raiz;
+  - a E18.5 não aceita raiz sem a capability requerida pelo Hero;
   - sem catálogo padrão implícito;
   - sem fallback silencioso;
   - versões publicadas imutáveis;
-  - mudança incompatível cria nova versão aplicável.
+  - mudança incompatível cria nova versão aplicável;
+  - a forma tipada de preservar a versão 1 e exigir a capability na nova versão será definida no recorte próprio da raiz.
 
 ### 2.5. Contrato-base de campo
 
@@ -233,6 +265,11 @@ Cada campo do módulo deve declarar:
 - `cardinality`;
 - `copySourceMap`;
 - `operationalValuePolicy`.
+
+Quando o módulo selecionar tratamento tipográfico garantido pela raiz, o campo também pode declarar:
+
+- `defaultTypographyTreatment`;
+- `allowedTypographyTreatments`.
 
 Regras:
 
@@ -248,7 +285,11 @@ Regras:
   - `absoluteMaxRestriction`.
 - `recommendedRangeOverride` deve respeitar o limite absoluto efetivo.
 - `absoluteMaxRestriction` só pode reduzir o teto herdado.
-- A E18.5 v1 não introduz `typographyTreatmentRef` no Hero.
+- `defaultTypographyTreatment` deve referenciar capability garantida pela raiz compatível.
+- `defaultTypographyTreatment` deve pertencer a `allowedTypographyTreatments`.
+- `allowedTypographyTreatments` deve ser lista fechada de referências válidas da raiz.
+- A ausência da capability requerida falha fechado; não aciona fallback.
+- Esse contrato não cria um mapeamento tipográfico geral para todos os papéis semânticos.
 - Campo factual deve declarar política operacional e não pode ser preenchido como fato por pesquisa.
 
 ### 2.6. Contrato de variante
@@ -262,12 +303,14 @@ Deltas permitidos, quando aprovados:
 - ativação obrigatória de campo já previsto;
 - restrição de faixa recomendada;
 - restrição de limite absoluto;
+- restrição de tratamentos tipográficos já autorizados pelo módulo;
 - comportamento estrutural enumerado e fechado.
 
 Deltas proibidos:
 
 - campo livre novo;
 - papel semântico inexistente;
+- tratamento tipográfico inexistente ou não autorizado pelo módulo;
 - ampliação do limite absoluto;
 - regra arbitrária;
 - taxon;
@@ -303,7 +346,11 @@ O resolver deve validar o delta e retornar apenas o contrato efetivo final.
   - cardinalidade: `{ min: 1, max: 1 }`.
 - `subtitle`:
   - papel: `paragraph`;
-  - cardinalidade: `{ min: 1, max: 1 }`.
+  - cardinalidade: `{ min: 1, max: 1 }`;
+  - `defaultTypographyTreatment: body.editorialEmphasis`;
+  - `allowedTypographyTreatments`:
+    - `body.editorialEmphasis`;
+    - `body.base`.
 - `primaryCta.label`:
   - papel: `cta_label`;
   - cardinalidade: `{ min: 1, max: 1 }`.
@@ -319,25 +366,31 @@ O resolver deve validar o delta e retornar apenas o contrato efetivo final.
 
 #### 2.7.3. Herança e exceções
 
-- Todos os campos textuais herdam integralmente a raiz.
+- Todos os campos textuais herdam faixas, limites e valores concretos da raiz.
 - Não há na proposta atual:
   - faixa numérica própria;
   - limite absoluto próprio;
-  - tratamento tipográfico próprio;
+  - tamanho de fonte próprio;
   - spacing próprio.
-- `subtitle` usa apenas `semanticRole = paragraph`.
+- `subtitle` permanece semanticamente `paragraph`.
+- `subtitle` seleciona `body.editorialEmphasis` como tratamento padrão disponibilizado pela raiz compatível.
+- `body.base` é alternativa permitida para seleção explícita por ocorrência futura.
+- A ausência de `body.editorialEmphasis` no preset é incompatibilidade, não autorização para fallback.
 - A existência de mídia não define sozinha nova variante.
 
 #### 2.7.4. Variante inicial em debate
 
 - `hero.standard`:
   - usa o contrato-base do Hero;
+  - herda `body.editorialEmphasis` como padrão do subtítulo;
   - não possui delta numérico;
-  - não possui delta tipográfico;
   - mídia permanece opcional.
 - `hero.media_split`:
   - rejeitada como variante aprovada no estado atual;
   - pode voltar ao debate somente com mudança estrutural reutilizável e contratualmente fechada.
+- Variante criada apenas para trocar `body.editorialEmphasis` por `body.base`:
+  - proibida;
+  - a escolha pertence à ocorrência futura da composição, dentro das opções do módulo.
 - Variante específica de nicho:
   - proibida.
 
@@ -533,13 +586,15 @@ Entrada mínima:
 Processamento:
 
 1. resolver raiz;
-2. validar compatibilidade do catálogo;
+2. validar compatibilidade e capabilities do catálogo;
 3. resolver módulo;
-4. validar delta da variante;
-5. aplicar precedência;
-6. calcular contrato efetivo;
-7. validar lifecycle e propósito;
-8. retornar resultado profundamente imutável.
+4. validar referências tipográficas do módulo;
+5. validar delta da variante;
+6. aplicar precedência;
+7. aplicar seleção por ocorrência quando fornecida por contrato futuro compatível;
+8. calcular contrato efetivo;
+9. validar lifecycle e propósito;
+10. retornar resultado profundamente imutável.
 
 Saída pública:
 
@@ -551,14 +606,15 @@ Saída pública:
 - papéis semânticos;
 - fontes finais;
 - políticas operacionais;
+- tratamentos tipográficos finais;
 - limites efetivos quando houver exceção;
 - comportamento estrutural efetivo quando aprovado.
 
-A saída não contém operações de delta para o consumidor executar.
+A saída não contém operações de delta nem fallback para o consumidor executar.
 
 ### 2.13. Artefatos previstos
 
-Criar somente após v2 mergeada:
+Criar somente após a evolução da raiz e a v2 deste plano serem mergeadas:
 
 - `lib/conversion-content/landing-page/module-catalog/contracts.ts`;
 - `lib/conversion-content/landing-page/module-catalog/registry.ts`;
@@ -575,8 +631,7 @@ Ajustar:
 
 Preservar:
 
-- `landingPageRoot`;
-- parametrização raiz;
+- `landingPageRoot` e versões históricas da raiz;
 - `commercial_activation`.
 
 Interface pública agregada prevista:
@@ -593,6 +648,12 @@ Não adicionar dependência npm.
 
 - Catálogo e versões válidos.
 - Compatibilidade explícita com a raiz.
+- Capability tipográfica requerida pelo módulo presente na raiz compatível.
+- Referência tipográfica desconhecida falha.
+- Tratamento padrão fora da lista permitida falha.
+- Ausência de `body.editorialEmphasis` em preset compatível falha.
+- Fallback automático para `body.base` falha.
+- Seleção por ocorrência fora da lista autorizada falha.
 - Módulo desconhecido falha fechado.
 - Variante desconhecida falha fechado.
 - Variante vinculada ao módulo errado falha fechado.
@@ -618,10 +679,11 @@ Não adicionar dependência npm.
 ### 2.15. Fluxo operacional
 
 - Gatilho:
+  - evolução versionada da raiz mergeada;
   - plano-base v2 consolidado e mergeado;
   - fase instruída pelo Estrategista.
 - Entrada:
-  - raiz v1;
+  - raiz versionada compatível com a capability requerida;
   - plano-base E18.5;
   - catálogo aprovado;
   - `item_key` oficiais;
@@ -632,6 +694,7 @@ Não adicionar dependência npm.
   - schema;
   - resolver;
   - validação de deltas;
+  - tratamentos tipográficos autorizados;
   - mapas;
   - perfis;
   - lifecycle;
@@ -651,7 +714,7 @@ Não adicionar dependência npm.
   - E20 e E19 em fases futuras.
 - Fallback:
   - falha fechada;
-  - sem versão, módulo ou variante implícita;
+  - sem versão, capability, módulo, variante ou tratamento implícito;
   - conflito retorna ao Estrategista.
 
 ## 3. Fases e próxima ação
@@ -660,7 +723,7 @@ Não adicionar dependência npm.
 
 - Status:
   - pendente;
-  - bloqueada até consolidação v2 e merge humano do plano-base.
+  - bloqueada até o merge da evolução versionada da raiz, consolidação v2 e merge humano do plano-base.
 - Automação:
   - não.
 - Risco:
@@ -669,9 +732,11 @@ Não adicionar dependência npm.
   - implementar atomicamente o contrato repo-only aprovado para módulos e variantes.
 - Escopo material previsto:
   - identidade e versões;
+  - compatibilidade com capabilities da raiz;
   - módulos aprovados;
   - variantes aprovadas;
   - campos e cardinalidades;
+  - tratamentos tipográficos autorizados;
   - deltas fechados;
   - resolução efetiva;
   - `copy_source_map`;
@@ -682,7 +747,11 @@ Não adicionar dependência npm.
   - validações.
 - Critérios de aceite:
   - nenhum valor comum da raiz duplicado;
-  - raiz preservada;
+  - versões históricas da raiz preservadas;
+  - capability requerida validada;
+  - `body.editorialEmphasis` padrão no subtítulo do Hero;
+  - `body.base` somente como alternativa explícita autorizada;
+  - nenhum fallback silencioso;
   - catálogo imutável;
   - resolver fail-closed;
   - consumidor recebe contrato efetivo;
@@ -693,6 +762,7 @@ Não adicionar dependência npm.
   - nenhum renderer, geração ou schema final de LP;
   - validações concluídas.
 - Próxima ação:
+  - abrir e concluir o recorte próprio da evolução da raiz;
   - continuar o debate do catálogo inicial;
   - consolidar os pareceres aplicáveis;
   - produzir v2 no mesmo PR;
@@ -703,6 +773,9 @@ Não adicionar dependência npm.
 
 ### 4.1. Fora do escopo
 
+- Implementação da evolução da raiz no PR #577.
+- Valores tipográficos concretos da nova raiz.
+- Forma interna de discriminar contratos das versões da raiz.
 - Catálogo de entradas.
 - Valores reais das entradas.
 - Resolução de pesquisas.
@@ -710,6 +783,7 @@ Não adicionar dependência npm.
 - Taxonomia.
 - Composição base.
 - Composição por taxon.
+- Escolha concreta de tratamento por ocorrência.
 - Ordem ou obrigatoriedade global das seções.
 - Herança concreta de composição.
 - Prontidão do taxon.
@@ -754,8 +828,12 @@ Não adicionar dependência npm.
 
 Parar e devolver ao Estrategista se:
 
+- a evolução versionada da raiz não estiver mergeada;
+- a raiz compatível não garantir a capability requerida;
+- a implementação tentar aplicar fallback automático para `body.base`;
 - a implementação exigir banco;
 - surgir necessidade de registrar composição;
+- surgir necessidade de escolher concretamente tratamento por ocorrência;
 - surgir necessidade de gerar ou renderizar conteúdo;
 - faltar `item_key` oficial necessário;
 - uma variante depender de taxon, campanha ou entrada específica;
@@ -772,10 +850,16 @@ Parar e devolver ao Estrategista se:
 
 - PR #577 preservado.
 - Plano-base permanece v1 em ajuste.
-- Correções conceituais do Analista incorporadas.
+- Parecer do Analista aprovado.
+- A evolução da raiz será tratada em recorte e PR próprios.
+- A definição material da E18.5 fica bloqueada até essa evolução ser mergeada.
+- O padrão de `hero.subtitle` será `body.editorialEmphasis`.
+- `body.base` será alternativa explícita autorizada para futura escolha por ocorrência na E20.
+- Fallback automático fica proibido.
 - `hero.media_split` não aprovada.
 - `hero.standard` permanece exemplo inicial em debate.
 - Próxima decisão humana:
+  - abrir o recorte próprio da evolução da raiz;
   - fechar a estrutura mínima do Hero;
   - decidir se o catálogo inicial será construído módulo a módulo;
   - definir o próximo módulo a debater.

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -2,9 +2,9 @@
 
 Fontes: chat, `README.md`, `AGENTS.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/schema.md`, `docs/lp-planejamento.md`, `docs/lousa-plano-base-e18-4.md`, `docs/lousa-plano-base-e20-2.md`, `docs/blueprint-corretor-imoveis-end-customer.md`, `docs/prompt-nicho-itens-estruturados.md`, consulta read-only ao Supabase, `lib/conversion-content/landing-page/`, `lib/conversion-content/landing-page/input-catalog/registry.ts`, PRs #559, #563, #564, #566, #567, #577 e #581, avaliações do Analista e decisões humanas de 14 a 17/07/2026.
 
-Versão: v1 em ajuste.
+Versão: v1 conceitualmente fechada.
 
-Status: plano simplificado; nove módulos mantidos no escopo; `hero`, `hero.standard@v1`, `trust_bar`, `trust_bar.standard@v1`, `problem_solution`, `problem_solution.standard@v1`, `offer`, `offer.standard@v1`, `process`, `process.standard@v1`, `technical_assurance`, `technical_assurance.standard@v1`, `social_proof`, `social_proof.standard@v1`, `faq`, `faq.standard@v1` e `faq.accordion@v1` conceitualmente fechados; um módulo pendente; nenhuma implementação autorizada neste PR.
+Status: nove módulos e suas variantes `standard@v1` conceitualmente fechados; `faq.accordion@v1` aprovada como única variante adicional para validação controlada; nenhuma implementação de código autorizada neste PR.
 
 Path: `docs/lousa-plano-base-e18-5.md`.
 
@@ -16,8 +16,8 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 
 - Definir e implementar, no repositório, o catálogo versionado dos nove módulos `landing_page`, de suas variantes `standard@v1` e da variante controlada `faq.accordion@v1`.
 - Entregar contratos pequenos, estritos, imutáveis e suficientes para consumo posterior pela E20 e pela E19.
-- Preservar extensibilidade sem antecipar variantes, campos ou capacidades sem uso aprovado.
-- Encerrar a E18.5 após os nove módulos, suas variantes `standard@v1`, `faq.accordion@v1` e a validação integrada dos contratos.
+- Preservar extensibilidade sem antecipar campos, capacidades ou variantes sem uso aprovado.
+- Encerrar o fechamento conceitual após os nove módulos, suas variantes aprovadas e a validação integrada dos contratos.
 
 ### 1.2. Estado confirmado
 
@@ -44,11 +44,11 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 
 Regras:
 
-- Os nove módulos serão fechados e implementados na E18.5.
+- Os nove módulos serão implementados na E18.5 após autorização humana.
 - `item_key` é evidência de pesquisa, não identidade canônica do módulo.
 - Os módulos são transversais e não recebem identidade de taxon.
 - Formatos curto, médio e longo pertencem à composição e à extensão da LP.
-- O próximo módulo para análise é `final_cta`.
+- Não há módulo conceitual pendente.
 
 ### 1.4. Escopo positivo
 
@@ -99,54 +99,45 @@ Variante define:
 - validações próprias;
 - requisitos técnicos, factuais, operacionais e de acessibilidade aplicáveis.
 
-A separação aplica-se aos nove módulos.
-
 ### 2.2. Extensibilidade das variantes
 
 - Cada módulo começa com uma variante `standard@v1`; `faq.accordion@v1` é a única exceção adicional aprovada antes da primeira LP.
 - Nova variante exige diferença estrutural ou comportamental reutilizável.
 - Nova variante pode adicionar ou especializar campos, mídia, interação, responsividade e validações próprias.
 - Nova variante deve constituir evolução aditiva e localizada; poderá exigir capabilities compartilhadas ou infraestrutura inerente à nova execução, tratadas nos respectivos recortes, sem alteração destrutiva do módulo, das variantes existentes ou das LPs anteriores.
-- Nova variante não altera contratos ou LPs de variantes anteriores.
 - Restrições de `standard@v1` não restringem variantes futuras.
-- Nova variante não exige nova `moduleVersion` quando preserva função, fronteiras e invariantes do módulo.
+- Nova variante não exige nova `moduleVersion` quando preserva função, fronteiras, invariantes e integração comum.
 - Nova `moduleVersion` é exigida quando mudam função, fronteiras, invariantes permanentes ou integração comum.
 - Nova `variantVersion` é exigida quando muda o contrato de uma variante existente.
-- Cada referência futura deve identificar `moduleKey`, `moduleVersion`, `variantKey` e `variantVersion`.
+- Cada referência identifica `moduleKey`, `moduleVersion`, `variantKey` e `variantVersion`.
 
 Não criam variante isoladamente:
 
-- taxon;
-- plano;
-- campanha ou origem de tráfego;
-- funil;
-- copy;
+- taxon, plano, campanha ou origem de tráfego;
+- funil ou copy;
 - troca de ativo;
 - canal ou destino concreto;
 - ordem na LP;
 - quantidade já permitida;
-- ajuste responsivo normal do renderer.
+- ajuste visual ou responsivo normal do renderer.
 
-### 2.3. Herança e limites
+### 2.3. Herança, limites e resolução
 
-- A raiz contém regras comuns.
-- Módulo e variante registram apenas deltas necessários.
+- A raiz contém regras comuns; módulo e variante registram apenas deltas necessários.
 - Módulo ou variante pode restringir a raiz, mas não ampliar limite absoluto vigente.
 - Necessidade acima do limite da raiz exige evolução versionada da raiz.
-- Capability da raiz só bloqueia a implementação quando for indispensável à variante aprovada em implementação.
-- Capability opcional ou destinada a variante não aprovada permanece evolução posterior.
-- Variante deve declarar compatibilidade explícita com a versão da raiz usada por seu contrato.
-- O comportamento de uma variante imutável não muda pela disponibilidade posterior de nova capability da raiz.
+- Capability da raiz só bloqueia a implementação quando for indispensável à variante aprovada.
+- Variante declara compatibilidade explícita com a versão da raiz utilizada.
+- Variante imutável não muda pela disponibilidade posterior de nova capability.
 - Não existe fallback silencioso.
 - Contrato ausente, incompatível ou inválido falha fechado.
-- Resultado resolvido deve ser completo e imutável.
+- Resultado resolvido deve ser completo, profundamente imutável e sem referência mutável compartilhada.
 
 ### 2.4. Contrato mínimo de campo
 
 Cada campo usado por uma variante declara:
 
-- `fieldKey`;
-- `fieldKind`;
+- `fieldKey` e `fieldKind`;
 - cardinalidade;
 - `semanticRole`, quando textual;
 - policy de origem do valor;
@@ -156,25 +147,23 @@ Cada campo usado por uma variante declara:
 Regras:
 
 - cardinalidade representa obrigatoriedade;
-- texto visível usa papel semântico existente na raiz compatível;
-- coleção possui contrato fechado do item;
-- coleção aninhada não integra a v1;
+- texto visível usa papel semântico existente na raiz;
+- coleção possui contrato fechado do item e não admite coleção aninhada na v1;
 - ação não armazena canal, URL, telefone, e-mail ou destino concreto;
 - mídia referencia ativo futuro e declara apenas requisitos necessários à variante;
-- tipos, policies e matrizes só são adicionados quando um dos nove módulos realmente precisar.
+- tipos, policies e capabilities só entram quando consumidos por variante aprovada.
 
 ### 2.5. Copy e sustentação factual
 
 - `copySourceMap` define até duas fontes primárias e uma auxiliar por campo textual, salvo decisão humana registrada.
 - `funnelCopyProfile` adapta seleção e redação para BOFU, MOFU e TOFU.
-- O funil orienta copy e seleção e pode influenciar a escolha entre ordens previamente permitidas pela composição da E20; não redefine sozinho a estrutura da LP.
+- O funil não redefine sozinho a estrutura ou a ordem da LP.
 - Pesquisa orienta copy, mas não comprova fatos sobre a operação.
 - Credencial, capacidade, condição, preço, prazo, parceria, resultado, garantia ou ação concreta exige suporte operacional real.
-- A E18.5 declara a exigência estrutural.
 - A E19 resolve valores e valida a instância concreta conforme a composição recebida.
 - Nenhum módulo pode inventar prova, certificação, garantia ou resultado.
 
-Policies iniciais devem ser limitadas às efetivamente consumidas pelas variantes aprovadas:
+Policies aprovadas:
 
 - `research_guided`;
 - `hybrid`;
@@ -183,8 +172,6 @@ Policies iniciais devem ser limitadas às efetivamente consumidas pelas variante
 - `not_copy`.
 
 `operational_required` exige valor originado de evidência operacional real e impede geração a partir da pesquisa.
-
-Novas policies somente entram quando outro módulo aprovado exigir comportamento não representável pelas existentes.
 
 ### 2.6. Ações e vínculos operacionais
 
@@ -197,11 +184,8 @@ Novas policies somente entram quando outro módulo aprovado exigir comportamento
 ### 2.7. Lifecycle e compatibilidade
 
 - `moduleCatalogVersion` declara versão e compatibilidade com a raiz; não possui lifecycle próprio.
-- Módulo e variante usam lifecycle:
-  - `experimental`;
-  - `active`;
-  - `deprecated`.
-- Todos começam `experimental` e com propósito `controlled_test`.
+- Módulo e variante usam lifecycle `experimental`, `active` ou `deprecated`.
+- Todos começam `experimental`, com propósito `controlled_test`.
 - Promoção para `active` exige uso em LP real, revisão e decisão humanas.
 - `deprecated` impede novas composições, mas preserva leitura e renderização histórica.
 - Remoção física exige inexistência de dependentes ou migração aprovada.
@@ -224,57 +208,40 @@ E19:
 
 - recebe pesquisas, composição e entradas;
 - resolve conteúdo, ativos e vínculos;
-- trata ausência ou invalidade de dados conforme a obrigatoriedade definida pela E20 e seu próprio contrato;
+- trata ausência ou invalidade conforme a obrigatoriedade definida pela E20;
 - gera e administra a LP real;
-- preserva as versões utilizadas.
+- preserva versões e payload resolvido de forma genérica.
 
 Renderer:
 
 - executa o contrato resolvido;
 - não escolhe variante, conteúdo ou fallback.
 
-### 2.9. Checklist de fechamento de cada módulo
+### 2.9. Checklist de fechamento
 
 Obrigatório:
 
-- identidade, função e evidência;
-- fronteiras;
-- invariantes permanentes;
+- identidade, função, evidência, fronteiras e invariantes;
 - variante `standard@v1`;
-- campos e cardinalidades necessários;
-- especializações da raiz;
-- fontes de copy;
-- requisitos factuais ou operacionais;
-- lifecycle e compatibilidade;
-- validações estruturais indispensáveis.
+- campos, cardinalidades, fontes de copy e suporte factual;
+- lifecycle, compatibilidade e validações estruturais.
 
-Condicional, somente quando utilizado por `standard@v1` ou por variante adicional aprovada:
+Condicional, quando usado por variante aprovada:
 
-- ação;
-- mídia;
-- interação;
-- responsividade especial;
-- acessibilidade específica;
-- fallback técnico;
-- referência técnica.
-
-O fechamento conceitual não exige detalhar comportamentos de variantes futuras não aprovadas.
+- ação, mídia ou interação;
+- responsividade ou acessibilidade específica;
+- fallback técnico ou referência técnica.
 
 ### 2.10. Significado de implementação
 
-Um módulo está implementado na E18.5 quando existem, conforme o contrato técnico adotado:
+Um módulo está implementado na E18.5 quando existem:
 
-- identidade versionada do módulo;
-- identidade versionada de `standard@v1` e de cada variante adicional aprovada;
-- tipos e schemas;
-- campos, cardinalidades e capabilities;
-- registry;
-- resolver ou mecanismo equivalente;
-- validadores;
-- fixtures somente quando úteis ao padrão de teste;
+- identidade versionada do módulo e de suas variantes aprovadas;
+- tipos, schemas, campos, cardinalidades e capabilities;
+- registry, resolver e validadores;
+- fixtures quando úteis;
 - casos executáveis e testes de contrato;
-- regras de lifecycle e compatibilidade;
-- exportação pelo boundary `lib/conversion-content/landing-page/`.
+- lifecycle, compatibilidade e exportação pelo boundary `lib/conversion-content/landing-page/`.
 
 Isso não inclui seção visual funcional.
 
@@ -282,669 +249,281 @@ Isso não inclui seção visual funcional.
 
 ### 3.1. Módulo `hero`
 
-- `moduleKey = hero`.
-- `moduleVersion = 1`.
-- Função:
-  - apresentar a proposta principal;
-  - estabelecer o recorte da LP;
-  - conduzir a uma rota prioritária de conversão ou continuidade.
-- Invariantes:
-  - uma proposta principal identificável;
-  - hierarquia semântica coerente;
-  - ausência de identidade de taxon, plano, campanha ou funil no contrato;
-  - integração abstrata com a ação principal quando a variante a utilizar.
-- Fronteiras:
-  - não contém formulário completo, galeria, carrossel, tour, navegação global, oferta detalhada ou prova extensa.
-- Evidência principal:
-  - `hero_segmentado`, pesquisa ativa de `lp_sections`, taxon `Corretor Imóveis`.
-- Variantes futuras podem possuir campos e capacidades próprias sem alterar `hero.standard@v1`.
+- Identidade: `hero@v1`.
+- Função: apresentar proposta principal, estabelecer o recorte da LP e conduzir à rota prioritária de conversão ou continuidade.
+- Invariantes: proposta principal identificável, hierarquia semântica coerente e integração abstrata com ação quando utilizada.
+- Fronteiras: sem formulário completo, galeria, carrossel, tour, navegação global, oferta detalhada ou prova extensa.
+- Evidência: `hero_segmentado` de `lp_sections` e Blueprint do corretor.
 
 ### 3.2. Variante `hero.standard@v1`
 
-Identidade:
-
-- `variantKey = hero.standard`.
-- `variantVersion = 1`.
-- Compatível com `hero@v1` e com a versão vigente da raiz utilizada na implementação inicial.
-- Única variante inicial.
-
-Campos:
-
-- `eyebrow`:
-  - texto, papel `eyebrow`, cardinalidade `0..1`, policy `research_guided`.
-- `title`:
-  - texto, papel `h1`, cardinalidade `1..1`, policy `hybrid`, suporte `when_factual`.
-- `subtitle`:
-  - texto, papel `paragraph`, cardinalidade `1..1`, policy `hybrid`, suporte `when_factual`.
-- `primaryCta`:
-  - ação, cardinalidade `1..1`, policy `not_copy`;
-  - label textual com papel `cta_label`, cardinalidade `1..1`, policy `hybrid`, suporte `when_present`;
-  - vínculo obrigatório com `primary_conversion_channel`.
-- `proofShort`:
-  - texto, papel `paragraph`, cardinalidade `0..1`, policy `hybrid`, suporte `when_present`.
-- `media`:
-  - mídia, cardinalidade `0..1`, policy `technical_reference`;
-  - somente imagem;
-  - modo `informative` ou `decorative`.
-
-Copy:
-
-- `eyebrow`: primária `positioning_opportunity`; auxiliar `search_intent`.
-- `title`: primárias `positioning_opportunity` e `desire`; auxiliar `commercial_keywords`.
-- `subtitle`: primárias `pain` e `desire`; auxiliar `belief`.
-- `primaryCta.label`: primária `trigger`; auxiliar `search_intent`.
-- `proofShort`: primária `proof_type`; auxiliar `objection`.
-
-Regras específicas:
-
-- Canais permitidos: `whatsapp`, `phone`, `email` e `external_url`.
-- Canal e destino concretos ficam fora do registry.
-- Imagem informativa exige alternativa acessível.
-- Imagem decorativa não transporta informação essencial.
-- Visibilidade da mídia em `hero.standard@v1` é `all_viewports`.
-- `subtitle` usa `body.base` na versão inicial.
-- `desktop_only` e `body.editorialEmphasis` não integram `hero.standard@v1` enquanto não houver evolução versionada e compatibilidade explícita.
-- A adoção futura dessas capacidades exige nova `variantVersion` ou novo contrato compatível, sem alterar LPs existentes.
-- Não pertencem a `hero.standard@v1`:
-  - CTA secundário;
-  - vídeo;
-  - formulário;
-  - interação;
-  - galeria, carrossel ou tour.
-- Essas exclusões não restringem futuras variantes de `hero`.
-
-Funil:
-
-- BOFU: direto e decisório.
-- MOFU: diferenciação e explicação moderada.
-- TOFU: contexto educativo e baixa fricção.
-- Funil não altera campos ou variante.
-
-Estado:
-
-- contrato conceitualmente fechado;
-- lifecycle `experimental`;
-- propósito `controlled_test`;
-- implementação ainda não autorizada por este ajuste documental.
+- Campos:
+  - `eyebrow`: `eyebrow`, `0..1`, `research_guided`;
+  - `title`: `h1`, `1..1`, `hybrid`, suporte `when_factual`;
+  - `subtitle`: `paragraph`, `1..1`, `hybrid`, suporte `when_factual`;
+  - `primaryCta`: ação `1..1`, `not_copy`, label `cta_label`, `hybrid`, suporte `when_present`, vínculo obrigatório com `primary_conversion_channel`;
+  - `proofShort`: `paragraph`, `0..1`, `hybrid`, suporte `when_present`;
+  - `media`: imagem `0..1`, `technical_reference`, modo `informative` ou `decorative`.
+- Copy:
+  - `eyebrow`: `positioning_opportunity`; auxiliar `search_intent`;
+  - `title`: `positioning_opportunity` e `desire`; auxiliar `commercial_keywords`;
+  - `subtitle`: `pain` e `desire`; auxiliar `belief`;
+  - CTA: `trigger`; auxiliar `search_intent`;
+  - `proofShort`: `proof_type`; auxiliar `objection`.
+- Regras:
+  - canais permitidos: `whatsapp`, `phone`, `email` e `external_url`;
+  - imagem informativa exige alternativa acessível;
+  - visibilidade da mídia `all_viewports`;
+  - `subtitle` usa `body.base`;
+  - `desktop_only` e `body.editorialEmphasis` exigem evolução versionada;
+  - sem CTA secundário, vídeo, formulário, interação, galeria, carrossel ou tour.
+- Estado: `experimental`, `controlled_test`, conceitualmente fechada.
 
 ### 3.3. Módulo `trust_bar`
 
-- `moduleKey = trust_bar`.
-- `moduleVersion = 1`.
-- Função:
-  - apresentar sinais curtos e verificáveis de confiança;
-  - reduzir insegurança inicial;
-  - sustentar continuidade da leitura ou aproximação da conversão.
-- Invariantes:
-  - sinais curtos;
-  - relevância para o público;
-  - sustentação factual real.
-- Fronteiras:
-  - não contém depoimento, prova social extensa, explicação institucional, política completa, prova técnica detalhada, CTA, formulário ou mídia.
-- Evidência principal:
-  - `barra_de_confianca`, pesquisa ativa de `lp_sections`, taxon `Corretor Imóveis`.
-- Variantes futuras podem usar outra execução estrutural sem alterar `trust_bar.standard@v1`.
+- Identidade: `trust_bar@v1`.
+- Função: apresentar sinais curtos e verificáveis de confiança.
+- Invariantes: brevidade, relevância e sustentação factual real.
+- Fronteiras: sem depoimento, explicação extensa, prova técnica detalhada, CTA, formulário ou mídia.
+- Evidência: `barra_de_confianca` de `lp_sections`.
 
 ### 3.4. Variante `trust_bar.standard@v1`
 
-Identidade:
-
-- `variantKey = trust_bar.standard`.
-- `variantVersion = 1`.
-- Compatível com `trust_bar@v1`.
-- Única variante inicial.
-
-Campos:
-
-- `items`:
-  - coleção, cardinalidade `2..4`, policy `not_copy`;
-  - item fechado com `text`;
-  - `text`: papel `benefit_item`, cardinalidade `1..1`, policy `hybrid`, suporte `when_present`.
-
-Copy:
-
-- primárias `proof_type` e `belief`;
-- auxiliar `objection`.
-
-Regras específicas:
-
-- cada item exige suporte operacional real;
-- a pesquisa orienta seleção e redação, mas não comprova o sinal;
-- a coleção não admite item aninhado;
-- não possui título, subtítulo, CTA, ícone ou mídia;
-- disposição horizontal, quebra e empilhamento são responsabilidade responsiva do renderer;
-- TOFU, MOFU e BOFU alteram seleção e redação, não o contrato nem a ordem estrutural da LP;
-- uma ocorrência válida de `trust_bar.standard@v1` exige de dois a quatro sinais sustentados;
-- o tratamento da ausência de dados depende da obrigatoriedade definida pela composição da E20 e será especificado pela E19.
-
-Estado:
-
-- contrato conceitualmente fechado;
-- lifecycle `experimental`;
-- propósito `controlled_test`;
-- implementação ainda não autorizada por este ajuste documental.
+- Campo `items`: coleção `2..4`, `not_copy`, item `text` com papel `benefit_item`, `hybrid`, suporte `when_present`.
+- Copy: `proof_type` e `belief`; auxiliar `objection`.
+- Regras:
+  - cada item exige suporte operacional real;
+  - sem título, subtítulo, CTA, ícone ou mídia;
+  - disposição responsiva pertence ao renderer;
+  - ausência depende da obrigatoriedade definida pela E20.
+- Estado: `experimental`, `controlled_test`, conceitualmente fechada.
 
 ### 3.5. Módulo `problem_solution`
 
-- `moduleKey = problem_solution`.
-- `moduleVersion = 1`.
-- Função:
-  - apresentar problemas, fricções ou riscos reconhecíveis pelo público;
-  - relacionar cada problema a uma resposta prática e coerente;
-  - transformar posicionamento abstrato em relevância concreta antes da oferta ou do processo.
-- Invariantes:
-  - cada problema possui uma solução diretamente correspondente;
-  - problema e solução permanecem distinguíveis;
-  - o problema não usa alarmismo, medo artificial ou alegação não sustentada;
-  - a solução não promete resultado, garantia ou capacidade inexistente;
-  - ausência de identidade de taxon, plano, campanha ou funil no contrato.
-- Fronteiras:
-  - não substitui proposta principal da Hero;
-  - não detalha catálogo de serviços, preço, condição comercial ou oferta;
-  - não descreve sequência de atendimento;
-  - não apresenta prova técnica, depoimento, credencial, FAQ ou CTA;
-  - não contém mídia, formulário ou interação na execução inicial.
-- Evidências principais:
-  - `dores_e_solucoes`, pesquisa ativa de `lp_sections`, taxon `Corretor Imóveis`;
-  - itens `pain`, `fear`, `objection`, `desire`, `belief` e `positioning_opportunity` de `strategic_core`;
-  - Blueprint do corretor, especialmente dores, objeções, riscos percebidos e diferenciais objetivos.
-- Variantes futuras podem usar outra execução estrutural sem alterar `problem_solution.standard@v1`.
+- Identidade: `problem_solution@v1`.
+- Função: relacionar problemas, fricções ou riscos reconhecíveis a respostas práticas.
+- Invariantes: correspondência direta, distinção clara, sem alarmismo ou promessa não sustentada.
+- Fronteiras: sem oferta detalhada, processo, prova, FAQ, CTA, mídia ou interação.
+- Evidência: `dores_e_solucoes`, `pain`, `fear`, `objection`, `desire`, `belief` e `positioning_opportunity`.
 
 ### 3.6. Variante `problem_solution.standard@v1`
 
-Identidade:
-
-- `variantKey = problem_solution.standard`.
-- `variantVersion = 1`.
-- Compatível com `problem_solution@v1` e com a versão vigente da raiz utilizada na implementação inicial.
-- Única variante inicial.
-
-Campos:
-
-- `title`:
-  - texto, papel `h2`, cardinalidade `1..1`, policy `research_guided`.
-- `items`:
-  - coleção, cardinalidade `2..4`, policy `not_copy`;
-  - item fechado com `problem` e `solution`;
-  - `problem`: texto, papel `card_title`, cardinalidade `1..1`, policy `research_guided`;
-  - `solution`: texto, papel `card_body`, cardinalidade `1..1`, policy `hybrid`, suporte `when_present`.
-
-Copy:
-
-- `title`: primárias `pain` e `desire`; auxiliar `positioning_opportunity`.
-- `problem`: primárias `pain` e `fear`; auxiliar `objection`.
-- `solution`: primárias `positioning_opportunity` e `desire`; auxiliar `belief`.
-
-Regras específicas:
-
-- uma ocorrência válida contém de dois a quatro pares completos;
-- cada item contém exatamente um `problem` e uma `solution`;
-- a solução responde diretamente ao problema do mesmo item;
-- problemas devem ser concretos, reconhecíveis e proporcionais, sem amplificação artificial;
-- toda solução apresentada exige suporte operacional real;
-- a pesquisa orienta a solução, mas não comprova serviço, método, prazo, condição, garantia ou resultado;
-- os papéis `h2`, `card_title` e `card_body` usam as faixas da raiz sem especialização na v1;
-- a coleção não admite item aninhado;
-- não possui subtítulo, CTA, mídia, ícone, prova, preço, lista detalhada de serviços ou etapas de processo;
-- diferenças de copy, quantidade dentro de `2..4`, ordem dos pares e funil não criam variante;
-- o tratamento da ausência de pares válidos depende da obrigatoriedade definida pela composição da E20 e será especificado pela E19.
-
-Funil:
-
-- BOFU prioriza fricções decisórias e respostas operacionais diretas.
-- MOFU prioriza compreensão, comparação e redução de objeções.
-- TOFU prioriza problemas amplos e respostas educativas de baixa pressão.
-- O funil altera seleção, prioridade e redação dos pares, sem alterar campos, cardinalidades, variante ou ordem estrutural da LP.
-
-Validações estruturais:
-
-- exigir `title` e `items`;
-- exigir cardinalidade `2..4` em `items`;
-- exigir exatamente `problem` e `solution` em cada item;
-- rejeitar coleção aninhada e campos extras;
-- validar os papéis semânticos e as policies declaradas;
-- exigir suporte `when_present` em `solution`;
-- rejeitar CTA, mídia, ação, prova, preço, processo ou referência técnica na variante;
-- resolver de forma fail-closed e imutável.
-
-Estado:
-
-- contrato conceitualmente fechado;
-- lifecycle `experimental`;
-- propósito `controlled_test`;
-- implementação ainda não autorizada por este ajuste documental.
+- Campos:
+  - `title`: `h2`, `1..1`, `research_guided`;
+  - `items`: coleção `2..4`, `not_copy`, com `problem` (`card_title`, `research_guided`) e `solution` (`card_body`, `hybrid`, suporte `when_present`).
+- Copy:
+  - `title`: `pain` e `desire`; auxiliar `positioning_opportunity`;
+  - `problem`: `pain` e `fear`; auxiliar `objection`;
+  - `solution`: `positioning_opportunity` e `desire`; auxiliar `belief`.
+- Regras:
+  - cada solução responde ao problema do mesmo item e exige suporte operacional;
+  - sem subtítulo, CTA, mídia, prova, preço, oferta detalhada ou processo;
+  - resolução fail-closed e imutável.
+- Estado: `experimental`, `controlled_test`, conceitualmente fechada.
 
 ### 3.7. Módulo `offer`
 
-- `moduleKey = offer`.
-- `moduleVersion = 1`.
-- Função:
-  - apresentar o que o negócio ou profissional efetivamente oferece;
-  - organizar a oferta por intenção, caso de uso ou necessidade atendida;
-  - permitir que o visitante reconheça rapidamente se existe aderência ao que procura.
-- Invariantes:
-  - cada item representa uma oferta ou escopo real e identificável;
-  - título e descrição do item permanecem coerentes entre si;
-  - toda capacidade ou condição apresentada possui sustentação operacional;
-  - a oferta não implica preço, prazo, garantia, disponibilidade temporal ou resultado não declarado;
-  - ausência de identidade de taxon, plano, campanha ou funil no contrato.
-- Fronteiras:
-  - não repete pares de problema e solução;
-  - não descreve etapas ou sequência de atendimento;
-  - não apresenta prova técnica, depoimento, credencial ou FAQ;
-  - não define preço, condição comercial, plano ou disponibilidade temporal na execução inicial;
-  - não contém CTA, mídia, formulário ou interação na execução inicial.
-- Evidências principais:
-  - `servicos_por_intencao`, pesquisa ativa de `lp_sections`, taxon `Corretor Imóveis`;
-  - itens `trigger`, `desire`, `positioning_opportunity`, `belief` e `objection` de `strategic_core`;
-  - `narrative_arc` de `lp_overview`, que recomenda segmentação por intenção antes de processo e fechamento;
-  - Blueprint do corretor, especialmente diferenciais objetivos e ofertas orientadas a intenção;
-  - catálogo de entradas vigente, com capacidades e recortes operacionais aplicáveis ao primeiro taxon.
-- Variantes futuras podem usar outra execução estrutural sem alterar `offer.standard@v1`.
+- Identidade: `offer@v1`.
+- Função: apresentar ofertas, escopos ou casos de uso efetivamente disponíveis.
+- Invariantes: item real e identificável, coerência entre título e descrição e sustentação operacional.
+- Fronteiras: sem problema-solução, processo, prova, FAQ, preço, condição comercial, CTA, mídia ou interação.
+- Evidência: `servicos_por_intencao`, `trigger`, `desire`, `positioning_opportunity`, `belief`, `objection`, Blueprint e catálogo de entradas.
 
 ### 3.8. Variante `offer.standard@v1`
 
-Identidade:
-
-- `variantKey = offer.standard`.
-- `variantVersion = 1`.
-- Compatível com `offer@v1` e com a versão vigente da raiz utilizada na implementação inicial.
-- Única variante inicial.
-
-Campos:
-
-- `title`:
-  - texto, papel `h2`, cardinalidade `1..1`, policy `research_guided`.
-- `items`:
-  - coleção, cardinalidade `1..4`, policy `not_copy`;
-  - item fechado com `itemTitle` e `description`;
-  - `itemTitle`: texto, papel `card_title`, cardinalidade `1..1`, policy `hybrid`, suporte `when_present`;
-  - `description`: texto, papel `card_body`, cardinalidade `1..1`, policy `hybrid`, suporte `when_present`.
-
-Copy:
-
-- `title`: primárias `desire` e `trigger`; auxiliar `positioning_opportunity`.
-- `itemTitle`: primárias `trigger` e `desire`; sem fonte auxiliar na v1.
-- `description`: primárias `positioning_opportunity` e `belief`; auxiliar `objection`.
-
-Regras específicas:
-
-- uma ocorrência válida contém de um a quatro itens completos;
-- o mínimo de um item permite LPs de intenção única sem forçar ofertas irrelevantes;
-- cada item contém exatamente `itemTitle` e `description`;
-- título e descrição representam uma oferta, escopo ou caso de uso efetivamente disponível como capacidade da operação;
-- todo item exige suporte por entradas operacionais aplicáveis ao taxon, negócio ou oferta;
-- o contrato transversal não fixa chaves de um taxon específico;
-- no primeiro taxon, exemplos de sustentação incluem intenção de transação, apoio em financiamento, orientação documental, localização, tipologia, faixa de preço e estágio, quando aplicáveis e reais;
-- pesquisa e Blueprint orientam seleção e redação, mas não comprovam capacidade, preço, prazo, condição, parceria, garantia, disponibilidade temporal ou resultado;
-- os papéis `h2`, `card_title` e `card_body` usam as faixas da raiz sem especialização na v1;
-- a coleção não admite item aninhado;
-- não possui subtítulo, CTA, mídia, ícone, prova, preço, condição comercial, processo ou referência técnica;
-- diferenças de copy, quantidade dentro de `1..4`, ordem dos itens e funil não criam variante;
-- o tratamento da ausência de item válido depende da obrigatoriedade definida pela composição da E20 e será especificado pela E19.
-
-Funil:
-
-- BOFU prioriza oferta específica, aderência imediata e escopo operacional direto.
-- MOFU prioriza comparação entre casos de uso e clareza sobre o atendimento disponível.
-- TOFU prioriza categorias amplas e linguagem educativa, sem transformar interesse inicial em compromisso inexistente.
-- O funil altera seleção, prioridade e redação dos itens, sem alterar campos, cardinalidades, variante ou ordem estrutural da LP.
-
-Validações estruturais:
-
-- exigir `title` e `items`;
-- exigir cardinalidade `1..4` em `items`;
-- exigir exatamente `itemTitle` e `description` em cada item;
-- rejeitar coleção aninhada e campos extras;
-- validar os papéis semânticos e as policies declaradas;
-- exigir suporte `when_present` em `itemTitle` e `description`;
-- rejeitar CTA, mídia, ação, prova, preço, condição comercial, processo ou referência técnica na variante;
-- resolver de forma fail-closed e imutável.
-
-Estado:
-
-- contrato conceitualmente fechado;
-- lifecycle `experimental`;
-- propósito `controlled_test`;
-- implementação ainda não autorizada por este ajuste documental.
+- Campos:
+  - `title`: `h2`, `1..1`, `research_guided`;
+  - `items`: coleção `1..4`, `not_copy`, com `itemTitle` (`card_title`, `hybrid`) e `description` (`card_body`, `hybrid`), ambos com suporte `when_present`.
+- Copy:
+  - `title`: `desire` e `trigger`; auxiliar `positioning_opportunity`;
+  - `itemTitle`: `trigger` e `desire`;
+  - `description`: `positioning_opportunity` e `belief`; auxiliar `objection`.
+- Regras:
+  - cada item exige capacidade operacional real;
+  - pesquisa não comprova preço, prazo, condição, parceria, garantia ou disponibilidade;
+  - sem CTA, mídia, prova, preço, condição comercial, processo ou referência técnica.
+- Estado: `experimental`, `controlled_test`, conceitualmente fechada.
 
 ### 3.9. Módulo `process`
 
-- `moduleKey = process`.
-- `moduleVersion = 1`.
-- Função:
-  - explicar como o atendimento ou a entrega progride por etapas compreensíveis;
-  - transformar uma oferta abstrata em método previsível;
-  - esclarecer próximos passos, responsabilidades e progressão sem prometer resultado.
-- Invariantes:
-  - existe uma sequência ordenada e inteligível;
-  - cada etapa representa ação, transição ou marco real do processo;
-  - etapas permanecem distintas e coerentes entre si;
-  - a sequência não inventa prazo, garantia, disponibilidade ou resultado;
-  - ausência de identidade de taxon, plano, campanha ou funil no contrato.
-- Fronteiras:
-  - não repete o catálogo de ofertas;
-  - não apresenta pares de problema e solução;
-  - não funciona como workflow, checklist operacional interno ou motor de automação;
-  - não apresenta prova técnica, depoimento, credencial, FAQ ou CTA;
-  - não contém preço, condição comercial, mídia, formulário ou interação na execução inicial.
-- Evidências principais:
-  - `processo_de_atendimento`, pesquisa ativa de `lp_sections`, taxon `Corretor Imóveis`;
-  - itens `belief`, `desire`, `positioning_opportunity`, `trigger` e `objection` de `strategic_core`;
-  - `narrative_arc` de `lp_overview`, que recomenda explicar o processo antes da remoção final de objeções e do contato;
-  - Blueprint do corretor, especialmente qualificação, visita, documentação, negociação e formalização;
-  - catálogo de entradas vigente, somente para sustentar capacidades e modos reais quando aplicáveis.
-- Variantes futuras podem usar outra execução estrutural sem alterar `process.standard@v1`.
+- Identidade: `process@v1`.
+- Função: explicar progressão real do atendimento ou entrega por etapas compreensíveis.
+- Invariantes: sequência ordenada, etapas distintas e ausência de prazo, garantia ou resultado inventado.
+- Fronteiras: sem oferta, problema-solução, workflow interno, prova, FAQ, CTA, preço, mídia ou interação.
+- Evidência: `processo_de_atendimento`, `belief`, `desire`, `positioning_opportunity`, `trigger`, `objection`, Blueprint e catálogo de entradas.
 
 ### 3.10. Variante `process.standard@v1`
 
-Identidade:
-
-- `variantKey = process.standard`.
-- `variantVersion = 1`.
-- Compatível com `process@v1` e com a versão vigente da raiz utilizada na implementação inicial.
-- Única variante inicial.
-
-Campos:
-
-- `title`:
-  - texto, papel `h2`, cardinalidade `1..1`, policy `research_guided`.
-- `steps`:
-  - coleção ordenada, cardinalidade `2..6`, policy `not_copy`;
-  - item fechado com `stepTitle` e `stepBody`;
-  - `stepTitle`: texto, papel `step_title`, cardinalidade `1..1`, policy `hybrid`, suporte `when_present`;
-  - `stepBody`: texto, papel `step_body`, cardinalidade `1..1`, policy `hybrid`, suporte `when_present`.
-
-Copy:
-
-- `title`: primárias `belief` e `desire`; auxiliar `positioning_opportunity`.
-- `stepTitle`: primárias `trigger` e `positioning_opportunity`; auxiliar `desire`.
-- `stepBody`: primárias `belief` e `desire`; auxiliar `objection`.
-
-Regras específicas:
-
-- uma ocorrência válida contém de duas a seis etapas completas e ordenadas;
-- cada etapa contém exatamente `stepTitle` e `stepBody`;
-- cada etapa representa parte real do método ou atendimento e deve possuir sustentação operacional;
-- a ordem deve refletir a progressão real, sem ser reorganizada apenas por copy, campanha ou funil;
-- etapas podem variar por ocorrência dentro do intervalo permitido quando a composição da E20 autorizar e os dados sustentarem a sequência;
-- pesquisa e Blueprint orientam seleção e redação, mas não comprovam etapa, prazo, responsabilidade, disponibilidade, garantia ou resultado;
-- os papéis `h2`, `step_title` e `step_body` usam as faixas da raiz sem especialização na v1;
-- a coleção não admite item aninhado;
-- a numeração ou marcador visual das etapas pertence ao renderer e não cria campo de conteúdo na v1;
-- não possui subtítulo, CTA, mídia, ícone obrigatório, prova, preço, condição comercial, formulário ou referência técnica;
-- diferenças de copy, quantidade dentro de `2..6` e nível de detalhe não criam variante;
-- o tratamento da ausência de sequência válida depende da obrigatoriedade definida pela composição da E20 e será especificado pela E19.
-
-Funil:
-
-- BOFU prioriza etapas concretas, responsabilidades e próximo passo imediato.
-- MOFU prioriza explicação do método, critérios e redução de incerteza.
-- TOFU prioriza visão geral educativa e baixa pressão.
-- O funil altera profundidade, seleção e redação, mas não altera campos, cardinalidades, variante nem a ordem operacional real.
-
-Validações estruturais:
-
-- exigir `title` e `steps`;
-- exigir cardinalidade `2..6` em `steps`;
-- exigir exatamente `stepTitle` e `stepBody` em cada etapa;
-- preservar a ordem declarada e rejeitar etapas vazias ou duplicadas;
-- rejeitar coleção aninhada e campos extras;
-- validar os papéis semânticos e as policies declaradas;
-- exigir suporte `when_present` em `stepTitle` e `stepBody`;
-- rejeitar CTA, mídia, ação, prova, preço, condição comercial, formulário ou referência técnica na variante;
-- resolver de forma fail-closed e imutável.
-
-Estado:
-
-- contrato conceitualmente fechado;
-- lifecycle `experimental`;
-- propósito `controlled_test`;
-- implementação ainda não autorizada por este ajuste documental.
+- Campos:
+  - `title`: `h2`, `1..1`, `research_guided`;
+  - `steps`: coleção ordenada `2..6`, `not_copy`, com `stepTitle` (`step_title`, `hybrid`) e `stepBody` (`step_body`, `hybrid`), ambos com suporte `when_present`.
+- Copy:
+  - `title`: `belief` e `desire`; auxiliar `positioning_opportunity`;
+  - `stepTitle`: `trigger` e `positioning_opportunity`; auxiliar `desire`;
+  - `stepBody`: `belief` e `desire`; auxiliar `objection`.
+- Regras:
+  - ordem reflete a progressão real;
+  - numeração visual pertence ao renderer;
+  - sem CTA, mídia, prova, preço, condição, formulário ou referência técnica.
+- Estado: `experimental`, `controlled_test`, conceitualmente fechada.
 
 ### 3.11. Módulo `technical_assurance`
 
-- `moduleKey = technical_assurance`.
-- `moduleVersion = 1`.
-- Função:
-  - explicar salvaguardas, critérios, documentos, credenciais ou verificações técnicas relevantes para a decisão;
-  - transformar sinais abstratos de confiança em fundamentos compreensíveis;
-  - reduzir risco percebido sem prometer eliminação de risco ou emitir conclusão técnica ou jurídica.
-- Invariantes:
-  - cada item descreve uma salvaguarda, evidência ou critério real e verificável;
-  - o conteúdo distingue orientação geral de afirmação factual sobre a operação;
-  - toda credencial, documento, método, verificação ou capacidade apresentada possui sustentação operacional;
-  - nenhum item implica aprovação, regularidade integral, ausência de risco, certificação, garantia ou resultado sem comprovação específica;
-  - ausência de identidade de taxon, plano, campanha ou funil no contrato.
-- Fronteiras:
-  - não substitui sinais curtos de `trust_bar`;
-  - não contém depoimento, avaliação de cliente, caso real ou métrica de resultado;
-  - não descreve etapas do processo, catálogo de ofertas ou respostas de FAQ;
-  - não presta consultoria técnica ou jurídica individualizada;
-  - não contém CTA, mídia, download, link de verificação, formulário ou interação na execução inicial.
-- Evidências principais:
-  - `prova_tecnica_documental`, pesquisa ativa de `lp_sections`, taxon `Corretor Imóveis`;
-  - itens `proof_type`, `belief`, `fear`, `objection` e `positioning_opportunity` de `strategic_core`;
-  - `narrative_arc` de `lp_overview`, que recomenda provar regularidade e autoridade;
-  - Blueprint do corretor, especialmente compliance, identificação profissional, documentação e segurança da decisão;
-  - catálogo de entradas vigente, somente para sustentar credenciais e capacidades reais quando aplicáveis.
-- Variantes futuras podem usar outra execução estrutural ou referências verificáveis sem alterar `technical_assurance.standard@v1`.
+- Identidade: `technical_assurance@v1`.
+- Função: explicar salvaguardas, critérios, documentos, credenciais ou verificações relevantes.
+- Invariantes: item real, verificável, operacionalmente sustentado e sem implicar aprovação, risco zero, certificação ou resultado.
+- Fronteiras: sem trust bar curta, depoimento, processo, oferta, FAQ, aconselhamento individualizado, CTA, mídia, download ou link.
+- Evidência: `prova_tecnica_documental`, `proof_type`, `belief`, `fear`, `objection`, `positioning_opportunity`, narrativa e Blueprint.
 
 ### 3.12. Variante `technical_assurance.standard@v1`
 
-Identidade:
-
-- `variantKey = technical_assurance.standard`.
-- `variantVersion = 1`.
-- Compatível com `technical_assurance@v1` e com a versão vigente da raiz utilizada na implementação inicial.
-- Única variante inicial.
-
-Campos:
-
-- `title`:
-  - texto, papel `h2`, cardinalidade `1..1`, policy `research_guided`.
-- `items`:
-  - coleção, cardinalidade `1..4`, policy `not_copy`;
-  - item fechado com `assuranceTitle` e `assuranceBody`;
-  - `assuranceTitle`: texto, papel `card_title`, cardinalidade `1..1`, policy `hybrid`, suporte `when_present`;
-  - `assuranceBody`: texto, papel `card_body`, cardinalidade `1..1`, policy `hybrid`, suporte `when_present`.
-
-Copy:
-
-- `title`: primárias `proof_type` e `belief`; auxiliar `objection`.
-- `assuranceTitle`: primária `proof_type`; auxiliar `belief`.
-- `assuranceBody`: primárias `proof_type` e `positioning_opportunity`; auxiliar `objection`.
-
-Regras específicas:
-
-- uma ocorrência válida contém de um a quatro itens completos;
-- cada item contém exatamente `assuranceTitle` e `assuranceBody`;
-- cada item representa salvaguarda, credencial, documento, checklist, método, verificação ou critério técnico efetivamente aplicável;
-- todo item exige suporte operacional real e rastreável;
-- o contrato transversal não fixa chaves de um taxon específico;
-- no primeiro taxon, exemplos de sustentação incluem credencial profissional, orientação documental e apoio em financiamento, quando aplicáveis e reais;
-- pesquisa e Blueprint orientam seleção e redação, mas não comprovam credencial, documento, certificação, verificação, regularidade, aprovação, garantia ou resultado;
-- conteúdo não pode afirmar conclusão jurídica, técnica ou financeira individualizada;
-- os papéis `h2`, `card_title` e `card_body` usam as faixas da raiz sem especialização na v1;
-- a coleção não admite item aninhado;
-- não possui subtítulo, CTA, mídia, ícone, link, download, depoimento, caso, métrica, preço, processo ou resposta de FAQ;
-- diferenças de copy, quantidade dentro de `1..4`, ordem dos itens e funil não criam variante;
-- o tratamento da ausência de item válido depende da obrigatoriedade definida pela composição da E20 e será especificado pela E19.
-
-Funil:
-
-- BOFU prioriza evidências concretas, aplicabilidade e limites da salvaguarda apresentada.
-- MOFU prioriza explicação dos critérios e de como reduzem incerteza.
-- TOFU prioriza educação geral, sem aconselhamento técnico ou jurídico individualizado.
-- O funil altera seleção, profundidade e redação, sem alterar campos, cardinalidades, variante ou ordem estrutural da LP.
-
-Validações estruturais:
-
-- exigir `title` e `items`;
-- exigir cardinalidade `1..4` em `items`;
-- exigir exatamente `assuranceTitle` e `assuranceBody` em cada item;
-- rejeitar coleção aninhada e campos extras;
-- validar os papéis semânticos e as policies declaradas;
-- exigir suporte `when_present` em `assuranceTitle` e `assuranceBody`;
-- rejeitar item sem sustentação operacional rastreável;
-- rejeitar CTA, mídia, ação, link, download, depoimento, caso, métrica, preço, processo, FAQ ou referência técnica concreta na variante;
-- resolver de forma fail-closed e imutável.
-
-Estado:
-
-- contrato conceitualmente fechado;
-- lifecycle `experimental`;
-- propósito `controlled_test`;
-- implementação ainda não autorizada por este ajuste documental.
+- Campos:
+  - `title`: `h2`, `1..1`, `research_guided`;
+  - `items`: coleção `1..4`, `not_copy`, com `assuranceTitle` (`card_title`, `hybrid`) e `assuranceBody` (`card_body`, `hybrid`), ambos com suporte `when_present`.
+- Copy:
+  - `title`: `proof_type` e `belief`; auxiliar `objection`;
+  - `assuranceTitle`: `proof_type`; auxiliar `belief`;
+  - `assuranceBody`: `proof_type` e `positioning_opportunity`; auxiliar `objection`.
+- Regras:
+  - todo item exige suporte real e rastreável;
+  - sem conclusão jurídica, técnica ou financeira individualizada;
+  - sem CTA, mídia, link, download, depoimento, caso, métrica, preço, processo ou FAQ.
+- Estado: `experimental`, `controlled_test`, conceitualmente fechada.
 
 ### 3.13. Módulo `social_proof`
 
-- `moduleKey = social_proof`; `moduleVersion = 1`.
-- Função: apresentar experiências reais de terceiros que reduzam incerteza sobre atendimento, entrega ou relação com a operação.
-- Invariantes:
-  - toda prova é real, rastreável e autorizada para uso;
-  - conteúdo e atribuição correspondem à mesma evidência;
-  - não há fabricação, alteração material, resultado garantido ou generalização indevida.
-- Fronteiras: não substitui `trust_bar` ou `technical_assurance`; não contém oferta, processo, FAQ, CTA, rating agregado, métrica, logo, caso detalhado ou mídia na execução inicial.
-- Evidências: `prova_social` de `lp_sections`, `proof_type`, `belief` e `objection` de `strategic_core`, `narrative_arc` de `lp_overview` e Blueprint do corretor.
-- Variantes futuras podem usar outra execução estrutural sem alterar `social_proof.standard@v1`.
+- Identidade: `social_proof@v1`.
+- Função: apresentar experiências reais de terceiros que reduzam incerteza.
+- Invariantes: prova real, rastreável, autorizada, sem fabricação, alteração material ou generalização indevida.
+- Fronteiras: sem trust bar, prova técnica, oferta, processo, FAQ, CTA, rating agregado, métrica, logo, caso detalhado ou mídia.
+- Evidência: `prova_social`, `proof_type`, `belief`, `objection`, narrativa e Blueprint.
 
 ### 3.14. Variante `social_proof.standard@v1`
 
-Identidade:
-
-- `variantKey = social_proof.standard`; `variantVersion = 1`.
-- Compatível com `social_proof@v1` e com a versão vigente da raiz utilizada na implementação inicial; única variante inicial.
-
-Campos:
-
-- `title`: texto, papel `h2`, cardinalidade `1..1`, policy `research_guided`.
-- `items`: coleção `1..3`, policy `not_copy`; item fechado com:
-  - `quote`: texto, papel `card_body`, `1..1`, policy `operational_required`;
-  - `attribution`: texto, papel `card_title`, `1..1`, policy `operational_required`;
-  - `evidenceRef`: referência técnica, `1..1`, policy `technical_reference`.
-
-Copy:
-
-- `title`: primárias `proof_type` e `belief`; auxiliar `objection`.
-- `quote` e `attribution`: sem fonte de pesquisa; derivam exclusivamente da evidência operacional referenciada.
-
-Regras e validações:
-
-- exigir de um a três itens completos e exatamente `quote`, `attribution` e `evidenceRef` em cada item;
-- impedir geração, composição ou alteração material do depoimento e exigir referência rastreável;
-- atribuição pública identificável depende de autorização; atribuição reduzida não elimina a rastreabilidade interna;
-- os papéis `h2`, `card_title` e `card_body` usam as faixas da raiz sem especialização;
-- rejeitar coleção aninhada, campos extras, CTA, mídia, rating, métrica, logo, caso detalhado ou prova sem suporte;
-- BOFU, MOFU e TOFU alteram seleção e título, não o conteúdo factual da prova nem o contrato;
-- ausência de item válido depende da obrigatoriedade da E20 e será tratada pela E19;
-- resolver de forma fail-closed e imutável.
-
-Estado:
-
-- contrato conceitualmente fechado; lifecycle `experimental`; propósito `controlled_test`;
-- implementação ainda não autorizada por este ajuste documental.
+- Campos:
+  - `title`: `h2`, `1..1`, `research_guided`;
+  - `items`: coleção `1..3`, `not_copy`, com `quote` (`card_body`, `operational_required`), `attribution` (`card_title`, `operational_required`) e `evidenceRef` (`technical_reference`).
+- Copy:
+  - `title`: `proof_type` e `belief`; auxiliar `objection`;
+  - `quote` e `attribution`: exclusivamente da evidência operacional referenciada.
+- Regras:
+  - impedir geração ou alteração material do depoimento;
+  - atribuição pública depende de autorização e não elimina rastreabilidade interna;
+  - sem CTA, mídia, rating, métrica, logo ou caso detalhado.
+- Estado: `experimental`, `controlled_test`, conceitualmente fechada.
 
 ### 3.15. Módulo `faq`
 
-- `moduleKey = faq`; `moduleVersion = 1`.
-- Função: responder dúvidas e objeções recorrentes em pares claros de pergunta e resposta, apoiando compreensão e decisão.
-- Invariantes: cada pergunta é relevante e possui resposta direta; fatos e condições reais exigem sustentação; não há aconselhamento individualizado, promessa ou resposta enganosa.
-- Fronteiras: não substitui oferta, processo ou prova técnica; não contém CTA, mídia, formulário ou ação; comportamento interativo pertence à variante que o declarar.
-- Evidências: `faq_objeções` de `lp_sections`, `faq_questions` e `search_intent` de `seo`, `objection`, `fear`, `belief` e `awareness_level` de `strategic_core` e Blueprint do corretor.
-- Variantes podem usar execuções estruturais ou comportamentais distintas sem alterar o contrato permanente de `faq@v1`.
+- Identidade: `faq@v1`.
+- Função: responder dúvidas e objeções recorrentes em pares claros de pergunta e resposta.
+- Invariantes: pergunta relevante, resposta direta, sustentação factual e ausência de aconselhamento individualizado ou promessa enganosa.
+- Fronteiras: sem oferta, processo, prova técnica, CTA, mídia, formulário ou ação; interação pertence à variante que a declarar.
+- Evidência: `faq_objeções`, `faq_questions`, `search_intent`, `objection`, `fear`, `belief`, `awareness_level` e Blueprint.
 
 ### 3.16. Variante `faq.standard@v1`
 
-- Identidade: `variantKey = faq.standard`; `variantVersion = 1`; compatível com `faq@v1` e com a versão vigente da raiz; variante base sem interação.
 - Campos:
-  - `title`: texto, papel `h2`, `1..1`, policy `research_guided`;
-  - `items`: coleção `2..6`, policy `not_copy`, com `question` (`faq_question`, `1..1`, `research_guided`) e `answer` (`faq_answer`, `1..1`, `hybrid`, suporte `when_factual`).
+  - `title`: `h2`, `1..1`, `research_guided`;
+  - `items`: coleção `2..6`, `not_copy`, com `question` (`faq_question`, `research_guided`) e `answer` (`faq_answer`, `hybrid`, suporte `when_factual`).
 - Copy:
-  - `title`: primárias `objection` e `awareness_level`; auxiliar `search_intent`;
-  - `question`: primárias `objection` e `fear`; auxiliar `faq_questions`;
-  - `answer`: primárias `belief` e `positioning_opportunity`; auxiliar `desire`.
-- Regras e validações:
-  - exigir de dois a seis pares completos, sem perguntas vazias ou duplicadas;
-  - cada resposta deve tratar diretamente sua pergunta e fatos operacionais, legais, técnicos ou financeiros exigem suporte real;
-  - usar `h2`, `faq_question` e `faq_answer` da raiz sem especialização;
-  - rejeitar coleção aninhada, campos extras, CTA, mídia, formulário, ação, interação ou aconselhamento individualizado;
-  - funil altera seleção, ordem e profundidade, sem alterar campos, cardinalidades ou variante;
-  - ausência de pares válidos depende da obrigatoriedade da E20 e será tratada pela E19;
-  - resolver de forma fail-closed e imutável.
-- Estado: contrato conceitualmente fechado; lifecycle `experimental`; propósito `controlled_test`; implementação ainda não autorizada.
+  - `title`: `objection` e `awareness_level`; auxiliar `search_intent`;
+  - `question`: `objection` e `fear`; auxiliar `faq_questions`;
+  - `answer`: `belief` e `positioning_opportunity`; auxiliar `desire`.
+- Regras:
+  - rejeitar perguntas vazias ou duplicadas;
+  - resposta trata diretamente sua pergunta;
+  - fatos operacionais, legais, técnicos ou financeiros exigem suporte real;
+  - sem CTA, mídia, formulário, ação ou interação.
+- Estado: `experimental`, `controlled_test`, conceitualmente fechada.
 
 ### 3.17. Variante `faq.accordion@v1`
 
-- Identidade: `variantKey = faq.accordion`; `variantVersion = 1`; compatível com `faq@v1` e com a versão vigente da raiz.
-- Finalidade: validar de forma controlada duas variantes do mesmo módulo e oferecer uma apresentação compacta, especialmente no mobile.
+- Identidade: `faq.accordion@v1`, compatível com `faq@v1` e com a raiz vigente.
+- Finalidade: validar duas variantes do mesmo módulo e oferecer apresentação compacta, especialmente no mobile.
 - Conteúdo:
   - reutiliza integralmente `title`, `items`, `question` e `answer` de `faq.standard@v1`;
-  - mantém cardinalidades, semantic roles, policies, fontes de copy e exigências de sustentação factual;
-  - não adiciona campo de conteúdo na v1.
-- Capability:
-  - acrescenta somente interação de acordeão e requisitos de acessibilidade associados;
-  - a identificação técnica compartilhada será materializada de forma versionada na implementação, sem alterar a raiz ou variantes anteriores silenciosamente.
-- Comportamento esperado:
+  - mantém cardinalidades, semantic roles, policies, copy e sustentação factual;
+  - não adiciona campo de conteúdo.
+- Capability: interação de acordeão e requisitos de acessibilidade associados.
+- Comportamento:
   - todos os itens iniciam fechados;
   - pergunta abre e fecha sua resposta;
-  - somente um item permanece aberto por vez;
-  - abrir outro item fecha o anteriormente aberto;
-  - pergunta é operável por teclado;
-  - estado expandido é exposto semanticamente;
-  - pergunta e resposta possuem associação acessível;
-  - alternar o estado preserva o foco no controle acionado.
-- Limites e validações:
-  - não definir agora elemento HTML, componente, ícone, animação ou implementação visual do renderer;
-  - rejeitar configuração que altere conteúdo, cardinalidade, copy ou sustentação factual herdados;
-  - resolver de forma fail-closed e imutável.
-- Estado: contrato conceitualmente fechado; lifecycle `experimental`; propósito `controlled_test`; candidata à composição da primeira LP controlada; implementação ainda não autorizada.
+  - somente um item permanece aberto;
+  - abrir outro fecha o anterior;
+  - operação por teclado;
+  - estado expandido exposto semanticamente;
+  - associação acessível entre pergunta e resposta;
+  - foco preservado no controle acionado.
+- Limites:
+  - não define elemento HTML, componente, ícone, animação ou visual do renderer;
+  - não altera conteúdo, cardinalidade, copy ou sustentação factual herdados.
+- Estado: `experimental`, `controlled_test`, candidata à primeira composição controlada.
 
-## 4. Módulos pendentes
+### 3.18. Módulo `final_cta`
+
+- Identidade: `final_cta@v1`.
+- Função: encerrar a jornada com próximo passo claro, qualificado e coerente com a intenção da LP.
+- Invariantes: uma ação principal identificável, linguagem não coercitiva, vínculo abstrato com canal operacional e sustentação de toda condição factual apresentada.
+- Fronteiras: não repete oferta, processo, FAQ ou prova; não contém formulário, mídia, ação secundária, canal ou destino concreto na execução inicial.
+- Evidência: `cta_final_qualificado`, `narrative_arc`, `mobile_priority`, `trigger`, `desire`, `objection`, `belief`, `positioning_opportunity`, `search_intent` e catálogo operacional.
+
+### 3.19. Variante `final_cta.standard@v1`
+
+- Identidade: `final_cta.standard@v1`, compatível com `final_cta@v1` e com a raiz vigente; única variante inicial.
+- Campos:
+  - `title`: texto, papel `h2`, `1..1`, policy `hybrid`, suporte `when_factual`;
+  - `body`: texto, papel `paragraph`, `1..1`, policy `hybrid`, suporte `when_factual`;
+  - `primaryCta`: ação `1..1`, policy `not_copy`, com label `cta_label`, `1..1`, `hybrid`, suporte `when_present`, e vínculo obrigatório com `primary_conversion_channel`.
+- Copy:
+  - `title`: primárias `trigger` e `desire`; auxiliar `positioning_opportunity`;
+  - `body`: primárias `desire` e `objection`; auxiliar `belief`;
+  - `primaryCta.label`: primária `trigger`; auxiliar `search_intent`.
+- Regras:
+  - uma única ação principal;
+  - canais permitidos: `whatsapp`, `phone`, `email` e `external_url`;
+  - canal e destino concretos ficam fora do registry;
+  - a copy pode orientar o visitante a informar intenção, localização, prazo ou faixa aplicável, sem armazenar esses valores no contrato;
+  - pesquisa orienta a redação, mas não comprova disponibilidade, prazo, resposta imediata, condição, garantia ou resultado;
+  - BOFU prioriza ação direta; MOFU, contato orientado; TOFU, próximo passo de baixa fricção;
+  - rejeitar CTA secundário, formulário, mídia, prova, preço, condição comercial ou referência técnica;
+  - validar vínculo operacional obrigatório e resolver de forma fail-closed e imutável.
+- Estado: `experimental`, `controlled_test`, conceitualmente fechada; implementação ainda não autorizada.
+
+## 4. Fechamento conceitual do catálogo
 
 ### 4.1. Estado
 
-Permanece pendente:
+- Os nove módulos estão conceitualmente fechados.
+- As nove variantes `standard@v1` estão conceitualmente fechadas.
+- `faq.accordion@v1` está conceitualmente fechada como exceção controlada.
+- Não há módulo ou variante aprovada pendente de parametrização.
 
-- `final_cta`.
+### 4.2. Sequência de implementação
 
-Ele receberá:
+Após autorização humana:
 
-- contrato permanente do módulo;
-- variante `standard@v1`;
-- somente os detalhes exigidos por sua execução atual.
-
-### 4.2. Sequência incremental
-
-A implementação dos nove módulos ocorrerá em etapas dentro da E18.5:
-
-1. contrato compartilhado de módulos e variantes;
-2. `hero` e `trust_bar`;
-3. `problem_solution`, `offer` e `process`;
-4. `technical_assurance` e `social_proof`;
-5. `faq.standard@v1`, `faq.accordion@v1` e `final_cta.standard@v1`;
-6. validação integrada, documentação final e encerramento da E18.5.
-
-A etapa seguinte só deve reproduzir o contrato compartilhado após ele estar validado pelos módulos anteriores.
+1. implementar o contrato compartilhado;
+2. implementar os nove módulos e suas variantes `standard@v1`;
+3. implementar `faq.accordion@v1` como segundo caso do mesmo módulo;
+4. validar contratos, registries, resolução, lifecycle, compatibilidade e imutabilidade;
+5. atualizar a documentação final e encerrar a E18.5 técnica.
 
 ### 4.3. Próxima ação
 
-- Analisar `final_cta` pelo checklist mínimo da seção 2.9.
-- Separar `final_cta` de `final_cta.standard@v1`.
-- Não alterar o arquivo novamente sem decisão humana sobre o contrato proposto.
-- Não implementar código durante o fechamento conceitual.
+- Submeter o plano completo à avaliação final.
+- Após aprovação humana, autorizar a implementação repo-only da E18.5.
+- Não implementar E20, E19, renderer, Admin, Builder, banco ou LP real neste recorte.
 
 ## 5. Validação e encerramento
 
 ### 5.1. Validações da implementação
 
-Quando a implementação for autorizada:
+Quando autorizada:
 
-- validar schemas e registries;
-- validar identidade e compatibilidade de módulo e variante;
+- validar schemas, registries, identidade e compatibilidade;
 - rejeitar campos, policies, capabilities e deltas desconhecidos;
 - garantir resolução fail-closed e resultado imutável;
-- validar apenas combinações efetivamente utilizadas;
+- validar combinações efetivamente utilizadas;
 - executar casos próprios e integração dos nove módulos e das duas variantes de FAQ;
 - executar `npm ci`, validações aplicáveis, `npm run check` e `git diff --check`.
 
@@ -952,14 +531,14 @@ Alteração exclusivamente documental:
 
 - `npm ci`: não aplicável;
 - `npm run check`: não aplicável;
-- `git diff --check`: obrigatório antes da entrega.
+- `git diff --check`: obrigatório antes da entrega quando houver ambiente local disponível.
 
 ### 5.2. Regra de parada
 
 Após os nove módulos, suas variantes `standard@v1` e `faq.accordion@v1`:
 
 - encerrar a E18.5;
-- não criar outra variante além de `faq.accordion@v1` antes da primeira LP;
+- não criar outra variante antes da primeira LP;
 - não adicionar campo para cenário futuro;
 - não criar policy ou capability sem consumidor;
 - não antecipar matriz especulativa;
@@ -970,14 +549,14 @@ Após os nove módulos, suas variantes `standard@v1` e `faq.accordion@v1`:
 
 - Implementação técnica significa contrato executável no repositório.
 - Os módulos permanecem hipóteses de produto.
-- Validação comercial ocorrerá somente quando a E20 compuser e a E19 gerar a primeira LP real.
+- Validação comercial ocorrerá quando a E20 compuser e a E19 gerar a primeira LP real.
 - Promoção de lifecycle exige evidência dessa utilização e decisão humana.
 
 ### 5.4. Critérios de parada imediata
 
 Parar e informar a divergência se:
 
-- surgir banco, rota, job, agente, automação ou infraestrutura nova;
+- surgir banco, rota, job, agente, automação ou infraestrutura nova sem fonte e recorte próprios;
 - módulo receber identidade de taxon;
 - variante representar somente copy, campanha, plano ou ativo;
 - regra de `standard@v1` for tratada como limite permanente do módulo;

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -1,10 +1,10 @@
 14/07/2026 — Plano-base E18.5 — Parametrização de módulos e variantes `landing_page`
 
-Fontes: chat, `README.md`, `AGENTS.md`, `docs/prompt-estrategista.md`, `docs/template-roadmap.md`, `docs/prompt-executor.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/schema.md`, `docs/lp-planejamento.md`, `docs/lousa-plano-base-e18-4.md`, `docs/template-blueprint.md`, `docs/blueprint-corretor-imoveis-end-customer.md`, `docs/prompt-nicho-itens-estruturados.md`, consulta read-only ao Supabase dos itens ativos de `lp_sections`, `lib/conversion-content/landing-page/`, PRs #559, #563, #564, #566, #567 e #577, avaliações do Analista e decisões humanas de 14, 15 e 16/07/2026.
+Fontes: chat, `README.md`, `AGENTS.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/schema.md`, `docs/lp-planejamento.md`, `docs/lousa-plano-base-e18-4.md`, `docs/lousa-plano-base-e20-2.md`, `docs/blueprint-corretor-imoveis-end-customer.md`, `docs/prompt-nicho-itens-estruturados.md`, consulta read-only ao Supabase, `lib/conversion-content/landing-page/`, `lib/conversion-content/landing-page/input-catalog/registry.ts`, PRs #559, #563, #564, #566, #567 e #577, avaliações do Analista e decisões humanas de 14, 15 e 16/07/2026.
 
 Versão: v1 em ajuste.
 
-Status: PR vivo para debate; grade metodológica comum registrada; módulo `hero` e variante `hero.standard` registrados para avaliação; grade inicial de nove módulos candidatos preservada; nenhuma implementação autorizada.
+Status: PR vivo para debate; grade metodológica comum registrada; `hero` e `hero.standard` permanecem como proposta consolidada com pendências; nove módulos candidatos preservados; nenhuma implementação autorizada.
 
 Path: `docs/lousa-plano-base-e18-5.md`.
 
@@ -14,311 +14,167 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 
 ### 1.1. Pré-requisitos confirmados
 
-- A E18.4 está concluída e a parametrização raiz v1 existe em `lib/conversion-content/landing-page/`.
-- A raiz possui registry versionado, schema estrito, resolver fail-closed, saída imutável, papéis semânticos, limites, critérios visuais e presets.
-- A raiz v1 não garante `body.editorialEmphasis` em todos os presets:
-  - `balanced` possui o tratamento;
-  - `compact` não possui;
-  - o contrato compartilhado o mantém opcional.
-- O subtítulo do Hero deve usar maior ênfase por padrão, sem fallback automático para `body.base`.
-- A garantia exige evolução versionada da raiz em recorte e PR próprios, preservando a `rootVersion 1`.
-- A raiz atual também não possui capability fechada de visibilidade responsiva por campo.
-- A visibilidade responsiva reutilizável por vários módulos deve ser tratada como capability comum da família, em evolução versionada própria da raiz.
-- A consulta ao banco confirmou como fonte estrutural principal:
-  - taxon: `Corretor Imóveis`;
-  - nível: `niche`;
-  - público: `end_customer`;
-  - bloco: `lp_sections`;
+- A E18.4 está concluída e a raiz versionada existe em `lib/conversion-content/landing-page/`.
+- A raiz v1 não garante `body.editorialEmphasis` em todos os presets nem possui capability fechada de visibilidade responsiva por campo.
+- Ambas as necessidades exigem evolução versionada própria, preservando `rootVersion 1`.
+- Fonte estrutural principal confirmada:
+  - taxon `Corretor Imóveis`;
+  - `taxonId = c7952d16-678c-4615-9483-a003e57d94aa`;
+  - nível `niche`;
+  - público `end_customer`;
+  - bloco `lp_sections`;
   - versão 1 ativa.
-- O ultranicho `Corretor de imóveis de médio padrão` será somente fonte complementar posterior.
-- Os módulos serão transversais e reutilizáveis dentro da família `landing_page`; não representarão nicho, profissão, campanha ou conteúdo concreto.
-- A precedência permanece `raiz → módulo → variante`.
+- O ultranicho de médio padrão permanece evidência complementar.
+- Módulos serão transversais; precedência: `raiz → módulo → variante`.
 - `commercial_activation`, E18.2 e E18.3 permanecem preservados.
 
 ### 1.2. Estado processual
 
-- O plano-base v1 e o PR #577 já existem.
-- As decisões do debate são incorporadas no mesmo PR; não criar arquivo paralelo.
-- A v1 permanecerá aberta até analisar, um a um, os nove módulos candidatos e suas variantes iniciais.
-- A existência na grade não equivale a aprovação material do módulo.
-- Rejeitar, fundir ou substituir candidato exige:
-  - justificativa estrutural;
-  - atualização explícita da grade;
-  - decisão humana.
-- A mesma grade metodológica será usada por todos os módulos aprovados.
-- A grade comum é obrigatória, mas seus blocos condicionais são preenchidos apenas quando aplicáveis à função do módulo.
-- Para cada módulo aprovado, fechar:
-  - identidade transversal;
-  - restrições normativas;
-  - evidências estruturais;
-  - função e fronteiras;
-  - campos e cardinalidades;
-  - herança e capabilities;
-  - política de origem dos valores;
-  - fontes de copy;
-  - perfis BOFU, MOFU e TOFU;
-  - mídia, ações, coleções ou interações quando aplicáveis;
-  - comportamento responsivo específico quando aplicável;
-  - variante inicial e deltas;
-  - versões e compatibilidades;
-  - lifecycle e propósitos permitidos;
-  - fronteiras com E20, E19 e renderer;
-  - casos executáveis e critérios de fechamento.
-- O Hero é o módulo-piloto; os demais seguem a ordem da grade inicial após o fechamento completo do Hero.
-- Depois da grade completa, o plano será dividido em fases executáveis específicas.
-- A avaliação única do Analista, Gestor Estrutural e Gestor de Updates ocorrerá somente com a v1 estável.
-- A v2 será consolidada no mesmo PR após os pareceres.
-- O Executor só poderá ser instruído após o merge humano da evolução da raiz e da v2 do PR #577.
+- O debate permanece no PR #577; não criar arquivo paralelo.
+- Cada candidato será analisado individualmente; existência na grade não equivale a aprovação.
+- Rejeição, fusão ou substituição exige justificativa e decisão humana.
+- A grade comum é obrigatória, com blocos condicionais conforme a função.
+- Cada módulo deve fechar identidade, evidência, fronteiras, campos, cardinalidades, policies, fontes, funil, responsividade aplicável, variante, versões, lifecycle, compatibilidades, casos da E18.5 e invariantes futuras da E19.
+- O Hero é o piloto; `trust_bar` só começa após seu fechamento.
+- Implementação somente após evolução da raiz, v2 estável, pareceres e merge humano.
 
 ### 1.3. Princípio canônico de herança
 
-- A raiz contém regras comuns da família.
-- O módulo declara apenas função estrutural, campos, cardinalidades, fontes, políticas e exceções justificadas.
-- O módulo não repete valores concretos da raiz.
-- A variante registra somente deltas fechados sobre campos já previstos.
-- A composição futura pode selecionar por ocorrência apenas opções previamente autorizadas.
-- O resolver aplica a precedência e entrega contrato efetivo completo e imutável.
-- A E18.5 declara tratamento padrão, alternativas autorizadas e capability exigida.
-- A E20 seleciona, por ocorrência concreta, somente alternativa autorizada e registra a justificativa aplicável.
-- A E19 gera o conteúdo concreto sem alterar o contrato parametrizado.
-- O renderer executa o contrato já resolvido; não escolhe alternativa, não corrige ausência de capability e não aplica fallback.
+- A raiz contém regras comuns; módulo e variante registram apenas especializações justificadas.
+- E18.5 autoriza opções; E20 seleciona por ocorrência; E19 gera e vincula valores; renderer apenas executa.
+- Escolha excepcional na E20 exige decisão humana documentada, sem pressupor campo, coluna ou persistência nova.
+- O resolver entrega contrato efetivo, completo, imutável e sem fallback.
 
 ### 1.4. Regras de exceção
 
-- Campo sem exceção herda a raiz.
-- Módulo pode restringir ou selecionar capacidades da raiz quando sua função justificar.
-- Variante pode restringir o módulo quando houver mudança reutilizável de execução ou comportamento.
-- Escolha por ocorrência já autorizada não cria variante.
-- Tipo de mídia, ativo concreto ou visibilidade responsiva autorizada não criam variante por si só.
-- Módulo ou variante não pode ampliar limite técnico absoluto.
-- Necessidade acima do limite deve avaliar antes revisão de texto, divisão de conteúdo, mudança semântica ou nova estrutura.
-- Diferença apenas de taxon, conteúdo, campanha, conta, tráfego, funil ou composição não cria módulo nem variante.
+- Escolha já autorizada por ocorrência não cria variante.
+- Tipo de mídia, ativo, taxon, campanha, funil, conteúdo ou visibilidade responsiva autorizada não criam variante isoladamente.
+- Módulo e variante não ampliam limite absoluto da raiz.
+- Campo novo exige nova versão do módulo.
 
 ### 1.5. Decisões técnicas incorporadas
 
-- Cardinalidade substitui propriedade `required` separada.
-- A obrigatoriedade pode ser verificada como pergunta analítica, mas não será duplicada no contrato.
-- Não haverá `structuralRules` aberto nem `addedFields` livre.
-- Campo novo exige nova versão do contrato do módulo.
-- Comportamento estrutural, quando necessário, será união fechada.
-- O consumidor não recebe operações de delta para aplicar.
-- A grade inicial v1 possui nove módulos candidatos:
-  - `hero`, derivado de `hero_segmentado`;
-  - `trust_bar`, derivado de `barra_de_confianca`;
-  - `problem_solution`, derivado de `dores_e_solucoes`;
-  - `offer`, derivado de `servicos_por_intencao`;
-  - `process`, derivado de `processo_de_atendimento`;
-  - `technical_assurance`, derivado de `prova_tecnica_documental`;
-  - `social_proof`, derivado de `prova_social`;
-  - `faq`, derivado de `faq_objeções`;
-  - `final_cta`, derivado de `cta_final_qualificado`.
-- Os `item_key` de `lp_sections` são referências de evidência, não identidade permanente do módulo.
-- Nomes diferentes de seção podem representar a mesma função estrutural transversal.
-- Cada candidato só será aprovado após confirmar função reutilizável e diferença real em relação aos demais.
-- `formato_curto`, `formato_medio` e `formato_longo` orientam composição e extensão; não são módulos nem variantes.
-- A grade inicial fica limitada aos nove candidatos; ampliação exige decisão posterior.
-- Para `hero.subtitle`:
-  - `semanticRole = paragraph`;
-  - padrão: `body.editorialEmphasis`;
-  - alternativa autorizada: `body.base`;
-  - ausência da capability falha fechado;
-  - E20 poderá selecionar a alternativa por ocorrência.
-- `hero.media_split` não está aprovada.
-- `hero.standard` é a única variante inicial aprovada do Hero e poderá possuir delta vazio como execução-base versionada.
+- Cardinalidade substitui `required`.
+- Não haverá regras abertas nem delta livre.
+- Grade candidata:
+  - `hero` ← `hero_segmentado`;
+  - `trust_bar` ← `barra_de_confianca`;
+  - `problem_solution` ← `dores_e_solucoes`;
+  - `offer` ← `servicos_por_intencao`;
+  - `process` ← `processo_de_atendimento`;
+  - `technical_assurance` ← `prova_tecnica_documental`;
+  - `social_proof` ← `prova_social`;
+  - `faq` ← `faq_objeções`;
+  - `final_cta` ← `cta_final_qualificado`.
+- `item_key` é evidência, não identidade canônica.
+- Formatos curto, médio e longo pertencem à composição/extensão.
+- `hero.subtitle`: `paragraph`, padrão `body.editorialEmphasis`, alternativa `body.base`, sem fallback.
+- `hero.standard` é a única variante inicial e pode ter delta vazio.
+- Canal e destino concretos de CTA permanecem fora do registry do módulo.
+- Nenhum `actionRole` está aprovado sem contrato fechado.
 
 ### 1.6. Estado técnico confirmado
 
-- Boundary atual: `lib/conversion-content/landing-page/`.
-- Namespace público: `landingPageRoot`.
-- Ainda não existem catálogo de módulos, variantes, composição, renderer ou render model de `landing_page`.
-- A E18.5 será repo-only.
-- A leitura dos itens estruturados serve como evidência; este recorte não altera banco.
-- Composição e seleção por ocorrência pertencem à E20.
-- Geração, snapshot e persistência por conta pertencem à E19.
-- `account_landing_pages` não será alterada.
+- Boundary: `lib/conversion-content/landing-page/`; namespace atual: `landingPageRoot`.
+- Ainda não existem catálogo de módulos, composição, renderer ou render model.
+- E18.5 é repo-only e não altera banco.
+- O catálogo operacional já define `primary_conversion_channel` e destinos condicionais.
+- E20 seleciona composição; E19 vincula valores, gera e preserva snapshot.
 
 ### 1.7. Pontos ainda em debate
 
-- Avaliação e ajustes da grade registrada do Hero.
-- Confirmação individual dos oito candidatos restantes.
-- Contratos específicos por `fieldKind` ainda não exemplificados pelo Hero.
-- Variante inicial e deltas dos demais módulos.
-- Critério mínimo para nova variante e exceção estrutural.
-- Lifecycle inicial e promoção para `validated`.
-- Evolução da raiz para `body.editorialEmphasis` e visibilidade responsiva.
-- Divisão final em fases executáveis.
+- Contrato da ação secundária e eventual necessidade de `actionRole`.
+- Acessibilidade de vídeo no campo `media`.
+- Confirmação dos oito candidatos restantes.
+- Evolução da raiz e divisão final em fases.
 
 ## 2. Contrato do caso
 
 ### 2.1. Problema
 
-- A raiz existe, mas ainda faltam contratos aprovados para todos os módulos, variantes, campos, fontes, perfis de funil e lifecycle.
-- Os nove itens estruturais do primeiro recorte não podem virar módulos automaticamente.
-- O catálogo precisa generalizar funções reais sem transportar identidade imobiliária.
-- A raiz v1 não garante o tratamento editorial exigido pelo Hero.
-- A raiz v1 não oferece escolha fechada de visibilidade responsiva por campo.
-- Um contrato único de campo com `semanticRole` obrigatório não atende mídia, ação, coleção ou referência técnica.
-- A política de origem precisa impedir que pesquisa seja tratada como fonte de preço, endereço, credencial, métrica, depoimento, registro, garantia ou disponibilidade.
-- Repetição de valores da raiz ou deltas aplicados por consumidores criaria múltiplas fontes da verdade.
-- Fallback para `body.base` esconderia capability ausente.
+- Faltam contratos aprovados para todos os módulos e variantes.
+- O catálogo deve generalizar funções sem carregar identidade imobiliária.
+- CTA não pode duplicar canal/destino da E20.2.
+- Mídia deve separar contrato estrutural de schema concreto da E19.
+- Policies devem impedir invenção de fatos e fallback deve permanecer proibido.
 
 ### 2.2. Resultado esperado
 
-- Criar catálogo repo-only versionado a partir dos nove módulos candidatos, incluindo apenas os contratos individualmente aprovados.
-- Usar grade metodológica única para todos os módulos, com blocos condicionais por função.
-- Usar `Corretor Imóveis`, `end_customer`, `lp_sections` v1 ativa como evidência estrutural principal.
-- Confirmar cada módulo e variante inicial individualmente.
-- Resolver `raiz → módulo → variante` em contrato final imutável.
-- Definir referências estruturais sem transformar `lp_sections.itemKey` em identidade canônica.
-- Definir fontes de copy somente com `item_key` oficiais dos blocos aplicáveis.
-- Separar pesquisa orientadora de valores factuais operacionais.
-- Tratar BOFU, MOFU e TOFU como perfis, não variantes.
-- Preservar versões históricas.
-- Não criar banco, composição, geração ou renderer.
+- Catálogo repo-only, versionado e imutável.
+- Grade única, com módulos aprovados individualmente.
+- Separação entre pesquisa, contrato estrutural, entrada operacional, composição e conteúdo.
+- BOFU, MOFU e TOFU como perfis, não variantes.
+- Sem banco, composição, geração ou renderer neste recorte.
 
 ### 2.3. Hierarquia para parametrização
 
 #### 2.3.1. Restrições normativas
 
-- parametrização raiz vigente;
+- raiz vigente;
 - `docs/lp-planejamento.md`;
-- contratos oficiais dos itens estruturados;
-- fronteiras da E18.5, E20 e E19;
-- decisões humanas já aprovadas e registradas;
-- compatibilidade histórica e versionamento imutável.
+- contratos de pesquisas e catálogo operacional;
+- fronteiras E18.5/E20/E19;
+- decisões humanas e versionamento histórico.
 
 #### 2.3.2. Evidências
 
-- itens estruturados do taxon;
-- Blueprints;
-- referências reais;
-- LPs analisadas;
-- contrastes entre taxons e ultranichos;
+- pesquisas estruturadas;
+- Blueprints e LPs reais;
+- contrastes entre taxons;
 - evidência executável existente.
 
 #### 2.3.3. Decisão humana de produto
 
 - resolve hipóteses e ambiguidades;
-- pode rejeitar recomendação empírica insuficiente;
-- pode aprovar padrão funcional próprio do LP Factory 10;
-- não pode violar contrato vigente sem evolução versionada explícita;
-- deve decidir rejeição, fusão ou substituição de candidato da grade.
+- pode rejeitar evidência insuficiente;
+- não viola contrato vigente sem evolução versionada.
 
 #### 2.3.4. Validação posterior
 
+- casos executáveis da parametrização;
 - LP real em conta de teste;
-- casos executáveis;
-- revisão humana;
-- evidência de uso reutilizável;
-- decisão de promoção, restrição, depreciação ou substituição.
+- invariantes de conteúdo na E19;
+- revisão e promoção humanas.
 
 #### 2.3.5. Regras específicas
 
-- A grade inicial usa `Corretor Imóveis`, `end_customer`, `lp_sections` v1 ativa.
-- O ultranicho de médio padrão não restringe o catálogo transversal.
 - Item de `lp_sections` não cria módulo automaticamente.
-- Módulo exige função estrutural reutilizável ainda não coberta.
-- Variante exige mudança reutilizável de estrutura, execução ou comportamento.
-- Conteúdo, parâmetro herdado, escolha de ocorrência, composição, fonte, funil ou valor operacional não criam variante.
-- Identidade do módulo não pode carregar taxon, profissão ou campanha.
-- Itens de extensão de página não pertencem ao catálogo.
+- Módulo exige função reutilizável nova; variante exige execução reutilizável diferente.
+- Taxon, entrada, copy, funil e composição não criam variante.
 
 #### 2.3.6. Grade metodológica comum
 
-Todos os módulos serão analisados pelos mesmos blocos obrigatórios:
+Todos os módulos devem analisar:
 
-1. identidade transversal;
-2. função estrutural;
-3. evidências e equivalência semântica;
-4. fronteiras positivas e negativas;
-5. catálogo de campos;
-6. `fieldKind` e contrato condicionado pelo tipo;
-7. cardinalidades sem `required`;
-8. herança, capabilities e exceções;
-9. política fechada de origem do valor;
-10. `copySourceMap` quando aplicável;
-11. perfis BOFU, MOFU e TOFU quando houver copy;
-12. comportamento responsivo específico quando necessário;
-13. variante inicial e deltas;
-14. versões e compatibilidades;
-15. lifecycle e propósitos;
-16. fronteiras com E20, E19 e renderer;
-17. casos positivos e negativos;
-18. critérios de fechamento.
+1. identidade e função;
+2. evidências e equivalência;
+3. fronteiras;
+4. campos, `fieldKind` e cardinalidades;
+5. herança, capabilities e policies;
+6. fontes e funil quando aplicáveis;
+7. responsividade e acessibilidade quando aplicáveis;
+8. variante, versões, lifecycle e compatibilidades;
+9. fronteiras E20/E19/renderer;
+10. casos E18.5, invariantes E19 e critérios de fechamento.
 
-Blocos condicionais serão preenchidos somente quando a função exigir:
+Blocos condicionais: CTA, mídia, coleção, valor operacional, referência técnica, interação, acessibilidade, visibilidade responsiva e variante adicional.
 
-- ação ou CTA;
-- mídia;
-- coleção;
-- valor operacional;
-- referência técnica;
-- acessibilidade específica;
-- comportamento interativo;
-- visibilidade responsiva específica;
-- variante estrutural adicional.
-
-Regras da grade:
-
-- O Hero é o primeiro preenchimento, não um molde rígido de conteúdo.
-- Outros módulos podem possuir campos, coleções, interações e responsividade diferentes.
-- Nenhum módulo é obrigado a possuir CTA, mídia, copy ou segunda variante.
-- Nenhuma variante adicional será criada apenas para manter simetria entre módulos.
-- O contrato específico deve ser o mínimo suficiente para representar a função reutilizável.
+O Hero é referência metodológica, não molde rígido de conteúdo.
 
 ### 2.4. Identidade, evidência e versionamento previstos
 
 - `family = landing_page`.
-- `rootVersion` será a versão que garanta as capabilities requeridas.
-- `moduleCatalogVersion = 1` para o primeiro catálogo publicado.
-- Grade candidata de `moduleKey`:
-  - `hero`;
-  - `trust_bar`;
-  - `problem_solution`;
-  - `offer`;
-  - `process`;
-  - `technical_assurance`;
-  - `social_proof`;
-  - `faq`;
-  - `final_cta`.
-- O registry será explícito e imutável por versão.
-- Módulo:
-  - `moduleKey`;
-  - `moduleVersion`;
-  - `lifecycle`;
-  - `structuralFunction`;
-  - `structuralEvidenceRefs`;
-  - `fieldCatalog`.
-- Cada `structuralEvidenceRef` deve registrar:
-  - taxon de origem;
-  - `audienceScope`;
-  - `researchVersion`;
-  - `itemKey` observado;
-  - função estrutural descrita pela fonte;
-  - função transversal inferida;
-  - justificativa da equivalência semântica.
-- `itemKey` observado não determina `moduleKey`.
-- Não haverá campo livre de força de evidência na v1; necessidade futura exige enum fechado e uso comprovado.
-- Variante:
-  - `variantKey`;
-  - `variantVersion`;
-  - `moduleKey`;
-  - `compatibleModuleVersion`;
-  - `lifecycle`;
-  - deltas fechados.
-- O catálogo declara compatibilidade explícita com `rootVersion`.
-- Não haverá versão ou catálogo implícito nem fallback silencioso.
+- `moduleCatalogVersion = 1` no primeiro catálogo.
+- Módulo declara `moduleKey`, `moduleVersion`, lifecycle, função, evidências e campos.
+- Evidência de pesquisa registra taxon, `taxonId`, público, bloco, `researchId`, versão, status, `itemKey`, estado ativo, função observada, função transversal e equivalência.
+- Variante declara identidade, versão, módulo compatível, lifecycle e deltas fechados.
+- Catálogo declara compatibilidade explícita com `rootVersion`.
 
 ### 2.5. Contrato-base de campo
 
-Todo campo declara:
+Todo campo declara `fieldKey`, `fieldKind`, cardinalidade e policy.
 
-- `fieldKey`;
-- `fieldKind`;
-- `cardinality`;
-- `operationalValuePolicy`.
-
-A união fechada prevista de `fieldKind` é:
+`fieldKind` fechado:
 
 - `text`;
 - `action`;
@@ -327,698 +183,337 @@ A união fechada prevista de `fieldKind` é:
 - `operational_value`;
 - `technical_reference`.
 
-Contratos condicionais por tipo:
+Regras:
 
-- `text`:
-  - exige `semanticRole` existente na raiz;
-  - pode declarar `copySourceMap`;
-  - pode selecionar tratamentos tipográficos autorizados.
-- `action`:
-  - representa objeto estrutural de ação;
-  - seu `label` é campo textual separado com `semanticRole = cta_label`;
-  - destino real é referência operacional futura;
-  - não haverá `actionRole` enquanto não existir contrato fechado e fonte aprovada.
-- `media`:
-  - usa contrato abstrato de referência;
-  - deve declarar tipo de mídia permitido;
-  - deve prever política de texto alternativo e uso decorativo;
-  - não recebe `semanticRole` visual por padrão.
-- `collection`:
-  - declara cardinalidade da coleção;
-  - declara contrato fechado do item;
-  - não recebe `semanticRole` na coleção como um todo.
-- `operational_value`:
-  - declara tipo do valor;
-  - exige fonte operacional aplicável;
-  - não pode ser inferido como fato pela pesquisa.
-- `technical_reference`:
-  - representa referência técnica, identificador ou vínculo abstrato;
-  - não é copy.
-
-Regras gerais:
-
-- `cardinality` contém somente `min` e `max`.
-- `{ min: 1, max: 1 }` representa campo único obrigatório.
-- `{ min: 0, max: 1 }` representa campo único opcional.
-- Coleção usa `max > 1` quando houver teto fechado.
-- Não haverá `required` ou propriedade equivalente.
-- Nenhum valor concreto da raiz é copiado.
-- Exceção de faixa ou limite deve ser justificada e só pode restringir o teto herdado.
-- Tratamento padrão deve pertencer à lista permitida.
-- Capability ausente falha fechado.
+- texto visível exige `semanticRole` da raiz;
+- ação possui label textual e vínculo operacional futuro, sem canal/destino no registry;
+- mídia declara tipos e requisitos abstratos de ativo e acessibilidade;
+- coleção declara contrato fechado do item;
+- valor operacional não pode ser inferido como fato;
+- referência técnica não é copy;
+- somente cardinalidade representa obrigatoriedade;
+- capability ausente falha fechado.
 
 #### 2.5.1. Política fechada de origem do valor
 
-`operationalValuePolicy` será união fechada com:
+- `research_generated_non_factual`: copy não factual gerada da pesquisa.
+- `research_guided`: pesquisa orienta, mas não fornece o valor final completo.
+- `operational_required`: valor deve vir de fonte operacional autorizada.
+- `hybrid`: orientação editorial com suporte operacional obrigatório para fato ou ação concreta.
+- `technical_reference`: mídia, link, identificador ou vínculo técnico.
+- `not_copy`: objeto estrutural ou técnico.
 
-- `research_generated_non_factual`:
-  - texto pode ser produzido a partir da pesquisa;
-  - não pode criar alegação operacional ou factual não sustentada.
-- `research_guided`:
-  - pesquisa orienta tema, enquadramento e vocabulário;
-  - não fornece por si só o valor final completo.
-- `operational_required`:
-  - valor deve vir da conta, negócio, oferta, campanha, LP ou fonte operacional autorizada.
-- `hybrid`:
-  - pesquisa orienta a copy;
-  - qualquer afirmação factual exige sustentação operacional.
-- `technical_reference`:
-  - mídia, link, identificador, evidência ou referência técnica.
-- `not_copy`:
-  - campo estrutural ou técnico sem geração de copy.
+E18.5 declara; E19 aplica na instância concreta.
 
-A E18.5 declara a política. A E19 aplica a política durante a geração concreta.
+#### 2.5.2. Matriz de compatibilidade das policies
+
+- `research_generated_non_factual` e `research_guided` admitem `copySourceMap` em texto.
+- `hybrid` pode admitir `copySourceMap`, mas fato, canal, ação ou prova exigem suporte operacional.
+- `operational_required` não pode ser preenchida somente por pesquisa.
+- `technical_reference` e `not_copy` não admitem `copySourceMap`.
+- Falham: policy incompatível com `fieldKind`, mídia com policy textual, `not_copy` com fontes, `hybrid` factual sem suporte e valor operacional gerado apenas da pesquisa.
 
 ### 2.6. Contrato de variante
 
-Deltas permitidos quando aprovados:
-
-- cardinalidade;
-- remoção de campo opcional;
-- ativação de campo previsto;
-- restrição de faixa ou limite;
-- restrição de tratamentos permitidos;
-- comportamento estrutural enumerado.
-
-Deltas proibidos:
-
-- campo livre;
-- papel ou tratamento desconhecido;
-- ampliação de limite;
-- regra arbitrária;
-- taxon, campanha ou conteúdo;
-- valor de conta ou composição;
-- URL, classe ou componente visual concreto.
-
-Regras adicionais:
-
-- O resolver valida o delta e retorna somente o contrato final.
-- Variante `standard` pode representar a execução-base versionada do módulo e possuir delta vazio quando `variantKey` for obrigatório.
-- Delta vazio não autoriza criar variantes redundantes.
-- Não se inventa delta para justificar a existência da variante-base.
-- Nova variante exige diferença reutilizável demonstrável dentro da mesma função estrutural.
-- Tipo de mídia, ativo concreto ou opção responsiva já autorizada não criam variante.
+- Deltas permitidos: cardinalidade, remoção/ativação de campo previsto, restrição de faixa/tratamento e comportamento enumerado.
+- Deltas proibidos: campo livre, papel desconhecido, ampliação de limite, taxon, conteúdo, valor operacional, URL, classe ou componente concreto.
+- `standard` pode ter delta vazio; outra variante vazia e redundante falha.
 
 ### 2.7. Módulo-piloto `hero`
 
 #### 2.7.1. Identidade e função estrutural
 
-- `moduleKey = hero`.
-- `moduleVersion = 1` proposto.
-- Função estrutural:
-  - apresentar o recorte da LP;
-  - comunicar a proposta de valor principal;
-  - indicar a ação prioritária esperada do visitante.
-- Não representa taxon, campanha, tráfego, funil ou composição.
-- A função deve permanecer transversal à família `landing_page`.
+- `moduleKey = hero`; `moduleVersion = 1` proposto.
+- Função: apresentar recorte, proposta principal e ação prioritária.
+- Não representa taxon, tráfego, funil ou composição.
 
 #### 2.7.2. Evidência estrutural inicial
 
-- taxon: `Corretor Imóveis`;
-- `audienceScope = end_customer`;
-- `researchVersion = 1`;
-- `itemKey = hero_segmentado`;
-- função observada: abertura segmentada da LP com promessa e CTA;
-- função transversal inferida: apresentar recorte, proposta de valor e ação principal;
-- o nome da seção imobiliária não determina o `moduleKey`.
+- taxon `Corretor Imóveis`;
+- `taxonId = c7952d16-678c-4615-9483-a003e57d94aa`;
+- público `end_customer`;
+- bloco `lp_sections`;
+- `researchId = 31e4c229-1582-4d2c-8e4a-7b74e6e07681`;
+- versão 1, pesquisa ativa;
+- `itemKey = hero_segmentado`, item ativo, ordem 1;
+- função observada: apresentar valor central e segmentar por intenção;
+- função transversal: apresentar recorte, proposta e ação principal.
 
 #### 2.7.3. Fronteiras
 
-Pertence ao Hero:
+Pertencem: enquadramento, título, explicação curta, CTA principal, CTA secundário opcional, microprova opcional e uma mídia opcional.
 
-- enquadramento inicial;
-- título principal;
-- explicação curta;
-- CTA principal;
-- CTA secundário opcional;
-- prova curta opcional;
-- uma mídia principal opcional.
-
-Não pertence ao Hero:
-
-- barra completa de confiança;
-- lista de serviços;
-- catálogo de ofertas;
-- processo detalhado;
-- prova técnica extensa;
-- conjunto de depoimentos;
-- FAQ;
-- formulário completo;
-- galeria, carrossel ou tour;
-- CTA final da página;
-- navegação;
-- composição ou ordem global.
+Não pertencem: trust bar completa, oferta, processo, prova extensa, depoimentos, FAQ, formulário completo, galeria, carrossel, tour, CTA final, navegação e ordem global.
 
 #### 2.7.4. Catálogo de campos proposto
 
-- `eyebrow`:
-  - `fieldKind = text`;
-  - `semanticRole = eyebrow`;
-  - `cardinality = { min: 0, max: 1 }`;
-  - `operationalValuePolicy = research_guided`;
-  - contextualiza categoria, intenção ou recorte sem repetir integralmente o título.
-- `title`:
-  - `fieldKind = text`;
-  - `semanticRole = h1`;
-  - `cardinality = { min: 1, max: 1 }`;
-  - `operationalValuePolicy = hybrid`;
-  - apresenta a principal proposta de valor;
-  - fatos concretos exigem entrada operacional.
-- `subtitle`:
-  - `fieldKind = text`;
-  - `semanticRole = paragraph`;
-  - `cardinality = { min: 1, max: 1 }`;
-  - `operationalValuePolicy = hybrid`;
-  - desenvolve promessa, benefício, contexto ou objeção principal;
-  - `defaultTypographyTreatment = body.editorialEmphasis`;
-  - `allowedTypographyTreatments = [body.editorialEmphasis, body.base]`.
-- `primaryCta`:
-  - `fieldKind = action`;
-  - `cardinality = { min: 1, max: 1 }`;
-  - `operationalValuePolicy = not_copy`;
-  - `label`:
-    - `fieldKind = text`;
-    - `semanticRole = cta_label`;
-    - `cardinality = { min: 1, max: 1 }`;
-    - `operationalValuePolicy = research_generated_non_factual`;
-  - `destinationRef`:
-    - `fieldKind = technical_reference`;
-    - `cardinality = { min: 1, max: 1 }`;
-    - `operationalValuePolicy = technical_reference`;
-    - não contém URL concreta no catálogo.
-- `secondaryCta`:
-  - `fieldKind = action`;
-  - `cardinality = { min: 0, max: 1 }`;
-  - `operationalValuePolicy = not_copy`;
-  - quando presente, exige `label` e `destinationRef` equivalentes ao contrato do CTA principal;
-  - representa ação complementar e não deve competir com a ação principal.
-- `proofShort`:
-  - `fieldKind = text`;
-  - `semanticRole = paragraph`;
-  - `cardinality = { min: 0, max: 1 }`;
-  - `operationalValuePolicy = operational_required`;
-  - pode apresentar credencial, prova ou redução curta de risco;
-  - a pesquisa pode indicar o tipo de prova, mas não fornecer prova concreta;
-  - sem entrada operacional válida, o campo é omitido.
-- `media`:
-  - `fieldKind = media`;
-  - `cardinality = { min: 0, max: 1 }`;
-  - `operationalValuePolicy = technical_reference`;
-  - `mediaKind` permitido:
-    - `image`;
-    - `video`;
-  - `assetRef` obrigatório quando o campo estiver presente;
-  - `accessibilityMode` obrigatório:
-    - `informative`;
-    - `decorative`;
-  - mídia informativa exige texto alternativo ou alternativa acessível aplicável;
+- `eyebrow`: texto/`eyebrow`, `0..1`, `research_guided`.
+- `title`: texto/`h1`, `1..1`, `hybrid`.
+- `subtitle`: texto/`paragraph`, `1..1`, `hybrid`; padrão `body.editorialEmphasis`, alternativa `body.base`.
+- `primaryCta`: ação `1..1`, `not_copy`:
+  - label `cta_label`, `1..1`, `hybrid`;
+  - compatível com `primary_conversion_channel`;
+  - canal e destino concretos fora do registry;
+  - E19 realiza o vínculo operacional.
+- `secondaryCta`: ação `0..1`, `not_copy`:
+  - label `cta_label`, `hybrid`;
+  - ação complementar;
+  - contrato estrutural permitido ainda pendente;
+  - canal e destino fora do registry.
+- `proofShort`: texto/`paragraph`, `0..1`, `hybrid`:
+  - microprova, credencial ou sinal curto de confiança;
+  - suporte factual operacional obrigatório quando presente;
+  - não recebe genericamente preço, prazo, disponibilidade ou condição comercial.
+- `media`: mídia `0..1`, `technical_reference`:
+  - `mediaKind = image | video`;
+  - referência do ativo pertence à instância futura;
+  - `accessibilityMode = informative | decorative`;
+  - imagem informativa exige `altText` não vazio;
+  - imagem decorativa normaliza `altText = ""`;
+  - `altText` é `hybrid` e depende do ativo/contexto real;
+  - legenda é separada de `altText`;
+  - vídeo exige alternativa acessível própria; contrato exato ainda pendente;
   - mídia decorativa não transporta informação essencial.
 
 #### 2.7.5. Herança e exceção tipográfica
 
-- Campos textuais herdam faixas, limites e valores da raiz.
-- Não há tamanho, limite ou spacing próprio aprovado.
-- `subtitle` permanece `paragraph` e usa tratamento da raiz.
-- A E18.5 define `body.editorialEmphasis` como padrão e `body.base` como alternativa autorizada.
-- A E20 pode selecionar `body.base` em ocorrência concreta com justificativa.
-- O renderer apenas executa o tratamento resolvido.
-- Ausência de `body.editorialEmphasis` é incompatibilidade, não fallback.
-- Mídia opcional não comprova variante.
+- Campos textuais herdam raiz; não há tamanho ou spacing próprio aprovado.
+- E18.5 autoriza `body.editorialEmphasis` e `body.base`; E20 seleciona.
+- Exceção exige decisão humana documentada, sem presumir persistência nova.
+- Renderer não escolhe nem aplica fallback.
 
 #### 2.7.6. Mídia e comportamento responsivo
 
-- Imagem ou vídeo no mesmo slot estrutural usam `hero.standard`.
-- A escolha de `mediaKind` pertence à ocorrência concreta e não cria variante.
-- Galeria, carrossel, tour ou coleção de mídia representam função distinta e não entram no campo `media` do Hero.
-- Política responsiva proposta para o campo `media`:
-  - padrão: `all_viewports`;
-  - alternativa autorizada: `desktop_only`.
-- `desktop_only` significa que a mídia aparece no desktop e é omitida no mobile, sem alterar a função estrutural do Hero.
-- A seleção de `desktop_only` pertence à E20.
-- O renderer apenas executa a opção resolvida.
-- `desktop_only` só é válido quando a mídia for decorativa, complementar ou redundante em relação ao conteúdo textual.
-- Não é permitido ocultar no mobile mídia que contenha informação essencial, prova necessária, instrução, condição, preço, oferta ou conteúdo sem alternativa textual equivalente.
-- A capability comum de visibilidade responsiva ainda não existe na raiz v1 e deve ser adicionada em evolução versionada própria antes da implementação material.
-- Ativo alternativo específico para mobile não entra no contrato inicial; poderá ser avaliado em nova versão se houver evidência real.
+- Imagem e vídeo no mesmo slot usam `hero.standard`.
+- Galeria, carrossel e tour ficam fora.
+- `responsiveVisibility = all_viewports | desktop_only`.
+- `desktop_only` é escolha da E20, não variante.
+- Contrato só autoriza ocultação para mídia decorativa, complementar ou redundante; E19 valida a mídia concreta.
+- Capability responsiva depende de nova raiz.
 
 #### 2.7.7. Fronteira com formulário
 
-- CTA que leva, abre ou aciona formulário continua dentro de `hero.standard` por meio de `destinationRef`.
-- Formulário completo incorporado visualmente ao Hero não pertence ao contrato inicial de `hero.standard`.
-- A decisão padrão futura é representar captação ou qualificação como módulo próprio composto com o Hero pela E20.
-- Nenhum `moduleKey` novo para formulário é definido neste recorte.
-- Uma variante de Hero com formulário só poderá ser proposta se evidência posterior demonstrar que:
-  - a função principal continua sendo a do Hero;
-  - o formulário é subordinado e inseparável da abertura;
-  - a execução é reutilizável entre taxons;
-  - composição com módulo próprio é insuficiente;
-  - privacidade, validação, responsividade e campos possuem contrato fechado.
-- Nenhuma variante com formulário está aprovada na v1.
+- CTA pode acionar formulário quando a operação resolvida permitir.
+- O Hero não armazena `destinationRef`, URL ou destino.
+- Formulário completo fica fora de `hero.standard` e tende a módulo próprio composto pela E20.
+- Variante com formulário não está aprovada.
 
 #### 2.7.8. `copySourceMap` do Hero
 
-- `eyebrow`:
-  - primária: `end_customer.strategic_core.positioning_opportunity`;
-  - auxiliar: `end_customer.seo.search_intent`.
-- `title`:
-  - primárias: `end_customer.strategic_core.positioning_opportunity`, `end_customer.strategic_core.desire`;
-  - auxiliar: `end_customer.seo.commercial_keywords`.
-- `subtitle`:
-  - primárias: `end_customer.strategic_core.pain`, `end_customer.strategic_core.desire`;
-  - auxiliar: `end_customer.strategic_core.belief`.
-- labels de CTA:
-  - primária: `end_customer.strategic_core.trigger`;
-  - auxiliar: `end_customer.seo.search_intent`.
-- `proofShort`:
-  - orientadora primária: `end_customer.strategic_core.proof_type`;
-  - auxiliar: `end_customer.strategic_core.objection`;
-  - valor factual obrigatoriamente operacional.
-- Não recebem `copySourceMap`:
-  - `destinationRef`;
-  - `assetRef`;
-  - `mediaKind`;
-  - `accessibilityMode`;
-  - política de visibilidade responsiva.
+- `eyebrow`: `positioning_opportunity`; auxiliar `search_intent`.
+- `title`: `positioning_opportunity` e `desire`; auxiliar `commercial_keywords`.
+- `subtitle`: `pain` e `desire`; auxiliar `belief`.
+- labels: `trigger`; auxiliar `search_intent`; ação concreta exige entrada operacional.
+- `proofShort`: `proof_type`; auxiliar `objection`; fato sempre operacional.
+- `altText` depende do ativo/contexto real, não da pesquisa isolada.
+- Ativo, tipo de mídia, modo de acessibilidade, visibilidade, canal e destino não recebem `copySourceMap`.
 
 #### 2.7.9. Perfis de funil do Hero
 
-- BOFU:
-  - título direto e específico;
-  - subtítulo orientado à decisão;
-  - objeção principal tratada com clareza;
-  - CTA de alta intenção;
-  - prova curta quando houver fonte operacional real;
-  - sem promessa, urgência ou condição não sustentada.
-- MOFU:
-  - título orientado à diferenciação;
-  - subtítulo explicativo;
-  - CTA proporcional;
-  - prova contextual quando disponível;
-  - menor pressão comercial que BOFU.
-- TOFU:
-  - título orientado a contexto, problema ou desejo;
-  - subtítulo educativo;
-  - CTA de baixa fricção;
-  - sem urgência, escassez ou pressão artificial;
-  - prova curta apenas quando contribuir para confiança.
-- Os perfis usam o mesmo catálogo de campos e cardinalidades.
-- Perfil altera transformação da copy, não estrutura, identidade ou variante.
+- BOFU: direto, decisório e de alta intenção, sem alegação não sustentada.
+- MOFU: diferenciação e explicação, com pressão menor.
+- TOFU: contexto educativo e baixa fricção, sem pressão artificial.
+- Perfil altera copy, não campos, estrutura ou variante.
 
 #### 2.7.10. Variante `hero.standard`
 
-- `variantKey = hero.standard`.
-- `variantVersion = 1` proposta.
-- `compatibleModuleVersion = 1` proposta.
-- Representa a execução-base versionada do Hero.
-- Delta vazio é permitido.
-- Não altera campos, cardinalidades ou limites.
-- Mídia permanece opcional.
-- CTA secundário permanece opcional.
-- `mediaKind = image | video` não cria variante.
-- `responsiveVisibility = all_viewports | desktop_only` não cria variante.
+- `variantVersion = 1`, compatível com `moduleVersion = 1`.
+- Execução-base com delta vazio.
+- Mídia e CTA secundário permanecem opcionais.
+- Imagem, vídeo, funil, visibilidade e troca para `body.base` não criam variante.
 - `hero.media_split` permanece rejeitada.
-- Troca isolada para `body.base` não cria variante.
-- Variante específica de nicho, campanha, tráfego ou funil é proibida.
 
 #### 2.7.11. Lifecycle e compatibilidade do Hero
 
-- `moduleCatalogVersion = 1` proposta para o primeiro catálogo publicado.
-- `moduleVersion = 1` proposta.
-- `variantVersion = 1` proposta.
-- `rootVersion` permanece pendente da evolução que garanta:
-  - `body.editorialEmphasis`;
-  - capability de visibilidade responsiva, caso `desktop_only` permaneça no contrato aprovado.
-- Lifecycle inicial proposto do módulo:
-  - `experimental`.
-- Lifecycle inicial proposto da variante:
-  - `experimental`.
-- Propósito permitido inicialmente:
-  - `controlled_test`.
-- `new_use` permanece proibido até promoção.
-- Promoção para `validated` exige:
-  - LP real em conta de teste;
-  - revisão humana;
-  - validação visual, responsiva e editorial;
-  - ausência de falha estrutural;
-  - decisão humana registrada.
+- `moduleCatalogVersion`, `moduleVersion` e `variantVersion` iniciais: 1 propostos.
+- `rootVersion` depende das capabilities tipográfica e responsiva.
+- Raiz `hypothesis`: somente `controlled_test`; `validated`: conforme demais camadas; `deprecated`: somente `historical_read`.
+- Módulo e variante começam `experimental`; propósito inicial `controlled_test`.
+- Elegibilidade cruza raiz, compatibilidade raiz–catálogo, catálogo, módulo, variante e propósito.
+- Promoção exige LP real, revisão e decisão humanas.
 
-#### 2.7.12. Casos positivos do Hero
+#### 2.7.12. Casos executáveis da E18.5 para o Hero
 
-- Hero mínimo válido:
-  - `title`;
-  - `subtitle`;
-  - `primaryCta`;
-  - sem eyebrow, CTA secundário, prova curta ou mídia.
-- Hero completo válido:
-  - eyebrow;
-  - title;
-  - subtitle;
-  - CTA principal;
-  - CTA secundário;
-  - prova curta sustentada operacionalmente;
-  - mídia com acessibilidade válida.
-- Hero com imagem:
-  - `hero.standard`;
-  - `mediaKind = image`;
-  - `all_viewports` ou `desktop_only` autorizado.
-- Hero com vídeo:
-  - `hero.standard`;
-  - `mediaKind = video`;
-  - mesmo slot estrutural.
-- Exceção tipográfica válida:
-  - E20 seleciona `body.base`;
-  - opção autorizada;
-  - justificativa registrada;
-  - renderer recebe tratamento resolvido.
-- CTA para formulário válido:
-  - CTA usa `destinationRef` operacional;
-  - formulário permanece fora do contrato do Hero.
+- Aceitar exatamente os sete campos e `hero.standard` com delta vazio.
+- Rejeitar campo, cardinalidade, policy, fonte, tratamento ou variante inválidos.
+- Falhar sem capabilities exigidas e sem fallback.
+- Garantir que CTA não armazene canal/destino.
+- Garantir labels e `proofShort` como `hybrid`.
+- Validar contrato abstrato de mídia, acessibilidade e responsividade.
+- Incluir raiz na elegibilidade e retornar resultado imutável.
 
-#### 2.7.13. Casos negativos do Hero
+#### 2.7.13. Invariantes futuras de conteúdo para E19
 
-- Estrutura inválida:
-  - ausência de `title`, `subtitle` ou `primaryCta`;
-  - mais de um título, mídia ou CTA secundário.
-- Origem inválida:
-  - prova concreta criada apenas a partir de `proof_type`;
-  - credencial, métrica ou condição inventada;
-  - destino do CTA inventado pela pesquisa;
-  - mídia sem referência operacional.
-- Tipografia inválida:
-  - raiz sem `body.editorialEmphasis`;
-  - tratamento não autorizado;
-  - fallback automático;
-  - renderer escolhendo tratamento.
-- Mídia inválida:
-  - `mediaKind` desconhecido;
-  - mídia informativa sem alternativa acessível;
-  - `desktop_only` ocultando informação essencial;
-  - galeria, carrossel ou tour tratados como mídia única do Hero.
-- Variante inválida:
-  - variante específica de corretor de imóveis;
-  - variante criada apenas por funil, imagem, vídeo ou visibilidade responsiva;
-  - variante com campo não previsto;
-  - variante redundante com delta vazio sem função de base autorizada.
-- Formulário inválido:
-  - formulário completo adicionado silenciosamente a `hero.standard`;
-  - variante de formulário criada sem análise estrutural própria.
+Não criam agora schema ou validador de conteúdo na E18.5:
+
+- título, subtítulo e CTA principal concretos conforme cardinalidade;
+- label compatível com canal, ação e destino resolvidos;
+- prova concreta sustentada;
+- ativo de mídia válido;
+- imagem informativa com `altText` e decorativa com `altText = ""`;
+- vídeo com alternativa acessível;
+- `desktop_only` sem ocultar informação essencial;
+- ausência de formulário completo, galeria, carrossel ou tour dentro de `hero.standard`.
 
 #### 2.7.14. Critérios de fechamento do Hero
 
-O Hero estará fechado para avaliação final quando forem aprovados:
+Fechar após aprovação de:
 
-- identidade e função;
-- fronteiras;
-- sete campos e seus contratos internos;
-- cardinalidades;
-- políticas de origem;
-- `copySourceMap`;
-- perfis de funil;
-- contrato de mídia e acessibilidade;
-- decisão sobre `desktop_only` e sua capability de raiz;
-- fronteira com formulário;
-- `hero.standard` com delta vazio;
-- versões e compatibilidades;
-- lifecycle experimental;
-- casos positivos e negativos.
+- identidade, evidência, fronteiras, sete campos e cardinalidades;
+- matriz de policies e fontes;
+- CTA sem destino concreto e contrato da ação secundária;
+- mídia e acessibilidade, inclusive vídeo;
+- visibilidade responsiva e nova raiz;
+- variante, versões, lifecycle e compatibilidades;
+- casos E18.5 e invariantes E19.
 
-Estado atual:
+Estado:
 
-- módulo e variante registrados como proposta consolidada para avaliação e ajustes;
-- nenhuma implementação autorizada;
-- próxima decisão humana: aprovar ou ajustar a grade do Hero antes de iniciar `trust_bar`.
+- `hero_segmentado` comprovado e rastreável;
+- labels e `proofShort` corrigidos para `hybrid`;
+- destino removido do registry;
+- acessibilidade de imagem registrada;
+- ação secundária e acessibilidade de vídeo ainda pendentes;
+- Hero ainda não fechado e implementação bloqueada.
 
 ### 2.8. `copy_source_map`
 
-- Cada referência declara público, bloco, `itemKey` e papel primário ou auxiliar.
-- Cada campo usa até duas fontes primárias e uma auxiliar.
-- Copy para visitante usa `end_customer` como fonte primária.
-- `business_buyer` pode auxiliar somente autoridade, processo, posicionamento ou prova institucional.
-- `strategic_core` e `seo` fornecem insumos aplicáveis de pesquisa.
-- `lp_overview` orienta transformação.
-- `lp_sections` comprova funções estruturais, mas não vira fonte fixa de copy.
-- Chave desconhecida e fato operacional inferido falham fechado.
+- Até duas fontes primárias e uma auxiliar por campo.
+- `end_customer` é fonte primária; `business_buyer` só auxilia autoridade, processo, posicionamento ou prova institucional.
+- `lp_sections` comprova função, não vira fonte fixa de copy.
+- Policies controlam quando `copySourceMap` é permitido.
 
 ### 2.9. `funnel_copy_profile`
 
-- Perfis: `bofu`, `mofu`, `tofu`.
-- Perfil orienta transformação, sem alterar schema, cardinalidade, limite, identidade do módulo ou estrutura aprovada.
-- Módulo adapta o perfil à função.
-- Variante apenas restringe ou especializa tratamento permitido quando houver mudança comportamental comprovada.
+- Perfis `bofu`, `mofu`, `tofu`.
+- Perfil altera transformação, nunca schema, cardinalidade, módulo ou variante.
 
 ### 2.10. Tratamentos comerciais
 
-- Promessa, prova, autoridade, credencial, comparação, preço, oferta, desconto, garantia, urgência, escassez, resultado, depoimento e métrica exigem fonte real aplicável.
-- Pesquisa não fornece como fato preço, condição, prazo, disponibilidade, garantia, credencial, depoimento, métrica, contato, endereço, URL ou informação legal específica.
-- Valor factual exige entrada operacional futura.
-- BOFU não autoriza alegação não sustentada.
-- TOFU não admite pressão artificial.
+- Prova, credencial, preço, oferta, garantia, urgência, resultado, depoimento e métrica exigem fonte real.
+- Pesquisa não cria fato operacional.
+- Label que nomeia canal ou ação concreta exige capacidade operacional correspondente.
 
 ### 2.11. Lifecycle e compatibilidade
 
-- Lifecycle: `candidate`, `experimental`, `validated`, `deprecated`.
-- Propósitos: `controlled_test`, `new_use`, `historical_read`.
-- `candidate` não entra em composição ou geração.
-- `experimental` serve a teste controlado.
-- `validated` permite novo uso quando todas as camadas aplicáveis também permitirem.
-- `deprecated` não entra em novo uso, mas permanece resolvível historicamente.
-- O catálogo declara compatibilidade entre `moduleCatalogVersion` e `rootVersion`.
-- A variante declara compatibilidade com `moduleVersion`.
-- A elegibilidade efetiva é a interseção das permissões de catálogo, módulo, variante e propósito; não será calculada por ordenação textual simples dos estados.
-- Exemplos:
-  - módulo `experimental` e variante `validated` permitem `controlled_test`, mas não `new_use`;
-  - módulo `deprecated` e variante `validated` permitem `historical_read`, mas não `new_use`;
-  - módulo `candidate` bloqueia qualquer resolução para uso.
-- Versões efetivas serão preservadas em snapshot futuro.
+- Raiz: `hypothesis | validated | deprecated`.
+- Catálogo, módulo e variante: `candidate | experimental | validated | deprecated`.
+- Propósitos: `controlled_test | new_use | historical_read`.
+- Elegibilidade é interseção de raiz, compatibilidade, catálogo, módulo, variante e propósito.
+- `candidate` bloqueia uso; `experimental` permite teste; `deprecated` só permite histórico.
 
 ### 2.12. Contrato de resolução previsto
 
-Resolver previsto: `resolveLandingPageModuleVariant(...)`.
-
-Entrada:
-
-- `rootVersion`;
-- `moduleCatalogVersion`;
-- `moduleKey`;
-- `variantKey`;
-- `purpose`.
+Entrada: `rootVersion`, `moduleCatalogVersion`, `moduleKey`, `variantKey`, `purpose`.
 
 Processamento:
 
-1. resolver raiz;
-2. validar compatibilidade do catálogo com a raiz;
-3. resolver módulo e sua versão pelo catálogo imutável;
-4. validar referências, campos e policies;
-5. resolver variante e validar compatibilidade com `moduleVersion`;
-6. validar e aplicar delta, inclusive delta vazio autorizado da variante-base;
-7. aplicar precedência;
-8. calcular contrato final;
-9. calcular elegibilidade pela interseção de permissões;
-10. retornar resultado imutável.
+1. resolver raiz, lifecycle e propósito;
+2. validar compatibilidade do catálogo;
+3. resolver módulo;
+4. validar evidências, campos, policies e matriz;
+5. resolver variante e compatibilidade;
+6. aplicar delta válido;
+7. calcular contrato e elegibilidade;
+8. retornar resultado imutável.
 
-A saída contém identidades, versões, lifecycle, elegibilidade efetiva, função, campos, cardinalidades, papéis, fontes, policies, tratamentos e limites efetivos; não contém deltas ou fallback para o consumidor.
+A saída não contém deltas, canal, destino concreto ou fallback.
 
 ### 2.13. Artefatos previstos
 
-Após a evolução da raiz e o merge da v2:
+Após raiz e v2:
 
-- `lib/conversion-content/landing-page/module-catalog/contracts.ts`;
+- `module-catalog/contracts.ts`;
 - `registry.ts`;
 - `schema.ts`;
 - `resolver.ts`;
 - `validation-cases.ts`;
 - `index.ts`.
 
-Ajustar somente `lib/conversion-content/index.ts`, `package.json` e o estado deste plano.
-
-Preservar `landingPageRoot`, versões históricas e `commercial_activation`.
-
-Interface prevista: `landingPageModules`.
-
-Script previsto: `validate:landing-page-modules`.
+Interface: `landingPageModules`. Script: `validate:landing-page-modules`.
 
 #### 2.13.1. Evolução futura do catálogo
 
-- A operação comum de criação de módulo ou variante será declarativa e versionada no repositório.
-- Novo módulo compatível exigirá normalmente:
-  - registrar módulo, versão, evidências e variante inicial em `registry.ts`;
-  - adicionar casos positivos e negativos em `validation-cases.ts`;
-  - publicar nova `moduleCatalogVersion` preservando catálogos anteriores.
-- Nova variante compatível exigirá normalmente:
-  - registrar variante e versão em `registry.ts`;
-  - vinculá-la ao módulo e à versão compatíveis;
-  - adicionar casos em `validation-cases.ts`;
-  - publicar nova `moduleCatalogVersion`.
-- `contracts.ts`, `schema.ts` e `resolver.ts` não mudam quando a necessidade couber no contrato fechado existente.
-- Campo novo em módulo publicado exige nova `moduleVersion`.
-- Novo `fieldKind`, policy, delta, comportamento ou forma de resolução exige evolução explícita de contrato, schema, resolver, registry e validações.
-- Capability comum ausente exige evolução da raiz e nova `rootVersion`.
-- Uso por taxon, ordem, obrigatoriedade e escolhas por ocorrência pertencem à E20.
-- Toda evolução ocorre por branch, PR, revisão e validações executáveis.
-- No MVP não haverá cadastro dinâmico no banco, Admin de contratos, mutação em runtime ou criação automática por taxon ou pesquisa.
-- Alteração de infraestrutura será exceção; extensão rotineira ficará no registry, validações e versionamento.
+- Extensão comum ocorre por registry, casos e nova versão aplicável.
+- Campo novo exige nova `moduleVersion`; capability comum exige nova `rootVersion`.
+- Contrato, schema e resolver só mudam quando a necessidade não couber no contrato fechado.
+- Sem cadastro dinâmico, mutação runtime ou criação automática no MVP.
 
 ### 2.14. Validações mínimas previstas
 
-- Catálogo e versões válidos.
-- Cada módulo publicado foi individualmente aprovado a partir da grade candidata.
-- Rejeição ou fusão de candidato possui decisão humana registrada.
-- Nenhum módulo carrega identidade de taxon.
-- `structuralEvidenceRefs` válidas e `itemKey` não usado como identidade automática.
-- Compatibilidade entre `moduleCatalogVersion` e `rootVersion` validada.
-- Compatibilidade entre variante e `moduleVersion` validada.
-- `fieldKind` conhecido e contrato condicional correto.
-- Campo textual sem `semanticRole` falha.
-- Campo não textual obrigado a ter `semanticRole` falha.
-- Cardinalidade inválida ou propriedade `required` falha.
-- `operationalValuePolicy` desconhecida falha.
-- Fato operacional originado apenas da pesquisa falha.
-- Referência, tratamento, módulo, variante ou campo desconhecido falha.
-- Tratamento padrão fora da lista permitida falha.
-- Ausência de capability exigida e fallback automático falham.
-- Delta vazio é aceito somente para variante-base autorizada.
-- Variante redundante sem diferença nem função de base autorizada falha.
-- Tipo de mídia desconhecido falha.
-- Política responsiva desconhecida falha.
-- `desktop_only` com conteúdo essencial falha.
-- Formulário completo em `hero.standard` falha.
-- Faixa, limite e comportamento inválidos falham.
-- Valor da raiz não é duplicado.
-- Fontes excedentes ou `itemKey` desconhecido falham.
-- `business_buyer` indevido falha.
-- Elegibilidade incompatível com o propósito falha.
-- Módulo `candidate` não resolve para uso.
-- Módulo ou variante `deprecated` não resolve para `new_use`.
-- Resultado é profundamente imutável.
-- Versão antiga permanece resolvível.
-- Versão publicada de catálogo, módulo ou variante não pode ser sobrescrita.
-- Extensão declarativa compatível não exige alteração do contrato, schema ou resolver.
-- Mudança de contrato sem nova versão aplicável falha.
-- Sem imports de banco, Supabase, env, API, renderer, rota ou Admin.
+Validações E18.5:
+
+- versões, evidências, compatibilidades e lifecycle válidos;
+- campos, cardinalidades, policies, fontes e tratamentos válidos;
+- matriz de policy respeitada;
+- nenhum destino concreto de CTA no registry;
+- capabilities exigidas sem fallback;
+- delta vazio somente na base autorizada;
+- contrato abstrato de mídia e acessibilidade válido;
+- formulário completo não adicionado ao Hero;
+- resultado imutável, versões históricas preservadas e sem imports fora do boundary.
+
+#### 2.14.1. Invariantes futuras para E19
+
+- presença e consistência do conteúdo concreto;
+- CTA vinculado à operação real;
+- prova sustentada;
+- ativo e acessibilidade válidos;
+- ocultação responsiva sem perda de informação;
+- ausência de estrutura não autorizada no Hero.
 
 ### 2.15. Fluxo operacional
 
-- Gatilho:
-  - evolução da raiz mergeada;
-  - plano v2 mergeado;
-  - fase instruída.
-- Entrada:
-  - raiz compatível;
-  - plano E18.5;
-  - catálogo aprovado derivado da grade candidata;
-  - `item_key` oficiais;
-  - decisões humanas registradas.
-- Processamento:
-  - contratos, registry, schema, resolver, evidências, fields, policies, deltas, mapas, perfis, lifecycle e casos executáveis.
-- Validação:
-  - `npm ci`;
-  - `npm run validate:landing-page-root`;
-  - `npm run validate:landing-page-modules`;
-  - `npm run validate:commercial-activation`;
-  - `npm run check`;
-  - `git diff --check`;
-  - checks do PR.
-- Persistência: repositório, sem banco.
-- Consumo: E20 e E19 futuramente.
-- Fallback: falha fechada.
+- Gatilho: raiz e plano v2 mergeados, fase instruída.
+- Entrada: raiz compatível, catálogo aprovado, itens oficiais e decisões humanas.
+- Processamento: contratos, registry, resolver, policies, mapas, lifecycle e casos E18.5.
+- Validação: `npm ci`, validações da raiz/módulos/commercial activation, `npm run check`, `git diff --check` e checks do PR.
+- Persistência: repositório; consumo futuro: E20 e E19; fallback: falha fechada.
 
 ## 3. Fases e próxima ação
 
 ### 3.1. E18.5.3–E18.5.9 — Catálogo versionado de módulos e variantes v1
 
-- Status:
-  - pendente;
-  - bloqueada até fechar a grade, mergear a evolução da raiz e consolidar a v2.
-- Automação: não.
-- Risco: médio controlado.
-- Objetivo: implementar o contrato repo-only dos módulos e variantes iniciais individualmente aprovados.
-- Critérios de aceite:
-  - grade metodológica comum aplicada;
-  - módulos transversais individualmente aprovados;
-  - nenhuma duplicação da raiz;
-  - compatibilidade e capabilities validadas;
-  - Hero e `hero.standard` conforme contrato aprovado;
-  - catálogo imutável e resolver fail-closed;
-  - extensão futura comum pelo registry e casos de validação;
-  - evolução de infraestrutura somente quando o contrato fechado não atender;
-  - nenhum taxon, composição, banco, renderer ou geração.
+- Status pendente e bloqueado até grade fechada, raiz evoluída e v2 consolidada.
+- Automação: não. Risco: médio controlado.
+- Aceite: módulos aprovados, sem duplicação da raiz/E20.2, compatibilidade validada, Hero conforme contrato, resolver fail-closed e separação E18.5/E19.
 - Próxima ação:
-  - avaliar e ajustar a grade consolidada do Hero;
-  - fechar o Hero por decisão humana;
-  - somente depois iniciar `trust_bar`;
-  - seguir módulo por módulo na ordem da grade;
-  - dividir depois em fases executáveis;
-  - concluir as evoluções necessárias da raiz;
-  - realizar avaliação única dos especialistas;
-  - consolidar v2 e solicitar merge humano.
+  - fechar ação secundária;
+  - fechar acessibilidade de vídeo;
+  - reavaliar Hero;
+  - depois iniciar `trust_bar` e seguir a grade;
+  - concluir raiz, pareceres, v2 e merge humano.
 
 ## 4. Escopo negativo e critérios de parada
 
 ### 4.1. Fora do escopo
 
-- Implementação da evolução da raiz no PR #577.
-- Valores concretos da nova raiz.
-- Módulos identificados por corretor, imóveis, médio padrão ou outro taxon.
-- Implementação específica dos taxons usados como evidência.
-- Cadastro dinâmico de módulos ou variantes no banco ou Admin.
-- Catálogo de entradas, valores reais, taxonomia ou resolução de pesquisas.
-- Composição, ordem global, prontidão de taxon ou conta de teste.
-- Geração, IA, prompt, schema final, renderer, render model ou publicação.
-- Tracking, analytics, teste A/B, Admin, Builder ou editor visual.
-- Banco, migration, RPC, policy, grant, trigger, storage ou upload.
-- CRM, webhook, job, agente, automação, workflow ou nova infraestrutura.
-- Nova dependência, bundler ou alteração em `commercial_activation`.
-- Criação de módulo de formulário neste recorte.
-- Aprovação de galeria, carrossel ou tour como campo do Hero.
+- Implementação da raiz no PR #577.
+- Banco, composição, geração, renderer, Admin, Builder, tracking, automação ou nova infraestrutura.
+- Módulo de formulário, galeria, carrossel ou tour neste recorte.
+- Persistência nova para justificativa da composição.
 
 ### 4.2. Critérios de parada
 
 Parar se:
 
-- a raiz compatível não estiver mergeada ou não garantir a capability;
-- surgir fallback automático;
-- módulo ou variante depender do taxon usado como evidência;
-- surgir necessidade de banco, composição, geração ou renderer;
-- faltar `item_key` oficial;
-- diferença puder ser atendida por conteúdo, parâmetro ou composição;
-- houver ampliação de limite absoluto;
-- houver tentativa de sobrescrever catálogo, módulo ou variante já publicado;
-- uma necessidade nova exigir alteração de contrato sem versionamento próprio;
-- formulário completo for incorporado silenciosamente ao Hero;
-- mídia essencial for ocultada no mobile;
-- houver conflito com E18.4, E20, E19 ou `commercial_activation`;
-- surgir nova dependência ou artefato fora do escopo;
-- preservação histórica não puder ser garantida.
+- raiz/capability/lifecycle não estiverem resolvidos;
+- surgir fallback, dependência de taxon ou ampliação de limite;
+- faltar evidência oficial;
+- destino concreto entrar no registry;
+- formulário ou mídia essencial forem tratados incorretamente;
+- validação de conteúdo for antecipada na E18.5;
+- houver conflito de fronteiras ou perda histórica.
 
 ### 4.3. Decisão atual
 
-- PR #577 preservado e plano-base mantido em v1.
-- Fonte principal: `Corretor Imóveis`, `end_customer`, `lp_sections` v1 ativa.
-- Fonte complementar: `Corretor de imóveis de médio padrão`.
-- Grade metodológica comum registrada para todos os módulos.
-- A grade comum possui núcleo obrigatório e blocos condicionais.
-- Grade inicial limitada aos candidatos:
-  - `hero`;
-  - `trust_bar`;
-  - `problem_solution`;
-  - `offer`;
-  - `process`;
-  - `technical_assurance`;
-  - `social_proof`;
-  - `faq`;
-  - `final_cta`.
-- Os módulos serão transversais e reutilizáveis na família `landing_page`.
-- `formato_curto`, `formato_medio` e `formato_longo` não são módulos.
-- Hero registrado com sete campos, mídia opcional e fronteira explícita com formulário.
-- `mediaKind = image | video` não cria variante.
-- `all_viewports | desktop_only` é escolha responsiva por ocorrência, dependente de capability futura da raiz, e não cria variante.
-- Formulário completo não pertence a `hero.standard`.
-- `hero.standard` é a única variante inicial e possui delta vazio autorizado.
-- `body.editorialEmphasis` é padrão; `body.base` é alternativa explícita; fallback é proibido.
-- Lifecycle inicial proposto do Hero e da variante: `experimental`.
-- A criação futura comum de módulos e variantes será declarativa em `registry.ts`, acompanhada de casos em `validation-cases.ts` e nova versão aplicável.
-- `contracts.ts`, `schema.ts` e `resolver.ts` só serão alterados quando a necessidade não couber no contrato fechado existente.
-- Versões publicadas são imutáveis; campo novo exige nova `moduleVersion` e capability comum exige nova `rootVersion`.
-- Uso por taxon pertence à composição da E20.
-- A implementação permanece bloqueada.
-- Próxima decisão humana: avaliar e ajustar o Hero antes de iniciar `trust_bar`.
+- PR #577 permanece em v1 e sem implementação autorizada.
+- `hero_segmentado` está comprovado e rastreável.
+- Grade comum e nove candidatos permanecem.
+- Hero conserva sete campos e `hero.standard` com delta vazio.
+- Labels e `proofShort` usam `hybrid`; canal/destino ficam fora do registry.
+- Imagem/vídeo e visibilidade responsiva não criam variante.
+- Formulário completo fica fora do Hero.
+- Elegibilidade inclui a raiz; E18.5 e E19 estão separadas.
+- Hero ainda não está fechado por ação secundária e acessibilidade de vídeo.
+- Próxima decisão humana: fechar esses pontos e reavaliar antes de `trust_bar`.

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -1,10 +1,10 @@
 14/07/2026 — Plano-base E18.5 — Parametrização de módulos e variantes `landing_page`
 
-Fontes: chat, `README.md`, `AGENTS.md`, `docs/prompt-estrategista.md`, `docs/template-roadmap.md`, `docs/template-briefing-codex.md`, `docs/prompt-executor.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/schema.md`, `docs/lp-planejamento.md`, `docs/lousa-plano-base-e18-4.md`, `docs/template-blueprint.md`, `docs/blueprint-corretor-imoveis-end-customer.md`, `docs/prompt-nicho-itens-estruturados.md`, `lib/conversion-content/landing-page/`, `lib/conversion-content/commercial-activation/`, `lib/conversion-content/commercial-activation/composition.ts`, PRs #559, #563, #564, #566 e #567 e estado atual do repositório.
+Fontes: chat, `README.md`, `AGENTS.md`, `docs/prompt-estrategista.md`, `docs/template-roadmap.md`, `docs/template-briefing-codex.md`, `docs/prompt-executor.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/schema.md`, `docs/lp-planejamento.md`, `docs/lousa-plano-base-e18-4.md`, `docs/template-blueprint.md`, `docs/blueprint-corretor-imoveis-end-customer.md`, `docs/prompt-nicho-itens-estruturados.md`, `lib/conversion-content/landing-page/`, contratos atuais de templates, compositions e módulos, PRs #559, #563, #564, #566, #567 e #577, avaliação do Analista e decisões humanas de 14/07/2026.
 
-Versão: v1.
+Versão: v1 em ajuste.
 
-Status: plano-base inicial para avaliação única do Analista, Gestor Estrutural e Gestor de Updates; nenhuma implementação autorizada antes da consolidação v2 e do merge deste plano na `main`.
+Status: PR vivo para debate e avaliação; correções conceituais do Analista incorporadas nesta v1; plano-base v2 ainda não consolidado; nenhuma implementação autorizada antes da consolidação v2 e do merge humano do PR #577.
 
 Path: `docs/lousa-plano-base-e18-5.md`.
 
@@ -14,1174 +14,628 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 
 ### 1.1. Pré-requisitos confirmados
 
-- O PR #559 foi mergeado na `main` em 13/07/2026 e criou conceitualmente o recorte `18.5`.
+- O PR #559 foi mergeado na `main` em 13/07/2026.
 - A E18.4 foi concluída, aprovada, documentada e formalmente encerrada.
 - A parametrização raiz v1 está implementada em `lib/conversion-content/landing-page/`.
-- O contrato raiz possui:
-  - registry versionado;
-  - schema estrito;
-  - resolver fail-closed;
-  - saída profundamente imutável;
-  - papéis semânticos;
-  - faixas editoriais recomendadas;
-  - limites técnicos absolutos;
-  - opções comuns de espaçamento;
-  - critérios visuais, responsivos e de acessibilidade;
-  - presets `balanced` e `compact`.
-- A precedência obrigatória está consolidada como:
+- A raiz possui registry versionado, schema estrito, resolver fail-closed, saída profundamente imutável, papéis semânticos, faixas editoriais recomendadas, limites técnicos absolutos, opções comuns de espaçamento, critérios visuais e presets.
+- A precedência obrigatória é:
   - parametrização raiz;
   - módulo;
   - variante.
-- A E18.5 não pode ampliar limite técnico absoluto acima da raiz vigente.
-- Ampliação acima do teto da raiz exige nova `rootVersion`.
-- A revisão futura de uma restrição própria de módulo ou variante dentro do teto da raiz exige nova versão do respectivo contrato da E18.5.
 - `commercial_activation`, E18.2 e E18.3 permanecem integralmente preservados.
 
-### 1.2. Estado técnico confirmado
+### 1.2. Estado processual
 
-- O boundary raiz atual é `lib/conversion-content/landing-page/`.
-- O namespace público atual da parametrização raiz é `landingPageRoot`.
-- Não existem atualmente módulos, variantes, schemas de conteúdo por variante, composição, renderer ou render model para `landing_page`.
-- O banco possui estruturas transversais já existentes:
-  - `content_templates`;
-  - `content_template_compositions`;
-  - `content_template_composition_items`;
-  - `content_artifacts`;
-  - `content_artifact_research_sources`.
-- `content_template_composition_items` já representa, no nível de composição:
+- O plano-base v1 e o PR #577 já existem.
+- O debate conceitual permanece aberto para fechar o contrato da E18.5.
+- As decisões aprovadas neste debate devem ser incorporadas no mesmo PR.
+- Não reiniciar o fluxo em novo arquivo ou novo PR.
+- A versão v2 será declarada somente após:
+  - conclusão do debate necessário;
+  - recebimento dos pareceres aplicáveis;
+  - consolidação única dos retornos;
+  - decisão humana sobre os pontos pendentes.
+- O Executor não pode ser instruído antes do merge humano da v2.
+
+### 1.3. Princípio canônico de herança
+
+- A raiz contém todas as regras comuns da família `landing_page`.
+- O módulo não repete valores da raiz.
+- O módulo declara:
+  - função estrutural;
+  - catálogo fechado de campos;
+  - associação de cada campo a um papel semântico da raiz;
+  - cardinalidade;
+  - fontes de copy;
+  - política de valor operacional;
+  - somente exceções próprias e justificadas.
+- A variante não repete o módulo.
+- A variante declara somente deltas fechados e tipados sobre campos já previstos pelo módulo.
+- O resolver aplica:
+  - raiz;
   - módulo;
-  - `variant_key`;
-  - ordem;
-  - obrigatoriedade;
-  - `config_json`.
-- Essas estruturas não autorizam criar registros de `landing_page` nesta fase.
-- A E18.5 define contratos repo-only reutilizáveis.
-- A criação de composição concreta e registros por taxon pertence à E20.
-- A geração, o snapshot e o consumo de LPs por conta pertencem à E19.
-- A persistência mínima atual de `account_landing_pages` contém apenas identidade básica e status `draft`; não deve ser ampliada neste recorte.
+  - variante.
+- O consumidor recebe o contrato efetivo completo e profundamente imutável.
+- E20, E19, geração, validação e renderer futuros não podem reaplicar a herança por conta própria.
 
-### 1.3. Problema a resolver
+### 1.4. Regras de exceção
 
-- A raiz define regras comuns, mas ainda não existe contrato aprovado para:
-  - funções estruturais dos módulos;
-  - campos de cada módulo;
-  - estruturas e cardinalidades;
-  - variantes reutilizáveis;
-  - especializações excepcionais sobre a raiz;
-  - origem estruturada da copy;
-  - transformação da copy por BOFU, MOFU e TOFU;
-  - tratamentos comerciais permitidos, restritos e proibidos;
-  - compatibilidade entre versões;
-  - ciclo de vida, depreciação e preservação histórica.
-- Sem esse contrato, E20 não pode montar composição base segura.
-- Sem esse contrato, E19 não pode gerar, validar ou renderizar LPs sem recriar regras independentes.
-- Reaproveitar diretamente os contratos de `commercial_activation` criaria acoplamento incorreto entre famílias distintas.
-- Recriar o catálogo removido da antiga E18.4 sem nova decisão repetiria a antecipação que a E18.4 corrigiu.
+- Campo sem exceção herda integralmente a raiz.
+- Módulo pode restringir a raiz quando a função estrutural justificar.
+- Variante pode restringir o módulo quando sua execução reutilizável justificar.
+- Módulo ou variante não pode ampliar limite técnico absoluto da raiz.
+- Necessidade acima do limite absoluto deve primeiro avaliar:
+  - revisão do texto;
+  - divisão do conteúdo;
+  - mudança do papel semântico;
+  - nova estrutura do módulo.
+- Nova `rootVersion` só deve ser avaliada quando a necessidade comum e comprovada não puder ser atendida pelas alternativas anteriores.
+- Ultrapassar faixa recomendada, permanecendo dentro do limite absoluto, não torna o conteúdo inválido e não cria variante automaticamente.
+- Diferença apenas de taxon, conteúdo, campanha, entrada da conta, origem de tráfego, funil ou composição não cria módulo nem variante.
 
-### 1.4. Resultado esperado
+### 1.5. Decisões técnicas incorporadas
 
-- Criar uma fonte repo-only versionada para módulos e variantes de `landing_page`.
-- Definir um catálogo inicial pequeno, suficiente para uma primeira LP real de teste.
-- Definir a função estrutural de cada módulo.
-- Definir campos, tipos estruturais e cardinalidades por variante.
-- Derivar regras editoriais e técnicas da parametrização raiz.
-- Registrar somente especializações justificadas.
-- Definir `copy_source_map` com `research_block`, `item_key`, `audience_scope` e papel da fonte.
-- Definir `funnel_copy_profile` para BOFU, MOFU e TOFU.
-- Impedir copy comercial não sustentada por fonte real.
-- Definir resolução determinística e fail-closed de raiz, catálogo, módulo, variante e propósito de uso.
-- Preservar contratos antigos para renderização histórica.
-- Entregar validação executável sem criar renderer, composição, geração ou persistência.
+- Valores já existentes na raiz não serão copiados para módulos ou variantes.
+- Especializações numéricas gerais observadas apenas no primeiro Blueprint não entram automaticamente no contrato.
+- Obrigatoriedade e quantidade serão representadas somente por cardinalidade:
+  - `{ min: 1, max: 1 }` para campo único obrigatório;
+  - `{ min: 0, max: 1 }` para campo único opcional;
+  - `{ min, max }` para coleções.
+- Não haverá propriedade `required` separada.
+- Não haverá objeto livre `structuralRules`.
+- Não haverá `addedFields` livre em variantes.
+- Campo realmente novo exige nova versão do contrato do módulo.
+- `structuralBehavior`, caso necessário, deverá ser união fechada, aprovada e validável.
+- Deltas de variante são internos ao registry e ao resolver.
+- O contrato público resolvido não expõe operações de delta para o consumidor aplicar.
+- A E18.5 associa campos a papéis semânticos, mas não cria agora mapeamento tipográfico como `paragraph → body.base`.
+- O Hero v1 não exige `body.editorialEmphasis`.
+- A E18.5 não altera a raiz para tornar `editorialEmphasis` obrigatório.
+- O futuro renderer deverá consumir a raiz e definir o mapeamento visual por contrato próprio, sem hardcode independente.
+- `hero.media_split` não está aprovada.
+- Mídia obrigatória, isoladamente, não comprova uma variante.
+- O catálogo inicial pode ter apenas uma variante para determinado módulo.
 
-### 1.5. Usuários e consumidores
+### 1.6. Estado técnico confirmado
 
-- Usuários diretos:
-  - Estrategista;
-  - Analista;
-  - Executor;
-  - futuros implementadores da E20 e E19.
-- Consumidores técnicos futuros:
-  - composição base da E20;
-  - schemas de conteúdo da E19;
-  - geração de copy da E19;
-  - validação de conteúdo;
-  - renderer;
-  - snapshot da LP;
-  - auditoria de compatibilidade.
-- O cliente final não interage diretamente com este recorte.
-
-### 1.6. Decisões de fronteira
-
-- Módulo representa uma função estrutural reutilizável da LP.
-- Variante representa mudança reutilizável de execução, estrutura ou comportamento dentro da mesma função do módulo.
-- Nova função estrutural deve ser avaliada como novo módulo.
-- Não usar módulo ou variante para representar:
-  - taxon;
-  - segmento, nicho ou ultranicho;
-  - conteúdo específico;
-  - entrada da conta;
-  - campanha;
-  - origem de tráfego;
-  - intenção BOFU, MOFU ou TOFU;
+- Boundary raiz atual:
+  - `lib/conversion-content/landing-page/`.
+- Namespace público atual:
+  - `landingPageRoot`.
+- Não existem atualmente para `landing_page`:
+  - catálogo de módulos;
+  - variantes;
+  - schemas finais de conteúdo;
   - composição;
-  - ordem da seção;
-  - obrigatoriedade da seção;
-  - diferença já atendida por campo, cardinalidade, opção ou parâmetro existente.
-- BOFU, MOFU e TOFU são perfis de transformação da copy, não variantes.
-- Google Ads, Meta Ads, SEO, WhatsApp, link na bio e QR Code são origens de tráfego ou distribuição, não variantes.
-- Os dados reais de preço, oferta, prova, credencial, garantia, contato, mídia e compliance não pertencem ao registry; pertencem às entradas operacionais e ao snapshot futuro.
-- `copy_source_map` autoriza fontes estruturadas, mas não cria fatos.
-- `funnel_copy_profile` transforma insumos, mas não substitui fonte obrigatória.
-- `lp_sections` orienta composição na E20; suas chaves dinâmicas não entram como fonte fixa de copy por campo na E18.5.
-- `lp_overview` orienta contexto geral da página e da transformação; não deve ser usado para inventar alegações factuais.
-- O registry da E18.5 não consulta banco, env, API ou arquivo remoto em runtime.
+  - renderer;
+  - render model.
+- O banco possui estruturas transversais de templates e compositions, mas elas não autorizam registros de `landing_page` nesta fase.
+- A E18.5 será repo-only.
+- Composição concreta e registros por taxon pertencem à E20.
+- Geração, snapshot, persistência e ciclo das LPs por conta pertencem à E19.
+- `account_landing_pages` não será alterada neste recorte.
 
-### 1.7. Base de evidência
+### 1.7. Pontos ainda em debate
 
-- Fonte conceitual principal:
-  - `docs/lp-planejamento.md`.
-- Fonte normativa da raiz:
-  - `docs/lousa-plano-base-e18-4.md`;
-  - implementação atual de `landingPageRoot`.
-- Fonte dos `research_block` e `item_key`:
-  - `docs/prompt-nicho-itens-estruturados.md`.
-- Fonte empírica parcial inicial:
-  - `docs/blueprint-corretor-imoveis-end-customer.md`.
-- Referência estrutural já implementada, sem reaproveitamento automático:
-  - `commercial_activation`.
-- O blueprint imobiliário sustenta como referência inicial:
-  - Hero com recorte claro;
-  - mídia principal;
-  - benefícios ou diferenciais objetivos;
-  - localização;
-  - qualificação simples ou progressiva;
-  - prova;
-  - FAQ;
-  - CTA;
-  - confiança e compliance.
-- A evidência é parcial e concentrada em um nicho.
-- Por isso:
-  - nenhum módulo é específico de imóveis;
-  - nenhum campo recebe semântica imobiliária;
-  - nenhuma variante é nomeada por nicho, produto, campanha ou canal;
-  - os contratos iniciais permanecem em lifecycle experimental ou candidato até LP real validada.
-
-### 1.8. Roadmap e gate documental
-
-- Seção afetada:
-  - E18 — Base transversal de templates, módulos, composições e artefatos.
-- Recorte:
-  - `18.5 — Parametrização de módulos e variantes landing_page`.
-- Subseções previstas:
-  - `18.5.1 — Objetivo e status`;
-  - `18.5.2 — Registros do recorte`, após implementação material;
-  - `18.5.3 — Módulos e funções estruturais`;
-  - `18.5.4 — Campos, estruturas e cardinalidades`;
-  - `18.5.5 — Variantes e critérios de criação`;
-  - `18.5.6 — Especializações sobre a parametrização raiz`;
-  - `18.5.7 — Mapa de fontes de copy`;
-  - `18.5.8 — Perfis de copy por intenção e funil`;
-  - `18.5.9 — Ciclo de vida, compatibilidade e validação`;
-  - `18.5.10 — Limites do recorte`.
-- Não criar `18.6`.
-- A documentação durável só será atualizada pelo Gestor de Docs ao final do plano.
-- O encerramento formal da E18.5 exigirá implementação material aprovada, merge do PR material, relatório final do Estrategista e merge do PR documental obrigatório.
+- Conjunto inicial exato de módulos.
+- Ordem de definição dos módulos.
+- Uso do Hero como módulo-piloto antes de ampliar o catálogo.
+- Critério mínimo de evidência para:
+  - criar módulo;
+  - criar variante;
+  - criar exceção editorial;
+  - criar exceção estrutural.
+- Necessidade real de múltiplas variantes no primeiro catálogo.
+- Contratos fechados de comportamento estrutural que forem efetivamente necessários.
+- Mapa de fontes de copy de cada módulo.
+- Adaptação dos perfis BOFU, MOFU e TOFU por módulo.
+- Lifecycle inicial de cada módulo e variante.
+- Validação necessária para promoção de `experimental` para `validated`.
 
 ## 2. Contrato do caso
 
-### 2.1. Boundary e artefatos previstos
+### 2.1. Problema
 
-- Boundary canônico:
-  - `lib/conversion-content/landing-page/module-catalog/`.
-- Arquivos previstos:
-  - `contracts.ts`;
-  - `registry.ts`;
-  - `schema.ts`;
-  - `resolver.ts`;
-  - `validation-cases.ts`;
-  - `index.ts`.
-- Arquivos a ajustar:
-  - `lib/conversion-content/index.ts`;
-  - `package.json`;
-  - `docs/lousa-plano-base-e18-5.md`, somente para estado da fase.
-- Interface pública agregada prevista:
-  - namespace `landingPageModules`.
-- Preservar:
-  - namespace `landingPageRoot`;
-  - arquivos e comportamento da parametrização raiz.
-- Script previsto:
-  - `validate:landing-page-modules`.
-- Não adicionar dependência npm.
-- Não alterar `package-lock.json` quando não houver mudança real de dependência.
+- A raiz já define as regras comuns, mas ainda não existe contrato aprovado para:
+  - funções estruturais dos módulos;
+  - campos e cardinalidades;
+  - variantes reutilizáveis;
+  - exceções justificadas;
+  - `copy_source_map`;
+  - `funnel_copy_profile`;
+  - tratamentos por BOFU, MOFU e TOFU;
+  - lifecycle e compatibilidade histórica.
+- Repetir parâmetros da raiz nos módulos criaria múltiplas fontes da verdade.
+- Permitir variantes abertas criaria especializações por taxon, campanha ou conteúdo.
+- Entregar deltas aos consumidores faria cada camada reimplementar a precedência.
 
-### 2.2. Versionamento e identidade
+### 2.2. Resultado esperado
 
-- Identidade inicial:
+- Criar fonte repo-only versionada para módulos e variantes.
+- Definir catálogo inicial pequeno e sustentado por evidência.
+- Fazer módulos herdarem a raiz sem repetição.
+- Fazer variantes registrarem apenas deltas.
+- Fazer o resolver retornar contrato efetivo completo e imutável.
+- Definir fontes de copy usando apenas `item_key` oficiais.
+- Separar valores factuais operacionais de orientação de pesquisa.
+- Definir BOFU, MOFU e TOFU como perfis de transformação, não como variantes.
+- Preservar versões antigas para leitura histórica.
+- Entregar validação executável sem banco, composição, geração ou renderer.
+
+### 2.3. Fonte e critério para parametrização
+
+A decisão sobre módulo, variante ou exceção deve seguir esta ordem de evidência:
+
+1. Parametrização raiz:
+   - contrato comum obrigatório;
+   - fonte dos papéis, limites e opções permitidas.
+2. `docs/lp-planejamento.md`:
+   - fronteiras entre raiz, módulo, variante, composição, conteúdo e entradas.
+3. Itens estruturados oficiais:
+   - `strategic_core`;
+   - `lp_overview`;
+   - `lp_sections`;
+   - `seo`.
+4. Blueprints e referências reais:
+   - evidência para funções, estruturas, campos e riscos;
+   - recomendação sem sustentação suficiente permanece hipótese.
+5. LP real validada:
+   - evidência posterior para promover, restringir, substituir ou depreciar contratos.
+
+Critérios:
+
+- Criar módulo somente quando existir função estrutural reutilizável não coberta.
+- Criar variante somente quando existir mudança reutilizável de estrutura, execução ou comportamento dentro da mesma função.
+- Não criar variante quando a diferença puder ser atendida por:
+  - conteúdo;
+  - parâmetro herdado;
+  - escolha de ocorrência;
+  - composição;
+  - fonte de copy;
+  - perfil de funil;
+  - valor operacional.
+- Não generalizar para toda a família um valor observado apenas em um nicho.
+
+### 2.4. Identidade e versionamento previstos
+
+- Identidade inicial prevista:
   - `family = landing_page`;
   - `rootVersion = 1`;
   - `moduleCatalogVersion = 1`.
-- O registry deve ser mapa explícito:
+- O registry deve ser explícito:
   - `moduleCatalogVersion → catálogo imutável`.
-- O catálogo contém módulos identificados por:
+- Módulo:
   - `moduleKey`;
-  - `moduleVersion`.
-- Cada variante é identificada por:
-  - `variantKey`, no formato `modulo.variante`;
+  - `moduleVersion`;
+  - `lifecycle`;
+  - `structuralFunction`;
+  - `fieldCatalog`.
+- Variante:
+  - `variantKey`;
   - `variantVersion`;
-  - `moduleKey` correspondente.
+  - `moduleKey`;
+  - `lifecycle`;
+  - deltas fechados.
 - Regras:
-  - uma alteração contratual incompatível cria nova `moduleCatalogVersion`;
-  - alteração do contrato de módulo incrementa `moduleVersion`;
-  - alteração do contrato de variante incrementa `variantVersion`;
-  - versões antigas não podem ser apagadas ou alteradas;
-  - o catálogo novo pode manter chaves antigas, adicionar chaves ou depreciá-las;
-  - não existe catálogo padrão implícito;
-  - `rootVersion` e `moduleCatalogVersion` são obrigatórios na resolução;
-  - `variantKey` deve começar com o `moduleKey` seguido de ponto;
-  - chave do registry e versão interna devem corresponder;
-  - o catálogo deve declarar compatibilidade explícita com a `rootVersion`;
-  - não existe fallback silencioso entre versões.
-
-### 2.3. Lifecycle
-
-- Lifecycle permitido para módulos e variantes:
-  - `candidate`;
-  - `experimental`;
-  - `validated`;
-  - `deprecated`.
-- Significado:
-  - `candidate`: contrato em avaliação; não pode entrar em composição ou geração;
-  - `experimental`: pode ser usado apenas em fluxo controlado de teste;
-  - `validated`: aprovado por LP real e decisão humana registrada; pode ser usado em novas composições e gerações quando os demais gates permitirem;
-  - `deprecated`: não pode entrar em nova composição ou geração; permanece resolvível para histórico.
-- Transições normais:
-  - `candidate → experimental`;
-  - `experimental → validated`;
-  - `candidate | experimental | validated → deprecated`.
-- Não alterar lifecycle dentro de versão já publicada sem decisão humana registrada.
-- Quando a decisão alterar a elegibilidade operacional do catálogo publicado, criar nova `moduleCatalogVersion`.
-- O catálogo v1 nasce como hipótese:
-  - variantes sustentadas pelo blueprint entram como `experimental`;
-  - variantes sem evidência direta suficiente entram como `candidate`;
-  - nenhuma variante nasce `validated`.
-
-### 2.4. Tipos estruturais comuns
-
-- `CopyFieldContract`:
-  - `fieldKey`;
-  - `semanticRole`;
-  - `required`;
-  - `recommendedRangeOverride`, quando houver;
-  - `absoluteMaxOverride`, quando houver;
-  - `copySourceMap`;
-  - `operationalValueRequired`, quando o valor não puder vir da pesquisa.
-- `CtaContract`:
-  - `label`, usando papel `cta_label`;
-  - `actionRole`;
-  - sem URL ou destino concreto.
-- `actionRole` permitido:
-  - `primary_conversion`;
-  - `secondary_conversion`;
-  - `contact`;
-  - `resource`;
-  - `internal_navigation`.
-- `MediaReferenceContract`:
-  - referência abstrata de ativo;
-  - `altText`;
-  - `caption` opcional;
-  - sem URL, upload, storage ou embed concreto.
-- `CollectionContract`:
-  - `minItems`;
-  - `maxItems`;
-  - contrato do item.
-- `LeadFieldSlotContract`:
-  - `slotKey`;
-  - `inputKind`;
-  - `label`;
-  - `required`.
-- `inputKind` permitido:
-  - `short_text`;
-  - `email`;
-  - `phone`;
-  - `single_select`;
-  - `multi_select`;
-  - `boolean`.
-- O contrato não define nome de coluna, tabela, formulário executável, destino de submissão, integração, automação, CRM ou webhook.
-- Campos factuais que exigem valor operacional devem ser marcados com `operationalValueRequired = true`.
-- Pesquisa estruturada pode orientar rótulo e enquadramento, mas não fornecer preço real, número, métrica, depoimento, credencial, garantia, disponibilidade, contato, endereço, URL ou dado legal.
-
-### 2.5. Catálogo inicial de módulos
-
-#### 2.5.1. `hero`
-
-- Função:
-  - apresentar recorte, proposta de valor e próxima ação principal.
-- Deve:
-  - realizar message match;
-  - conter um único campo mapeado para `h1`;
-  - evitar promessa sem fonte.
-- Não deve representar campanha, taxon ou composição.
-- Lifecycle inicial:
-  - `experimental`.
-
-#### 2.5.2. `media`
-
-- Função:
-  - apresentar evidência visual ou demonstração do produto, serviço, contexto ou resultado.
-- Deve exigir alt text e limitar cardinalidade.
-- Não deve armazenar URL real no registry, autorizar embed ou definir storage.
-- Lifecycle inicial:
-  - `experimental`.
-
-#### 2.5.3. `benefits`
-
-- Função:
-  - sintetizar benefícios, diferenciais ou resultados esperados de forma comparável.
-- Deve diferenciar benefício de prova factual e impedir transformação de benefício em resultado garantido.
-- Lifecycle inicial:
-  - `experimental`.
-
-#### 2.5.4. `offer`
-
-- Função:
-  - explicar o que é oferecido, para quem serve e qual próximo passo.
-- Deve separar copy parametrizada de preço e condições operacionais.
-- Não deve criar oferta, preço, desconto, garantia ou escassez.
-- Lifecycle inicial:
-  - `experimental`.
-
-#### 2.5.5. `proof`
-
-- Função:
-  - apresentar evidência, autoridade, credencial, depoimento ou métrica verificável.
-- Deve marcar valores factuais como operacionais e exigir sustentação real.
-- Lifecycle inicial:
-  - `experimental`.
-
-#### 2.5.6. `location`
-
-- Função:
-  - explicar relevância geográfica, territorial ou contextual quando isso afetar a decisão.
-- É reutilizável para negócios locais, serviços regionais, imóveis, eventos e ofertas com contexto territorial.
-- Não representa taxon.
-- Lifecycle inicial:
-  - `experimental`.
-
-#### 2.5.7. `qualification`
-
-- Função:
-  - captar contato ou qualificar o lead com fricção controlada.
-- Define estrutura e cardinalidade de slots.
-- Não define persistência, destino, catálogo de dados da conta, regras comerciais ou CRM.
-- Lifecycle inicial:
-  - `experimental`.
-
-#### 2.5.8. `how_it_works`
-
-- Função:
-  - explicar processo, etapas, jornada ou funcionamento.
-- Lifecycle inicial:
-  - `experimental`.
-
-#### 2.5.9. `faq`
-
-- Função:
-  - responder dúvidas e objeções recorrentes.
-- Não deve criar FAQ genérica sem fonte ou repetir conteúdo sem função.
-- Lifecycle inicial:
-  - `experimental`.
-
-#### 2.5.10. `final_cta`
-
-- Função:
-  - encerrar a narrativa e apresentar ação de conversão coerente.
-- Não define destino real do CTA.
-- Lifecycle inicial:
-  - `experimental`.
-
-#### 2.5.11. `trust`
-
-- Função:
-  - apresentar privacidade, identificação, compliance e sinais institucionais.
-- Deve exigir valores reais quando citar identificação, registro ou política.
-- Não substitui revisão jurídica ou regulatória.
-- Lifecycle inicial:
-  - `experimental`.
-
-### 2.6. Variantes iniciais, campos e cardinalidades
-
-#### 2.6.1. `hero.standard`
-
-- Lifecycle: `experimental`.
-- Estrutura:
-  - `eyebrow`: 0–1, papel `eyebrow`;
-  - `title`: exatamente 1, papel `h1`;
-  - `subtitle`: exatamente 1, papel `paragraph`;
-  - `primaryCta`: exatamente 1;
-  - `secondaryCta`: 0–1;
-  - `proofShort`: 0–1, papel `paragraph`;
-  - `media`: 0–1 referência.
-- Uso:
-  - abertura textual com mídia opcional.
-- Não representa produto único, portfólio, canal ou funil.
-
-#### 2.6.2. `hero.media_split`
-
-- Lifecycle: `experimental`.
-- Estrutura:
-  - mesmos campos de `hero.standard`;
-  - `media`: exatamente 1.
-- Diferença estrutural:
-  - mídia é parte obrigatória da execução do Hero.
-- Não deve ser criada apenas porque o conteúdo possui imagem.
-
-#### 2.6.3. `media.gallery`
-
-- Lifecycle: `experimental`.
-- Estrutura:
-  - `eyebrow`: 0–1;
-  - `title`: 0–1, papel `h2`;
-  - `items`: 1–12 referências de mídia;
-  - cada item exige `altText`;
-  - cada item admite `caption` 0–1.
-- Não autoriza carrossel automático ou autoplay.
-
-#### 2.6.4. `media.external_tour`
-
-- Lifecycle: `experimental`.
-- Estrutura:
-  - `eyebrow`: 0–1;
-  - `title`: 0–1;
-  - `previewMedia`: exatamente 1;
-  - `tourCta`: exatamente 1, `actionRole = resource`.
-- O destino externo é valor operacional.
-- O contrato não autoriza embed.
-
-#### 2.6.5. `benefits.cards`
-
-- Lifecycle: `experimental`.
-- Estrutura:
-  - `eyebrow`: 0–1;
-  - `title`: exatamente 1, papel `h2`;
-  - `items`: 2–6;
-  - item:
-    - `title`: exatamente 1, papel `card_title`;
-    - `body`: exatamente 1, papel `card_body`;
-    - `iconRef`: 0–1 referência abstrata.
-- Não usar ícone concreto, classe ou token no registry.
-
-#### 2.6.6. `benefits.list`
-
-- Lifecycle: `experimental`.
-- Estrutura:
-  - `eyebrow`: 0–1;
-  - `title`: exatamente 1;
-  - `items`: 3–8;
-  - item `text`: exatamente 1, papel `benefit_item`.
-- A diferença para cards é estrutural, não apenas visual.
-
-#### 2.6.7. `offer.summary`
-
-- Lifecycle: `experimental`.
-- Estrutura:
-  - `eyebrow`: 0–1;
-  - `title`: exatamente 1, papel `h2`;
-  - `description`: exatamente 1, papel `paragraph`;
-  - `highlights`: 0–6, papel `benefit_item`;
-  - `priceText`: 0–1, valor operacional obrigatório;
-  - `primaryCta`: 0–1;
-  - `secondaryCta`: 0–1;
-  - `disclaimer`: 0–1, papel `privacy_note`.
-- Preço, desconto, condição e prazo não podem ser inferidos da pesquisa.
-
-#### 2.6.8. `proof.metrics`
-
-- Lifecycle: `candidate`.
-- Estrutura:
-  - `eyebrow`: 0–1;
-  - `title`: 0–1;
-  - `items`: 1–4;
-  - item:
-    - `value`: exatamente 1, operacional e verificável;
-    - `label`: exatamente 1, papel `card_title`;
-    - `context`: 0–1, papel `card_body`;
-    - `evidenceRef`: exatamente 1 no snapshot futuro.
-- Não pode entrar em composição enquanto permanecer `candidate`.
-
-#### 2.6.9. `proof.testimonials`
-
-- Lifecycle: `candidate`.
-- Estrutura:
-  - `eyebrow`: 0–1;
-  - `title`: 0–1;
-  - `items`: 1–6;
-  - item:
-    - `quote`: exatamente 1, operacional;
-    - `authorName`: exatamente 1, operacional;
-    - `authorContext`: 0–1, operacional;
-    - `media`: 0–1;
-    - `evidenceRef`: exatamente 1 no snapshot futuro.
-- Depoimento não pode ser gerado a partir de pesquisa.
-
-#### 2.6.10. `proof.authority`
-
-- Lifecycle: `experimental`.
-- Estrutura:
-  - `eyebrow`: 0–1;
-  - `title`: 0–1;
-  - `description`: 0–1;
-  - `credentials`: 1–6 valores operacionais;
-  - `identityMedia`: 0–1.
-- Credencial, registro e certificação exigem valor real.
-
-#### 2.6.11. `location.summary`
-
-- Lifecycle: `experimental`.
-- Estrutura:
-  - `eyebrow`: 0–1;
-  - `title`: exatamente 1;
-  - `description`: 0–1;
-  - `highlights`: 1–8;
-  - `media`: 0–1;
-  - `mapCta`: 0–1, `actionRole = resource | internal_navigation`.
-- Endereço, mapa e rota são valores operacionais.
-
-#### 2.6.12. `qualification.simple_form`
-
-- Lifecycle: `experimental`.
-- Estrutura:
-  - `eyebrow`: 0–1;
-  - `title`: exatamente 1;
-  - `description`: 0–1;
-  - `fieldSlots`: 1–4;
-  - `submitCta`: exatamente 1;
-  - `privacyNote`: exatamente 1;
-  - `consentSlot`: 0–1.
-- Todos os campos são exibidos em uma etapa.
-- O contrato não cria formulário funcional.
-
-#### 2.6.13. `qualification.progressive_form`
-
-- Lifecycle: `experimental`.
-- Estrutura:
-  - `eyebrow`: 0–1;
-  - `title`: exatamente 1;
-  - `description`: 0–1;
-  - `steps`: 2–5;
-  - total de `fieldSlots`: 2–8;
-  - cada etapa contém 1–4 slots;
-  - `submitCta`: exatamente 1;
-  - `privacyNote`: exatamente 1;
-  - `consentSlot`: 0–1.
-- A variante existe por mudança reutilizável de comportamento em etapas.
-- Não representa financiamento, imóvel ou qualquer taxon.
-
-#### 2.6.14. `how_it_works.steps`
-
-- Lifecycle: `experimental`.
-- Estrutura:
-  - `eyebrow`: 0–1;
-  - `title`: exatamente 1;
-  - `steps`: 2–6;
-  - item:
-    - `label`: exatamente 1, papel `step_label`;
-    - `title`: exatamente 1, papel `step_title`;
-    - `body`: exatamente 1, papel `step_body`.
-
-#### 2.6.15. `faq.accordion`
-
-- Lifecycle: `experimental`.
-- Estrutura:
-  - `eyebrow`: 0–1;
-  - `title`: exatamente 1;
-  - `questions`: 2–8;
-  - item:
-    - `question`: exatamente 1, papel `faq_question`;
-    - `answer`: exatamente 1, papel `faq_answer`.
-- `accordion` descreve comportamento estrutural de expansão.
-- Não autoriza FAQ inventada.
-
-#### 2.6.16. `final_cta.simple`
-
-- Lifecycle: `experimental`.
-- Estrutura:
-  - `eyebrow`: 0–1;
-  - `title`: exatamente 1;
-  - `description`: exatamente 1;
-  - `primaryCta`: exatamente 1;
-  - `proofShort`: 0–1;
-  - `privacyNote`: 0–1.
-
-#### 2.6.17. `final_cta.contact_options`
-
-- Lifecycle: `candidate`.
-- Estrutura:
-  - `eyebrow`: 0–1;
-  - `title`: exatamente 1;
-  - `description`: 0–1;
-  - `options`: 2–3;
-  - cada opção contém `label` exatamente 1 e `actionRole = contact`;
-  - `privacyNote`: 0–1.
-- Os canais e destinos reais vêm das entradas operacionais.
-- Não pode entrar em composição enquanto permanecer `candidate`.
-
-#### 2.6.18. `trust.compliance`
-
-- Lifecycle: `experimental`.
-- Estrutura:
-  - `title`: 0–1;
-  - `identityItems`: 1–8 valores operacionais;
-  - `privacyNote`: exatamente 1;
-  - `contactOptions`: 0–3;
-  - `legalLinks`: 0–3 referências operacionais.
-- Não declara conformidade jurídica integral.
-- Não cria política de privacidade ou texto regulatório automaticamente.
-
-### 2.7. Especializações sobre a raiz
-
-- Regra geral:
-  - campo sem especialização herda integralmente a raiz;
-  - módulo pode restringir a raiz;
-  - variante pode restringir o módulo;
-  - variante não pode ampliar regra efetiva do módulo;
-  - nenhuma camada pode ampliar limite absoluto da raiz.
-- Limite técnico absoluto efetivo:
-  - menor valor entre raiz, módulo e variante.
-- Faixa recomendada efetiva:
-  - especialização mais específica válida;
-  - mínimo maior ou igual a 1;
-  - mínimo menor ou igual ao máximo;
-  - máximo menor ou igual ao limite absoluto efetivo.
-- Especializações v1 sustentadas pelo blueprint:
-  - `hero.title`, papel `h1`: recomendado 45–80, absoluto herdado;
-  - `hero.subtitle`, papel `paragraph`: recomendado 90–160, absoluto herdado;
-  - CTA primário de Hero, papel `cta_label`: recomendado 14–28, absoluto herdado;
-  - CTA secundário de Hero, papel `cta_label`: recomendado 14–30, absoluto herdado;
-  - `proofShort`, papel `paragraph`: recomendado 40–90, absoluto herdado;
-  - títulos de seção, papel `h2`: recomendado 25–60, absoluto herdado;
-  - `benefits.cards.items.body`, papel `card_body`: recomendado 60–120, absoluto herdado;
-  - `faq.question`: recomendado 45–90, absoluto herdado;
-  - `faq.answer`: recomendado 90–220, absoluto herdado;
-  - `privacyNote`: recomendado 80–180, absoluto herdado.
-- Não criar outras especializações numéricas na v1 sem evidência ou decisão humana.
-- Opções de `spacing`:
-  - todas as variantes herdam `compact`, `default` e `spacious`;
-  - nenhuma restrição própria entra na v1 por falta de evidência suficiente;
-  - escolha por ocorrência pertence à composição futura.
-
-### 2.8. Contrato de `copy_source_map`
-
-- Cada referência deve declarar:
-  - `audienceScope`;
-  - `researchBlock`;
-  - `itemKey`;
-  - `sourceRole = primary | auxiliary`.
-- `audienceScope` permitido:
-  - `end_customer`;
-  - `business_buyer`.
-- Regra padrão:
-  - copy destinada ao visitante usa `end_customer` como fonte primária;
-  - `business_buyer` pode ser auxiliar apenas para autoridade do fornecedor, processo de atendimento, posicionamento do negócio e prova institucional;
-  - `business_buyer` não substitui dor, desejo, objeção, intenção de busca ou vocabulário do `end_customer`.
-- Limite por campo:
-  - até 2 referências primárias;
-  - até 1 referência auxiliar.
-- Seleção dos itens:
-  - maior `priority`;
-  - depois menor `sort_order`;
-  - sem mistura de versões ou conjuntos fora do contrato da E10.8.
-- Blocos permitidos no mapa de campo:
-  - `strategic_core`;
-  - `seo`.
-- `lp_overview`:
-  - contexto de transformação e direção;
-  - não fonte factual de copy.
-- `lp_sections`:
-  - fonte estrutural da futura composição E20;
-  - proibido como fonte fixa de copy por campo.
-- Chave desconhecida deve falhar fechado.
-- Campo marcado como operacional não pode ter seu valor factual preenchido por pesquisa.
-
-### 2.9. Mapa inicial de fontes de copy
-
-#### 2.9.1. Hero
+  - `rootVersion` e `moduleCatalogVersion` obrigatórios;
+  - compatibilidade explícita entre catálogo e raiz;
+  - sem catálogo padrão implícito;
+  - sem fallback silencioso;
+  - versões publicadas imutáveis;
+  - mudança incompatível cria nova versão aplicável.
+
+### 2.5. Contrato-base de campo
+
+Cada campo do módulo deve declarar:
+
+- `fieldKey`;
+- `semanticRole`;
+- `cardinality`;
+- `copySourceMap`;
+- `operationalValuePolicy`.
+
+Regras:
+
+- `semanticRole` referencia papel existente na raiz.
+- `cardinality` contém apenas `min` e `max`.
+- `min` deve ser maior ou igual a zero.
+- `max` deve ser maior ou igual a `min`.
+- Campo único usa `max = 1`.
+- Coleção usa `max > 1`.
+- Nenhum limite ou tamanho da raiz é copiado.
+- Exceção opcional só entra com justificativa:
+  - `recommendedRangeOverride`;
+  - `absoluteMaxRestriction`.
+- `recommendedRangeOverride` deve respeitar o limite absoluto efetivo.
+- `absoluteMaxRestriction` só pode reduzir o teto herdado.
+- A E18.5 v1 não introduz `typographyTreatmentRef` no Hero.
+- Campo factual deve declarar política operacional e não pode ser preenchido como fato por pesquisa.
+
+### 2.6. Contrato de variante
+
+A variante referencia apenas campos existentes no `fieldCatalog` do módulo.
+
+Deltas permitidos, quando aprovados:
+
+- mudança de cardinalidade;
+- remoção de campo opcional;
+- ativação obrigatória de campo já previsto;
+- restrição de faixa recomendada;
+- restrição de limite absoluto;
+- comportamento estrutural enumerado e fechado.
+
+Deltas proibidos:
+
+- campo livre novo;
+- papel semântico inexistente;
+- ampliação do limite absoluto;
+- regra arbitrária;
+- taxon;
+- campanha;
+- conteúdo concreto;
+- valor de conta;
+- composição;
+- ordem global da LP;
+- URL ou destino real;
+- classe, token ou componente visual concreto.
+
+O resolver deve validar o delta e retornar apenas o contrato efetivo final.
+
+### 2.7. Módulo-piloto `hero`
+
+#### 2.7.1. Função estrutural
+
+- Apresentar o recorte da LP, a proposta de valor e a principal ação esperada.
+- Não representar:
+  - taxon;
+  - campanha;
+  - origem de tráfego;
+  - BOFU, MOFU ou TOFU;
+  - composição.
+
+#### 2.7.2. Catálogo fechado de campos proposto
 
 - `eyebrow`:
-  - primária: `end_customer.seo.search_intent`;
-  - auxiliar: `end_customer.strategic_core.positioning_opportunity`.
+  - papel: `eyebrow`;
+  - cardinalidade: `{ min: 0, max: 1 }`.
+- `title`:
+  - papel: `h1`;
+  - cardinalidade: `{ min: 1, max: 1 }`.
+- `subtitle`:
+  - papel: `paragraph`;
+  - cardinalidade: `{ min: 1, max: 1 }`.
+- `primaryCta.label`:
+  - papel: `cta_label`;
+  - cardinalidade: `{ min: 1, max: 1 }`.
+- `secondaryCta.label`:
+  - papel: `cta_label`;
+  - cardinalidade: `{ min: 0, max: 1 }`.
+- `proofShort`:
+  - papel: `paragraph`;
+  - cardinalidade: `{ min: 0, max: 1 }`.
+- `media`:
+  - referência abstrata de mídia;
+  - cardinalidade: `{ min: 0, max: 1 }`.
+
+#### 2.7.3. Herança e exceções
+
+- Todos os campos textuais herdam integralmente a raiz.
+- Não há na proposta atual:
+  - faixa numérica própria;
+  - limite absoluto próprio;
+  - tratamento tipográfico próprio;
+  - spacing próprio.
+- `subtitle` usa apenas `semanticRole = paragraph`.
+- A existência de mídia não define sozinha nova variante.
+
+#### 2.7.4. Variante inicial em debate
+
+- `hero.standard`:
+  - usa o contrato-base do Hero;
+  - não possui delta numérico;
+  - não possui delta tipográfico;
+  - mídia permanece opcional.
+- `hero.media_split`:
+  - rejeitada como variante aprovada no estado atual;
+  - pode voltar ao debate somente com mudança estrutural reutilizável e contratualmente fechada.
+- Variante específica de nicho:
+  - proibida.
+
+### 2.8. `copy_source_map`
+
+Cada referência deve declarar:
+
+- `audienceScope`;
+- `researchBlock`;
+- `itemKey`;
+- `sourceRole`.
+
+Regras:
+
+- `sourceRole`:
+  - `primary`;
+  - `auxiliary`.
+- Até 2 fontes primárias e 1 auxiliar por campo.
+- Copy para visitante usa `end_customer` como fonte primária.
+- `business_buyer` só pode auxiliar quando o campo tratar:
+  - autoridade do fornecedor;
+  - processo real;
+  - posicionamento do negócio;
+  - prova institucional.
+- `business_buyer` não substitui dor, desejo, objeção, intenção de busca ou vocabulário do visitante.
+- Blocos factuais de copy:
+  - `strategic_core`;
+  - `seo`.
+- `lp_overview` pode orientar contexto de transformação, sem fornecer fato.
+- `lp_sections` orienta composição futura, sem virar fonte fixa de campo.
+- Chave desconhecida falha fechado.
+- Valor operacional não pode ser inferido como fato a partir da pesquisa.
+
+Mapa inicial do Hero para debate:
+
 - `title`:
   - primárias:
     - `end_customer.strategic_core.positioning_opportunity`;
     - `end_customer.strategic_core.desire`;
-  - auxiliar: `end_customer.seo.commercial_keywords`.
+  - auxiliar:
+    - `end_customer.seo.commercial_keywords`.
 - `subtitle`:
   - primárias:
     - `end_customer.strategic_core.pain`;
     - `end_customer.strategic_core.desire`;
-  - auxiliar: `end_customer.strategic_core.belief`.
+  - auxiliar:
+    - `end_customer.strategic_core.belief`.
 - CTAs:
-  - primária: `end_customer.strategic_core.trigger`;
-  - auxiliar: `end_customer.seo.search_intent`.
+  - primária:
+    - `end_customer.strategic_core.trigger`;
+  - auxiliar:
+    - `end_customer.seo.search_intent`.
 - `proofShort`:
-  - primária: `end_customer.strategic_core.proof_type`;
-  - auxiliar: `end_customer.strategic_core.objection`.
-
-#### 2.9.2. Media
-
-- `title` e `caption`:
-  - primárias:
-    - `end_customer.strategic_core.desire`;
-    - `end_customer.strategic_core.vocabulary`.
-- O tipo, a seleção e o valor do ativo são operacionais.
-- `lp_overview.image_style` orienta transformação futura, mas não entra como fonte factual.
-
-#### 2.9.3. Benefits
-
-- `title`:
-  - primárias:
-    - `end_customer.strategic_core.desire`;
-    - `end_customer.strategic_core.positioning_opportunity`;
-  - auxiliar: `end_customer.strategic_core.pain`.
-- Itens:
-  - primárias:
-    - `end_customer.strategic_core.desire`;
-    - `end_customer.strategic_core.pain`;
-  - auxiliar: `end_customer.strategic_core.objection`.
-
-#### 2.9.4. Offer
-
-- `title` e `description`:
-  - primárias:
-    - `end_customer.strategic_core.desire`;
-    - `end_customer.strategic_core.trigger`;
-  - auxiliar: `end_customer.strategic_core.positioning_opportunity`.
-- `highlights`:
-  - primárias:
-    - `end_customer.strategic_core.desire`;
+  - primária:
     - `end_customer.strategic_core.proof_type`;
-  - auxiliar: `end_customer.strategic_core.trend`.
-- `priceText` e disclaimer factual:
-  - valores operacionais obrigatórios.
+  - auxiliar:
+    - `end_customer.strategic_core.objection`.
 
-#### 2.9.5. Proof
+### 2.9. `funnel_copy_profile`
 
-- Título e introdução:
-  - primárias:
-    - `end_customer.strategic_core.proof_type`;
-    - `end_customer.strategic_core.belief`;
-  - auxiliar: `end_customer.strategic_core.fear`.
-- Rótulo de métrica:
-  - primária: `end_customer.strategic_core.proof_type`;
-  - auxiliar: `end_customer.strategic_core.positioning_opportunity`.
-- Título de autoridade:
-  - primárias:
-    - `business_buyer.strategic_core.proof_type`;
-    - `business_buyer.strategic_core.positioning_opportunity`;
-  - auxiliar: `end_customer.strategic_core.belief`.
-- Métricas, depoimentos, nomes, credenciais e evidências:
-  - valores operacionais obrigatórios.
+Perfis previstos:
 
-#### 2.9.6. Location
+- `bofu`;
+- `mofu`;
+- `tofu`.
 
-- `title` e `description`:
-  - primárias:
-    - `end_customer.seo.local_terms`;
-    - `end_customer.seo.search_intent`;
-  - auxiliar: `end_customer.strategic_core.desire`.
-- `highlights`:
-  - primárias:
-    - `end_customer.seo.local_terms`;
-    - `end_customer.strategic_core.desire`;
-  - auxiliar: `end_customer.strategic_core.pain`.
-- Endereço, mapa e rota são operacionais.
+Regras:
 
-#### 2.9.7. Qualification
+- Perfil não é canal, módulo, variante, taxon ou composição.
+- O perfil orienta transformação da copy.
+- O perfil não altera:
+  - schema;
+  - cardinalidade;
+  - limite absoluto;
+  - estrutura aprovada.
+- Módulo adapta o perfil à sua função.
+- Variante pode apenas restringir ou especializar comportamento permitido.
+- Tratamento proibido não pode ser promovido por variante.
 
-- `title` e `description`:
-  - primárias:
-    - `end_customer.strategic_core.objection`;
-    - `end_customer.strategic_core.fear`;
-  - auxiliar: `end_customer.strategic_core.awareness_level`.
-- Rótulos e perguntas:
-  - primárias:
-    - `end_customer.strategic_core.objection`;
-    - `end_customer.strategic_core.fear`;
-  - auxiliar: `end_customer.strategic_core.vocabulary`.
-- `submitCta.label`:
-  - primária: `end_customer.strategic_core.trigger`;
-  - auxiliar: `end_customer.strategic_core.desire`.
-- `privacyNote`:
-  - primárias:
-    - `end_customer.strategic_core.fear`;
-    - `end_customer.strategic_core.belief`;
-  - auxiliar: `end_customer.strategic_core.proof_type`.
+Direção do Hero:
 
-#### 2.9.8. How it works
-
-- Título e campos dos passos:
-  - primárias:
-    - `end_customer.strategic_core.objection`;
-    - `business_buyer.strategic_core.belief`;
-  - auxiliar: `end_customer.strategic_core.fear`.
-- O processo factual deve vir de valor operacional do negócio.
-
-#### 2.9.9. FAQ
-
-- `question`:
-  - primárias:
-    - `end_customer.seo.faq_questions`;
-    - `end_customer.strategic_core.objection`;
-  - auxiliar: `end_customer.strategic_core.fear`.
-- `answer`:
-  - primárias:
-    - `end_customer.strategic_core.objection`;
-    - `end_customer.strategic_core.belief`;
-  - auxiliar: `end_customer.strategic_core.proof_type`.
-- Resposta factual, legal, financeira ou regulatória exige valor operacional ou fonte própria do recorte futuro.
-
-#### 2.9.10. Final CTA
-
-- `title`:
-  - primárias:
-    - `end_customer.strategic_core.trigger`;
-    - `end_customer.strategic_core.desire`;
-  - auxiliar: `end_customer.strategic_core.positioning_opportunity`.
-- `description`:
-  - primárias:
-    - `end_customer.strategic_core.objection`;
-    - `end_customer.strategic_core.desire`;
-  - auxiliar: `end_customer.strategic_core.proof_type`.
-- CTA:
-  - primária: `end_customer.strategic_core.trigger`;
-  - auxiliar: `end_customer.seo.search_intent`.
-
-#### 2.9.11. Trust
-
-- Título e rótulos:
-  - primárias:
-    - `business_buyer.strategic_core.proof_type`;
-    - `business_buyer.strategic_core.belief`;
-  - auxiliar: `end_customer.strategic_core.fear`.
-- Identidade, registro, política, contato e links:
-  - valores operacionais obrigatórios.
-
-### 2.10. Contexto de `lp_overview`
-
-- O resolver deve expor, como referências contextuais aceitas para consumidores futuros:
-  - `narrative_arc`;
-  - `visual_tone`;
-  - `color_direction`;
-  - `page_length`;
-  - `image_style`;
-  - `visual_density`;
-  - `typography_direction`;
-  - `mobile_priority`.
-- Essas chaves orientam transformação, composição e futura renderização, mas não autorizam fatos, não alteram o design system, não criam variantes e não sobrescrevem raiz, módulo ou variante.
-
-### 2.11. `funnel_copy_profile`
-
-- Perfis permitidos:
-  - `bofu`;
-  - `mofu`;
-  - `tofu`.
-- O perfil é selecionado por intenção informada no fluxo futuro.
-- O perfil não é canal, módulo, variante, taxon ou composição.
-- O perfil deve declarar objetivo de comunicação, nível presumido de consciência, intensidade da conversão, profundidade explicativa, fricção máxima de qualificação e tratamentos.
-- O módulo adapta o perfil à sua função.
-- A variante pode apenas restringir ou tornar mais específico; nunca promover tratamento proibido a permitido.
-- O perfil não pode ampliar limite técnico ou cardinalidade.
-
-#### 2.11.1. BOFU
-
-- Objetivo:
-  - conversão direta ou microconversão de alta intenção.
-- Consciência presumida:
-  - média a alta.
-- Direção:
+- BOFU:
   - recorte específico;
-  - benefício concreto;
-  - prova;
-  - objeção;
-  - CTA direto.
-- Qualificação:
-  - simples ou progressiva, quando aplicável.
-- Módulos mais adequados:
-  - Hero;
-  - Offer;
-  - Proof;
-  - Qualification;
-  - FAQ;
-  - Final CTA;
-  - Trust.
-
-#### 2.11.2. MOFU
-
-- Objetivo:
-  - avaliação, comparação e avanço de consideração.
-- Consciência presumida:
-  - média.
-- Direção:
-  - explicar;
-  - diferenciar;
-  - demonstrar;
-  - responder riscos;
-  - oferecer próximo passo proporcional.
-- Qualificação:
-  - baixa a moderada.
-- Módulos mais adequados:
-  - Hero;
-  - Media;
-  - Benefits;
-  - Proof;
-  - Location;
-  - How it works;
-  - FAQ;
-  - Final CTA;
-  - Trust.
-- Oferta e CTA direto:
-  - permitidos com intensidade restrita.
-
-#### 2.11.3. TOFU
-
-- Objetivo:
-  - descoberta, consciência e primeiro avanço.
-- Consciência presumida:
-  - baixa a média.
-- Direção:
+  - benefício concreto sustentado;
+  - objeção direta;
+  - CTA de maior intenção.
+- MOFU:
+  - diferenciação;
+  - explicação;
+  - prova contextual;
+  - CTA proporcional.
+- TOFU:
   - contexto;
-  - dor;
-  - desejo;
-  - educação;
-  - prova de relevância;
+  - dor e desejo;
+  - baixa pressão;
   - CTA de baixa fricção.
-- Qualificação:
-  - apenas simples e curta, quando necessária.
-- Módulos mais adequados:
-  - Hero;
-  - Media;
-  - Benefits;
-  - Location;
-  - How it works;
-  - FAQ;
-  - Trust.
-- Offer e Final CTA:
-  - somente em forma proporcional e não agressiva.
-- Qualificação progressiva:
-  - proibida na v1 para TOFU.
 
-### 2.12. Matriz de tratamentos comerciais
+### 2.10. Tratamentos comerciais
 
-- Estados:
-  - `allowed`;
-  - `restricted`;
-  - `prohibited`.
-- Regra global:
-  - tratamento sem fonte real é sempre `prohibited`, mesmo quando a matriz indicar `allowed`.
+Tratamento comercial só pode ser usado com fonte real aplicável.
 
-| Tratamento | BOFU | MOFU | TOFU | Condição |
-|---|---|---|---|---|
-| CTA direto de conversão | allowed | restricted | restricted | coerente com intenção e ação disponível |
-| CTA educacional ou recurso | allowed | allowed | allowed | recurso real e destino válido |
-| preço explícito | allowed | restricted | prohibited | valor operacional atual |
-| oferta transacional | allowed | restricted | restricted | condição real; em TOFU apenas baixa pressão |
-| urgência | restricted | prohibited | prohibited | prazo ou evento real |
-| escassez | restricted | prohibited | prohibited | disponibilidade real e verificável |
-| garantia | restricted | restricted | prohibited | garantia formal e condições disponíveis |
-| prova ou resultado | allowed | allowed | allowed | evidência real e rastreável |
-| comparação | allowed | allowed | restricted | critério objetivo, sem alegação enganosa |
-| credencial | allowed | allowed | allowed | credencial real e vigente |
-| autoridade | allowed | allowed | allowed | identidade e especialização reais |
-| formulário simples | allowed | allowed | restricted | fricção proporcional |
-| formulário progressivo | allowed | restricted | prohibited | necessidade real de qualificação |
-| enquadramento de risco ou medo | restricted | restricted | restricted | sem alarmismo ou manipulação |
-| superlativo ou promessa forte | restricted | restricted | restricted | sustentação explícita e linguagem não absoluta |
+Tratamentos a governar:
 
-- Proibições permanentes:
-  - prova inventada;
-  - depoimento gerado;
-  - resultado garantido sem contrato;
-  - escassez artificial;
-  - urgência artificial;
-  - comparação sem base objetiva;
-  - preço estimado apresentado como real;
-  - credencial inexistente;
-  - autoridade simulada;
-  - keyword stuffing;
-  - omissão deliberada de condição relevante;
-  - linguagem discriminatória;
-  - manipulação por medo.
+- promessa;
+- prova;
+- autoridade;
+- credencial;
+- comparação;
+- preço;
+- oferta;
+- desconto;
+- garantia;
+- urgência;
+- escassez;
+- resultado;
+- depoimento;
+- métrica.
 
-### 2.13. Adaptação do perfil por módulo
+Regras gerais:
 
-- Hero:
-  - adapta intensidade da proposta e do CTA;
-  - não muda estrutura pelo funil.
-- Media:
-  - BOFU prioriza demonstração;
-  - MOFU prioriza avaliação;
-  - TOFU prioriza descoberta.
-- Benefits:
-  - BOFU prioriza ganho concreto;
-  - MOFU prioriza diferenciação;
-  - TOFU prioriza compreensão.
-- Offer:
-  - BOFU admite oferta transacional sustentada;
-  - MOFU usa explicação e próximo passo;
-  - TOFU restringe pressão comercial.
-- Proof:
-  - BOFU prioriza redução de risco;
-  - MOFU prioriza comparação e confiança;
-  - TOFU prioriza legitimidade.
-- Location:
-  - adapta a relevância, sem criar fatos geográficos.
-- Qualification:
-  - BOFU permite maior profundidade;
-  - MOFU limita fricção;
-  - TOFU admite somente `simple_form`.
-- How it works:
-  - BOFU remove incerteza operacional;
-  - MOFU explica processo;
-  - TOFU educa sobre jornada.
-- FAQ:
-  - BOFU responde objeções de decisão;
-  - MOFU responde dúvidas de avaliação;
-  - TOFU responde dúvidas introdutórias.
-- Final CTA:
-  - BOFU direto;
-  - MOFU proporcional;
-  - TOFU de baixa fricção.
-- Trust:
-  - invariantes factuais e de privacidade em todos os perfis.
+- Pesquisa pode orientar tema, objeção, desejo, posicionamento e tipo de prova.
+- Pesquisa não fornece como fato:
+  - preço;
+  - condição;
+  - prazo;
+  - disponibilidade;
+  - garantia;
+  - credencial;
+  - depoimento;
+  - métrica;
+  - registro;
+  - contato;
+  - endereço;
+  - URL;
+  - informação legal específica.
+- Valor factual exige entrada operacional ou fonte própria futura.
+- BOFU admite maior intensidade apenas quando sustentada.
+- MOFU restringe pressão e prioriza comparação e explicação.
+- TOFU proíbe urgência, escassez e pressão artificial.
 
-### 2.14. Contrato de resolução
+### 2.11. Lifecycle e compatibilidade
 
-- Resolver público previsto:
-  - `resolveLandingPageModuleVariant(...)`.
-- Entrada mínima:
-  - `rootVersion`;
-  - `moduleCatalogVersion`;
-  - `moduleKey`;
-  - `variantKey`;
-  - `purpose`.
-- `purpose` permitido:
-  - `controlled_test`;
-  - `new_use`;
-  - `historical_read`.
-- Comportamento:
-  - resolver primeiro a raiz;
-  - validar compatibilidade do catálogo com a raiz;
-  - resolver módulo;
-  - resolver variante;
-  - aplicar precedência raiz → módulo → variante;
-  - calcular limites efetivos;
-  - validar lifecycle contra o propósito;
-  - retornar payload profundamente imutável.
-- Elegibilidade:
-  - `controlled_test`: aceita `experimental` e `validated`;
-  - `new_use`: aceita somente `validated`;
-  - `historical_read`: aceita `experimental`, `validated` e `deprecated` por versão exata;
-  - `candidate`: não é resolvível para uso.
-- Não existe fallback de catálogo, módulo, variante, versão ou lifecycle.
-- Erros mínimos:
-  - `UNKNOWN_ROOT_VERSION`;
-  - `UNKNOWN_MODULE_CATALOG_VERSION`;
-  - `ROOT_CATALOG_INCOMPATIBLE`;
-  - `UNKNOWN_MODULE`;
-  - `UNKNOWN_VARIANT`;
-  - `MODULE_VARIANT_MISMATCH`;
-  - `INVALID_MODULE_CONTRACT`;
-  - `INVALID_VARIANT_CONTRACT`;
-  - `LIFECYCLE_NOT_ELIGIBLE`;
-  - `INVALID_SPECIALIZATION`;
-  - `INVALID_COPY_SOURCE_MAP`;
-  - `INVALID_FUNNEL_PROFILE`.
+Lifecycle previsto:
 
-### 2.15. Compatibilidade histórica
+- `candidate`;
+- `experimental`;
+- `validated`;
+- `deprecated`.
 
-- O contrato resolvido deve expor:
-  - `rootVersion`;
-  - `moduleCatalogVersion`;
-  - `moduleKey`;
-  - `moduleVersion`;
-  - `variantKey`;
-  - `variantVersion`;
-  - lifecycle;
-  - contrato efetivo.
-- Consumidores futuros devem persistir essas identidades no snapshot da LP.
-- A E18.5 não altera agora `account_landing_pages` nem `content_artifacts`.
-- Uma variante `deprecated`:
-  - não entra em novas composições;
-  - não entra em novas gerações;
-  - continua resolvível em `historical_read`.
-- Uma variante só pode deixar de existir em código quando nenhum artefato publicado depender dela ou houver plano de migração aprovado e executado.
-- Remover a variante do catálogo atual não autoriza apagar a definição das versões antigas.
-- A renderer futura deve resolver o contrato exato do snapshot, não o catálogo mais recente.
-- Migração automática de LP existente é proibida sem plano próprio.
+Significado:
 
-### 2.16. Validações executáveis mínimas
+- `candidate`:
+  - em avaliação;
+  - não pode entrar em composição ou geração.
+- `experimental`:
+  - uso apenas em teste controlado.
+- `validated`:
+  - aprovado por LP real e decisão humana.
+- `deprecated`:
+  - não entra em novo uso;
+  - permanece resolvível para histórico.
 
-- Catálogo v1 válido.
-- Todos os módulos têm chave única e função estrutural não vazia.
-- Todas as variantes têm chave única e prefixo correspondente ao módulo.
-- Chave do catálogo corresponde a `moduleCatalogVersion`.
-- `rootVersion` compatível existe.
-- Lifecycle válido.
+Propósitos previstos:
+
+- `controlled_test`;
+- `new_use`;
+- `historical_read`.
+
+Regras:
+
+- `controlled_test` aceita `experimental` e `validated`.
+- `new_use` aceita somente `validated`.
+- `historical_read` aceita versão exata `experimental`, `validated` ou `deprecated`.
+- `candidate` não é resolvível para uso.
+- LP futura deve preservar snapshot das versões efetivas.
+- Renderer futuro deve resolver o contrato exato do snapshot.
+- Remoção física exige ausência de dependência publicada ou plano de migração aprovado.
+
+### 2.12. Contrato de resolução previsto
+
+Resolver público previsto:
+
+- `resolveLandingPageModuleVariant(...)`.
+
+Entrada mínima:
+
+- `rootVersion`;
+- `moduleCatalogVersion`;
+- `moduleKey`;
+- `variantKey`;
+- `purpose`.
+
+Processamento:
+
+1. resolver raiz;
+2. validar compatibilidade do catálogo;
+3. resolver módulo;
+4. validar delta da variante;
+5. aplicar precedência;
+6. calcular contrato efetivo;
+7. validar lifecycle e propósito;
+8. retornar resultado profundamente imutável.
+
+Saída pública:
+
+- identidades e versões;
+- lifecycle;
+- função estrutural;
+- campos finais;
+- cardinalidades finais;
+- papéis semânticos;
+- fontes finais;
+- políticas operacionais;
+- limites efetivos quando houver exceção;
+- comportamento estrutural efetivo quando aprovado.
+
+A saída não contém operações de delta para o consumidor executar.
+
+### 2.13. Artefatos previstos
+
+Criar somente após v2 mergeada:
+
+- `lib/conversion-content/landing-page/module-catalog/contracts.ts`;
+- `lib/conversion-content/landing-page/module-catalog/registry.ts`;
+- `lib/conversion-content/landing-page/module-catalog/schema.ts`;
+- `lib/conversion-content/landing-page/module-catalog/resolver.ts`;
+- `lib/conversion-content/landing-page/module-catalog/validation-cases.ts`;
+- `lib/conversion-content/landing-page/module-catalog/index.ts`.
+
+Ajustar:
+
+- `lib/conversion-content/index.ts`;
+- `package.json`;
+- `docs/lousa-plano-base-e18-5.md`, somente para estado e evidências da fase.
+
+Preservar:
+
+- `landingPageRoot`;
+- parametrização raiz;
+- `commercial_activation`.
+
+Interface pública agregada prevista:
+
+- `landingPageModules`.
+
+Script previsto:
+
+- `validate:landing-page-modules`.
+
+Não adicionar dependência npm.
+
+### 2.14. Validações mínimas previstas
+
+- Catálogo e versões válidos.
+- Compatibilidade explícita com a raiz.
 - Módulo desconhecido falha fechado.
 - Variante desconhecida falha fechado.
 - Variante vinculada ao módulo errado falha fechado.
-- `candidate` rejeitada em todos os propósitos de uso.
-- `experimental` aceita em `controlled_test` e rejeitada em `new_use`.
-- `validated` aceita em todos os propósitos aplicáveis.
-- `deprecated` aceita somente em `historical_read`.
-- Campo obrigatório ausente falha.
-- Campo desconhecido falha.
-- Cardinalidade mínima e máxima inválidas falham.
-- `minItems > maxItems` falha.
+- Campo da variante fora do catálogo do módulo falha.
+- Cardinalidade inválida falha.
 - Papel semântico desconhecido falha.
-- Opção de spacing fora da raiz falha.
-- Especialização com mínimo menor que 1 falha.
-- Especialização com mínimo maior que máximo falha.
-- Especialização acima do limite absoluto efetivo falha.
-- Variante que amplia restrição do módulo falha.
-- `copy_source_map` com mais de 2 fontes primárias falha.
-- `copy_source_map` com mais de 1 auxiliar falha.
-- `researchBlock` desconhecido falha.
-- `itemKey` desconhecido no bloco fixo falha.
-- `lp_sections` como fonte de copy falha.
-- `business_buyer` usado como fonte primária de dor, desejo, objeção, SEO ou vocabulário do visitante falha.
-- Campo operacional sem marcação obrigatória falha.
-- Métrica, depoimento, credencial, preço, endereço ou compliance com origem de pesquisa como valor factual falha.
+- Valor da raiz não é duplicado no módulo.
+- Exceção acima do limite absoluto falha.
+- Ampliação de restrição pelo nível filho falha.
+- Regra estrutural não enumerada falha.
+- `copy_source_map` excedendo fontes permitidas falha.
+- `itemKey` desconhecido falha.
+- Fonte de `business_buyer` usada indevidamente falha.
+- Fato operacional originado da pesquisa falha.
 - Perfil de funil desconhecido falha.
-- Override de variante que promove tratamento proibido falha.
-- Tratamento sem fonte real permanece proibido.
-- TOFU com `qualification.progressive_form` falha.
+- Tratamento proibido promovido por variante falha.
+- Lifecycle incompatível com propósito falha.
 - Resultado resolvido é profundamente imutável.
-- Chamadas diferentes não compartilham referência mutável.
-- Nova versão de catálogo pode ser adicionada sem alterar a v1.
+- Chamadas não compartilham referências mutáveis.
 - Versão antiga permanece resolvível.
-- Registry não contém taxon, campaign, account, composition, sortOrder, isRequired, conteúdo concreto, URL concreta ou preço concreto.
 - Ausência de imports de banco, Supabase, env, API, renderer, rota ou Admin.
 
-### 2.17. Fluxo operacional
+### 2.15. Fluxo operacional
 
 - Gatilho:
   - plano-base v2 consolidado e mergeado;
-  - fase atual instruída pelo Estrategista.
+  - fase instruída pelo Estrategista.
 - Entrada:
-  - parametrização raiz v1;
+  - raiz v1;
   - plano-base E18.5;
-  - catálogo inicial aprovado;
+  - catálogo aprovado;
   - `item_key` oficiais;
-  - evidência parcial do blueprint.
+  - evidências aprovadas.
 - Processamento:
-  - criar contratos públicos;
-  - criar registry versionado;
-  - criar schema estrito;
-  - criar resolver;
-  - calcular especializações efetivas;
-  - validar mapas e perfis;
-  - criar casos executáveis;
-  - ajustar exports e script.
+  - contratos;
+  - registry;
+  - schema;
+  - resolver;
+  - validação de deltas;
+  - mapas;
+  - perfis;
+  - lifecycle;
+  - casos executáveis.
 - Validação:
   - `npm ci`;
   - `npm run validate:landing-page-root`;
@@ -1191,35 +645,14 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
   - `git diff --check`;
   - checks do PR.
 - Persistência:
-  - arquivos versionados no repositório;
+  - repositório;
   - sem banco.
 - Consumo:
   - E20 e E19 em fases futuras.
 - Fallback:
   - falha fechada;
-  - sem versão ou variante implícita;
-  - conflito ou necessidade de escopo novo retorna ao Estrategista.
-
-### 2.18. Relatório documental
-
-- Usar relatório consolidado somente ao final do plano.
-- O relatório final deve informar ao Gestor de Docs:
-  - catálogo inicial;
-  - variantes e lifecycle;
-  - boundary e arquivos;
-  - especializações efetivas;
-  - `copy_source_map`;
-  - `funnel_copy_profile`;
-  - matriz de tratamentos;
-  - compatibilidade histórica;
-  - checks;
-  - ausência de banco, composição, geração e Admin.
-- Atualizações duráveis previstas:
-  - `docs/roadmap.md`;
-  - `docs/base-tecnica.md`;
-  - referências comprovadamente afetadas em `docs/lp-planejamento.md`, apenas se houver delta real.
-- `docs/schema.md`:
-  - N/A se não houver mudança de banco.
+  - sem versão, módulo ou variante implícita;
+  - conflito retorna ao Estrategista.
 
 ## 3. Fases e próxima ação
 
@@ -1227,53 +660,44 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 
 - Status:
   - pendente;
-  - bloqueada até consolidação v2 e merge do plano-base.
+  - bloqueada até consolidação v2 e merge humano do plano-base.
 - Automação:
   - não.
 - Risco:
   - médio controlado.
 - Objetivo:
-  - implementar atomicamente o contrato repo-only completo de módulos e variantes v1.
-- Artefatos a criar:
-  - `lib/conversion-content/landing-page/module-catalog/contracts.ts`;
-  - `lib/conversion-content/landing-page/module-catalog/registry.ts`;
-  - `lib/conversion-content/landing-page/module-catalog/schema.ts`;
-  - `lib/conversion-content/landing-page/module-catalog/resolver.ts`;
-  - `lib/conversion-content/landing-page/module-catalog/validation-cases.ts`;
-  - `lib/conversion-content/landing-page/module-catalog/index.ts`.
-- Artefatos a ajustar:
-  - `lib/conversion-content/index.ts`;
-  - `package.json`;
-  - `docs/lousa-plano-base-e18-5.md`, somente estado e evidências da fase.
-- Implementação:
-  - catálogo e versões;
-  - módulos e variantes;
-  - campos, estruturas e cardinalidades;
-  - especializações sobre a raiz;
-  - mapas de fontes;
-  - perfis de funil;
-  - matriz de tratamentos;
+  - implementar atomicamente o contrato repo-only aprovado para módulos e variantes.
+- Escopo material previsto:
+  - identidade e versões;
+  - módulos aprovados;
+  - variantes aprovadas;
+  - campos e cardinalidades;
+  - deltas fechados;
+  - resolução efetiva;
+  - `copy_source_map`;
+  - `funnel_copy_profile`;
+  - tratamentos comerciais;
   - lifecycle;
-  - compatibilidade;
-  - resolver;
+  - compatibilidade histórica;
   - validações.
 - Critérios de aceite:
-  - todos os contratos da seção 2 implementados;
+  - nenhum valor comum da raiz duplicado;
   - raiz preservada;
-  - catálogo v1 imutável;
+  - catálogo imutável;
   - resolver fail-closed;
-  - módulos e variantes não representam taxon, conteúdo, campanha ou composição;
-  - fontes de copy usam apenas chaves autorizadas;
+  - consumidor recebe contrato efetivo;
+  - variante não cria campo livre;
+  - módulo e variante não representam taxon, campanha, conteúdo ou composição;
   - fatos operacionais não são inferidos da pesquisa;
-  - lifecycle e propósito de uso aplicados;
-  - versões antigas preserváveis;
-  - nenhum renderer, schema final de LP ou geração antecipada;
   - nenhuma mudança de banco;
+  - nenhum renderer, geração ou schema final de LP;
   - validações concluídas.
-- Próxima ação após execução:
-  - avaliação do Analista;
-  - se aprovado, encerrar a implementação material e emitir relatório final ao Gestor de Docs;
-  - se precisar de ajuste, retornar à mesma fase.
+- Próxima ação:
+  - continuar o debate do catálogo inicial;
+  - consolidar os pareceres aplicáveis;
+  - produzir v2 no mesmo PR;
+  - solicitar merge humano;
+  - somente depois instruir o Executor.
 
 ## 4. Escopo negativo e critérios de parada
 
@@ -1286,7 +710,7 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 - Taxonomia.
 - Composição base.
 - Composição por taxon.
-- Ordem ou obrigatoriedade das seções.
+- Ordem ou obrigatoriedade global das seções.
 - Herança concreta de composição.
 - Prontidão do taxon.
 - Autorização de conta de teste.
@@ -1328,29 +752,30 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 
 ### 4.2. Critérios de parada
 
-- Parar e devolver ao Estrategista se:
-  - a implementação exigir banco;
-  - surgir necessidade de registrar composição;
-  - surgir necessidade de gerar ou renderizar conteúdo;
-  - faltar `item_key` oficial necessário;
-  - uma variante depender de taxon, campanha ou entrada específica;
-  - uma diferença puder ser atendida por parâmetro já existente;
-  - houver necessidade de ampliar limite absoluto da raiz;
-  - houver conflito com a E18.4;
-  - houver conflito com E20 ou E19;
-  - a implementação exigir mudança de `commercial_activation`;
-  - a implementação exigir nova dependência;
-  - a implementação exigir URL, rota, formulário funcional ou integração;
-  - a preservação histórica não puder ser garantida no contrato repo-only;
-  - o diff ultrapassar os artefatos autorizados sem decisão humana.
+Parar e devolver ao Estrategista se:
+
+- a implementação exigir banco;
+- surgir necessidade de registrar composição;
+- surgir necessidade de gerar ou renderizar conteúdo;
+- faltar `item_key` oficial necessário;
+- uma variante depender de taxon, campanha ou entrada específica;
+- uma diferença puder ser atendida por parâmetro, conteúdo ou composição;
+- houver necessidade de ampliar limite absoluto da raiz;
+- houver conflito com E18.4, E20 ou E19;
+- a implementação exigir mudança de `commercial_activation`;
+- a implementação exigir nova dependência;
+- a implementação exigir URL, rota, formulário funcional ou integração;
+- a preservação histórica não puder ser garantida;
+- o diff ultrapassar os artefatos autorizados sem decisão humana.
 
 ### 4.3. Decisão atual
 
-- Plano-base v1 criado para avaliação única dos especialistas.
-- Nenhuma fase autorizada ao Executor.
-- Próxima ação:
-  - abrir PR vivo apenas com este plano-base;
-  - solicitar avaliação do Analista, Gestor Estrutural e Gestor de Updates;
-  - consolidar todos os retornos no mesmo PR como v2;
-  - solicitar merge humano;
-  - somente após confirmação do merge, instruir a fase 3.1 ao Executor.
+- PR #577 preservado.
+- Plano-base permanece v1 em ajuste.
+- Correções conceituais do Analista incorporadas.
+- `hero.media_split` não aprovada.
+- `hero.standard` permanece exemplo inicial em debate.
+- Próxima decisão humana:
+  - fechar a estrutura mínima do Hero;
+  - decidir se o catálogo inicial será construído módulo a módulo;
+  - definir o próximo módulo a debater.

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -1,10 +1,10 @@
 14/07/2026 — Plano-base E18.5 — Parametrização de módulos e variantes `landing_page`
 
-Fontes: chat, `README.md`, `AGENTS.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/schema.md`, `docs/lp-planejamento.md`, `docs/lousa-plano-base-e18-4.md`, `docs/lousa-plano-base-e20-2.md`, `docs/blueprint-corretor-imoveis-end-customer.md`, `docs/prompt-nicho-itens-estruturados.md`, consulta read-only ao Supabase, `lib/conversion-content/landing-page/`, `lib/conversion-content/landing-page/input-catalog/registry.ts`, PRs #559, #563, #564, #566, #567, #577 e #581, avaliações do Analista e decisões humanas de 14 a 17/07/2026.
+Fontes: chat, `README.md`, `AGENTS.md`, `docs/prompt-estrategista.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/schema.md`, `docs/lp-planejamento.md`, `docs/lousa-plano-base-e18-4.md`, `docs/lousa-plano-base-e20-2.md`, `docs/blueprint-corretor-imoveis-end-customer.md`, `docs/prompt-nicho-itens-estruturados.md`, consulta read-only ao Supabase, `lib/conversion-content/landing-page/`, `lib/conversion-content/landing-page/input-catalog/registry.ts`, PRs #559, #563, #564, #566, #567, #577 e #581, avaliações do Analista e decisões humanas de 14 a 17/07/2026.
 
 Versão: v1 conceitualmente fechada.
 
-Status: nove módulos e suas variantes `standard@v1` conceitualmente fechados; `faq.accordion@v1` aprovada como única variante adicional para validação controlada; nenhuma implementação de código autorizada neste PR.
+Status: nove módulos e nove variantes `standard@v1` conceitualmente fechados; `faq.accordion@v1` aprovada como única variante adicional para validação controlada; uma fase executável definida; nenhuma implementação de código autorizada neste PR.
 
 Path: `docs/lousa-plano-base-e18-5.md`.
 
@@ -14,21 +14,19 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 
 ### 1.1. Objetivo da E18.5
 
-- Definir e implementar, no repositório, o catálogo versionado dos nove módulos `landing_page`, de suas variantes `standard@v1` e da variante controlada `faq.accordion@v1`.
+- Implementar no repositório o catálogo versionado dos nove módulos `landing_page`, suas variantes `standard@v1` e `faq.accordion@v1`.
 - Entregar contratos pequenos, estritos, imutáveis e suficientes para consumo posterior pela E20 e pela E19.
-- Preservar extensibilidade sem antecipar campos, capacidades ou variantes sem uso aprovado.
-- Encerrar o fechamento conceitual após os nove módulos, suas variantes aprovadas e a validação integrada dos contratos.
+- Preservar extensibilidade sem antecipar campos, capabilities ou variantes sem uso aprovado.
 
 ### 1.2. Estado confirmado
 
 - A E18.4 está concluída e a raiz versionada existe em `lib/conversion-content/landing-page/`.
 - A precedência permanece `raiz → módulo → variante`.
-- A E18.5 permanece repo-only.
-- Ainda não existem composição, renderer ou render model.
+- A E18.5 é repo-only; ainda não existem composição, renderer ou render model deste recorte.
 - O catálogo operacional já define `primary_conversion_channel` e destinos condicionais.
 - `commercial_activation`, E18.2 e E18.3 permanecem preservados.
-- O trabalho documental continua no PR #577 e na branch `docs/e18-5-modules-variants`.
-- O PR #577 não deve ser mergeado sem confirmação humana explícita.
+- O trabalho documental ocorre no PR #577 e na branch `docs/e18-5-modules-variants`.
+- O PR não deve ser mergeado sem confirmação humana explícita.
 
 ### 1.3. Grade fechada de módulos
 
@@ -44,7 +42,6 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 
 Regras:
 
-- Os nove módulos serão implementados na E18.5 após autorização humana.
 - `item_key` é evidência de pesquisa, não identidade canônica do módulo.
 - Os módulos são transversais e não recebem identidade de taxon.
 - Formatos curto, médio e longo pertencem à composição e à extensão da LP.
@@ -52,543 +49,370 @@ Regras:
 
 ### 1.4. Escopo positivo
 
-A E18.5 define e implementa:
-
-- identidade e versão do catálogo;
-- identidade, versão, função e invariantes dos módulos;
-- identidade, versão, campos, cardinalidades e capacidades das variantes `standard@v1` e de `faq.accordion@v1`;
-- especializações necessárias sobre a raiz;
-- fontes de copy e perfis de funil;
-- exigências factuais ou operacionais;
-- schemas, tipos, registry, resolver, validadores e testes de contrato;
+- identidade e versão do catálogo, módulos e variantes;
+- função, invariantes, fronteiras, campos, cardinalidades e capabilities;
+- especializações sobre a raiz, fontes de copy e perfis de funil;
+- exigências factuais e operacionais;
+- tipos, schemas, registry, resolver, validadores, testes e exportação pública;
 - lifecycle, compatibilidade e descontinuação.
 
 ### 1.5. Escopo negativo
 
-Ficam fora:
-
-- banco e migrations;
-- Admin e Builder;
-- composição concreta por taxon;
-- geração ou edição de LP real;
-- renderer e componentes visuais;
-- persistência e snapshot;
-- tracking;
-- conteúdo operacional concreto;
-- variantes além de `standard@v1`, exceto `faq.accordion@v1`, explicitamente aprovada para validação controlada;
-- capacidades sem consumidor aprovado.
+- banco, migrations, Admin, Builder, composição concreta, LP real, renderer ou componente visual;
+- persistência, snapshot, tracking ou conteúdo operacional concreto;
+- variantes além de `standard@v1`, exceto `faq.accordion@v1`;
+- capabilities sem consumidor aprovado.
 
 ## 2. Contrato compartilhado
 
 ### 2.1. Separação entre módulo e variante
 
-Módulo define somente:
+Módulo define:
 
 - função estrutural reutilizável;
-- fronteiras com outros módulos;
-- invariantes realmente permanentes;
-- requisitos mínimos de integração;
-- compatibilidade comum.
+- fronteiras, invariantes permanentes e integração comum;
+- compatibilidade compartilhada.
 
 Variante define:
 
 - execução estrutural ou comportamental concreta;
-- campos e cardinalidades;
-- capacidades utilizadas;
-- especializações da raiz;
-- validações próprias;
-- requisitos técnicos, factuais, operacionais e de acessibilidade aplicáveis.
+- campos, cardinalidades, capabilities e deltas sobre a raiz;
+- validações e requisitos técnicos, factuais, operacionais ou de acessibilidade.
 
 ### 2.2. Extensibilidade das variantes
 
-- Cada módulo começa com uma variante `standard@v1`; `faq.accordion@v1` é a única exceção adicional aprovada antes da primeira LP.
+- Cada módulo começa com `standard@v1`; `faq.accordion@v1` é a única exceção antes da primeira LP.
 - Nova variante exige diferença estrutural ou comportamental reutilizável.
-- Nova variante pode adicionar ou especializar campos, mídia, interação, responsividade e validações próprias.
-- Nova variante deve constituir evolução aditiva e localizada; poderá exigir capabilities compartilhadas ou infraestrutura inerente à nova execução, tratadas nos respectivos recortes, sem alteração destrutiva do módulo, das variantes existentes ou das LPs anteriores.
-- Restrições de `standard@v1` não restringem variantes futuras.
-- Nova variante não exige nova `moduleVersion` quando preserva função, fronteiras, invariantes e integração comum.
-- Nova `moduleVersion` é exigida quando mudam função, fronteiras, invariantes permanentes ou integração comum.
-- Nova `variantVersion` é exigida quando muda o contrato de uma variante existente.
-- Cada referência identifica `moduleKey`, `moduleVersion`, `variantKey` e `variantVersion`.
+- A evolução deve ser aditiva e localizada, sem alteração destrutiva do módulo, das variantes existentes ou das LPs anteriores.
+- Capability compartilhada ou infraestrutura inerente à nova execução pertence ao respectivo recorte e deve ser versionada quando necessário.
+- Nova `moduleVersion` é exigida quando mudam função, fronteiras, invariantes ou integração comum.
+- Nova `variantVersion` é exigida quando muda o contrato da variante.
+- Toda referência identifica `moduleKey`, `moduleVersion`, `variantKey` e `variantVersion`.
 
 Não criam variante isoladamente:
 
-- taxon, plano, campanha ou origem de tráfego;
-- funil ou copy;
-- troca de ativo;
-- canal ou destino concreto;
-- ordem na LP;
-- quantidade já permitida;
-- ajuste visual ou responsivo normal do renderer.
+- taxon, plano, campanha, funil ou copy;
+- troca de ativo, canal ou destino concreto;
+- ordem na LP, quantidade já permitida ou ajuste visual/responsivo normal.
 
 ### 2.3. Herança, limites e resolução
 
-- A raiz contém regras comuns; módulo e variante registram apenas deltas necessários.
-- Módulo ou variante pode restringir a raiz, mas não ampliar limite absoluto vigente.
-- Necessidade acima do limite da raiz exige evolução versionada da raiz.
-- Capability da raiz só bloqueia a implementação quando for indispensável à variante aprovada.
+- A raiz contém regras comuns; módulo e variante registram somente deltas necessários.
+- Módulo ou variante pode restringir a raiz, mas não ampliar seu limite absoluto.
+- Ampliação exige nova versão da raiz.
 - Variante declara compatibilidade explícita com a versão da raiz utilizada.
 - Variante imutável não muda pela disponibilidade posterior de nova capability.
-- Não existe fallback silencioso.
-- Contrato ausente, incompatível ou inválido falha fechado.
-- Resultado resolvido deve ser completo, profundamente imutável e sem referência mutável compartilhada.
+- Contrato ausente, incompatível ou inválido falha fechado, sem fallback silencioso.
+- Resultado resolvido é completo, profundamente imutável e sem referência mutável compartilhada.
 
 ### 2.4. Contrato mínimo de campo
 
-Cada campo usado por uma variante declara:
+Cada campo declara:
 
-- `fieldKey` e `fieldKind`;
-- cardinalidade;
+- `fieldKey`, `fieldKind`, cardinalidade e policy;
 - `semanticRole`, quando textual;
-- policy de origem do valor;
-- suporte operacional, quando aplicável;
-- capability específica, quando aplicável.
+- suporte operacional e capability específica, quando aplicáveis.
 
 Notação da seção 3:
 
-- campo textual usa `fieldKey: semanticRole, cardinalidade, policy[, suporte]`; somente nessa notação `fieldKind = text` fica implícito;
-- coleção, ação, mídia e referência técnica declaram o `fieldKind` explicitamente;
-- campos internos de coleção declaram sua própria cardinalidade, sem inferência por omissão.
-
-Regras:
-
-- cardinalidade representa obrigatoriedade;
-- texto visível usa papel semântico existente na raiz;
-- coleção possui contrato fechado do item e não admite coleção aninhada na v1;
-- ação não armazena canal, URL, telefone, e-mail ou destino concreto;
-- mídia referencia ativo futuro e declara apenas requisitos necessários à variante;
-- tipos, policies e capabilities só entram quando consumidos por variante aprovada.
+- texto: `fieldKey: semanticRole, cardinalidade, policy[, suporte]`; nessa notação `fieldKind = text` fica implícito;
+- coleção, ação, mídia e referência técnica declaram o tipo explicitamente;
+- campos internos de coleção declaram cardinalidade própria;
+- coleção aninhada não integra a v1;
+- ação não armazena canal ou destino concreto.
 
 ### 2.5. Copy e sustentação factual
 
-- `copySourceMap` define até duas fontes primárias e uma auxiliar por campo textual, salvo decisão humana registrada.
-- `funnelCopyProfile` adapta seleção e redação para BOFU, MOFU e TOFU.
-- O funil não redefine sozinho a estrutura ou a ordem da LP.
-- Pesquisa orienta copy, mas não comprova fatos sobre a operação.
+- `copySourceMap` define até duas fontes primárias e uma auxiliar por campo textual.
+- `funnelCopyProfile` adapta seleção e redação para BOFU, MOFU e TOFU, sem redefinir sozinho estrutura ou ordem.
+- Pesquisa orienta copy, mas não comprova fatos da operação.
 - Credencial, capacidade, condição, preço, prazo, parceria, resultado, garantia ou ação concreta exige suporte operacional real.
-- A E19 resolve valores e valida a instância concreta conforme a composição recebida.
-- Nenhum módulo pode inventar prova, certificação, garantia ou resultado.
-
-Policies aprovadas:
-
-- `research_guided`;
-- `hybrid`;
-- `operational_required`;
-- `technical_reference`;
-- `not_copy`.
-
-`operational_required` exige valor originado de evidência operacional real e impede geração a partir da pesquisa.
+- A E19 resolve valores e valida a instância concreta.
+- Policies aprovadas: `research_guided`, `hybrid`, `operational_required`, `technical_reference` e `not_copy`.
 
 ### 2.6. Ações e vínculos operacionais
 
-- Ação possui label textual e vínculo abstrato com campo estável do catálogo operacional.
+- Ação possui label e vínculo abstrato com campo estável do catálogo operacional.
 - O registry não armazena valor, canal ou destino concreto.
-- O vínculo declara se o campo operacional é obrigatório quando a ação estiver presente.
-- A E19 resolve o campo operacional, seus condicionais e o destino.
+- A E19 resolve o campo operacional, condicionais e destino.
 - Nova chave operacional não pode ser criada implicitamente pela E18.5.
 
 ### 2.7. Lifecycle e compatibilidade
 
-- `moduleCatalogVersion` declara versão e compatibilidade com a raiz; não possui lifecycle próprio.
-- Módulo e variante usam lifecycle `experimental`, `active` ou `deprecated`.
+- `moduleCatalogVersion` declara versão e compatibilidade com a raiz.
+- Módulo e variante usam `experimental`, `active` ou `deprecated`.
 - Todos começam `experimental`, com propósito `controlled_test`.
-- Promoção para `active` exige uso em LP real, revisão e decisão humanas.
-- `deprecated` impede novas composições, mas preserva leitura e renderização histórica.
-- Remoção física exige inexistência de dependentes ou migração aprovada.
-- Implementação técnica não equivale a validação comercial.
+- Promoção para `active` exige LP real, revisão e decisão humanas.
+- `deprecated` bloqueia novas composições, mas preserva leitura histórica.
 
 ### 2.8. Fronteiras entre etapas
 
-E18.5:
-
-- define o que é estruturalmente válido;
-- implementa contratos repo-only;
-- não resolve instâncias concretas.
-
-E20:
-
-- escolhe módulos, variantes, versões, ordem, obrigatoriedade e opções por ocorrência;
-- define a composição aplicável ao taxon.
-
-E19:
-
-- recebe pesquisas, composição e entradas;
-- resolve conteúdo, ativos e vínculos;
-- trata ausência ou invalidade conforme a obrigatoriedade definida pela E20;
-- gera e administra a LP real;
-- preserva versões e payload resolvido de forma genérica.
-
-Renderer:
-
-- executa o contrato resolvido;
-- não escolhe variante, conteúdo ou fallback.
+- E18.5 define validade estrutural e implementa contratos repo-only.
+- E20 escolhe módulos, variantes, versões, ordem, obrigatoriedade e opções por ocorrência.
+- E19 resolve conteúdo, ativos e vínculos, trata ausência conforme E20 e preserva versões e payload.
+- Renderer executa o contrato resolvido; não escolhe variante, conteúdo ou fallback.
 
 ### 2.9. Checklist de fechamento
 
 Obrigatório:
 
 - identidade, função, evidência, fronteiras e invariantes;
-- variante `standard@v1`;
-- campos, cardinalidades, fontes de copy e suporte factual;
-- lifecycle, compatibilidade e validações estruturais.
+- `standard@v1`, campos, cardinalidades, copy, suporte factual, lifecycle e compatibilidade.
 
-Condicional, quando usado por variante aprovada:
+Condicional:
 
-- ação, mídia ou interação;
-- responsividade ou acessibilidade específica;
-- fallback técnico ou referência técnica.
+- ação, mídia, interação, responsividade, acessibilidade, fallback técnico ou referência técnica.
 
 ### 2.10. Significado de implementação
 
-Um módulo está implementado na E18.5 quando existem:
+Um módulo está implementado quando existem:
 
-- identidade versionada do módulo e de suas variantes aprovadas;
-- tipos, schemas, campos, cardinalidades e capabilities;
-- registry, resolver e validadores;
-- fixtures quando úteis;
-- casos executáveis e testes de contrato;
-- lifecycle, compatibilidade e exportação pelo boundary `lib/conversion-content/landing-page/`.
-
-Isso não inclui seção visual funcional.
+- identidade versionada do módulo e variantes aprovadas;
+- tipos, schemas, fields, cardinalidades e capabilities;
+- registry, resolver, validadores, casos executáveis e testes;
+- lifecycle, compatibilidade e exportação pelo boundary existente.
 
 Compatibilidade comum da seção 3:
 
-- salvo indicação contrária, cada variante `standard@v1` é compatível exclusivamente com o respectivo módulo `@v1` e com a versão da raiz declarada pelo catálogo inicial;
-- `faq.accordion@v1` possui a mesma compatibilidade explícita com `faq@v1` e com essa versão da raiz;
-- definições compartilhadas podem ser reutilizadas na implementação, mas uma variante não herda semanticamente o contrato de uma variante irmã.
+- cada `standard@v1` é compatível somente com o respectivo módulo `@v1` e com a raiz inicial;
+- `faq.accordion@v1` é compatível com `faq@v1` e com a mesma raiz;
+- definições compartilhadas podem ser reutilizadas, mas variantes irmãs não herdam semanticamente entre si.
 
 ## 3. Contratos conceitualmente fechados
 
 ### 3.1. Módulo `hero`
 
 - Identidade: `hero@v1`.
-- Função: apresentar proposta principal, estabelecer o recorte da LP e conduzir à rota prioritária de conversão ou continuidade.
-- Invariantes: proposta principal identificável, hierarquia semântica coerente e integração abstrata com ação quando utilizada.
+- Função: apresentar a proposta principal e conduzir à rota prioritária.
+- Invariantes: proposta identificável, hierarquia coerente e ação abstrata quando usada.
 - Fronteiras: sem formulário completo, galeria, carrossel, tour, navegação global, oferta detalhada ou prova extensa.
-- Evidência: `hero_segmentado` de `lp_sections` e Blueprint do corretor.
+- Evidência: `hero_segmentado` e Blueprint.
 
 ### 3.2. Variante `hero.standard@v1`
 
-- Campos:
-  - `eyebrow`: `eyebrow`, `0..1`, `research_guided`;
-  - `title`: `h1`, `1..1`, `hybrid`, suporte `when_factual`;
-  - `subtitle`: `paragraph`, `1..1`, `hybrid`, suporte `when_factual`;
-  - `primaryCta`: ação `1..1`, `not_copy`, label `cta_label`, `1..1`, `hybrid`, suporte `when_present`, vínculo obrigatório com `primary_conversion_channel`;
-  - `proofShort`: `paragraph`, `0..1`, `hybrid`, suporte `when_present`;
-  - `media`: imagem `0..1`, `technical_reference`, modo `informative` ou `decorative`.
-- Copy:
-  - `eyebrow`: `positioning_opportunity`; auxiliar `search_intent`;
-  - `title`: `positioning_opportunity` e `desire`; auxiliar `commercial_keywords`;
-  - `subtitle`: `pain` e `desire`; auxiliar `belief`;
-  - CTA: `trigger`; auxiliar `search_intent`;
-  - `proofShort`: `proof_type`; auxiliar `objection`.
-- Regras:
-  - canais permitidos: `whatsapp`, `phone`, `email` e `external_url`;
-  - imagem informativa exige alternativa acessível;
-  - visibilidade da mídia `all_viewports`;
-  - `subtitle` usa `body.base`;
-  - `desktop_only` e `body.editorialEmphasis` exigem evolução versionada;
-  - sem CTA secundário, vídeo, formulário, interação, galeria, carrossel ou tour.
-- Estado: `experimental`, `controlled_test`, conceitualmente fechada.
+- Campos: `eyebrow` (`eyebrow`, `0..1`, `research_guided`); `title` (`h1`, `1..1`, `hybrid`, `when_factual`); `subtitle` (`paragraph`, `1..1`, `hybrid`, `when_factual`); `primaryCta` (ação `1..1`, label `cta_label`, `hybrid`, `when_present`, vínculo com `primary_conversion_channel`); `proofShort` (`paragraph`, `0..1`, `hybrid`, `when_present`); `media` (imagem `0..1`, `technical_reference`).
+- Copy: posicionamento/desejo no título; dor/desejo no subtítulo; trigger no CTA; prova/objeção em `proofShort`.
+- Regras: canais `whatsapp`, `phone`, `email`, `external_url`; mídia informativa exige alternativa; `all_viewports`; sem CTA secundário, vídeo, formulário ou interação.
+- Estado: `experimental`, `controlled_test`.
 
 ### 3.3. Módulo `trust_bar`
 
 - Identidade: `trust_bar@v1`.
-- Função: apresentar sinais curtos e verificáveis de confiança.
-- Invariantes: brevidade, relevância e sustentação factual real.
-- Fronteiras: sem depoimento, explicação extensa, prova técnica detalhada, CTA, formulário ou mídia.
-- Evidência: `barra_de_confianca` de `lp_sections`.
+- Função: sinais curtos e verificáveis de confiança.
+- Invariantes: brevidade, relevância e suporte real.
+- Fronteiras: sem depoimento, prova extensa, CTA, formulário ou mídia.
+- Evidência: `barra_de_confianca`.
 
 ### 3.4. Variante `trust_bar.standard@v1`
 
-- Campo `items`: coleção `2..4`, `not_copy`, com `text`: `benefit_item`, `1..1`, `hybrid`, suporte `when_present`.
-- Copy: `proof_type` e `belief`; auxiliar `objection`.
-- Regras:
-  - cada item exige suporte operacional real;
-  - sem título, subtítulo, CTA, ícone ou mídia;
-  - disposição responsiva pertence ao renderer;
-  - ausência depende da obrigatoriedade definida pela E20.
-- Estado: `experimental`, `controlled_test`, conceitualmente fechada.
+- `items`: coleção `2..4`, `not_copy`; `text`: `benefit_item`, `1..1`, `hybrid`, `when_present`.
+- Copy: `proof_type`, `belief`; auxiliar `objection`.
+- Regras: cada item exige suporte; sem título, CTA, ícone ou mídia; responsividade pertence ao renderer.
+- Estado: `experimental`, `controlled_test`.
 
 ### 3.5. Módulo `problem_solution`
 
 - Identidade: `problem_solution@v1`.
-- Função: relacionar problemas, fricções ou riscos reconhecíveis a respostas práticas.
-- Invariantes: correspondência direta, distinção clara, sem alarmismo ou promessa não sustentada.
+- Função: relacionar problema ou risco a resposta prática.
+- Invariantes: correspondência direta, distinção clara, sem alarmismo.
 - Fronteiras: sem oferta detalhada, processo, prova, FAQ, CTA, mídia ou interação.
-- Evidência: `dores_e_solucoes`, `pain`, `fear`, `objection`, `desire`, `belief` e `positioning_opportunity`.
+- Evidência: `dores_e_solucoes`, `pain`, `fear`, `objection`, `desire`, `belief`, `positioning_opportunity`.
 
 ### 3.6. Variante `problem_solution.standard@v1`
 
-- Campos:
-  - `title`: `h2`, `1..1`, `research_guided`;
-  - `items`: coleção `2..4`, `not_copy`, com:
-    - `problem`: `card_title`, `1..1`, `research_guided`;
-    - `solution`: `card_body`, `1..1`, `hybrid`, suporte `when_present`.
-- Copy:
-  - `title`: `pain` e `desire`; auxiliar `positioning_opportunity`;
-  - `problem`: `pain` e `fear`; auxiliar `objection`;
-  - `solution`: `positioning_opportunity` e `desire`; auxiliar `belief`.
-- Regras:
-  - cada solução responde ao problema do mesmo item e exige suporte operacional;
-  - sem subtítulo, CTA, mídia, prova, preço, oferta detalhada ou processo;
-  - resolução fail-closed e imutável.
-- Estado: `experimental`, `controlled_test`, conceitualmente fechada.
+- `title`: `h2`, `1..1`, `research_guided`.
+- `items`: coleção `2..4`, com `problem` (`card_title`, `1..1`, `research_guided`) e `solution` (`card_body`, `1..1`, `hybrid`, `when_present`).
+- Copy: dor/desejo no título; dor/medo no problema; posicionamento/desejo na solução.
+- Regras: solução responde ao problema do item; sem CTA, mídia, prova, preço, oferta ou processo.
+- Estado: `experimental`, `controlled_test`.
 
 ### 3.7. Módulo `offer`
 
 - Identidade: `offer@v1`.
-- Função: apresentar ofertas, escopos ou casos de uso efetivamente disponíveis.
-- Invariantes: item real e identificável, coerência entre título e descrição e sustentação operacional.
-- Fronteiras: sem problema-solução, processo, prova, FAQ, preço, condição comercial, CTA, mídia ou interação.
+- Função: apresentar ofertas ou casos de uso disponíveis.
+- Invariantes: item real, coerente e operacionalmente sustentado.
+- Fronteiras: sem preço, condição comercial, CTA, mídia, prova, processo ou FAQ.
 - Evidência: `servicos_por_intencao`, `trigger`, `desire`, `positioning_opportunity`, `belief`, `objection`, Blueprint e catálogo de entradas.
 
 ### 3.8. Variante `offer.standard@v1`
 
-- Campos:
-  - `title`: `h2`, `1..1`, `research_guided`;
-  - `items`: coleção `1..4`, `not_copy`, com:
-    - `itemTitle`: `card_title`, `1..1`, `hybrid`, suporte `when_present`;
-    - `description`: `card_body`, `1..1`, `hybrid`, suporte `when_present`.
-- Copy:
-  - `title`: `desire` e `trigger`; auxiliar `positioning_opportunity`;
-  - `itemTitle`: `trigger` e `desire`;
-  - `description`: `positioning_opportunity` e `belief`; auxiliar `objection`.
-- Regras:
-  - cada item exige capacidade operacional real;
-  - pesquisa não comprova preço, prazo, condição, parceria, garantia ou disponibilidade;
-  - sem CTA, mídia, prova, preço, condição comercial, processo ou referência técnica.
-- Estado: `experimental`, `controlled_test`, conceitualmente fechada.
+- `title`: `h2`, `1..1`, `research_guided`.
+- `items`: coleção `1..4`, com `itemTitle` (`card_title`, `1..1`, `hybrid`, `when_present`) e `description` (`card_body`, `1..1`, `hybrid`, `when_present`).
+- Copy: desejo/trigger no título e item; posicionamento/belief na descrição.
+- Regras: cada item exige capacidade real; pesquisa não comprova preço, prazo, parceria, garantia ou disponibilidade.
+- Estado: `experimental`, `controlled_test`.
 
 ### 3.9. Módulo `process`
 
 - Identidade: `process@v1`.
-- Função: explicar progressão real do atendimento ou entrega por etapas compreensíveis.
-- Invariantes: sequência ordenada, etapas distintas e ausência de prazo, garantia ou resultado inventado.
-- Fronteiras: sem oferta, problema-solução, workflow interno, prova, FAQ, CTA, preço, mídia ou interação.
-- Evidência: `processo_de_atendimento`, `belief`, `desire`, `positioning_opportunity`, `trigger`, `objection`, Blueprint e catálogo de entradas.
+- Função: explicar progressão real por etapas.
+- Invariantes: ordem, etapas distintas e ausência de prazo ou resultado inventado.
+- Fronteiras: sem oferta, prova, FAQ, CTA, preço, mídia ou interação.
+- Evidência: `processo_de_atendimento`, `belief`, `desire`, `positioning_opportunity`, `trigger`, `objection`, Blueprint e catálogo.
 
 ### 3.10. Variante `process.standard@v1`
 
-- Campos:
-  - `title`: `h2`, `1..1`, `research_guided`;
-  - `steps`: coleção ordenada `2..6`, `not_copy`, com:
-    - `stepTitle`: `step_title`, `1..1`, `hybrid`, suporte `when_present`;
-    - `stepBody`: `step_body`, `1..1`, `hybrid`, suporte `when_present`.
-- Copy:
-  - `title`: `belief` e `desire`; auxiliar `positioning_opportunity`;
-  - `stepTitle`: `trigger` e `positioning_opportunity`; auxiliar `desire`;
-  - `stepBody`: `belief` e `desire`; auxiliar `objection`.
-- Regras:
-  - ordem reflete a progressão real;
-  - numeração visual pertence ao renderer;
-  - sem CTA, mídia, prova, preço, condição, formulário ou referência técnica.
-- Estado: `experimental`, `controlled_test`, conceitualmente fechada.
+- `title`: `h2`, `1..1`, `research_guided`.
+- `steps`: coleção ordenada `2..6`, com `stepTitle` (`step_title`, `1..1`, `hybrid`, `when_present`) e `stepBody` (`step_body`, `1..1`, `hybrid`, `when_present`).
+- Copy: belief/desejo no título e corpo no título da etapa.
+- Regras: ordem reflete progressão real; numeração é do renderer; sem CTA, mídia, prova, preço ou formulário.
+- Estado: `experimental`, `controlled_test`.
 
 ### 3.11. Módulo `technical_assurance`
 
 - Identidade: `technical_assurance@v1`.
-- Função: explicar salvaguardas, critérios, documentos, credenciais ou verificações relevantes.
-- Invariantes: item real, verificável, operacionalmente sustentado e sem implicar aprovação, risco zero, certificação ou resultado.
-- Fronteiras: sem trust bar curta, depoimento, processo, oferta, FAQ, aconselhamento individualizado, CTA, mídia, download ou link.
+- Função: explicar salvaguardas, critérios, documentos, credenciais ou verificações.
+- Invariantes: item real e verificável, sem implicar risco zero, aprovação ou resultado.
+- Fronteiras: sem trust bar, depoimento, processo, oferta, FAQ, CTA, mídia, download ou link.
 - Evidência: `prova_tecnica_documental`, `proof_type`, `belief`, `fear`, `objection`, `positioning_opportunity`, narrativa e Blueprint.
 
 ### 3.12. Variante `technical_assurance.standard@v1`
 
-- Campos:
-  - `title`: `h2`, `1..1`, `research_guided`;
-  - `items`: coleção `1..4`, `not_copy`, com:
-    - `assuranceTitle`: `card_title`, `1..1`, `hybrid`, suporte `when_present`;
-    - `assuranceBody`: `card_body`, `1..1`, `hybrid`, suporte `when_present`.
-- Copy:
-  - `title`: `proof_type` e `belief`; auxiliar `objection`;
-  - `assuranceTitle`: `proof_type`; auxiliar `belief`;
-  - `assuranceBody`: `proof_type` e `positioning_opportunity`; auxiliar `objection`.
-- Regras:
-  - todo item exige suporte real e rastreável;
-  - sem conclusão jurídica, técnica ou financeira individualizada;
-  - sem CTA, mídia, link, download, depoimento, caso, métrica, preço, processo ou FAQ.
-- Estado: `experimental`, `controlled_test`, conceitualmente fechada.
+- `title`: `h2`, `1..1`, `research_guided`.
+- `items`: coleção `1..4`, com `assuranceTitle` (`card_title`, `1..1`, `hybrid`, `when_present`) e `assuranceBody` (`card_body`, `1..1`, `hybrid`, `when_present`).
+- Copy: prova/belief no título; prova/posicionamento no corpo.
+- Regras: todo item exige suporte rastreável; sem aconselhamento individualizado, CTA, mídia, link, depoimento, preço, processo ou FAQ.
+- Estado: `experimental`, `controlled_test`.
 
 ### 3.13. Módulo `social_proof`
 
 - Identidade: `social_proof@v1`.
-- Função: apresentar experiências reais de terceiros que reduzam incerteza.
-- Invariantes: prova real, rastreável, autorizada, sem fabricação, alteração material ou generalização indevida.
-- Fronteiras: sem trust bar, prova técnica, oferta, processo, FAQ, CTA, rating agregado, métrica, logo, caso detalhado ou mídia.
+- Função: apresentar experiências reais de terceiros.
+- Invariantes: prova real, rastreável, autorizada e sem alteração material.
+- Fronteiras: sem trust bar, prova técnica, oferta, processo, FAQ, CTA, rating, métrica, logo, caso detalhado ou mídia.
 - Evidência: `prova_social`, `proof_type`, `belief`, `objection`, narrativa e Blueprint.
 
 ### 3.14. Variante `social_proof.standard@v1`
 
-- Campos:
-  - `title`: `h2`, `1..1`, `research_guided`;
-  - `items`: coleção `1..3`, `not_copy`, com:
-    - `quote`: `card_body`, `1..1`, `operational_required`;
-    - `attribution`: `card_title`, `1..1`, `operational_required`;
-    - `evidenceRef`: referência técnica, `1..1`, `technical_reference`.
-- Copy:
-  - `title`: `proof_type` e `belief`; auxiliar `objection`;
-  - `quote` e `attribution`: exclusivamente da evidência operacional referenciada.
-- Regras:
-  - impedir geração ou alteração material do depoimento;
-  - atribuição pública depende de autorização e não elimina rastreabilidade interna;
-  - sem CTA, mídia, rating, métrica, logo ou caso detalhado.
-- Estado: `experimental`, `controlled_test`, conceitualmente fechada.
+- `title`: `h2`, `1..1`, `research_guided`.
+- `items`: coleção `1..3`, com `quote` (`card_body`, `1..1`, `operational_required`), `attribution` (`card_title`, `1..1`, `operational_required`) e `evidenceRef` (referência técnica `1..1`, `technical_reference`).
+- Copy: título por prova/belief; quote e atribuição exclusivamente da evidência.
+- Regras: impedir fabricação ou alteração; atribuição pública depende de autorização.
+- Estado: `experimental`, `controlled_test`.
 
 ### 3.15. Módulo `faq`
 
 - Identidade: `faq@v1`.
-- Função: responder dúvidas e objeções recorrentes em pares claros de pergunta e resposta.
-- Invariantes: pergunta relevante, resposta direta, sustentação factual e ausência de aconselhamento individualizado ou promessa enganosa.
-- Fronteiras: sem oferta, processo, prova técnica, CTA, mídia, formulário ou ação; interação pertence à variante que a declarar.
+- Função: responder dúvidas e objeções em pares de pergunta e resposta.
+- Invariantes: pergunta relevante, resposta direta, suporte factual e ausência de aconselhamento ou promessa enganosa.
+- Fronteiras: sem oferta, processo, prova técnica, CTA, mídia, formulário ou ação; interação pertence à variante.
 - Evidência: `faq_objeções`, `faq_questions`, `search_intent`, `objection`, `fear`, `belief`, `awareness_level` e Blueprint.
 
 ### 3.16. Variante `faq.standard@v1`
 
-- Campos:
-  - `title`: `h2`, `1..1`, `research_guided`;
-  - `items`: coleção `2..6`, `not_copy`, com:
-    - `question`: `faq_question`, `1..1`, `research_guided`;
-    - `answer`: `faq_answer`, `1..1`, `hybrid`, suporte `when_factual`.
-- Copy:
-  - `title`: `objection` e `awareness_level`; auxiliar `search_intent`;
-  - `question`: `objection` e `fear`; auxiliar `faq_questions`;
-  - `answer`: `belief` e `positioning_opportunity`; auxiliar `desire`.
-- Regras:
-  - rejeitar perguntas vazias ou duplicadas;
-  - resposta trata diretamente sua pergunta;
-  - fatos operacionais, legais, técnicos ou financeiros exigem suporte real;
-  - sem CTA, mídia, formulário, ação ou interação.
-- Estado: `experimental`, `controlled_test`, conceitualmente fechada.
+- `title`: `h2`, `1..1`, `research_guided`.
+- `items`: coleção `2..6`, com `question` (`faq_question`, `1..1`, `research_guided`) e `answer` (`faq_answer`, `1..1`, `hybrid`, `when_factual`).
+- Copy: objeção/awareness no título; objeção/medo na pergunta; belief/posicionamento na resposta.
+- Regras: sem duplicidade; resposta direta; fatos legais, técnicos, financeiros ou operacionais exigem suporte; sem interação.
+- Estado: `experimental`, `controlled_test`.
 
 ### 3.17. Variante `faq.accordion@v1`
 
-- Identidade: `faq.accordion@v1`, compatível com `faq@v1` e com a raiz vigente.
-- Finalidade: validar duas variantes do mesmo módulo e oferecer apresentação compacta, especialmente no mobile.
-- Conteúdo:
-  - declara o mesmo contrato de campos de `faq.standard@v1`;
-  - a implementação pode reutilizar definições imutáveis compartilhadas, sem estabelecer herança entre variantes;
-  - mantém cardinalidades, semantic roles, policies, copy e sustentação factual;
-  - não adiciona campo de conteúdo.
-- Capability: interação de acordeão e requisitos de acessibilidade associados.
-- Comportamento:
-  - todos os itens iniciam fechados;
-  - pergunta abre e fecha sua resposta;
-  - somente um item permanece aberto;
-  - abrir outro fecha o anterior;
-  - operação por teclado;
-  - estado expandido exposto semanticamente;
-  - associação acessível entre pergunta e resposta;
-  - foco preservado no controle acionado.
-- Limites:
-  - não define elemento HTML, componente, ícone, animação ou visual do renderer;
-  - não altera conteúdo, cardinalidade, copy ou sustentação factual declarados em seu próprio contrato.
+- Identidade: compatível com `faq@v1` e a raiz inicial.
+- Declara o mesmo contrato de campos da variante standard, sem herança semântica; não adiciona conteúdo.
+- Capability: interação de acordeão e acessibilidade.
+- Comportamento: todos fechados inicialmente; abre/fecha pelo controle; somente um aberto; teclado; estado e associação acessíveis; foco preservado.
+- Limites: não define HTML, componente, ícone, animação ou visual.
 - Estado: `experimental`, `controlled_test`, candidata à primeira composição controlada.
 
 ### 3.18. Módulo `final_cta`
 
 - Identidade: `final_cta@v1`.
-- Função: encerrar a jornada com próximo passo claro, qualificado e coerente com a intenção da LP.
-- Invariantes: uma ação principal identificável, linguagem não coercitiva, vínculo abstrato com canal operacional e sustentação de toda condição factual apresentada.
-- Fronteiras: não repete oferta, processo, FAQ ou prova; não contém formulário, mídia, ação secundária, canal ou destino concreto na execução inicial.
+- Função: encerrar a jornada com próximo passo claro e qualificado.
+- Invariantes: uma ação principal, linguagem não coercitiva, vínculo abstrato e suporte factual.
+- Fronteiras: sem repetição de oferta, processo, FAQ ou prova; sem formulário, mídia, ação secundária ou destino concreto.
 - Evidência: `cta_final_qualificado`, `narrative_arc`, `mobile_priority`, `trigger`, `desire`, `objection`, `belief`, `positioning_opportunity`, `search_intent` e catálogo operacional.
 
 ### 3.19. Variante `final_cta.standard@v1`
 
-- Identidade: `final_cta.standard@v1`, compatível com `final_cta@v1` e com a raiz vigente; única variante inicial.
-- Campos:
-  - `title`: `h2`, `1..1`, `hybrid`, suporte `when_factual`;
-  - `body`: `paragraph`, `1..1`, `hybrid`, suporte `when_factual`;
-  - `primaryCta`: ação `1..1`, `not_copy`, com label `cta_label`, `1..1`, `hybrid`, suporte `when_present`, e vínculo obrigatório com `primary_conversion_channel`.
-- Copy:
-  - `title`: `trigger` e `desire`; auxiliar `positioning_opportunity`;
-  - `body`: `desire` e `objection`; auxiliar `belief`;
-  - `primaryCta.label`: `trigger`; auxiliar `search_intent`.
-- Regras:
-  - uma única ação principal;
-  - canais permitidos: `whatsapp`, `phone`, `email` e `external_url`;
-  - canal e destino concretos ficam fora do registry;
-  - a copy pode orientar o visitante a informar intenção, localização, prazo ou faixa aplicável, sem armazenar esses valores no contrato;
-  - pesquisa orienta a redação, mas não comprova disponibilidade, prazo, resposta imediata, condição, garantia ou resultado;
-  - BOFU prioriza ação direta; MOFU, contato orientado; TOFU, próximo passo de baixa fricção;
-  - rejeitar CTA secundário, formulário, mídia, prova, preço, condição comercial ou referência técnica;
-  - validar vínculo operacional obrigatório e resolver de forma fail-closed e imutável.
-- Estado: `experimental`, `controlled_test`, conceitualmente fechada; implementação ainda não autorizada.
+- `title`: `h2`, `1..1`, `hybrid`, `when_factual`.
+- `body`: `paragraph`, `1..1`, `hybrid`, `when_factual`.
+- `primaryCta`: ação `1..1`, label `cta_label`, `hybrid`, `when_present`, vínculo obrigatório com `primary_conversion_channel`.
+- Copy: trigger/desejo no título; desejo/objeção no body; trigger no label.
+- Regras: canais `whatsapp`, `phone`, `email`, `external_url`; uma ação; sem destino no registry; sem CTA secundário, formulário, mídia, preço ou condição.
+- Estado: `experimental`, `controlled_test`.
 
-## 4. Fechamento conceitual do catálogo
+## 4. Fases e próxima ação
 
 ### 4.1. Estado
 
-- Os nove módulos estão conceitualmente fechados.
-- As nove variantes `standard@v1` estão conceitualmente fechadas.
-- `faq.accordion@v1` está conceitualmente fechada como exceção controlada.
-- Não há módulo ou variante aprovada pendente de parametrização.
+- Os nove módulos, as nove variantes `standard@v1` e `faq.accordion@v1` estão conceitualmente fechados.
+- Não há parametrização aprovada pendente.
 
-### 4.2. Sequência de implementação
+### 4.2. Fase executável
 
-Após autorização humana:
+#### 4.2.1. Fase 3.1 — E18.5.3–E18.5.9 — Catálogo repo-only de módulos e variantes
 
-1. implementar o contrato compartilhado;
-2. implementar os nove módulos e suas variantes `standard@v1`;
-3. implementar `faq.accordion@v1` como segundo caso do mesmo módulo;
-4. validar contratos, registries, resolução, lifecycle, compatibilidade e imutabilidade;
-5. atualizar a documentação final e encerrar a E18.5 técnica.
+- Automação: não.
+- Objetivo:
+  - implementar no boundary existente o contrato compartilhado, os nove módulos, as nove variantes `standard@v1` e `faq.accordion@v1`.
+- Entregas:
+  - contratos e tipos públicos profundamente `readonly`;
+  - schemas estritos, registry versionado, resolver fail-closed, validadores e casos executáveis;
+  - exportação pública e script próprio de validação no `package.json`;
+  - fixtures somente quando úteis ao padrão de teste.
+- Critérios de aceite:
+  - identidade e compatibilidade completas;
+  - lifecycle `experimental` e propósito `controlled_test`;
+  - todos os módulos e variantes aprovados resolvidos e validados;
+  - `faq.accordion@v1` preserva `faq.standard@v1` e valida interaction sem herança entre variantes;
+  - rejeição de campos, policies, capabilities, versões e deltas desconhecidos;
+  - resultado profundamente imutável, sem fallback ou referência mutável compartilhada;
+  - nenhuma regra específica de E19, E20, renderer, Admin, Builder ou banco;
+  - `npm ci`, validação própria da E18.5, `npm run check` e `git diff --check` aprovados.
+- Parada:
+  - necessidade de banco, migration, rota, renderer, composição, persistência, tracking, infraestrutura ou mudança destrutiva retorna ao Estrategista.
 
 ### 4.3. Próxima ação
 
-- Submeter o plano completo à avaliação final.
-- Após aprovação humana, autorizar a implementação repo-only da E18.5.
-- Não implementar E20, E19, renderer, Admin, Builder, banco ou LP real neste recorte.
+- Executar o item 5 de `docs/prompt-estrategista.md`.
+- Solicitar avaliação única do plano completo pelo Analista, Gestor Estrutural e Gestor de Updates.
+- Não chamar Gestor de Automação, pois a fase está marcada como `Automação: não`.
+- Consolidar os pareceres no mesmo PR como plano-base v2 antes de solicitar o merge humano.
+- Não autorizar a fase 3.1 antes da consolidação e do merge do plano-base v2 na `main`.
 
 ## 5. Validação e encerramento
 
-### 5.1. Validações da implementação
+### 5.1. Validação do plano v1
 
-Quando autorizada:
-
-- validar schemas, registries, identidade e compatibilidade;
-- rejeitar campos, policies, capabilities e deltas desconhecidos;
-- garantir resolução fail-closed e resultado imutável;
-- validar combinações efetivamente utilizadas;
-- executar casos próprios e integração dos nove módulos, das nove variantes `standard@v1` e de `faq.accordion@v1`;
-- executar `npm ci`, validações aplicáveis, `npm run check` e `git diff --check`.
+- Existe uma única fase executável e necessária ao recorte.
+- A fase usa identificadores implementáveis da E18.5 e declara `Automação: não`.
+- Validações técnicas integram os critérios de aceite, sem fase administrativa separada.
+- Não existe fase própria de governança, handoff, revisão, documentação final ou encerramento.
+- Os identificadores previstos não atualizam `docs/roadmap.md` automaticamente.
 
 Alteração exclusivamente documental:
 
 - `npm ci`: não aplicável;
 - `npm run check`: não aplicável;
-- `git diff --check`: obrigatório antes da entrega quando houver ambiente local disponível.
+- `git diff --check`: obrigatório quando houver ambiente local disponível.
 
 ### 5.2. Regra de parada
 
-Após os nove módulos, suas variantes `standard@v1` e `faq.accordion@v1`:
-
-- encerrar a E18.5;
+- encerrar a E18.5 após a implementação aprovada;
 - não criar outra variante antes da primeira LP;
 - não adicionar campo para cenário futuro;
 - não criar policy ou capability sem consumidor;
-- não antecipar matriz especulativa;
-- não absorver renderer, composição ou geração;
+- não antecipar renderer, composição ou geração;
 - avançar para E20 e depois E19.
 
 ### 5.3. Estado de validação
 
 - Implementação técnica significa contrato executável no repositório.
-- Os módulos permanecem hipóteses de produto.
-- Validação comercial ocorrerá quando a E20 compuser e a E19 gerar a primeira LP real.
-- Promoção de lifecycle exige evidência dessa utilização e decisão humana.
+- Os módulos permanecem hipóteses até validação por LP real.
+- Promoção de lifecycle exige evidência e decisão humana.
 
 ### 5.4. Critérios de parada imediata
 
-Parar e informar a divergência se:
+Parar e informar se:
 
-- surgir banco, rota, job, agente, automação ou infraestrutura nova sem fonte e recorte próprios;
+- surgir banco, rota, job, agente, automação ou infraestrutura sem fonte e recorte próprios;
 - módulo receber identidade de taxon;
-- variante representar somente copy, campanha, plano ou ativo;
+- variante representar apenas copy, campanha, plano ou ativo;
 - regra de `standard@v1` for tratada como limite permanente do módulo;
 - variante não aprovada for antecipada;
 - destino concreto entrar no registry;
 - conteúdo factual puder ser inventado;
 - E19, E20 ou renderer forem implementados implicitamente;
-- alteração sair do arquivo e da branch autorizados;
+- alteração sair do arquivo ou branch autorizados;
 - houver tentativa de merge na `main`.

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -4,7 +4,7 @@ Fontes: chat, `README.md`, `AGENTS.md`, `docs/roadmap.md`, `docs/base-tecnica.md
 
 Versão: v1 em ajuste.
 
-Status: plano simplificado; nove módulos mantidos no escopo; `hero`, `hero.standard@v1`, `trust_bar`, `trust_bar.standard@v1`, `problem_solution`, `problem_solution.standard@v1`, `offer` e `offer.standard@v1` conceitualmente fechados; cinco módulos pendentes; nenhuma implementação autorizada neste PR.
+Status: plano simplificado; nove módulos mantidos no escopo; `hero`, `hero.standard@v1`, `trust_bar`, `trust_bar.standard@v1`, `problem_solution`, `problem_solution.standard@v1`, `offer`, `offer.standard@v1`, `process` e `process.standard@v1` conceitualmente fechados; quatro módulos pendentes; nenhuma implementação autorizada neste PR.
 
 Path: `docs/lousa-plano-base-e18-5.md`.
 
@@ -48,7 +48,7 @@ Regras:
 - `item_key` é evidência de pesquisa, não identidade canônica do módulo.
 - Os módulos são transversais e não recebem identidade de taxon.
 - Formatos curto, médio e longo pertencem à composição e à extensão da LP.
-- O próximo módulo para análise é `process`.
+- O próximo módulo para análise é `technical_assurance`.
 
 ### 1.4. Escopo positivo
 
@@ -604,13 +604,106 @@ Estado:
 - propósito `controlled_test`;
 - implementação ainda não autorizada por este ajuste documental.
 
+### 3.9. Módulo `process`
+
+- `moduleKey = process`.
+- `moduleVersion = 1`.
+- Função:
+  - explicar como o atendimento ou a entrega progride por etapas compreensíveis;
+  - transformar uma oferta abstrata em método previsível;
+  - esclarecer próximos passos, responsabilidades e progressão sem prometer resultado.
+- Invariantes:
+  - existe uma sequência ordenada e inteligível;
+  - cada etapa representa ação, transição ou marco real do processo;
+  - etapas permanecem distintas e coerentes entre si;
+  - a sequência não inventa prazo, garantia, disponibilidade ou resultado;
+  - ausência de identidade de taxon, plano, campanha ou funil no contrato.
+- Fronteiras:
+  - não repete o catálogo de ofertas;
+  - não apresenta pares de problema e solução;
+  - não funciona como workflow, checklist operacional interno ou motor de automação;
+  - não apresenta prova técnica, depoimento, credencial, FAQ ou CTA;
+  - não contém preço, condição comercial, mídia, formulário ou interação na execução inicial.
+- Evidências principais:
+  - `processo_de_atendimento`, pesquisa ativa de `lp_sections`, taxon `Corretor Imóveis`;
+  - itens `belief`, `desire`, `positioning_opportunity`, `trigger` e `objection` de `strategic_core`;
+  - `narrative_arc` de `lp_overview`, que recomenda explicar o processo antes da remoção final de objeções e do contato;
+  - Blueprint do corretor, especialmente qualificação, visita, documentação, negociação e formalização;
+  - catálogo de entradas vigente, somente para sustentar capacidades e modos reais quando aplicáveis.
+- Variantes futuras podem usar outra execução estrutural sem alterar `process.standard@v1`.
+
+### 3.10. Variante `process.standard@v1`
+
+Identidade:
+
+- `variantKey = process.standard`.
+- `variantVersion = 1`.
+- Compatível com `process@v1` e com a versão vigente da raiz utilizada na implementação inicial.
+- Única variante inicial.
+
+Campos:
+
+- `title`:
+  - texto, papel `h2`, cardinalidade `1..1`, policy `research_guided`.
+- `steps`:
+  - coleção ordenada, cardinalidade `2..6`, policy `not_copy`;
+  - item fechado com `stepTitle` e `stepBody`;
+  - `stepTitle`: texto, papel `step_title`, cardinalidade `1..1`, policy `hybrid`, suporte `when_present`;
+  - `stepBody`: texto, papel `step_body`, cardinalidade `1..1`, policy `hybrid`, suporte `when_present`.
+
+Copy:
+
+- `title`: primárias `belief` e `desire`; auxiliar `positioning_opportunity`.
+- `stepTitle`: primárias `trigger` e `positioning_opportunity`; auxiliar `desire`.
+- `stepBody`: primárias `belief` e `desire`; auxiliar `objection`.
+
+Regras específicas:
+
+- uma ocorrência válida contém de duas a seis etapas completas e ordenadas;
+- cada etapa contém exatamente `stepTitle` e `stepBody`;
+- cada etapa representa parte real do método ou atendimento e deve possuir sustentação operacional;
+- a ordem deve refletir a progressão real, sem ser reorganizada apenas por copy, campanha ou funil;
+- etapas podem variar por ocorrência dentro do intervalo permitido quando a composição da E20 autorizar e os dados sustentarem a sequência;
+- pesquisa e Blueprint orientam seleção e redação, mas não comprovam etapa, prazo, responsabilidade, disponibilidade, garantia ou resultado;
+- os papéis `h2`, `step_title` e `step_body` usam as faixas da raiz sem especialização na v1;
+- a coleção não admite item aninhado;
+- a numeração ou marcador visual das etapas pertence ao renderer e não cria campo de conteúdo na v1;
+- não possui subtítulo, CTA, mídia, ícone obrigatório, prova, preço, condição comercial, formulário ou referência técnica;
+- diferenças de copy, quantidade dentro de `2..6` e nível de detalhe não criam variante;
+- o tratamento da ausência de sequência válida depende da obrigatoriedade definida pela composição da E20 e será especificado pela E19.
+
+Funil:
+
+- BOFU prioriza etapas concretas, responsabilidades e próximo passo imediato.
+- MOFU prioriza explicação do método, critérios e redução de incerteza.
+- TOFU prioriza visão geral educativa e baixa pressão.
+- O funil altera profundidade, seleção e redação, mas não altera campos, cardinalidades, variante nem a ordem operacional real.
+
+Validações estruturais:
+
+- exigir `title` e `steps`;
+- exigir cardinalidade `2..6` em `steps`;
+- exigir exatamente `stepTitle` e `stepBody` em cada etapa;
+- preservar a ordem declarada e rejeitar etapas vazias ou duplicadas;
+- rejeitar coleção aninhada e campos extras;
+- validar os papéis semânticos e as policies declaradas;
+- exigir suporte `when_present` em `stepTitle` e `stepBody`;
+- rejeitar CTA, mídia, ação, prova, preço, condição comercial, formulário ou referência técnica na variante;
+- resolver de forma fail-closed e imutável.
+
+Estado:
+
+- contrato conceitualmente fechado;
+- lifecycle `experimental`;
+- propósito `controlled_test`;
+- implementação ainda não autorizada por este ajuste documental.
+
 ## 4. Módulos pendentes
 
 ### 4.1. Estado
 
 Permanecem pendentes:
 
-- `process`;
 - `technical_assurance`;
 - `social_proof`;
 - `faq`;
@@ -637,8 +730,8 @@ A etapa seguinte só deve reproduzir o contrato compartilhado após ele estar va
 
 ### 4.3. Próxima ação
 
-- Analisar `process` pelo checklist mínimo da seção 2.9.
-- Separar `process` de `process.standard@v1`.
+- Analisar `technical_assurance` pelo checklist mínimo da seção 2.9.
+- Separar `technical_assurance` de `technical_assurance.standard@v1`.
 - Não alterar o arquivo novamente sem decisão humana sobre o contrato proposto.
 - Não implementar código durante o fechamento conceitual.
 

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -25,7 +25,7 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
   - bloco `lp_sections`;
   - versão 1 ativa.
 - O ultranicho de médio padrão permanece evidência complementar.
-- Módulos serão transversais; precedência: `raiz → módulo → variante`.
+- Os módulos serão transversais; a precedência permanece `raiz → módulo → variante`.
 - `commercial_activation`, E18.2 e E18.3 permanecem preservados.
 
 ### 1.2. Estado processual
@@ -34,14 +34,22 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 - Cada candidato será analisado individualmente; existência na grade não equivale a aprovação.
 - Rejeição, fusão ou substituição exige justificativa e decisão humana.
 - A grade comum é obrigatória, com blocos condicionais conforme a função.
-- Cada módulo deve fechar identidade, evidência, fronteiras, campos, cardinalidades, policies, fontes, funil, responsividade aplicável, variante, versões, lifecycle, compatibilidades, casos da E18.5 e invariantes futuras da E19.
+- Cada módulo deve fechar:
+  - identidade e evidência;
+  - fronteiras;
+  - campos e cardinalidades;
+  - policies e suporte operacional;
+  - fontes e perfis de funil;
+  - responsividade e acessibilidade aplicáveis;
+  - variante, versões, lifecycle e compatibilidades;
+  - casos da E18.5 e invariantes futuras da E19.
 - O Hero é o piloto; `trust_bar` só começa após seu fechamento.
 - Implementação somente após evolução da raiz, v2 estável, pareceres e merge humano.
 
 ### 1.3. Princípio canônico de herança
 
 - A raiz contém regras comuns; módulo e variante registram apenas especializações justificadas.
-- E18.5 autoriza opções; E20 seleciona por ocorrência; E19 gera e vincula valores; renderer apenas executa.
+- A E18.5 autoriza opções; a E20 seleciona por ocorrência; a E19 gera e vincula valores; o renderer apenas executa.
 - Escolha excepcional na E20 exige decisão humana documentada, sem pressupor campo, coluna ou persistência nova.
 - O resolver entrega contrato efetivo, completo, imutável e sem fallback.
 
@@ -67,27 +75,38 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
   - `faq` ← `faq_objeções`;
   - `final_cta` ← `cta_final_qualificado`.
 - `item_key` é evidência, não identidade canônica.
-- Formatos curto, médio e longo pertencem à composição/extensão.
-- `hero.subtitle`: `paragraph`, padrão `body.editorialEmphasis`, alternativa `body.base`, sem fallback.
+- Formatos curto, médio e longo pertencem à composição e à extensão.
+- `hero.subtitle`:
+  - `semanticRole = paragraph`;
+  - padrão `body.editorialEmphasis`;
+  - alternativa `body.base`;
+  - sem fallback.
 - `hero.standard` é a única variante inicial e pode ter delta vazio.
 - Canal e destino concretos de CTA permanecem fora do registry do módulo.
 - Nenhum `actionRole` está aprovado sem contrato fechado.
 - `moduleCatalogVersion` possui versão e compatibilidade; lifecycle próprio do catálogo não está aprovado.
+- Decisão humana de 16/07/2026:
+  - autorizar conceitualmente `desktop_only` como opção responsiva de `hero.media`;
+  - condicionar seu uso à evolução versionada da raiz;
+  - proibir a ocultação de informação essencial.
+- A relação entre lifecycle da raiz e propósito é política nova da E18.5; não é comportamento já implementado pelo resolver da raiz.
 
 ### 1.6. Estado técnico confirmado
 
 - Boundary: `lib/conversion-content/landing-page/`; namespace atual: `landingPageRoot`.
 - Ainda não existem catálogo de módulos, composição, renderer ou render model.
-- E18.5 é repo-only e não altera banco.
+- A E18.5 é repo-only e não altera banco.
 - O catálogo operacional já define `primary_conversion_channel` e destinos condicionais.
-- E20 seleciona composição; E19 vincula valores, gera e preserva snapshot.
+- A E20 seleciona composição; a E19 vincula valores, gera e preserva snapshot.
 
 ### 1.7. Pontos ainda em debate
 
 - Destinação do campo candidato `secondaryCta` na v1.
 - Contrato exato de acessibilidade para vídeo.
+- Contrato futuro de vínculo entre CTA principal e ocorrência de formulário na composição.
 - Confirmação dos oito candidatos restantes.
-- Evolução da raiz e divisão final em fases.
+- Evolução tipográfica e responsiva da raiz.
+- Divisão final em fases.
 
 ## 2. Contrato do caso
 
@@ -97,6 +116,7 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 - O catálogo deve generalizar funções sem carregar identidade imobiliária.
 - CTA não pode duplicar canal ou destino da E20.2.
 - Campos híbridos precisam representar declarativamente quando suporte operacional é exigido.
+- A combinação entre `fieldKind` e `operationalValuePolicy` precisa ser fechada por allowlist.
 - Mídia deve separar contrato estrutural e acessibilidade do schema concreto da E19.
 - Policies devem impedir invenção de fatos e fallback deve permanecer proibido.
 
@@ -129,6 +149,7 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 
 - resolve hipóteses e ambiguidades;
 - pode rejeitar evidência insuficiente;
+- pode aprovar padrão funcional do produto;
 - não viola contrato vigente sem evolução versionada.
 
 #### 2.3.4. Validação posterior
@@ -159,7 +180,17 @@ Todos os módulos devem analisar:
 9. fronteiras E20/E19/renderer;
 10. casos E18.5, invariantes E19 e critérios de fechamento.
 
-Blocos condicionais: CTA, mídia, coleção, valor operacional, referência técnica, interação, acessibilidade, visibilidade responsiva e variante adicional.
+Blocos condicionais:
+
+- CTA;
+- mídia;
+- coleção;
+- valor operacional;
+- referência técnica;
+- interação;
+- acessibilidade;
+- visibilidade responsiva;
+- variante adicional.
 
 O Hero é referência metodológica, não molde rígido de conteúdo.
 
@@ -182,7 +213,12 @@ O Hero é referência metodológica, não molde rígido de conteúdo.
 
 ### 2.5. Contrato-base de campo
 
-Todo campo declara `fieldKey`, `fieldKind`, cardinalidade e policy.
+Todo campo declara:
+
+- `fieldKey`;
+- `fieldKind`;
+- cardinalidade;
+- `operationalValuePolicy`.
 
 `fieldKind` fechado:
 
@@ -206,14 +242,20 @@ Regras:
 
 #### 2.5.1. Política fechada de origem do valor
 
-- `research_generated_non_factual`: copy não factual gerada da pesquisa.
-- `research_guided`: pesquisa orienta, mas não fornece o valor final completo.
-- `operational_required`: valor deve vir de fonte operacional autorizada.
-- `hybrid`: orientação editorial combinada com suporte operacional conforme exigência declarada pelo campo.
-- `technical_reference`: mídia, link, identificador ou vínculo técnico.
-- `not_copy`: objeto estrutural ou técnico.
+- `research_generated_non_factual`:
+  - copy não factual gerada da pesquisa.
+- `research_guided`:
+  - pesquisa orienta, mas não fornece o valor final completo.
+- `operational_required`:
+  - valor deve vir de fonte operacional autorizada.
+- `hybrid`:
+  - orientação editorial combinada com suporte operacional conforme exigência declarada pelo campo.
+- `technical_reference`:
+  - mídia, link, identificador ou vínculo técnico.
+- `not_copy`:
+  - objeto estrutural ou técnico.
 
-E18.5 declara; E19 aplica na instância concreta.
+A E18.5 declara; a E19 aplica na instância concreta.
 
 #### 2.5.2. Exigência declarativa de suporte operacional
 
@@ -232,21 +274,49 @@ Regras:
 - policy `hybrid` exige `operationalSupportRequirement` explícito.
 - policy `operational_required` equivale materialmente a `when_present`.
 - `technical_reference` e `not_copy` não usam essa propriedade.
-- E18.5 valida a declaração abstrata; E19 valida o suporte concreto.
+- A E18.5 valida a declaração abstrata; a E19 valida o suporte concreto.
 
-#### 2.5.3. Matriz de compatibilidade das policies
+#### 2.5.3. Allowlist de `fieldKind × operationalValuePolicy`
 
-- `research_generated_non_factual` e `research_guided` admitem `copySourceMap` em texto.
-- `hybrid` admite `copySourceMap`, mas deve declarar `operationalSupportRequirement`.
-- `operational_required` não pode ser preenchida somente por pesquisa.
-- `technical_reference` e `not_copy` não admitem `copySourceMap`.
-- Falham:
-  - policy incompatível com `fieldKind`;
-  - mídia com policy textual;
-  - `not_copy` com fontes;
-  - `hybrid` sem exigência de suporte;
-  - suporte exigido sem vínculo operacional aplicável;
-  - valor operacional gerado apenas da pesquisa.
+Combinações válidas na v1:
+
+- `text`:
+  - `research_generated_non_factual`;
+  - `research_guided`;
+  - `hybrid`;
+  - `operational_required`.
+- `action`:
+  - `not_copy`.
+- `media`:
+  - `technical_reference`.
+- `technical_reference`:
+  - `technical_reference`.
+- `operational_value`:
+  - `operational_required`.
+- `collection`:
+  - `not_copy` no contêiner;
+  - cada campo do item declara sua própria combinação conforme esta allowlist;
+  - coleção aninhada não está aprovada na v1.
+
+Regras adicionais:
+
+- qualquer combinação ausente da allowlist falha fechado;
+- `research_generated_non_factual` e `research_guided` admitem `copySourceMap` somente em `text`;
+- `hybrid` admite `copySourceMap` somente em `text` e exige `operationalSupportRequirement`;
+- `operational_required` não pode ser preenchida somente por pesquisa;
+- `technical_reference` e `not_copy` não admitem `copySourceMap`;
+- contêiner `collection` não gera copy; seus campos internos seguem seus próprios contratos.
+
+Falham:
+
+- policy não listada para o `fieldKind`;
+- mídia com policy textual;
+- ação com policy diferente de `not_copy`;
+- `not_copy` com fontes;
+- `hybrid` sem exigência de suporte;
+- suporte exigido sem vínculo operacional aplicável;
+- valor operacional gerado apenas da pesquisa;
+- item de coleção sem contrato fechado.
 
 #### 2.5.4. Dependência operacional de ações
 
@@ -255,22 +325,39 @@ Ação pode declarar `operationalBindingRequirement`:
 - referencia somente `fieldKey` estável do catálogo operacional;
 - não armazena valor, canal, URL, telefone, e-mail ou destino;
 - declara se o vínculo é obrigatório quando a ação estiver presente;
-- E19 resolve o campo e valida seus condicionais e destinos aplicáveis.
+- a E19 resolve o campo e valida seus condicionais e destinos aplicáveis.
 
 Nova chave operacional não pode ser criada implicitamente pela E18.5.
 
 ### 2.6. Contrato de variante
 
-- Deltas permitidos: cardinalidade, remoção ou ativação de campo previsto, restrição de faixa ou tratamento e comportamento enumerado.
-- Deltas proibidos: campo livre, papel desconhecido, ampliação de limite, taxon, conteúdo, valor operacional, URL, classe ou componente concreto.
+- Deltas permitidos:
+  - cardinalidade;
+  - remoção ou ativação de campo previsto;
+  - restrição de faixa ou tratamento;
+  - comportamento enumerado.
+- Deltas proibidos:
+  - campo livre;
+  - papel desconhecido;
+  - ampliação de limite;
+  - taxon;
+  - conteúdo;
+  - valor operacional;
+  - URL;
+  - classe;
+  - componente concreto.
 - `standard` pode ter delta vazio; outra variante vazia e redundante falha.
 
 ### 2.7. Módulo-piloto `hero`
 
 #### 2.7.1. Identidade e função estrutural
 
-- `moduleKey = hero`; `moduleVersion = 1` proposto.
-- Função: apresentar recorte, proposta principal e ação prioritária.
+- `moduleKey = hero`.
+- `moduleVersion = 1` proposto.
+- Função:
+  - apresentar recorte;
+  - comunicar proposta principal;
+  - indicar ação prioritária.
 - Não representa taxon, tráfego, funil ou composição.
 
 #### 2.7.2. Evidência estrutural inicial
@@ -281,8 +368,11 @@ Nova chave operacional não pode ser criada implicitamente pela E18.5.
 - bloco `lp_sections`;
 - `researchId = 31e4c229-1582-4d2c-8e4a-7b74e6e07681`;
 - `itemId = ee178af8-294c-403c-8c53-d0baef42ee8c`;
-- versão 1, pesquisa ativa;
-- `itemKey = hero_segmentado`, item ativo, ordem 1;
+- versão 1;
+- pesquisa ativa;
+- `itemKey = hero_segmentado`;
+- item ativo;
+- ordem 1;
 - função observada: apresentar valor central e segmentar por intenção;
 - interpretação v1:
   - a intenção já está resolvida para a LP concreta;
@@ -294,98 +384,211 @@ Escolha interativa entre intenções exigiria análise estrutural futura e não 
 
 #### 2.7.3. Fronteiras
 
-Pertencem: enquadramento, título, explicação curta, CTA principal, candidato a CTA secundário, microprova opcional e uma mídia opcional.
+Pertencem:
 
-Não pertencem: trust bar completa, oferta, processo, prova extensa, depoimentos, FAQ, formulário completo, seletor interativo de intenção, galeria, carrossel, tour, CTA final, navegação e ordem global.
+- enquadramento;
+- título;
+- explicação curta;
+- CTA principal;
+- candidato a CTA secundário;
+- microprova opcional;
+- uma mídia opcional.
+
+Não pertencem:
+
+- trust bar completa;
+- oferta;
+- processo;
+- prova extensa;
+- depoimentos;
+- FAQ;
+- formulário completo;
+- seletor interativo de intenção;
+- galeria;
+- carrossel;
+- tour;
+- CTA final;
+- navegação;
+- ordem global.
 
 #### 2.7.4. Catálogo de campos proposto
 
 - `eyebrow`:
-  - texto/`eyebrow`, `0..1`, `research_guided`;
+  - `fieldKind = text`;
+  - `semanticRole = eyebrow`;
+  - cardinalidade `0..1`;
+  - policy `research_guided`;
   - `operationalSupportRequirement = none`.
 - `title`:
-  - texto/`h1`, `1..1`, `hybrid`;
+  - `fieldKind = text`;
+  - `semanticRole = h1`;
+  - cardinalidade `1..1`;
+  - policy `hybrid`;
   - `operationalSupportRequirement = when_factual`.
 - `subtitle`:
-  - texto/`paragraph`, `1..1`, `hybrid`;
+  - `fieldKind = text`;
+  - `semanticRole = paragraph`;
+  - cardinalidade `1..1`;
+  - policy `hybrid`;
   - `operationalSupportRequirement = when_factual`;
-  - padrão `body.editorialEmphasis`, alternativa `body.base`.
+  - padrão `body.editorialEmphasis`;
+  - alternativa `body.base`.
 - `primaryCta`:
-  - ação `1..1`, `not_copy`;
-  - label `cta_label`, `1..1`, `hybrid`;
-  - label usa `operationalSupportRequirement = when_present`;
+  - `fieldKind = action`;
+  - cardinalidade `1..1`;
+  - policy `not_copy`;
+  - label:
+    - `fieldKind = text`;
+    - `semanticRole = cta_label`;
+    - cardinalidade `1..1`;
+    - policy `hybrid`;
+    - `operationalSupportRequirement = when_present`;
   - `operationalBindingRequirement.catalogFieldKey = primary_conversion_channel`;
   - vínculo obrigatório quando a ação estiver presente;
-  - canal e destino concretos ficam fora do registry;
-  - E19 resolve o canal e os destinos condicionais aplicáveis.
+  - canal e destino concretos ficam fora do registry.
 - `secondaryCta`:
-  - candidato a ação `0..1`, ainda não aprovado para publicação;
+  - candidato a ação `0..1`;
+  - ainda não aprovado para publicação;
   - não existe `secondary_conversion_channel` ou vínculo operacional equivalente aprovado;
-  - E18.5 não criará nova entrada operacional;
+  - a E18.5 não criará nova entrada operacional;
   - deve ser removido da v1 ou receber decisão explícita sobre reutilização de fonte existente ou navegação interna.
 - `proofShort`:
-  - texto/`paragraph`, `0..1`, `hybrid`;
+  - `fieldKind = text`;
+  - `semanticRole = paragraph`;
+  - cardinalidade `0..1`;
+  - policy `hybrid`;
   - `operationalSupportRequirement = when_present`;
-  - microprova, credencial ou sinal curto de confiança;
+  - finalidade limitada a microprova, credencial ou sinal curto de confiança;
   - não recebe genericamente preço, prazo, disponibilidade ou condição comercial.
 - `media`:
-  - mídia `0..1`, `technical_reference`;
+  - `fieldKind = media`;
+  - cardinalidade `0..1`;
+  - policy `technical_reference`;
   - `mediaKind = image | video`;
   - referência do ativo pertence à instância futura;
   - `accessibilityMode = informative | decorative`;
-  - acessibilidade usa contrato próprio de mídia, não `operationalValuePolicy` textual;
+  - acessibilidade usa contrato próprio de mídia, não policy textual;
   - imagem informativa exige alternativa acessível não vazia;
   - imagem decorativa exige ausência de descrição semântica, normalizada pelo contrato final;
   - conteúdo da alternativa acessível deriva do ativo, função e contexto reais;
   - legenda não integra o contrato inicial e não se confunde com alternativa acessível;
-  - vídeo exige alternativa acessível própria; contrato exato ainda pendente;
+  - vídeo exige alternativa acessível própria;
+  - contrato exato de vídeo ainda pendente;
   - mídia decorativa não transporta informação essencial.
 
-O conjunto candidato contém sete campos, mas `secondaryCta` não entra no `fieldCatalog` publicável enquanto seu contrato não for decidido.
+Estado dos campos:
+
+- o conjunto candidato contém sete campos;
+- `secondaryCta` não entra no `fieldCatalog` publicável enquanto seu contrato não for decidido;
+- o Hero possui seis campos admitidos no catálogo publicável candidato;
+- quatro possuem contrato interno definido:
+  - `eyebrow`;
+  - `title`;
+  - `subtitle`;
+  - `proofShort`;
+- `primaryCta` permanece parcialmente pendente para o canal `form`;
+- `media` permanece parcialmente pendente para acessibilidade de vídeo;
+- as capabilities tipográfica e responsiva da raiz são dependências externas, não pendências internas desses campos.
 
 #### 2.7.5. Herança e exceção tipográfica
 
 - Campos textuais herdam raiz; não há tamanho ou spacing próprio aprovado.
-- E18.5 autoriza `body.editorialEmphasis` e `body.base`; E20 seleciona.
+- A E18.5 autoriza `body.editorialEmphasis` e `body.base`; a E20 seleciona.
 - Exceção exige decisão humana documentada, sem presumir persistência nova.
-- Renderer não escolhe nem aplica fallback.
+- O renderer não escolhe nem aplica fallback.
+- A capability tipográfica ainda depende de nova `rootVersion`.
 
 #### 2.7.6. Mídia e comportamento responsivo
 
 - Imagem e vídeo no mesmo slot usam `hero.standard`.
 - Galeria, carrossel e tour ficam fora.
-- `responsiveVisibility = all_viewports | desktop_only`.
-- `desktop_only` é escolha da E20, não variante.
-- Contrato só autoriza ocultação para mídia decorativa, complementar ou redundante; E19 valida a mídia concreta.
-- Capability responsiva depende de nova raiz.
+- Opções conceitualmente autorizadas:
+  - `all_viewports`;
+  - `desktop_only`.
+- Decisão humana de 16/07/2026:
+  - `desktop_only` é opção responsiva aprovada para `hero.media`;
+  - pertence à escolha por ocorrência da E20;
+  - não cria variante;
+  - só pode ser usada quando a mídia for decorativa, complementar ou redundante;
+  - não pode ocultar informação essencial.
+- Aprovação conceitual não equivale a capability técnica disponível.
+- A raiz v1 não possui a capability necessária.
+- A implementação de `desktop_only` permanece bloqueada até evolução versionada da raiz.
+- A E19 valida a mídia concreta e a preservação da informação.
 
 #### 2.7.7. Fronteira com formulário
 
-- CTA pode acionar formulário quando a operação resolvida permitir.
-- O Hero não armazena `destinationRef`, URL ou destino.
-- Formulário completo fica fora de `hero.standard` e tende a módulo próprio composto pela E20.
+- O Hero não armazena `destinationRef`, URL, identificador de formulário ou destino concreto.
+- Quando `primary_conversion_channel` for:
+  - `whatsapp`:
+    - a E19 resolve `whatsapp_destination`;
+  - `phone`:
+    - a E19 resolve `phone_destination`;
+  - `email`:
+    - a E19 resolve `email_destination`;
+  - `external_url`:
+    - a E19 resolve `external_url_destination`.
+- Quando `primary_conversion_channel = form`:
+  - `privacy_policy_url` comprova requisito de privacidade, mas não identifica a ocorrência concreta do formulário;
+  - o CTA depende de futura ocorrência de módulo de formulário aprovada na composição;
+  - a E20 deverá compor o Hero com essa ocorrência;
+  - a E19 deverá vincular o CTA à ocorrência composta;
+  - esse vínculo ainda não possui contrato aprovado;
+  - o caso `form` não é considerado completamente resolvido pelo Hero.
+- Não criar agora:
+  - nova entrada operacional;
+  - identificador de formulário;
+  - propriedade de composição;
+  - `moduleKey` de formulário.
+- Formulário completo fica fora de `hero.standard`.
 - Variante com formulário não está aprovada.
 
 #### 2.7.8. `copySourceMap` do Hero
 
-- `eyebrow`: `positioning_opportunity`; auxiliar `search_intent`.
-- `title`: `positioning_opportunity` e `desire`; auxiliar `commercial_keywords`.
-- `subtitle`: `pain` e `desire`; auxiliar `belief`.
-- labels: `trigger`; auxiliar `search_intent`; ação concreta exige vínculo operacional.
-- `proofShort`: `proof_type`; auxiliar `objection`; suporte operacional obrigatório quando presente.
-- Alternativa acessível de mídia não usa `copySourceMap` nem `operationalValuePolicy`; E19 a produz a partir do ativo e contexto sob o contrato de acessibilidade.
+- `eyebrow`:
+  - primária `positioning_opportunity`;
+  - auxiliar `search_intent`.
+- `title`:
+  - primárias `positioning_opportunity` e `desire`;
+  - auxiliar `commercial_keywords`.
+- `subtitle`:
+  - primárias `pain` e `desire`;
+  - auxiliar `belief`.
+- labels:
+  - primária `trigger`;
+  - auxiliar `search_intent`;
+  - ação concreta exige vínculo operacional.
+- `proofShort`:
+  - primária `proof_type`;
+  - auxiliar `objection`;
+  - suporte operacional obrigatório quando presente.
+- Alternativa acessível de mídia:
+  - não usa `copySourceMap`;
+  - não usa `operationalValuePolicy`;
+  - a E19 a produz a partir do ativo e contexto sob o contrato de acessibilidade.
 - Ativo, tipo de mídia, modo de acessibilidade, visibilidade, canal e destino não recebem `copySourceMap`.
 
 #### 2.7.9. Perfis de funil do Hero
 
-- BOFU: direto, decisório e de alta intenção, sem alegação não sustentada.
-- MOFU: diferenciação e explicação, com pressão menor.
-- TOFU: contexto educativo e baixa fricção, sem pressão artificial.
+- BOFU:
+  - direto;
+  - decisório;
+  - alta intenção;
+  - sem alegação não sustentada.
+- MOFU:
+  - diferenciação;
+  - explicação;
+  - pressão menor.
+- TOFU:
+  - contexto educativo;
+  - baixa fricção;
+  - sem pressão artificial.
 - Perfil altera copy, não campos, estrutura ou variante.
 
 #### 2.7.10. Variante `hero.standard`
 
-- `variantVersion = 1`, compatível com `moduleVersion = 1`.
+- `variantVersion = 1`.
+- Compatível com `moduleVersion = 1`.
 - Execução-base com delta vazio.
 - Mídia permanece opcional.
 - O estado do CTA secundário depende da decisão final do campo candidato.
@@ -394,11 +597,25 @@ O conjunto candidato contém sete campos, mas `secondaryCta` não entra no `fiel
 
 #### 2.7.11. Lifecycle e compatibilidade do Hero
 
-- `moduleCatalogVersion`, `moduleVersion` e `variantVersion` iniciais: 1 propostos.
+- `moduleCatalogVersion = 1` proposto.
+- `moduleVersion = 1` proposto.
+- `variantVersion = 1` proposto.
 - `moduleCatalogVersion` não possui lifecycle próprio aprovado; declara apenas versão e compatibilidade com a raiz.
 - `rootVersion` depende das capabilities tipográfica e responsiva.
-- Raiz `hypothesis`: somente `controlled_test`; `validated`: conforme demais camadas; `deprecated`: somente `historical_read`.
-- Módulo e variante começam `experimental`; propósito inicial `controlled_test`.
+- Lifecycle da raiz disponível no contrato atual:
+  - `hypothesis`;
+  - `validated`;
+  - `deprecated`.
+- Política nova de elegibilidade criada pela E18.5:
+  - raiz `hypothesis` permite somente `controlled_test`;
+  - raiz `validated` segue a interseção das demais camadas;
+  - raiz `deprecated` permite somente `historical_read`.
+- Essa política:
+  - interpreta o lifecycle fornecido pela raiz;
+  - não é comportamento já implementado no resolver da raiz;
+  - será aplicada pelo futuro resolver da E18.5.
+- Módulo e variante começam `experimental`.
+- Propósito inicial: `controlled_test`.
 - Elegibilidade cruza:
   - lifecycle da raiz;
   - compatibilidade raiz–catálogo;
@@ -412,12 +629,15 @@ O conjunto candidato contém sete campos, mas `secondaryCta` não entra no `fiel
 - Validar identidade, evidência, proveniência e interpretação editorial de `hero_segmentado`.
 - Rejeitar publicação enquanto campo candidato não possuir contrato fechado.
 - Rejeitar campo, cardinalidade, policy, fonte, tratamento ou variante inválidos.
+- Rejeitar combinação ausente da allowlist.
 - Validar `operationalSupportRequirement` e sua compatibilidade com policy e campo.
 - Validar vínculo abstrato do CTA principal com `primary_conversion_channel`.
 - Garantir que CTA não armazene canal ou destino concreto.
+- Registrar o caso `form` como vínculo de composição ainda pendente.
 - Validar contrato abstrato de mídia, acessibilidade e responsividade.
 - Falhar sem capabilities exigidas e sem fallback.
 - Incluir raiz na elegibilidade sem exigir lifecycle do catálogo.
+- Tratar lifecycle–propósito como política da E18.5.
 - Retornar resultado imutável.
 
 #### 2.7.13. Invariantes futuras de conteúdo para E19
@@ -426,10 +646,12 @@ Não criam agora schema ou validador de conteúdo na E18.5:
 
 - título, subtítulo e CTA principal concretos conforme cardinalidade;
 - label compatível com canal, ação e destino resolvidos;
+- CTA para formulário vinculado à ocorrência composta quando esse contrato existir;
 - suporte operacional exigido disponível;
 - prova concreta sustentada;
 - ativo de mídia válido;
-- imagem informativa com alternativa acessível e decorativa sem descrição semântica;
+- imagem informativa com alternativa acessível;
+- imagem decorativa sem descrição semântica;
 - vídeo com alternativa acessível;
 - `desktop_only` sem ocultar informação essencial;
 - ausência de formulário completo, seletor interativo, galeria, carrossel ou tour dentro de `hero.standard`.
@@ -440,8 +662,10 @@ Fechar após aprovação de:
 
 - identidade, evidência, interpretação da segmentação e fronteiras;
 - campos publicáveis e cardinalidades;
-- matriz de policies e `operationalSupportRequirement`;
-- vínculo do CTA principal e decisão sobre `secondaryCta`;
+- allowlist de policies e `operationalSupportRequirement`;
+- vínculo do CTA principal;
+- contrato do caso `form`;
+- decisão sobre `secondaryCta`;
 - mídia e acessibilidade, inclusive vídeo;
 - visibilidade responsiva e nova raiz;
 - variante, versões, lifecycle e compatibilidades;
@@ -451,24 +675,32 @@ Estado:
 
 - `hero_segmentado` comprovado com `researchId` e `itemId`;
 - segmentação v1 definida como editorial, não interativa;
+- allowlist de policies registrada;
 - labels e `proofShort` usam `hybrid` com suporte declarativo;
 - CTA principal referencia somente a chave operacional aprovada;
-- destino concreto permanece fora do registry;
+- destinos concretos permanecem fora do registry;
+- caso `form` delimitado como vínculo futuro de composição;
 - alternativa acessível saiu de `operationalValuePolicy`;
+- `desktop_only` possui aprovação humana conceitual, mas capability técnica ainda não existe;
 - lifecycle próprio do catálogo foi retirado;
+- lifecycle–propósito foi identificado como política nova da E18.5;
 - `secondaryCta` e acessibilidade de vídeo ainda pendentes;
 - Hero ainda não fechado e implementação bloqueada.
 
 ### 2.8. `copy_source_map`
 
 - Até duas fontes primárias e uma auxiliar por campo.
-- `end_customer` é fonte primária; `business_buyer` só auxilia autoridade, processo, posicionamento ou prova institucional.
+- `end_customer` é fonte primária.
+- `business_buyer` só auxilia autoridade, processo, posicionamento ou prova institucional.
 - `lp_sections` comprova função, não vira fonte fixa de copy.
 - Policies e exigência de suporte controlam quando `copySourceMap` é permitido.
 
 ### 2.9. `funnel_copy_profile`
 
-- Perfis `bofu`, `mofu`, `tofu`.
+- Perfis:
+  - `bofu`;
+  - `mofu`;
+  - `tofu`.
 - Perfil altera transformação, nunca schema, cardinalidade, módulo ou variante.
 
 ### 2.10. Tratamentos comerciais
@@ -479,29 +711,60 @@ Estado:
 
 ### 2.11. Lifecycle e compatibilidade
 
-- Raiz: `hypothesis | validated | deprecated`.
-- Módulo e variante: `candidate | experimental | validated | deprecated`.
+- Raiz:
+  - `hypothesis`;
+  - `validated`;
+  - `deprecated`.
+- Módulo e variante:
+  - `candidate`;
+  - `experimental`;
+  - `validated`;
+  - `deprecated`.
 - `moduleCatalogVersion` possui versão e compatibilidade, sem lifecycle próprio na v1.
-- Propósitos: `controlled_test | new_use | historical_read`.
-- Elegibilidade é interseção de lifecycle da raiz, compatibilidade raiz–catálogo, lifecycle do módulo, lifecycle da variante e propósito.
-- `candidate` bloqueia uso; `experimental` permite teste; `deprecated` só permite histórico.
+- Propósitos:
+  - `controlled_test`;
+  - `new_use`;
+  - `historical_read`.
+- A relação lifecycle da raiz–propósito é política criada pela E18.5, não comportamento implementado pela raiz.
+- Elegibilidade é interseção de:
+  - lifecycle da raiz interpretado pela E18.5;
+  - compatibilidade raiz–catálogo;
+  - lifecycle do módulo;
+  - lifecycle da variante;
+  - propósito.
+- `candidate` bloqueia uso.
+- `experimental` permite teste controlado.
+- `deprecated` só permite leitura histórica.
 
 ### 2.12. Contrato de resolução previsto
 
-Entrada: `rootVersion`, `moduleCatalogVersion`, `moduleKey`, `variantKey`, `purpose`.
+Entrada:
+
+- `rootVersion`;
+- `moduleCatalogVersion`;
+- `moduleKey`;
+- `variantKey`;
+- `purpose`.
 
 Processamento:
 
-1. resolver raiz, lifecycle e propósito;
-2. validar compatibilidade do catálogo com a raiz;
-3. resolver módulo e lifecycle;
-4. validar evidências, campos, policies, suporte e vínculos abstratos;
-5. resolver variante, lifecycle e compatibilidade;
-6. aplicar delta válido;
-7. calcular contrato e elegibilidade;
-8. retornar resultado imutável.
+1. resolver raiz e ler seu lifecycle;
+2. aplicar a política lifecycle–propósito definida pela E18.5;
+3. validar compatibilidade do catálogo com a raiz;
+4. resolver módulo e lifecycle;
+5. validar evidências, campos, allowlist, suporte e vínculos abstratos;
+6. resolver variante, lifecycle e compatibilidade;
+7. aplicar delta válido;
+8. calcular contrato e elegibilidade;
+9. retornar resultado imutável.
 
-A saída não contém deltas, canal, destino concreto, lifecycle de catálogo ou fallback.
+A saída não contém:
+
+- deltas;
+- canal concreto;
+- destino concreto;
+- lifecycle de catálogo;
+- fallback.
 
 ### 2.13. Artefatos previstos
 
@@ -514,12 +777,15 @@ Após raiz e v2:
 - `validation-cases.ts`;
 - `index.ts`.
 
-Interface: `landingPageModules`. Script: `validate:landing-page-modules`.
+Interface prevista: `landingPageModules`.
+
+Script previsto: `validate:landing-page-modules`.
 
 #### 2.13.1. Evolução futura do catálogo
 
 - Extensão comum ocorre por registry, casos e nova versão aplicável.
-- Campo novo exige nova `moduleVersion`; capability comum exige nova `rootVersion`.
+- Campo novo exige nova `moduleVersion`.
+- Capability comum exige nova `rootVersion`.
 - Contrato, schema e resolver só mudam quando a necessidade não couber no contrato fechado.
 - Sem cadastro dinâmico, mutação runtime ou criação automática no MVP.
 
@@ -527,22 +793,30 @@ Interface: `landingPageModules`. Script: `validate:landing-page-modules`.
 
 Validações E18.5:
 
-- versões, evidências, compatibilidades e lifecycle de raiz, módulo e variante válidos;
+- versões, evidências e compatibilidades válidas;
+- lifecycle de raiz, módulo e variante válido;
 - ausência de lifecycle próprio não aprovado no catálogo;
 - campos, cardinalidades, policies, fontes e tratamentos válidos;
-- matriz de policy e suporte operacional respeitada;
+- combinação presente na allowlist;
+- matriz de suporte operacional respeitada;
 - vínculo de ação referencia apenas `fieldKey` aprovado do catálogo operacional;
 - nenhum destino concreto de CTA no registry;
+- caso `form` não tratado como resolvido sem vínculo de composição;
 - capabilities exigidas sem fallback;
+- `desktop_only` reconhecido como decisão conceitual dependente de nova raiz;
 - delta vazio somente na base autorizada;
 - contrato abstrato de mídia e acessibilidade válido;
 - formulário ou seletor interativo não adicionados ao Hero;
-- resultado imutável, versões históricas preservadas e sem imports fora do boundary.
+- política lifecycle–propósito atribuída à E18.5, não ao resolver atual da raiz;
+- resultado imutável;
+- versões históricas preservadas;
+- sem imports fora do boundary.
 
 #### 2.14.1. Invariantes futuras para E19
 
 - presença e consistência do conteúdo concreto;
 - CTA vinculado à operação real;
+- CTA de formulário vinculado à ocorrência composta, quando o contrato existir;
 - suporte operacional exigido resolvido;
 - prova sustentada;
 - ativo e acessibilidade válidos;
@@ -551,25 +825,60 @@ Validações E18.5:
 
 ### 2.15. Fluxo operacional
 
-- Gatilho: raiz e plano v2 mergeados, fase instruída.
-- Entrada: raiz compatível, catálogo aprovado, itens oficiais e decisões humanas.
-- Processamento: contratos, registry, resolver, policies, suporte, mapas, lifecycle e casos E18.5.
-- Validação: `npm ci`, validações da raiz, módulos e commercial activation, `npm run check`, `git diff --check` e checks do PR.
-- Persistência: repositório; consumo futuro: E20 e E19; fallback: falha fechada.
+- Gatilho:
+  - raiz e plano v2 mergeados;
+  - fase instruída.
+- Entrada:
+  - raiz compatível;
+  - catálogo aprovado;
+  - itens oficiais;
+  - decisões humanas.
+- Processamento:
+  - contratos;
+  - registry;
+  - resolver;
+  - policies;
+  - allowlist;
+  - suporte;
+  - mapas;
+  - lifecycle;
+  - casos E18.5.
+- Validação:
+  - `npm ci`;
+  - validações da raiz;
+  - validação de módulos;
+  - validação de commercial activation;
+  - `npm run check`;
+  - `git diff --check`;
+  - checks do PR.
+- Persistência: repositório.
+- Consumo futuro: E20 e E19.
+- Fallback: falha fechada.
 
 ## 3. Fases e próxima ação
 
 ### 3.1. E18.5.3–E18.5.9 — Catálogo versionado de módulos e variantes v1
 
-- Status pendente e bloqueado até grade fechada, raiz evoluída e v2 consolidada.
-- Automação: não. Risco: médio controlado.
-- Aceite: módulos aprovados, sem duplicação da raiz ou E20.2, compatibilidade validada, Hero conforme contrato, resolver fail-closed e separação E18.5/E19.
+- Status:
+  - pendente;
+  - bloqueado até grade fechada, raiz evoluída e v2 consolidada.
+- Automação: não.
+- Risco: médio controlado.
+- Critérios de aceite:
+  - módulos aprovados;
+  - nenhuma duplicação da raiz ou E20.2;
+  - compatibilidade validada;
+  - Hero conforme contrato;
+  - resolver fail-closed;
+  - separação E18.5/E19.
 - Próxima ação:
   - decidir `secondaryCta`;
   - fechar acessibilidade de vídeo;
+  - definir futuramente o vínculo do CTA para formulário na composição;
+  - concluir a evolução tipográfica e responsiva da raiz;
   - reavaliar Hero;
   - depois iniciar `trust_bar` e seguir a grade;
-  - concluir raiz, pareceres, v2 e merge humano.
+  - concluir pareceres, v2 e merge humano.
 
 ## 4. Escopo negativo e critérios de parada
 
@@ -578,6 +887,7 @@ Validações E18.5:
 - Implementação da raiz no PR #577.
 - Banco, composição, geração, renderer, Admin, Builder, tracking, automação ou nova infraestrutura.
 - Nova entrada operacional para sustentar `secondaryCta`.
+- Implementação do vínculo entre CTA e ocorrência de formulário.
 - Módulo de formulário, seletor interativo, galeria, carrossel ou tour neste recorte.
 - Persistência nova para justificativa da composição.
 
@@ -590,9 +900,12 @@ Parar se:
 - surgir fallback, dependência de taxon ou ampliação de limite;
 - faltar evidência oficial;
 - destino concreto entrar no registry;
+- combinação não listada for aceita;
 - campo híbrido depender de regra hardcoded por `fieldKey`;
-- formulário, seletor interativo ou mídia essencial forem tratados incorretamente;
+- formulário for tratado como resolvido sem vínculo de composição;
+- seletor interativo ou mídia essencial forem tratados incorretamente;
 - validação de conteúdo for antecipada na E18.5;
+- política da E18.5 for atribuída como comportamento já implementado pela raiz;
 - houver conflito de fronteiras ou perda histórica.
 
 ### 4.3. Decisão atual
@@ -600,14 +913,35 @@ Parar se:
 - PR #577 permanece em v1 e sem implementação autorizada.
 - `hero_segmentado` está comprovado com `itemId` e interpretado editorialmente na v1.
 - Grade comum e nove candidatos permanecem.
-- Hero mantém seis campos com contrato interno fechado e `secondaryCta` como candidato pendente.
+- O Hero possui seis campos admitidos no catálogo publicável candidato.
+- Quatro campos possuem contrato interno definido:
+  - `eyebrow`;
+  - `title`;
+  - `subtitle`;
+  - `proofShort`.
+- `primaryCta` permanece parcialmente pendente para formulário.
+- `media` permanece parcialmente pendente para vídeo.
+- `secondaryCta` permanece candidato fora do catálogo publicável.
+- As capabilities tipográfica e responsiva da raiz são dependências externas.
+- Allowlist completa de policies registrada.
 - `hero.standard` permanece a única variante inicial, com delta vazio.
 - Labels e `proofShort` usam `hybrid` com exigência declarativa de suporte.
 - CTA principal referencia `primary_conversion_channel`, sem canal ou destino concreto no registry.
+- O caso `form` depende de vínculo futuro com ocorrência de formulário na composição.
 - Alternativa acessível da mídia usa contrato próprio, não policy textual.
+- `desktop_only` possui aprovação humana conceitual e permanece bloqueado tecnicamente até nova `rootVersion`.
 - Imagem, vídeo e visibilidade responsiva não criam variante.
 - Formulário completo e seletor interativo ficam fora do Hero.
 - Elegibilidade inclui a raiz e não presume lifecycle do catálogo.
+- Lifecycle–propósito é política nova da E18.5.
 - E18.5 e E19 permanecem separadas.
-- Hero ainda não está fechado por `secondaryCta`, acessibilidade de vídeo e evolução da raiz.
-- Próxima decisão humana: fechar esses pontos e reavaliar antes de `trust_bar`.
+- Frentes materiais ainda abertas:
+  - decisão sobre `secondaryCta`;
+  - acessibilidade de vídeo;
+  - vínculo futuro do CTA para formulário;
+  - evolução tipográfica e responsiva da raiz.
+- Frente documental concluída nesta atualização:
+  - aprovação humana de `desktop_only` registrada;
+  - lifecycle–propósito identificado como política própria da E18.5.
+- Hero ainda não está fechado.
+- Próxima decisão humana: fechar as frentes materiais e reavaliar antes de `trust_bar`.

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -4,7 +4,7 @@ Fontes: chat, `README.md`, `AGENTS.md`, `docs/roadmap.md`, `docs/base-tecnica.md
 
 Versão: v1 em ajuste.
 
-Status: plano simplificado; nove módulos mantidos no escopo; `hero`, `hero.standard@v1`, `trust_bar`, `trust_bar.standard@v1`, `problem_solution` e `problem_solution.standard@v1` conceitualmente fechados; seis módulos pendentes; nenhuma implementação autorizada neste PR.
+Status: plano simplificado; nove módulos mantidos no escopo; `hero`, `hero.standard@v1`, `trust_bar`, `trust_bar.standard@v1`, `problem_solution`, `problem_solution.standard@v1`, `offer` e `offer.standard@v1` conceitualmente fechados; cinco módulos pendentes; nenhuma implementação autorizada neste PR.
 
 Path: `docs/lousa-plano-base-e18-5.md`.
 
@@ -48,7 +48,7 @@ Regras:
 - `item_key` é evidência de pesquisa, não identidade canônica do módulo.
 - Os módulos são transversais e não recebem identidade de taxon.
 - Formatos curto, médio e longo pertencem à composição e à extensão da LP.
-- O próximo módulo para análise é `offer`.
+- O próximo módulo para análise é `process`.
 
 ### 1.4. Escopo positivo
 
@@ -510,13 +510,106 @@ Estado:
 - propósito `controlled_test`;
 - implementação ainda não autorizada por este ajuste documental.
 
+### 3.7. Módulo `offer`
+
+- `moduleKey = offer`.
+- `moduleVersion = 1`.
+- Função:
+  - apresentar o que o negócio ou profissional efetivamente oferece;
+  - organizar a oferta por intenção, caso de uso ou necessidade atendida;
+  - permitir que o visitante reconheça rapidamente se existe aderência ao que procura.
+- Invariantes:
+  - cada item representa uma oferta ou escopo real e identificável;
+  - título e descrição do item permanecem coerentes entre si;
+  - toda capacidade, disponibilidade ou condição apresentada possui sustentação operacional;
+  - a oferta não implica preço, prazo, garantia ou resultado não declarado;
+  - ausência de identidade de taxon, plano, campanha ou funil no contrato.
+- Fronteiras:
+  - não repete pares de problema e solução;
+  - não descreve etapas ou sequência de atendimento;
+  - não apresenta prova técnica, depoimento, credencial ou FAQ;
+  - não define preço, condição comercial, plano ou disponibilidade na execução inicial;
+  - não contém CTA, mídia, formulário ou interação na execução inicial.
+- Evidências principais:
+  - `servicos_por_intencao`, pesquisa ativa de `lp_sections`, taxon `Corretor Imóveis`;
+  - itens `trigger`, `desire`, `positioning_opportunity`, `belief` e `objection` de `strategic_core`;
+  - `narrative_arc` de `lp_overview`, que recomenda segmentação por intenção antes de processo e fechamento;
+  - Blueprint do corretor, especialmente diferenciais objetivos e ofertas orientadas a intenção;
+  - catálogo de entradas vigente, com capacidades e recortes operacionais aplicáveis ao primeiro taxon.
+- Variantes futuras podem usar outra execução estrutural sem alterar `offer.standard@v1`.
+
+### 3.8. Variante `offer.standard@v1`
+
+Identidade:
+
+- `variantKey = offer.standard`.
+- `variantVersion = 1`.
+- Compatível com `offer@v1` e com a versão vigente da raiz utilizada na implementação inicial.
+- Única variante inicial.
+
+Campos:
+
+- `title`:
+  - texto, papel `h2`, cardinalidade `1..1`, policy `research_guided`.
+- `items`:
+  - coleção, cardinalidade `1..4`, policy `not_copy`;
+  - item fechado com `title` e `description`;
+  - `title`: texto, papel `card_title`, cardinalidade `1..1`, policy `hybrid`, suporte `when_present`;
+  - `description`: texto, papel `card_body`, cardinalidade `1..1`, policy `hybrid`, suporte `when_present`.
+
+Copy:
+
+- `title`: primárias `desire` e `trigger`; auxiliar `positioning_opportunity`.
+- `items.title`: primárias `trigger` e `desire`; auxiliar `search_intent`.
+- `items.description`: primárias `positioning_opportunity` e `belief`; auxiliar `objection`.
+
+Regras específicas:
+
+- uma ocorrência válida contém de um a quatro itens completos;
+- o mínimo de um item permite LPs de intenção única sem forçar ofertas irrelevantes;
+- cada item contém exatamente `title` e `description`;
+- título e descrição representam uma oferta, escopo ou caso de uso efetivamente disponível;
+- todo item exige suporte por entradas operacionais aplicáveis ao taxon, negócio ou oferta;
+- o contrato transversal não fixa chaves de um taxon específico;
+- no primeiro taxon, exemplos de sustentação incluem intenção de transação, apoio em financiamento, orientação documental, localização, tipologia, faixa de preço e estágio, quando aplicáveis e reais;
+- pesquisa e Blueprint orientam seleção e redação, mas não comprovam disponibilidade, capacidade, preço, prazo, condição, parceria, garantia ou resultado;
+- os papéis `h2`, `card_title` e `card_body` usam as faixas da raiz sem especialização na v1;
+- a coleção não admite item aninhado;
+- não possui subtítulo, CTA, mídia, ícone, prova, preço, condição comercial, processo ou referência técnica;
+- diferenças de copy, quantidade dentro de `1..4`, ordem dos itens e funil não criam variante;
+- o tratamento da ausência de item válido depende da obrigatoriedade definida pela composição da E20 e será especificado pela E19.
+
+Funil:
+
+- BOFU prioriza oferta específica, aderência imediata e escopo operacional direto.
+- MOFU prioriza comparação entre casos de uso e clareza sobre o atendimento disponível.
+- TOFU prioriza categorias amplas e linguagem educativa, sem transformar interesse inicial em compromisso inexistente.
+- O funil altera seleção, prioridade e redação dos itens, sem alterar campos, cardinalidades, variante ou ordem estrutural da LP.
+
+Validações estruturais:
+
+- exigir `title` e `items`;
+- exigir cardinalidade `1..4` em `items`;
+- exigir exatamente `title` e `description` em cada item;
+- rejeitar coleção aninhada e campos extras;
+- validar os papéis semânticos e as policies declaradas;
+- exigir suporte `when_present` em `items.title` e `items.description`;
+- rejeitar CTA, mídia, ação, prova, preço, condição comercial, processo ou referência técnica na variante;
+- resolver de forma fail-closed e imutável.
+
+Estado:
+
+- contrato conceitualmente fechado;
+- lifecycle `experimental`;
+- propósito `controlled_test`;
+- implementação ainda não autorizada por este ajuste documental.
+
 ## 4. Módulos pendentes
 
 ### 4.1. Estado
 
 Permanecem pendentes:
 
-- `offer`;
 - `process`;
 - `technical_assurance`;
 - `social_proof`;
@@ -544,8 +637,8 @@ A etapa seguinte só deve reproduzir o contrato compartilhado após ele estar va
 
 ### 4.3. Próxima ação
 
-- Analisar `offer` pelo checklist mínimo da seção 2.9.
-- Separar `offer` de `offer.standard@v1`.
+- Analisar `process` pelo checklist mínimo da seção 2.9.
+- Separar `process` de `process.standard@v1`.
 - Não alterar o arquivo novamente sem decisão humana sobre o contrato proposto.
 - Não implementar código durante o fechamento conceitual.
 

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -521,14 +521,14 @@ Estado:
 - Invariantes:
   - cada item representa uma oferta ou escopo real e identificável;
   - título e descrição do item permanecem coerentes entre si;
-  - toda capacidade, disponibilidade ou condição apresentada possui sustentação operacional;
-  - a oferta não implica preço, prazo, garantia ou resultado não declarado;
+  - toda capacidade ou condição apresentada possui sustentação operacional;
+  - a oferta não implica preço, prazo, garantia, disponibilidade temporal ou resultado não declarado;
   - ausência de identidade de taxon, plano, campanha ou funil no contrato.
 - Fronteiras:
   - não repete pares de problema e solução;
   - não descreve etapas ou sequência de atendimento;
   - não apresenta prova técnica, depoimento, credencial ou FAQ;
-  - não define preço, condição comercial, plano ou disponibilidade na execução inicial;
+  - não define preço, condição comercial, plano ou disponibilidade temporal na execução inicial;
   - não contém CTA, mídia, formulário ou interação na execução inicial.
 - Evidências principais:
   - `servicos_por_intencao`, pesquisa ativa de `lp_sections`, taxon `Corretor Imóveis`;
@@ -568,11 +568,11 @@ Regras específicas:
 - uma ocorrência válida contém de um a quatro itens completos;
 - o mínimo de um item permite LPs de intenção única sem forçar ofertas irrelevantes;
 - cada item contém exatamente `itemTitle` e `description`;
-- título e descrição representam uma oferta, escopo ou caso de uso efetivamente disponível;
+- título e descrição representam uma oferta, escopo ou caso de uso efetivamente disponível como capacidade da operação;
 - todo item exige suporte por entradas operacionais aplicáveis ao taxon, negócio ou oferta;
 - o contrato transversal não fixa chaves de um taxon específico;
 - no primeiro taxon, exemplos de sustentação incluem intenção de transação, apoio em financiamento, orientação documental, localização, tipologia, faixa de preço e estágio, quando aplicáveis e reais;
-- pesquisa e Blueprint orientam seleção e redação, mas não comprovam disponibilidade, capacidade, preço, prazo, condição, parceria, garantia ou resultado;
+- pesquisa e Blueprint orientam seleção e redação, mas não comprovam capacidade, preço, prazo, condição, parceria, garantia, disponibilidade temporal ou resultado;
 - os papéis `h2`, `card_title` e `card_body` usam as faixas da raiz sem especialização na v1;
 - a coleção não admite item aninhado;
 - não possui subtítulo, CTA, mídia, ícone, prova, preço, condição comercial, processo ou referência técnica;

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -4,7 +4,7 @@ Fontes: chat, `README.md`, `AGENTS.md`, `docs/prompt-estrategista.md`, `docs/tem
 
 Versão: v1 em ajuste.
 
-Status: PR vivo para debate; grade inicial de nove módulos definida a partir de `Corretor Imóveis`, `audience_scope = end_customer`, `lp_sections` v1 ativa; os contratos serão fechados um a um antes da avaliação única dos especialistas; nenhuma implementação autorizada.
+Status: PR vivo para debate; grade inicial de nove módulos candidatos definida a partir de `Corretor Imóveis`, `audience_scope = end_customer`, `lp_sections` v1 ativa; cada candidato será analisado individualmente antes de sua aprovação material; rejeição, fusão ou substituição exige decisão humana; a grade metodológica será aplicada primeiro ao Hero; nenhuma implementação autorizada.
 
 Path: `docs/lousa-plano-base-e18-5.md`.
 
@@ -37,16 +37,28 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 
 - O plano-base v1 e o PR #577 já existem.
 - As decisões do debate são incorporadas no mesmo PR; não criar arquivo paralelo.
-- A v1 permanecerá aberta até definir, um a um, os nove módulos e suas variantes iniciais.
-- Para cada módulo, fechar:
-  - função estrutural;
+- A v1 permanecerá aberta até analisar, um a um, os nove módulos candidatos e suas variantes iniciais.
+- A existência na grade não equivale a aprovação material do módulo.
+- Rejeitar, fundir ou substituir candidato exige:
+  - justificativa estrutural;
+  - atualização explícita da grade;
+  - decisão humana.
+- Para cada módulo aprovado, fechar:
+  - identidade transversal;
+  - restrições normativas;
+  - evidências estruturais;
+  - função e fronteiras;
   - campos e cardinalidades;
-  - herança e exceções;
-  - variante inicial e deltas;
+  - herança e capabilities;
+  - política de origem dos valores;
   - fontes de copy;
   - perfis BOFU, MOFU e TOFU;
-  - lifecycle e limites.
-- O Hero é o módulo-piloto; os demais seguem a ordem da grade inicial.
+  - variante inicial e deltas;
+  - versões e compatibilidades;
+  - lifecycle e propósitos permitidos;
+  - fronteiras com E20, E19 e renderer;
+  - casos executáveis e critérios de fechamento.
+- O Hero é o módulo-piloto; os demais seguem a ordem da grade inicial após o fechamento completo do Hero.
 - Depois da grade completa, o plano será dividido em fases executáveis específicas.
 - A avaliação única do Analista, Gestor Estrutural e Gestor de Updates ocorrerá somente com a v1 estável.
 - A v2 será consolidada no mesmo PR após os pareceres.
@@ -60,8 +72,10 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 - A variante registra somente deltas fechados sobre campos já previstos.
 - A composição futura pode selecionar por ocorrência apenas opções previamente autorizadas.
 - O resolver aplica a precedência e entrega contrato efetivo completo e imutável.
-- E20, E19, geração e renderer não podem reaplicar a herança.
-- O renderer executa o contrato resolvido; não escolhe fallback.
+- A E18.5 declara tratamento padrão, alternativas autorizadas e capability exigida.
+- A E20 seleciona, por ocorrência concreta, somente alternativa autorizada e registra a justificativa aplicável.
+- A E19 gera o conteúdo concreto sem alterar o contrato parametrizado.
+- O renderer executa o contrato já resolvido; não escolhe alternativa, não corrige ausência de capability e não aplica fallback.
 
 ### 1.4. Regras de exceção
 
@@ -76,6 +90,7 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 ### 1.5. Decisões técnicas incorporadas
 
 - Cardinalidade substitui propriedade `required` separada.
+- A obrigatoriedade pode ser verificada como pergunta analítica, mas não será duplicada no contrato.
 - Não haverá `structuralRules` aberto nem `addedFields` livre.
 - Campo novo exige nova versão do contrato do módulo.
 - Comportamento estrutural, quando necessário, será união fechada.
@@ -90,10 +105,11 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
   - `social_proof`, derivado de `prova_social`;
   - `faq`, derivado de `faq_objeções`;
   - `final_cta`, derivado de `cta_final_qualificado`.
-- Os `item_key` de `lp_sections` são evidência da função, não identidade permanente do módulo.
+- Os `item_key` de `lp_sections` são referências de evidência, não identidade permanente do módulo.
+- Nomes diferentes de seção podem representar a mesma função estrutural transversal.
 - Cada candidato só será aprovado após confirmar função reutilizável e diferença real em relação aos demais.
 - `formato_curto`, `formato_medio` e `formato_longo` orientam composição e extensão; não são módulos nem variantes.
-- O catálogo inicial fica limitado a nove módulos; ampliação exige decisão posterior.
+- A grade inicial fica limitada aos nove candidatos; ampliação exige decisão posterior.
 - Para `hero.subtitle`:
   - `semanticRole = paragraph`;
   - padrão: `body.editorialEmphasis`;
@@ -101,7 +117,7 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
   - ausência da capability falha fechado;
   - E20 poderá selecionar a alternativa por ocorrência.
 - `hero.media_split` não está aprovada.
-- `hero.standard` é a única variante inicial aprovada do Hero.
+- `hero.standard` é a única variante inicial aprovada do Hero e poderá possuir delta vazio como execução-base versionada.
 
 ### 1.6. Estado técnico confirmado
 
@@ -116,14 +132,15 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 
 ### 1.7. Pontos ainda em debate
 
-- Confirmação individual dos oito módulos restantes.
-- Campos, cardinalidades e papéis semânticos de cada módulo.
+- Aplicação completa da grade ao Hero.
+- Confirmação individual dos oito candidatos restantes.
+- Contratos específicos por `fieldKind`.
+- Política de origem de cada campo de cada módulo.
 - Variante inicial e deltas de cada módulo.
 - Critério mínimo para nova variante e exceção estrutural.
 - Mapas de fontes de copy.
 - Perfis BOFU, MOFU e TOFU.
-- Lifecycle inicial.
-- Critério de promoção de `experimental` para `validated`.
+- Lifecycle inicial e promoção para `validated`.
 - Divisão final em fases executáveis.
 
 ## 2. Contrato do caso
@@ -134,33 +151,61 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 - Os nove itens estruturais do primeiro recorte não podem virar módulos automaticamente.
 - O catálogo precisa generalizar funções reais sem transportar identidade imobiliária.
 - A raiz v1 não garante o tratamento editorial exigido pelo Hero.
+- Um contrato único de campo com `semanticRole` obrigatório não atende mídia, ação, coleção ou referência técnica.
+- A política de origem precisa impedir que pesquisa seja tratada como fonte de preço, endereço, credencial, métrica, depoimento, registro, garantia ou disponibilidade.
 - Repetição de valores da raiz ou deltas aplicados por consumidores criaria múltiplas fontes da verdade.
 - Fallback para `body.base` esconderia capability ausente.
 
 ### 2.2. Resultado esperado
 
-- Criar catálogo repo-only versionado com nove módulos transversais.
+- Criar catálogo repo-only versionado a partir dos nove módulos candidatos, incluindo apenas os contratos individualmente aprovados.
 - Usar `Corretor Imóveis`, `end_customer`, `lp_sections` v1 ativa como evidência estrutural principal.
 - Confirmar cada módulo e variante inicial individualmente.
 - Resolver `raiz → módulo → variante` em contrato final imutável.
-- Definir fontes somente com `item_key` oficiais.
+- Definir referências estruturais sem transformar `lp_sections.itemKey` em identidade canônica.
+- Definir fontes de copy somente com `item_key` oficiais dos blocos aplicáveis.
 - Separar pesquisa orientadora de valores factuais operacionais.
 - Tratar BOFU, MOFU e TOFU como perfis, não variantes.
 - Preservar versões históricas.
 - Não criar banco, composição, geração ou renderer.
 
-### 2.3. Fonte e critério para parametrização
+### 2.3. Hierarquia para parametrização
 
-Ordem de evidência:
+#### 2.3.1. Restrições normativas
 
-1. parametrização raiz;
-2. `docs/lp-planejamento.md`;
-3. itens estruturados oficiais;
-4. Blueprints e referências reais;
-5. decisão interna de produto;
-6. LP real validada.
+- parametrização raiz vigente;
+- `docs/lp-planejamento.md`;
+- contratos oficiais dos itens estruturados;
+- fronteiras da E18.5, E20 e E19;
+- decisões humanas já aprovadas e registradas;
+- compatibilidade histórica e versionamento imutável.
 
-Regras específicas:
+#### 2.3.2. Evidências
+
+- itens estruturados do taxon;
+- Blueprints;
+- referências reais;
+- LPs analisadas;
+- contrastes entre taxons e ultranichos;
+- evidência executável existente.
+
+#### 2.3.3. Decisão humana de produto
+
+- resolve hipóteses e ambiguidades;
+- pode rejeitar recomendação empírica insuficiente;
+- pode aprovar padrão funcional próprio do LP Factory 10;
+- não pode violar contrato vigente sem evolução versionada explícita;
+- deve decidir rejeição, fusão ou substituição de candidato da grade.
+
+#### 2.3.4. Validação posterior
+
+- LP real em conta de teste;
+- casos executáveis;
+- revisão humana;
+- evidência de uso reutilizável;
+- decisão de promoção, restrição, depreciação ou substituição.
+
+#### 2.3.5. Regras específicas
 
 - A grade inicial usa `Corretor Imóveis`, `end_customer`, `lp_sections` v1 ativa.
 - O ultranicho de médio padrão não restringe o catálogo transversal.
@@ -171,11 +216,11 @@ Regras específicas:
 - Identidade do módulo não pode carregar taxon, profissão ou campanha.
 - Itens de extensão de página não pertencem ao catálogo.
 
-### 2.4. Identidade e versionamento previstos
+### 2.4. Identidade, evidência e versionamento previstos
 
 - `family = landing_page`.
 - `rootVersion` será a versão que garanta as capabilities requeridas.
-- `moduleCatalogVersion = 1`.
+- `moduleCatalogVersion = 1` para o primeiro catálogo publicado.
 - Grade candidata de `moduleKey`:
   - `hero`;
   - `trust_bar`;
@@ -187,34 +232,111 @@ Regras específicas:
   - `faq`;
   - `final_cta`.
 - O registry será explícito e imutável por versão.
-- Módulo: chave, versão, lifecycle, função e catálogo de campos.
-- Variante: chave, versão, módulo, lifecycle e deltas fechados.
+- Módulo:
+  - `moduleKey`;
+  - `moduleVersion`;
+  - `lifecycle`;
+  - `structuralFunction`;
+  - `structuralEvidenceRefs`;
+  - `fieldCatalog`.
+- Cada `structuralEvidenceRef` deve registrar:
+  - taxon de origem;
+  - `audienceScope`;
+  - `researchVersion`;
+  - `itemKey` observado;
+  - função estrutural descrita pela fonte;
+  - função transversal inferida;
+  - justificativa da equivalência semântica.
+- `itemKey` observado não determina `moduleKey`.
+- Não haverá campo livre de força de evidência na v1; necessidade futura exige enum fechado e uso comprovado.
+- Variante:
+  - `variantKey`;
+  - `variantVersion`;
+  - `moduleKey`;
+  - `compatibleModuleVersion`;
+  - `lifecycle`;
+  - deltas fechados.
+- O catálogo declara compatibilidade explícita com `rootVersion`.
 - Não haverá versão ou catálogo implícito nem fallback silencioso.
 
 ### 2.5. Contrato-base de campo
 
-Cada campo declara:
+Todo campo declara:
 
 - `fieldKey`;
-- `semanticRole`;
+- `fieldKind`;
 - `cardinality`;
-- `copySourceMap`;
 - `operationalValuePolicy`.
 
-Quando aplicável:
+A união fechada prevista de `fieldKind` é:
 
-- `defaultTypographyTreatment`;
-- `allowedTypographyTreatments`.
+- `text`;
+- `action`;
+- `media`;
+- `collection`;
+- `operational_value`;
+- `technical_reference`.
 
-Regras:
+Contratos condicionais por tipo:
 
-- papéis e tratamentos devem existir na raiz;
-- cardinalidade contém somente `min` e `max`;
-- nenhum valor concreto da raiz é copiado;
-- exceção de faixa ou limite deve ser justificada e só pode restringir o teto herdado;
-- tratamento padrão deve pertencer à lista permitida;
-- capability ausente falha fechado;
-- fato operacional não pode ser preenchido como fato por pesquisa.
+- `text`:
+  - exige `semanticRole` existente na raiz;
+  - pode declarar `copySourceMap`;
+  - pode selecionar tratamentos tipográficos autorizados.
+- `action`:
+  - representa objeto estrutural de ação;
+  - seu `label` é campo textual separado com `semanticRole = cta_label`;
+  - destino real é referência operacional futura;
+  - não haverá `actionRole` enquanto não existir contrato fechado e fonte aprovada.
+- `media`:
+  - usa contrato abstrato de referência;
+  - deve prever política de texto alternativo e uso decorativo na parametrização específica;
+  - não recebe `semanticRole` visual por padrão.
+- `collection`:
+  - declara cardinalidade da coleção;
+  - declara contrato fechado do item;
+  - não recebe `semanticRole` na coleção como um todo.
+- `operational_value`:
+  - declara tipo do valor;
+  - exige fonte operacional aplicável;
+  - não pode ser inferido como fato pela pesquisa.
+- `technical_reference`:
+  - representa referência técnica, identificador ou vínculo abstrato;
+  - não é copy.
+
+Regras gerais:
+
+- `cardinality` contém somente `min` e `max`.
+- `{ min: 1, max: 1 }` representa campo único obrigatório.
+- `{ min: 0, max: 1 }` representa campo único opcional.
+- Coleção usa `max > 1` quando houver teto fechado.
+- Não haverá `required` ou propriedade equivalente.
+- Nenhum valor concreto da raiz é copiado.
+- Exceção de faixa ou limite deve ser justificada e só pode restringir o teto herdado.
+- Tratamento padrão deve pertencer à lista permitida.
+- Capability ausente falha fechado.
+
+#### 2.5.1. Política fechada de origem do valor
+
+`operationalValuePolicy` será união fechada com:
+
+- `research_generated_non_factual`:
+  - texto pode ser produzido a partir da pesquisa;
+  - não pode criar alegação operacional ou factual não sustentada.
+- `research_guided`:
+  - pesquisa orienta tema, enquadramento e vocabulário;
+  - não fornece por si só o valor final completo.
+- `operational_required`:
+  - valor deve vir da conta, negócio, oferta, campanha, LP ou fonte operacional autorizada.
+- `hybrid`:
+  - pesquisa orienta a copy;
+  - qualquer afirmação factual exige sustentação operacional.
+- `technical_reference`:
+  - mídia, link, identificador, evidência ou referência técnica.
+- `not_copy`:
+  - campo estrutural ou técnico sem geração de copy.
+
+A E18.5 declara a política. A E19 aplica a política durante a geração concreta.
 
 ### 2.6. Contrato de variante
 
@@ -237,41 +359,104 @@ Deltas proibidos:
 - valor de conta ou composição;
 - URL, classe ou componente visual concreto.
 
-O resolver valida o delta e retorna somente o contrato final.
+Regras adicionais:
+
+- O resolver valida o delta e retorna somente o contrato final.
+- Variante `standard` pode representar a execução-base versionada do módulo e possuir delta vazio quando `variantKey` for obrigatório.
+- Delta vazio não autoriza criar variantes redundantes.
+- Não se inventa delta para justificar a existência da variante-base.
+- Nova variante exige diferença reutilizável demonstrável dentro da mesma função estrutural.
 
 ### 2.7. Módulo-piloto `hero`
 
-#### 2.7.1. Função estrutural
+#### 2.7.1. Identidade e função estrutural
 
+- `moduleKey = hero`.
 - Apresentar o recorte da LP, a proposta de valor e a principal ação.
-- A evidência inicial é `hero_segmentado`, sem transportar para o contrato as intenções ou a profissão do recorte.
 - Não representa taxon, campanha, tráfego, funil ou composição.
+- A função deve permanecer transversal à família `landing_page`.
 
-#### 2.7.2. Catálogo fechado de campos proposto
+#### 2.7.2. Evidência estrutural inicial
 
-- `eyebrow`: `eyebrow`, `{ min: 0, max: 1 }`.
-- `title`: `h1`, `{ min: 1, max: 1 }`.
-- `subtitle`: `paragraph`, `{ min: 1, max: 1 }`, padrão `body.editorialEmphasis`, permitidos `body.editorialEmphasis` e `body.base`.
-- `primaryCta.label`: `cta_label`, `{ min: 1, max: 1 }`.
-- `secondaryCta.label`: `cta_label`, `{ min: 0, max: 1 }`.
-- `proofShort`: `paragraph`, `{ min: 0, max: 1 }`.
-- `media`: referência abstrata, `{ min: 0, max: 1 }`.
+- taxon: `Corretor Imóveis`;
+- `audienceScope = end_customer`;
+- `researchVersion = 1`;
+- `itemKey = hero_segmentado`;
+- função observada: abertura segmentada da LP com promessa e CTA;
+- função transversal inferida: apresentar recorte, proposta de valor e ação principal;
+- o nome da seção imobiliária não determina o `moduleKey`.
 
-#### 2.7.3. Herança e exceções
+#### 2.7.3. Catálogo preliminar de campos
+
+O catálogo será fechado pela grade completa antes de avançar ao próximo módulo.
+
+- `eyebrow`:
+  - `fieldKind = text`;
+  - `semanticRole = eyebrow`;
+  - `cardinality = { min: 0, max: 1 }`.
+- `title`:
+  - `fieldKind = text`;
+  - `semanticRole = h1`;
+  - `cardinality = { min: 1, max: 1 }`.
+- `subtitle`:
+  - `fieldKind = text`;
+  - `semanticRole = paragraph`;
+  - `cardinality = { min: 1, max: 1 }`;
+  - padrão `body.editorialEmphasis`;
+  - permitidos `body.editorialEmphasis` e `body.base`.
+- `primaryCta`:
+  - `fieldKind = action`;
+  - `cardinality = { min: 1, max: 1 }`;
+  - `label` textual com `semanticRole = cta_label`.
+- `secondaryCta`:
+  - `fieldKind = action`;
+  - `cardinality = { min: 0, max: 1 }`;
+  - `label` textual com `semanticRole = cta_label`.
+- `proofShort`:
+  - `fieldKind = text`;
+  - `semanticRole = paragraph`;
+  - `cardinality = { min: 0, max: 1 }`.
+- `media`:
+  - `fieldKind = media`;
+  - referência abstrata;
+  - `cardinality = { min: 0, max: 1 }`;
+  - contrato de acessibilidade ainda deve ser fechado na análise do Hero.
+
+A política de origem de cada campo será decidida na aplicação completa da grade ao Hero.
+
+#### 2.7.4. Herança e exceção tipográfica
 
 - Campos textuais herdam faixas, limites e valores da raiz.
-- Não há tamanho, limite ou spacing próprio.
+- Não há tamanho, limite ou spacing próprio aprovado.
 - `subtitle` permanece `paragraph` e usa tratamento da raiz.
-- `body.base` é alternativa explícita, não fallback.
+- A E18.5 define `body.editorialEmphasis` como padrão e `body.base` como alternativa autorizada.
+- A E20 pode selecionar `body.base` em ocorrência concreta com justificativa.
+- O renderer apenas executa o tratamento resolvido.
+- Ausência de `body.editorialEmphasis` é incompatibilidade, não fallback.
 - Mídia opcional não comprova variante.
 
-#### 2.7.4. Variante inicial definida
+#### 2.7.5. Variante inicial definida
 
-- `hero.standard` usa o contrato-base, mantém mídia opcional e não possui delta numérico.
+- `variantKey = hero.standard`.
+- Representa a execução-base versionada do Hero.
+- Delta vazio é permitido.
+- Mídia permanece opcional pelo contrato do módulo.
 - É a única variante inicial aprovada do Hero.
 - `hero.media_split` permanece rejeitada.
 - Troca isolada para `body.base` não cria variante.
 - Variante específica de nicho é proibida.
+
+#### 2.7.6. Pendências para fechamento do Hero
+
+- confirmar o catálogo fechado de campos;
+- confirmar cardinalidades sem `required`;
+- classificar cada campo por `operationalValuePolicy`;
+- validar o `copySourceMap` de cada campo textual;
+- separar perfis BOFU, MOFU e TOFU da estrutura;
+- definir `moduleVersion`, `variantVersion` e compatibilidades;
+- definir lifecycle inicial do módulo e da variante;
+- criar casos positivos e negativos;
+- confirmar dependência da raiz que garanta `body.editorialEmphasis`.
 
 ### 2.8. `copy_source_map`
 
@@ -279,24 +464,24 @@ O resolver valida o delta e retorna somente o contrato final.
 - Cada campo usa até duas fontes primárias e uma auxiliar.
 - Copy para visitante usa `end_customer` como fonte primária.
 - `business_buyer` pode auxiliar somente autoridade, processo, posicionamento ou prova institucional.
-- `strategic_core` e `seo` fornecem insumos factuais de pesquisa.
+- `strategic_core` e `seo` fornecem insumos aplicáveis de pesquisa.
 - `lp_overview` orienta transformação.
 - `lp_sections` comprova funções estruturais, mas não vira fonte fixa de copy.
 - Chave desconhecida e fato operacional inferido falham fechado.
 
-Mapa inicial do Hero:
+Mapa inicial do Hero para validação:
 
 - `title`: `positioning_opportunity`, `desire`; auxiliar `commercial_keywords`.
 - `subtitle`: `pain`, `desire`; auxiliar `belief`.
-- CTAs: `trigger`; auxiliar `search_intent`.
+- labels de CTA: `trigger`; auxiliar `search_intent`.
 - `proofShort`: `proof_type`; auxiliar `objection`.
 
 ### 2.9. `funnel_copy_profile`
 
 - Perfis: `bofu`, `mofu`, `tofu`.
-- Perfil orienta transformação, sem alterar schema, cardinalidade, limite ou estrutura.
+- Perfil orienta transformação, sem alterar schema, cardinalidade, limite, identidade do módulo ou estrutura aprovada.
 - Módulo adapta o perfil à função.
-- Variante apenas restringe ou especializa tratamento permitido.
+- Variante apenas restringe ou especializa tratamento permitido quando houver mudança comportamental comprovada.
 - Hero:
   - BOFU: recorte específico, benefício sustentado, objeção direta e CTA de maior intenção;
   - MOFU: diferenciação, explicação, prova contextual e CTA proporcional;
@@ -307,16 +492,24 @@ Mapa inicial do Hero:
 - Promessa, prova, autoridade, credencial, comparação, preço, oferta, desconto, garantia, urgência, escassez, resultado, depoimento e métrica exigem fonte real aplicável.
 - Pesquisa não fornece como fato preço, condição, prazo, disponibilidade, garantia, credencial, depoimento, métrica, contato, endereço, URL ou informação legal específica.
 - Valor factual exige entrada operacional futura.
+- BOFU não autoriza alegação não sustentada.
 - TOFU não admite pressão artificial.
 
 ### 2.11. Lifecycle e compatibilidade
 
 - Lifecycle: `candidate`, `experimental`, `validated`, `deprecated`.
+- Propósitos: `controlled_test`, `new_use`, `historical_read`.
 - `candidate` não entra em composição ou geração.
 - `experimental` serve a teste controlado.
-- `validated` exige LP real e decisão humana.
-- `deprecated` não entra em novo uso, mas permanece resolvível.
-- Propósitos: `controlled_test`, `new_use`, `historical_read`.
+- `validated` permite novo uso quando todas as camadas aplicáveis também permitirem.
+- `deprecated` não entra em novo uso, mas permanece resolvível historicamente.
+- O catálogo declara compatibilidade entre `moduleCatalogVersion` e `rootVersion`.
+- A variante declara compatibilidade com `moduleVersion`.
+- A elegibilidade efetiva é a interseção das permissões de catálogo, módulo, variante e propósito; não será calculada por ordenação textual simples dos estados.
+- Exemplos:
+  - módulo `experimental` e variante `validated` permitem `controlled_test`, mas não `new_use`;
+  - módulo `deprecated` e variante `validated` permitem `historical_read`, mas não `new_use`;
+  - módulo `candidate` bloqueia qualquer resolução para uso.
 - Versões efetivas serão preservadas em snapshot futuro.
 
 ### 2.12. Contrato de resolução previsto
@@ -334,16 +527,17 @@ Entrada:
 Processamento:
 
 1. resolver raiz;
-2. validar compatibilidade;
-3. resolver módulo;
-4. validar referências;
-5. validar variante;
-6. aplicar precedência;
-7. calcular contrato final;
-8. validar lifecycle;
-9. retornar resultado imutável.
+2. validar compatibilidade do catálogo com a raiz;
+3. resolver módulo e sua versão pelo catálogo imutável;
+4. validar referências, campos e policies;
+5. resolver variante e validar compatibilidade com `moduleVersion`;
+6. validar e aplicar delta, inclusive delta vazio autorizado da variante-base;
+7. aplicar precedência;
+8. calcular contrato final;
+9. calcular elegibilidade pela interseção de permissões;
+10. retornar resultado imutável.
 
-A saída contém identidades, versões, lifecycle, função, campos, cardinalidades, papéis, fontes, políticas, tratamentos e limites efetivos; não contém deltas ou fallback para o consumidor.
+A saída contém identidades, versões, lifecycle, elegibilidade efetiva, função, campos, cardinalidades, papéis, fontes, policies, tratamentos e limites efetivos; não contém deltas ou fallback para o consumidor.
 
 ### 2.13. Artefatos previstos
 
@@ -367,49 +561,51 @@ Script previsto: `validate:landing-page-modules`.
 #### 2.13.1. Evolução futura do catálogo
 
 - A operação comum de criação de módulo ou variante será declarativa e versionada no repositório.
-- Novo módulo que use campos, deltas, papéis e capabilities já suportados exigirá normalmente:
-  - registrar o módulo, sua versão e sua variante inicial em `registry.ts`;
+- Novo módulo compatível exigirá normalmente:
+  - registrar módulo, versão, evidências e variante inicial em `registry.ts`;
   - adicionar casos positivos e negativos em `validation-cases.ts`;
-  - publicar nova `moduleCatalogVersion` que preserve integralmente os catálogos anteriores.
-- Nova variante que use deltas já suportados exigirá normalmente:
-  - registrar a variante e sua versão em `registry.ts`;
-  - vinculá-la explicitamente ao módulo e à versão compatíveis;
-  - adicionar os respectivos casos em `validation-cases.ts`;
-  - publicar nova `moduleCatalogVersion` sem alterar versões anteriores.
-- `contracts.ts`, `schema.ts` e `resolver.ts` não devem ser alterados quando a necessidade puder ser expressa pelo contrato fechado existente.
-- Campo novo em módulo já publicado exige nova `moduleVersion`; não autoriza editar silenciosamente a versão publicada.
-- Novo tipo de delta, novo comportamento estrutural ou nova forma de resolução exige:
-  - evolução explícita de `contracts.ts`;
-  - ajuste correspondente de `schema.ts` e `resolver.ts`;
-  - atualização do registry e dos casos de validação;
-  - nova versão compatível do catálogo.
-- Capability comum ausente, como novo papel semântico, tratamento ou opção aplicável à família, não deve ser criada no módulo:
-  - exige evolução própria da raiz;
-  - cria nova `rootVersion`;
-  - somente depois autoriza catálogo compatível.
-- A inclusão do novo módulo ou variante em um taxon, sua ordem, obrigatoriedade e escolhas por ocorrência pertencem à composição futura da E20; não são efeito automático do registry.
-- Toda evolução ocorrerá por branch, PR, revisão e validações executáveis.
-- No MVP não haverá:
-  - cadastro dinâmico de módulos ou variantes no banco;
-  - Admin para editar contratos;
-  - mutação de versão publicada em runtime;
-  - criação automática de módulo ou variante a partir de taxon ou pesquisa.
-- A alteração de infraestrutura será exceção; a extensão rotineira deverá limitar-se ao registry, aos casos de validação e ao novo versionamento aplicável.
+  - publicar nova `moduleCatalogVersion` preservando catálogos anteriores.
+- Nova variante compatível exigirá normalmente:
+  - registrar variante e versão em `registry.ts`;
+  - vinculá-la ao módulo e à versão compatíveis;
+  - adicionar casos em `validation-cases.ts`;
+  - publicar nova `moduleCatalogVersion`.
+- `contracts.ts`, `schema.ts` e `resolver.ts` não mudam quando a necessidade couber no contrato fechado existente.
+- Campo novo em módulo publicado exige nova `moduleVersion`.
+- Novo `fieldKind`, policy, delta, comportamento ou forma de resolução exige evolução explícita de contrato, schema, resolver, registry e validações.
+- Capability comum ausente exige evolução da raiz e nova `rootVersion`.
+- Uso por taxon, ordem, obrigatoriedade e escolhas por ocorrência pertencem à E20.
+- Toda evolução ocorre por branch, PR, revisão e validações executáveis.
+- No MVP não haverá cadastro dinâmico no banco, Admin de contratos, mutação em runtime ou criação automática por taxon ou pesquisa.
+- Alteração de infraestrutura será exceção; extensão rotineira ficará no registry, validações e versionamento.
 
 ### 2.14. Validações mínimas previstas
 
 - Catálogo e versões válidos.
-- Exatamente nove módulos aprovados.
+- Cada módulo publicado foi individualmente aprovado a partir da grade candidata.
+- Rejeição ou fusão de candidato possui decisão humana registrada.
 - Nenhum módulo carrega identidade de taxon.
-- Compatibilidade e capabilities da raiz validadas.
+- `structuralEvidenceRefs` válidas e `itemKey` não usado como identidade automática.
+- Compatibilidade entre `moduleCatalogVersion` e `rootVersion` validada.
+- Compatibilidade entre variante e `moduleVersion` validada.
+- `fieldKind` conhecido e contrato condicional correto.
+- Campo textual sem `semanticRole` falha.
+- Campo não textual obrigado a ter `semanticRole` falha.
+- Cardinalidade inválida ou propriedade `required` falha.
+- `operationalValuePolicy` desconhecida falha.
+- Fato operacional originado apenas da pesquisa falha.
 - Referência, tratamento, módulo, variante ou campo desconhecido falha.
-- Tratamento padrão deve estar na lista permitida.
+- Tratamento padrão fora da lista permitida falha.
 - Ausência de `body.editorialEmphasis` e fallback automático falham.
-- Cardinalidade, faixa, limite e comportamento inválidos falham.
+- Delta vazio é aceito somente para variante-base autorizada.
+- Variante redundante sem diferença nem função de base autorizada falha.
+- Faixa, limite e comportamento inválidos falham.
 - Valor da raiz não é duplicado.
 - Fontes excedentes ou `itemKey` desconhecido falham.
-- `business_buyer` indevido e fato operacional inferido falham.
-- Lifecycle incompatível falha.
+- `business_buyer` indevido falha.
+- Elegibilidade incompatível com o propósito falha.
+- Módulo `candidate` não resolve para uso.
+- Módulo ou variante `deprecated` não resolve para `new_use`.
 - Resultado é profundamente imutável.
 - Versão antiga permanece resolvível.
 - Versão publicada de catálogo, módulo ou variante não pode ser sobrescrita.
@@ -426,10 +622,11 @@ Script previsto: `validate:landing-page-modules`.
 - Entrada:
   - raiz compatível;
   - plano E18.5;
-  - nove módulos aprovados;
-  - `item_key` oficiais.
+  - catálogo aprovado derivado da grade candidata;
+  - `item_key` oficiais;
+  - decisões humanas registradas.
 - Processamento:
-  - contratos, registry, schema, resolver, deltas, mapas, perfis, lifecycle e casos executáveis.
+  - contratos, registry, schema, resolver, evidências, fields, policies, deltas, mapas, perfis, lifecycle e casos executáveis.
 - Validação:
   - `npm ci`;
   - `npm run validate:landing-page-root`;
@@ -448,21 +645,28 @@ Script previsto: `validate:landing-page-modules`.
 
 - Status:
   - pendente;
-  - bloqueada até fechar a grade, mergear a evolução da raiz e consolidar a v2.
+  - bloqueada até fechar individualmente os módulos aprovados, mergear a evolução da raiz e consolidar a v2.
 - Automação: não.
 - Risco: médio controlado.
-- Objetivo: implementar o contrato repo-only dos nove módulos e variantes iniciais.
+- Objetivo: implementar o contrato repo-only dos módulos aprovados a partir dos nove candidatos e de suas variantes iniciais.
 - Critérios de aceite:
-  - nove módulos transversais;
+  - catálogo derivado da análise individual dos nove candidatos;
+  - módulos transversais;
   - nenhuma duplicação da raiz;
-  - compatibilidade e capability validadas;
+  - compatibilidades e capabilities validadas;
+  - contratos discriminados por `fieldKind`;
+  - policies de origem fechadas;
+  - variante-base com delta vazio somente quando autorizada;
+  - elegibilidade calculada por interseção;
   - `hero.subtitle` com ênfase padrão e alternativa explícita;
   - catálogo imutável e resolver fail-closed;
   - extensão futura comum pelo registry e casos de validação;
   - evolução de infraestrutura somente quando o contrato fechado não atender;
   - nenhum taxon, composição, banco, renderer ou geração.
 - Próxima ação:
-  - debater `trust_bar` e sua variante inicial;
+  - aplicar a grade completa ao Hero;
+  - fechar campos, policies, fontes, perfis, versões, lifecycle e casos do Hero;
+  - somente depois iniciar `trust_bar`;
   - seguir módulo por módulo na ordem da grade;
   - dividir depois em fases executáveis;
   - concluir a evolução da raiz;
@@ -478,6 +682,7 @@ Script previsto: `validate:landing-page-modules`.
 - Módulos identificados por corretor, imóveis, médio padrão ou outro taxon.
 - Implementação específica dos taxons usados como evidência.
 - Cadastro dinâmico de módulos ou variantes no banco ou Admin.
+- `actionRole` sem contrato fechado e fonte aprovada.
 - Catálogo de entradas, valores reais, taxonomia ou resolução de pesquisas.
 - Composição, ordem global, prontidão de taxon ou conta de teste.
 - Geração, IA, prompt, schema final, renderer, render model ou publicação.
@@ -493,8 +698,9 @@ Parar se:
 - a raiz compatível não estiver mergeada ou não garantir a capability;
 - surgir fallback automático;
 - módulo ou variante depender do taxon usado como evidência;
+- `itemKey` for tratado como identidade automática de módulo;
 - surgir necessidade de banco, composição, geração ou renderer;
-- faltar `item_key` oficial;
+- faltar `item_key` oficial necessário para copy;
 - diferença puder ser atendida por conteúdo, parâmetro ou composição;
 - houver ampliação de limite absoluto;
 - houver tentativa de sobrescrever catálogo, módulo ou variante já publicado;
@@ -508,7 +714,7 @@ Parar se:
 - PR #577 preservado e plano-base mantido em v1.
 - Fonte principal: `Corretor Imóveis`, `end_customer`, `lp_sections` v1 ativa.
 - Fonte complementar: `Corretor de imóveis de médio padrão`.
-- Grade inicial limitada a:
+- Grade inicial de candidatos:
   - `hero`;
   - `trust_bar`;
   - `problem_solution`;
@@ -518,13 +724,19 @@ Parar se:
   - `social_proof`;
   - `faq`;
   - `final_cta`.
-- Os módulos serão transversais e reutilizáveis na família `landing_page`.
+- Os candidatos serão analisados individualmente; rejeição ou fusão exige decisão humana.
+- Os módulos aprovados serão transversais e reutilizáveis na família `landing_page`.
 - `formato_curto`, `formato_medio` e `formato_longo` não são módulos.
-- Hero e `hero.standard` estão fechados para a v1.
+- Hero e `hero.standard` possuem decisões-base aprovadas, mas a grade completa do Hero ainda deve ser fechada.
+- `hero.standard` pode possuir delta vazio como execução-base versionada.
 - `body.editorialEmphasis` é padrão; `body.base` é alternativa explícita; fallback é proibido.
+- A E20 controla a seleção tipográfica por ocorrência; o renderer apenas executa.
+- O contrato de campo será discriminado por `fieldKind` e não exigirá `semanticRole` para campos não textuais.
+- A política de origem será união fechada.
+- Elegibilidade será calculada pela interseção de catálogo, módulo, variante e propósito.
 - A criação futura comum de módulos e variantes será declarativa em `registry.ts`, acompanhada de casos em `validation-cases.ts` e nova versão aplicável.
 - `contracts.ts`, `schema.ts` e `resolver.ts` só serão alterados quando a necessidade não couber no contrato fechado existente.
 - Versões publicadas são imutáveis; campo novo exige nova `moduleVersion` e capability comum exige nova `rootVersion`.
 - Uso por taxon pertence à composição da E20.
 - A implementação permanece bloqueada.
-- Próxima decisão humana: contrato e variante inicial de `trust_bar`.
+- Próxima decisão humana: aplicar e fechar a grade completa do Hero.

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -90,6 +90,10 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
   - condicionar seu uso à evolução versionada da raiz;
   - proibir a ocultação de informação essencial.
 - A relação entre lifecycle da raiz e propósito é política nova da E18.5; não é comportamento já implementado pelo resolver da raiz.
+- Decisão humana de 16/07/2026 sobre `secondaryCta`:
+  - retirar o campo da v1 de `hero` e de `hero.standard`;
+  - não criar entrada operacional para sustentá-lo;
+  - permitir reavaliação futura somente com evidência real, contrato fechado e nova `moduleVersion`.
 
 ### 1.6. Estado técnico confirmado
 
@@ -101,7 +105,6 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 
 ### 1.7. Pontos ainda em debate
 
-- Destinação do campo candidato `secondaryCta` na v1.
 - Contrato exato de acessibilidade para vídeo.
 - Contrato futuro de vínculo entre CTA principal e ocorrência de formulário na composição.
 - Confirmação dos oito candidatos restantes.
@@ -390,12 +393,12 @@ Pertencem:
 - título;
 - explicação curta;
 - CTA principal;
-- candidato a CTA secundário;
 - microprova opcional;
 - uma mídia opcional.
 
 Não pertencem:
 
+- CTA secundário na v1;
 - trust bar completa;
 - oferta;
 - processo;
@@ -446,12 +449,6 @@ Não pertencem:
   - `operationalBindingRequirement.catalogFieldKey = primary_conversion_channel`;
   - vínculo obrigatório quando a ação estiver presente;
   - canal e destino concretos ficam fora do registry.
-- `secondaryCta`:
-  - candidato a ação `0..1`;
-  - ainda não aprovado para publicação;
-  - não existe `secondary_conversion_channel` ou vínculo operacional equivalente aprovado;
-  - a E18.5 não criará nova entrada operacional;
-  - deve ser removido da v1 ou receber decisão explícita sobre reutilização de fonte existente ou navegação interna.
 - `proofShort`:
   - `fieldKind = text`;
   - `semanticRole = paragraph`;
@@ -478,9 +475,13 @@ Não pertencem:
 
 Estado dos campos:
 
-- o conjunto candidato contém sete campos;
-- `secondaryCta` não entra no `fieldCatalog` publicável enquanto seu contrato não for decidido;
-- o Hero possui seis campos admitidos no catálogo publicável candidato;
+- a v1 do Hero contém seis campos no catálogo publicável:
+  - `eyebrow`;
+  - `title`;
+  - `subtitle`;
+  - `primaryCta`;
+  - `proofShort`;
+  - `media`;
 - quatro possuem contrato interno definido:
   - `eyebrow`;
   - `title`;
@@ -488,6 +489,7 @@ Estado dos campos:
   - `proofShort`;
 - `primaryCta` permanece parcialmente pendente para o canal `form`;
 - `media` permanece parcialmente pendente para acessibilidade de vídeo;
+- `secondaryCta` foi retirado da v1 por decisão humana;
 - as capabilities tipográfica e responsiva da raiz são dependências externas, não pendências internas desses campos.
 
 #### 2.7.5. Herança e exceção tipográfica
@@ -591,7 +593,8 @@ Estado dos campos:
 - Compatível com `moduleVersion = 1`.
 - Execução-base com delta vazio.
 - Mídia permanece opcional.
-- O estado do CTA secundário depende da decisão final do campo candidato.
+- `secondaryCta` não pertence à v1.
+- Inclusão futura de `secondaryCta` exige nova `moduleVersion`, vínculo operacional aprovado e casos próprios.
 - Imagem, vídeo, funil, visibilidade e troca para `body.base` não criam variante.
 - `hero.media_split` permanece rejeitada.
 
@@ -627,7 +630,9 @@ Estado dos campos:
 #### 2.7.12. Casos executáveis da E18.5 para o Hero
 
 - Validar identidade, evidência, proveniência e interpretação editorial de `hero_segmentado`.
-- Rejeitar publicação enquanto campo candidato não possuir contrato fechado.
+- Aceitar exatamente os seis campos publicáveis da v1.
+- Rejeitar `secondaryCta` em `moduleVersion = 1`.
+- Exigir nova `moduleVersion` para inclusão futura de `secondaryCta`.
 - Rejeitar campo, cardinalidade, policy, fonte, tratamento ou variante inválidos.
 - Rejeitar combinação ausente da allowlist.
 - Validar `operationalSupportRequirement` e sua compatibilidade com policy e campo.
@@ -654,18 +659,17 @@ Não criam agora schema ou validador de conteúdo na E18.5:
 - imagem decorativa sem descrição semântica;
 - vídeo com alternativa acessível;
 - `desktop_only` sem ocultar informação essencial;
-- ausência de formulário completo, seletor interativo, galeria, carrossel ou tour dentro de `hero.standard`.
+- ausência de CTA secundário, formulário completo, seletor interativo, galeria, carrossel ou tour dentro de `hero.standard` v1.
 
 #### 2.7.14. Critérios de fechamento do Hero
 
 Fechar após aprovação de:
 
 - identidade, evidência, interpretação da segmentação e fronteiras;
-- campos publicáveis e cardinalidades;
+- seis campos publicáveis e cardinalidades;
 - allowlist de policies e `operationalSupportRequirement`;
 - vínculo do CTA principal;
 - contrato do caso `form`;
-- decisão sobre `secondaryCta`;
 - mídia e acessibilidade, inclusive vídeo;
 - visibilidade responsiva e nova raiz;
 - variante, versões, lifecycle e compatibilidades;
@@ -684,7 +688,8 @@ Estado:
 - `desktop_only` possui aprovação humana conceitual, mas capability técnica ainda não existe;
 - lifecycle próprio do catálogo foi retirado;
 - lifecycle–propósito foi identificado como política nova da E18.5;
-- `secondaryCta` e acessibilidade de vídeo ainda pendentes;
+- `secondaryCta` foi retirado da v1;
+- acessibilidade de vídeo ainda está pendente;
 - Hero ainda não fechado e implementação bloqueada.
 
 ### 2.8. `copy_source_map`
@@ -711,60 +716,31 @@ Estado:
 
 ### 2.11. Lifecycle e compatibilidade
 
-- Raiz:
-  - `hypothesis`;
-  - `validated`;
-  - `deprecated`.
-- Módulo e variante:
-  - `candidate`;
-  - `experimental`;
-  - `validated`;
-  - `deprecated`.
+- Raiz: `hypothesis | validated | deprecated`.
+- Módulo e variante: `candidate | experimental | validated | deprecated`.
 - `moduleCatalogVersion` possui versão e compatibilidade, sem lifecycle próprio na v1.
-- Propósitos:
-  - `controlled_test`;
-  - `new_use`;
-  - `historical_read`.
-- A relação lifecycle da raiz–propósito é política criada pela E18.5, não comportamento implementado pela raiz.
-- Elegibilidade é interseção de:
-  - lifecycle da raiz interpretado pela E18.5;
-  - compatibilidade raiz–catálogo;
-  - lifecycle do módulo;
-  - lifecycle da variante;
-  - propósito.
-- `candidate` bloqueia uso.
-- `experimental` permite teste controlado.
-- `deprecated` só permite leitura histórica.
+- Propósitos: `controlled_test | new_use | historical_read`.
+- Elegibilidade é interseção de lifecycle da raiz, compatibilidade raiz–catálogo, lifecycle do módulo, lifecycle da variante e propósito.
+- A relação lifecycle da raiz–propósito é política nova da E18.5.
+- `candidate` bloqueia uso; `experimental` permite teste; `deprecated` só permite histórico.
 
 ### 2.12. Contrato de resolução previsto
 
-Entrada:
-
-- `rootVersion`;
-- `moduleCatalogVersion`;
-- `moduleKey`;
-- `variantKey`;
-- `purpose`.
+Entrada: `rootVersion`, `moduleCatalogVersion`, `moduleKey`, `variantKey`, `purpose`.
 
 Processamento:
 
 1. resolver raiz e ler seu lifecycle;
-2. aplicar a política lifecycle–propósito definida pela E18.5;
+2. aplicar a política lifecycle–propósito da E18.5;
 3. validar compatibilidade do catálogo com a raiz;
 4. resolver módulo e lifecycle;
-5. validar evidências, campos, allowlist, suporte e vínculos abstratos;
+5. validar evidências, campos, policies, suporte e vínculos abstratos;
 6. resolver variante, lifecycle e compatibilidade;
 7. aplicar delta válido;
 8. calcular contrato e elegibilidade;
 9. retornar resultado imutável.
 
-A saída não contém:
-
-- deltas;
-- canal concreto;
-- destino concreto;
-- lifecycle de catálogo;
-- fallback.
+A saída não contém deltas, canal, destino concreto, lifecycle de catálogo ou fallback.
 
 ### 2.13. Artefatos previstos
 
@@ -777,15 +753,12 @@ Após raiz e v2:
 - `validation-cases.ts`;
 - `index.ts`.
 
-Interface prevista: `landingPageModules`.
-
-Script previsto: `validate:landing-page-modules`.
+Interface: `landingPageModules`. Script: `validate:landing-page-modules`.
 
 #### 2.13.1. Evolução futura do catálogo
 
 - Extensão comum ocorre por registry, casos e nova versão aplicável.
-- Campo novo exige nova `moduleVersion`.
-- Capability comum exige nova `rootVersion`.
+- Campo novo exige nova `moduleVersion`; capability comum exige nova `rootVersion`.
 - Contrato, schema e resolver só mudam quando a necessidade não couber no contrato fechado.
 - Sem cadastro dinâmico, mutação runtime ou criação automática no MVP.
 
@@ -793,30 +766,23 @@ Script previsto: `validate:landing-page-modules`.
 
 Validações E18.5:
 
-- versões, evidências e compatibilidades válidas;
-- lifecycle de raiz, módulo e variante válido;
+- versões, evidências, compatibilidades e lifecycle de raiz, módulo e variante válidos;
 - ausência de lifecycle próprio não aprovado no catálogo;
 - campos, cardinalidades, policies, fontes e tratamentos válidos;
-- combinação presente na allowlist;
-- matriz de suporte operacional respeitada;
+- allowlist de policy e suporte operacional respeitada;
 - vínculo de ação referencia apenas `fieldKey` aprovado do catálogo operacional;
 - nenhum destino concreto de CTA no registry;
-- caso `form` não tratado como resolvido sem vínculo de composição;
+- `secondaryCta` rejeitado na v1;
 - capabilities exigidas sem fallback;
-- `desktop_only` reconhecido como decisão conceitual dependente de nova raiz;
 - delta vazio somente na base autorizada;
 - contrato abstrato de mídia e acessibilidade válido;
 - formulário ou seletor interativo não adicionados ao Hero;
-- política lifecycle–propósito atribuída à E18.5, não ao resolver atual da raiz;
-- resultado imutável;
-- versões históricas preservadas;
-- sem imports fora do boundary.
+- resultado imutável, versões históricas preservadas e sem imports fora do boundary.
 
 #### 2.14.1. Invariantes futuras para E19
 
 - presença e consistência do conteúdo concreto;
 - CTA vinculado à operação real;
-- CTA de formulário vinculado à ocorrência composta, quando o contrato existir;
 - suporte operacional exigido resolvido;
 - prova sustentada;
 - ativo e acessibilidade válidos;
@@ -825,60 +791,24 @@ Validações E18.5:
 
 ### 2.15. Fluxo operacional
 
-- Gatilho:
-  - raiz e plano v2 mergeados;
-  - fase instruída.
-- Entrada:
-  - raiz compatível;
-  - catálogo aprovado;
-  - itens oficiais;
-  - decisões humanas.
-- Processamento:
-  - contratos;
-  - registry;
-  - resolver;
-  - policies;
-  - allowlist;
-  - suporte;
-  - mapas;
-  - lifecycle;
-  - casos E18.5.
-- Validação:
-  - `npm ci`;
-  - validações da raiz;
-  - validação de módulos;
-  - validação de commercial activation;
-  - `npm run check`;
-  - `git diff --check`;
-  - checks do PR.
-- Persistência: repositório.
-- Consumo futuro: E20 e E19.
-- Fallback: falha fechada.
+- Gatilho: raiz e plano v2 mergeados, fase instruída.
+- Entrada: raiz compatível, catálogo aprovado, itens oficiais e decisões humanas.
+- Processamento: contratos, registry, resolver, policies, suporte, mapas, lifecycle e casos E18.5.
+- Validação: `npm ci`, validações da raiz, módulos e commercial activation, `npm run check`, `git diff --check` e checks do PR.
+- Persistência: repositório; consumo futuro: E20 e E19; fallback: falha fechada.
 
 ## 3. Fases e próxima ação
 
 ### 3.1. E18.5.3–E18.5.9 — Catálogo versionado de módulos e variantes v1
 
-- Status:
-  - pendente;
-  - bloqueado até grade fechada, raiz evoluída e v2 consolidada.
-- Automação: não.
-- Risco: médio controlado.
-- Critérios de aceite:
-  - módulos aprovados;
-  - nenhuma duplicação da raiz ou E20.2;
-  - compatibilidade validada;
-  - Hero conforme contrato;
-  - resolver fail-closed;
-  - separação E18.5/E19.
+- Status pendente e bloqueado até grade fechada, raiz evoluída e v2 consolidada.
+- Automação: não. Risco: médio controlado.
+- Aceite: módulos aprovados, sem duplicação da raiz ou E20.2, compatibilidade validada, Hero conforme contrato, resolver fail-closed e separação E18.5/E19.
 - Próxima ação:
-  - decidir `secondaryCta`;
   - fechar acessibilidade de vídeo;
-  - definir futuramente o vínculo do CTA para formulário na composição;
-  - concluir a evolução tipográfica e responsiva da raiz;
   - reavaliar Hero;
   - depois iniciar `trust_bar` e seguir a grade;
-  - concluir pareceres, v2 e merge humano.
+  - concluir raiz, pareceres, v2 e merge humano.
 
 ## 4. Escopo negativo e critérios de parada
 
@@ -887,7 +817,7 @@ Validações E18.5:
 - Implementação da raiz no PR #577.
 - Banco, composição, geração, renderer, Admin, Builder, tracking, automação ou nova infraestrutura.
 - Nova entrada operacional para sustentar `secondaryCta`.
-- Implementação do vínculo entre CTA e ocorrência de formulário.
+- `secondaryCta` na v1 do Hero.
 - Módulo de formulário, seletor interativo, galeria, carrossel ou tour neste recorte.
 - Persistência nova para justificativa da composição.
 
@@ -900,12 +830,10 @@ Parar se:
 - surgir fallback, dependência de taxon ou ampliação de limite;
 - faltar evidência oficial;
 - destino concreto entrar no registry;
-- combinação não listada for aceita;
 - campo híbrido depender de regra hardcoded por `fieldKey`;
-- formulário for tratado como resolvido sem vínculo de composição;
-- seletor interativo ou mídia essencial forem tratados incorretamente;
+- `secondaryCta` for reintroduzido na v1;
+- formulário, seletor interativo ou mídia essencial forem tratados incorretamente;
 - validação de conteúdo for antecipada na E18.5;
-- política da E18.5 for atribuída como comportamento já implementado pela raiz;
 - houver conflito de fronteiras ou perda histórica.
 
 ### 4.3. Decisão atual
@@ -913,35 +841,16 @@ Parar se:
 - PR #577 permanece em v1 e sem implementação autorizada.
 - `hero_segmentado` está comprovado com `itemId` e interpretado editorialmente na v1.
 - Grade comum e nove candidatos permanecem.
-- O Hero possui seis campos admitidos no catálogo publicável candidato.
-- Quatro campos possuem contrato interno definido:
-  - `eyebrow`;
-  - `title`;
-  - `subtitle`;
-  - `proofShort`.
-- `primaryCta` permanece parcialmente pendente para formulário.
-- `media` permanece parcialmente pendente para vídeo.
-- `secondaryCta` permanece candidato fora do catálogo publicável.
-- As capabilities tipográfica e responsiva da raiz são dependências externas.
-- Allowlist completa de policies registrada.
+- Hero possui seis campos publicáveis na v1.
+- Quatro campos têm contrato interno definido; `primaryCta` permanece pendente para `form` e `media` para vídeo.
+- `secondaryCta` foi retirado da v1; eventual retorno exige nova `moduleVersion` e contrato aprovado.
 - `hero.standard` permanece a única variante inicial, com delta vazio.
 - Labels e `proofShort` usam `hybrid` com exigência declarativa de suporte.
 - CTA principal referencia `primary_conversion_channel`, sem canal ou destino concreto no registry.
-- O caso `form` depende de vínculo futuro com ocorrência de formulário na composição.
 - Alternativa acessível da mídia usa contrato próprio, não policy textual.
-- `desktop_only` possui aprovação humana conceitual e permanece bloqueado tecnicamente até nova `rootVersion`.
 - Imagem, vídeo e visibilidade responsiva não criam variante.
 - Formulário completo e seletor interativo ficam fora do Hero.
 - Elegibilidade inclui a raiz e não presume lifecycle do catálogo.
-- Lifecycle–propósito é política nova da E18.5.
 - E18.5 e E19 permanecem separadas.
-- Frentes materiais ainda abertas:
-  - decisão sobre `secondaryCta`;
-  - acessibilidade de vídeo;
-  - vínculo futuro do CTA para formulário;
-  - evolução tipográfica e responsiva da raiz.
-- Frente documental concluída nesta atualização:
-  - aprovação humana de `desktop_only` registrada;
-  - lifecycle–propósito identificado como política própria da E18.5.
-- Hero ainda não está fechado.
-- Próxima decisão humana: fechar as frentes materiais e reavaliar antes de `trust_bar`.
+- Hero ainda não está fechado por acessibilidade de vídeo, vínculo futuro do caso `form` e evolução da raiz.
+- Próxima decisão humana: fechar acessibilidade de vídeo e reavaliar o Hero antes de `trust_bar`.

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -1,0 +1,1356 @@
+14/07/2026 — Plano-base E18.5 — Parametrização de módulos e variantes `landing_page`
+
+Fontes: chat, `README.md`, `AGENTS.md`, `docs/prompt-estrategista.md`, `docs/template-roadmap.md`, `docs/template-briefing-codex.md`, `docs/prompt-executor.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/schema.md`, `docs/lp-planejamento.md`, `docs/lousa-plano-base-e18-4.md`, `docs/template-blueprint.md`, `docs/blueprint-corretor-imoveis-end-customer.md`, `docs/prompt-nicho-itens-estruturados.md`, `lib/conversion-content/landing-page/`, `lib/conversion-content/commercial-activation/`, `lib/conversion-content/commercial-activation/composition.ts`, PRs #559, #563, #564, #566 e #567 e estado atual do repositório.
+
+Versão: v1.
+
+Status: plano-base inicial para avaliação única do Analista, Gestor Estrutural e Gestor de Updates; nenhuma implementação autorizada antes da consolidação v2 e do merge deste plano na `main`.
+
+Path: `docs/lousa-plano-base-e18-5.md`.
+
+Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_page`.
+
+## 1. Estado e decisões fixas
+
+### 1.1. Pré-requisitos confirmados
+
+- O PR #559 foi mergeado na `main` em 13/07/2026 e criou conceitualmente o recorte `18.5`.
+- A E18.4 foi concluída, aprovada, documentada e formalmente encerrada.
+- A parametrização raiz v1 está implementada em `lib/conversion-content/landing-page/`.
+- O contrato raiz possui:
+  - registry versionado;
+  - schema estrito;
+  - resolver fail-closed;
+  - saída profundamente imutável;
+  - papéis semânticos;
+  - faixas editoriais recomendadas;
+  - limites técnicos absolutos;
+  - opções comuns de espaçamento;
+  - critérios visuais, responsivos e de acessibilidade;
+  - presets `balanced` e `compact`.
+- A precedência obrigatória está consolidada como:
+  - parametrização raiz;
+  - módulo;
+  - variante.
+- A E18.5 não pode ampliar limite técnico absoluto acima da raiz vigente.
+- Ampliação acima do teto da raiz exige nova `rootVersion`.
+- A revisão futura de uma restrição própria de módulo ou variante dentro do teto da raiz exige nova versão do respectivo contrato da E18.5.
+- `commercial_activation`, E18.2 e E18.3 permanecem integralmente preservados.
+
+### 1.2. Estado técnico confirmado
+
+- O boundary raiz atual é `lib/conversion-content/landing-page/`.
+- O namespace público atual da parametrização raiz é `landingPageRoot`.
+- Não existem atualmente módulos, variantes, schemas de conteúdo por variante, composição, renderer ou render model para `landing_page`.
+- O banco possui estruturas transversais já existentes:
+  - `content_templates`;
+  - `content_template_compositions`;
+  - `content_template_composition_items`;
+  - `content_artifacts`;
+  - `content_artifact_research_sources`.
+- `content_template_composition_items` já representa, no nível de composição:
+  - módulo;
+  - `variant_key`;
+  - ordem;
+  - obrigatoriedade;
+  - `config_json`.
+- Essas estruturas não autorizam criar registros de `landing_page` nesta fase.
+- A E18.5 define contratos repo-only reutilizáveis.
+- A criação de composição concreta e registros por taxon pertence à E20.
+- A geração, o snapshot e o consumo de LPs por conta pertencem à E19.
+- A persistência mínima atual de `account_landing_pages` contém apenas identidade básica e status `draft`; não deve ser ampliada neste recorte.
+
+### 1.3. Problema a resolver
+
+- A raiz define regras comuns, mas ainda não existe contrato aprovado para:
+  - funções estruturais dos módulos;
+  - campos de cada módulo;
+  - estruturas e cardinalidades;
+  - variantes reutilizáveis;
+  - especializações excepcionais sobre a raiz;
+  - origem estruturada da copy;
+  - transformação da copy por BOFU, MOFU e TOFU;
+  - tratamentos comerciais permitidos, restritos e proibidos;
+  - compatibilidade entre versões;
+  - ciclo de vida, depreciação e preservação histórica.
+- Sem esse contrato, E20 não pode montar composição base segura.
+- Sem esse contrato, E19 não pode gerar, validar ou renderizar LPs sem recriar regras independentes.
+- Reaproveitar diretamente os contratos de `commercial_activation` criaria acoplamento incorreto entre famílias distintas.
+- Recriar o catálogo removido da antiga E18.4 sem nova decisão repetiria a antecipação que a E18.4 corrigiu.
+
+### 1.4. Resultado esperado
+
+- Criar uma fonte repo-only versionada para módulos e variantes de `landing_page`.
+- Definir um catálogo inicial pequeno, suficiente para uma primeira LP real de teste.
+- Definir a função estrutural de cada módulo.
+- Definir campos, tipos estruturais e cardinalidades por variante.
+- Derivar regras editoriais e técnicas da parametrização raiz.
+- Registrar somente especializações justificadas.
+- Definir `copy_source_map` com `research_block`, `item_key`, `audience_scope` e papel da fonte.
+- Definir `funnel_copy_profile` para BOFU, MOFU e TOFU.
+- Impedir copy comercial não sustentada por fonte real.
+- Definir resolução determinística e fail-closed de raiz, catálogo, módulo, variante e propósito de uso.
+- Preservar contratos antigos para renderização histórica.
+- Entregar validação executável sem criar renderer, composição, geração ou persistência.
+
+### 1.5. Usuários e consumidores
+
+- Usuários diretos:
+  - Estrategista;
+  - Analista;
+  - Executor;
+  - futuros implementadores da E20 e E19.
+- Consumidores técnicos futuros:
+  - composição base da E20;
+  - schemas de conteúdo da E19;
+  - geração de copy da E19;
+  - validação de conteúdo;
+  - renderer;
+  - snapshot da LP;
+  - auditoria de compatibilidade.
+- O cliente final não interage diretamente com este recorte.
+
+### 1.6. Decisões de fronteira
+
+- Módulo representa uma função estrutural reutilizável da LP.
+- Variante representa mudança reutilizável de execução, estrutura ou comportamento dentro da mesma função do módulo.
+- Nova função estrutural deve ser avaliada como novo módulo.
+- Não usar módulo ou variante para representar:
+  - taxon;
+  - segmento, nicho ou ultranicho;
+  - conteúdo específico;
+  - entrada da conta;
+  - campanha;
+  - origem de tráfego;
+  - intenção BOFU, MOFU ou TOFU;
+  - composição;
+  - ordem da seção;
+  - obrigatoriedade da seção;
+  - diferença já atendida por campo, cardinalidade, opção ou parâmetro existente.
+- BOFU, MOFU e TOFU são perfis de transformação da copy, não variantes.
+- Google Ads, Meta Ads, SEO, WhatsApp, link na bio e QR Code são origens de tráfego ou distribuição, não variantes.
+- Os dados reais de preço, oferta, prova, credencial, garantia, contato, mídia e compliance não pertencem ao registry; pertencem às entradas operacionais e ao snapshot futuro.
+- `copy_source_map` autoriza fontes estruturadas, mas não cria fatos.
+- `funnel_copy_profile` transforma insumos, mas não substitui fonte obrigatória.
+- `lp_sections` orienta composição na E20; suas chaves dinâmicas não entram como fonte fixa de copy por campo na E18.5.
+- `lp_overview` orienta contexto geral da página e da transformação; não deve ser usado para inventar alegações factuais.
+- O registry da E18.5 não consulta banco, env, API ou arquivo remoto em runtime.
+
+### 1.7. Base de evidência
+
+- Fonte conceitual principal:
+  - `docs/lp-planejamento.md`.
+- Fonte normativa da raiz:
+  - `docs/lousa-plano-base-e18-4.md`;
+  - implementação atual de `landingPageRoot`.
+- Fonte dos `research_block` e `item_key`:
+  - `docs/prompt-nicho-itens-estruturados.md`.
+- Fonte empírica parcial inicial:
+  - `docs/blueprint-corretor-imoveis-end-customer.md`.
+- Referência estrutural já implementada, sem reaproveitamento automático:
+  - `commercial_activation`.
+- O blueprint imobiliário sustenta como referência inicial:
+  - Hero com recorte claro;
+  - mídia principal;
+  - benefícios ou diferenciais objetivos;
+  - localização;
+  - qualificação simples ou progressiva;
+  - prova;
+  - FAQ;
+  - CTA;
+  - confiança e compliance.
+- A evidência é parcial e concentrada em um nicho.
+- Por isso:
+  - nenhum módulo é específico de imóveis;
+  - nenhum campo recebe semântica imobiliária;
+  - nenhuma variante é nomeada por nicho, produto, campanha ou canal;
+  - os contratos iniciais permanecem em lifecycle experimental ou candidato até LP real validada.
+
+### 1.8. Roadmap e gate documental
+
+- Seção afetada:
+  - E18 — Base transversal de templates, módulos, composições e artefatos.
+- Recorte:
+  - `18.5 — Parametrização de módulos e variantes landing_page`.
+- Subseções previstas:
+  - `18.5.1 — Objetivo e status`;
+  - `18.5.2 — Registros do recorte`, após implementação material;
+  - `18.5.3 — Módulos e funções estruturais`;
+  - `18.5.4 — Campos, estruturas e cardinalidades`;
+  - `18.5.5 — Variantes e critérios de criação`;
+  - `18.5.6 — Especializações sobre a parametrização raiz`;
+  - `18.5.7 — Mapa de fontes de copy`;
+  - `18.5.8 — Perfis de copy por intenção e funil`;
+  - `18.5.9 — Ciclo de vida, compatibilidade e validação`;
+  - `18.5.10 — Limites do recorte`.
+- Não criar `18.6`.
+- A documentação durável só será atualizada pelo Gestor de Docs ao final do plano.
+- O encerramento formal da E18.5 exigirá implementação material aprovada, merge do PR material, relatório final do Estrategista e merge do PR documental obrigatório.
+
+## 2. Contrato do caso
+
+### 2.1. Boundary e artefatos previstos
+
+- Boundary canônico:
+  - `lib/conversion-content/landing-page/module-catalog/`.
+- Arquivos previstos:
+  - `contracts.ts`;
+  - `registry.ts`;
+  - `schema.ts`;
+  - `resolver.ts`;
+  - `validation-cases.ts`;
+  - `index.ts`.
+- Arquivos a ajustar:
+  - `lib/conversion-content/index.ts`;
+  - `package.json`;
+  - `docs/lousa-plano-base-e18-5.md`, somente para estado da fase.
+- Interface pública agregada prevista:
+  - namespace `landingPageModules`.
+- Preservar:
+  - namespace `landingPageRoot`;
+  - arquivos e comportamento da parametrização raiz.
+- Script previsto:
+  - `validate:landing-page-modules`.
+- Não adicionar dependência npm.
+- Não alterar `package-lock.json` quando não houver mudança real de dependência.
+
+### 2.2. Versionamento e identidade
+
+- Identidade inicial:
+  - `family = landing_page`;
+  - `rootVersion = 1`;
+  - `moduleCatalogVersion = 1`.
+- O registry deve ser mapa explícito:
+  - `moduleCatalogVersion → catálogo imutável`.
+- O catálogo contém módulos identificados por:
+  - `moduleKey`;
+  - `moduleVersion`.
+- Cada variante é identificada por:
+  - `variantKey`, no formato `modulo.variante`;
+  - `variantVersion`;
+  - `moduleKey` correspondente.
+- Regras:
+  - uma alteração contratual incompatível cria nova `moduleCatalogVersion`;
+  - alteração do contrato de módulo incrementa `moduleVersion`;
+  - alteração do contrato de variante incrementa `variantVersion`;
+  - versões antigas não podem ser apagadas ou alteradas;
+  - o catálogo novo pode manter chaves antigas, adicionar chaves ou depreciá-las;
+  - não existe catálogo padrão implícito;
+  - `rootVersion` e `moduleCatalogVersion` são obrigatórios na resolução;
+  - `variantKey` deve começar com o `moduleKey` seguido de ponto;
+  - chave do registry e versão interna devem corresponder;
+  - o catálogo deve declarar compatibilidade explícita com a `rootVersion`;
+  - não existe fallback silencioso entre versões.
+
+### 2.3. Lifecycle
+
+- Lifecycle permitido para módulos e variantes:
+  - `candidate`;
+  - `experimental`;
+  - `validated`;
+  - `deprecated`.
+- Significado:
+  - `candidate`: contrato em avaliação; não pode entrar em composição ou geração;
+  - `experimental`: pode ser usado apenas em fluxo controlado de teste;
+  - `validated`: aprovado por LP real e decisão humana registrada; pode ser usado em novas composições e gerações quando os demais gates permitirem;
+  - `deprecated`: não pode entrar em nova composição ou geração; permanece resolvível para histórico.
+- Transições normais:
+  - `candidate → experimental`;
+  - `experimental → validated`;
+  - `candidate | experimental | validated → deprecated`.
+- Não alterar lifecycle dentro de versão já publicada sem decisão humana registrada.
+- Quando a decisão alterar a elegibilidade operacional do catálogo publicado, criar nova `moduleCatalogVersion`.
+- O catálogo v1 nasce como hipótese:
+  - variantes sustentadas pelo blueprint entram como `experimental`;
+  - variantes sem evidência direta suficiente entram como `candidate`;
+  - nenhuma variante nasce `validated`.
+
+### 2.4. Tipos estruturais comuns
+
+- `CopyFieldContract`:
+  - `fieldKey`;
+  - `semanticRole`;
+  - `required`;
+  - `recommendedRangeOverride`, quando houver;
+  - `absoluteMaxOverride`, quando houver;
+  - `copySourceMap`;
+  - `operationalValueRequired`, quando o valor não puder vir da pesquisa.
+- `CtaContract`:
+  - `label`, usando papel `cta_label`;
+  - `actionRole`;
+  - sem URL ou destino concreto.
+- `actionRole` permitido:
+  - `primary_conversion`;
+  - `secondary_conversion`;
+  - `contact`;
+  - `resource`;
+  - `internal_navigation`.
+- `MediaReferenceContract`:
+  - referência abstrata de ativo;
+  - `altText`;
+  - `caption` opcional;
+  - sem URL, upload, storage ou embed concreto.
+- `CollectionContract`:
+  - `minItems`;
+  - `maxItems`;
+  - contrato do item.
+- `LeadFieldSlotContract`:
+  - `slotKey`;
+  - `inputKind`;
+  - `label`;
+  - `required`.
+- `inputKind` permitido:
+  - `short_text`;
+  - `email`;
+  - `phone`;
+  - `single_select`;
+  - `multi_select`;
+  - `boolean`.
+- O contrato não define nome de coluna, tabela, formulário executável, destino de submissão, integração, automação, CRM ou webhook.
+- Campos factuais que exigem valor operacional devem ser marcados com `operationalValueRequired = true`.
+- Pesquisa estruturada pode orientar rótulo e enquadramento, mas não fornecer preço real, número, métrica, depoimento, credencial, garantia, disponibilidade, contato, endereço, URL ou dado legal.
+
+### 2.5. Catálogo inicial de módulos
+
+#### 2.5.1. `hero`
+
+- Função:
+  - apresentar recorte, proposta de valor e próxima ação principal.
+- Deve:
+  - realizar message match;
+  - conter um único campo mapeado para `h1`;
+  - evitar promessa sem fonte.
+- Não deve representar campanha, taxon ou composição.
+- Lifecycle inicial:
+  - `experimental`.
+
+#### 2.5.2. `media`
+
+- Função:
+  - apresentar evidência visual ou demonstração do produto, serviço, contexto ou resultado.
+- Deve exigir alt text e limitar cardinalidade.
+- Não deve armazenar URL real no registry, autorizar embed ou definir storage.
+- Lifecycle inicial:
+  - `experimental`.
+
+#### 2.5.3. `benefits`
+
+- Função:
+  - sintetizar benefícios, diferenciais ou resultados esperados de forma comparável.
+- Deve diferenciar benefício de prova factual e impedir transformação de benefício em resultado garantido.
+- Lifecycle inicial:
+  - `experimental`.
+
+#### 2.5.4. `offer`
+
+- Função:
+  - explicar o que é oferecido, para quem serve e qual próximo passo.
+- Deve separar copy parametrizada de preço e condições operacionais.
+- Não deve criar oferta, preço, desconto, garantia ou escassez.
+- Lifecycle inicial:
+  - `experimental`.
+
+#### 2.5.5. `proof`
+
+- Função:
+  - apresentar evidência, autoridade, credencial, depoimento ou métrica verificável.
+- Deve marcar valores factuais como operacionais e exigir sustentação real.
+- Lifecycle inicial:
+  - `experimental`.
+
+#### 2.5.6. `location`
+
+- Função:
+  - explicar relevância geográfica, territorial ou contextual quando isso afetar a decisão.
+- É reutilizável para negócios locais, serviços regionais, imóveis, eventos e ofertas com contexto territorial.
+- Não representa taxon.
+- Lifecycle inicial:
+  - `experimental`.
+
+#### 2.5.7. `qualification`
+
+- Função:
+  - captar contato ou qualificar o lead com fricção controlada.
+- Define estrutura e cardinalidade de slots.
+- Não define persistência, destino, catálogo de dados da conta, regras comerciais ou CRM.
+- Lifecycle inicial:
+  - `experimental`.
+
+#### 2.5.8. `how_it_works`
+
+- Função:
+  - explicar processo, etapas, jornada ou funcionamento.
+- Lifecycle inicial:
+  - `experimental`.
+
+#### 2.5.9. `faq`
+
+- Função:
+  - responder dúvidas e objeções recorrentes.
+- Não deve criar FAQ genérica sem fonte ou repetir conteúdo sem função.
+- Lifecycle inicial:
+  - `experimental`.
+
+#### 2.5.10. `final_cta`
+
+- Função:
+  - encerrar a narrativa e apresentar ação de conversão coerente.
+- Não define destino real do CTA.
+- Lifecycle inicial:
+  - `experimental`.
+
+#### 2.5.11. `trust`
+
+- Função:
+  - apresentar privacidade, identificação, compliance e sinais institucionais.
+- Deve exigir valores reais quando citar identificação, registro ou política.
+- Não substitui revisão jurídica ou regulatória.
+- Lifecycle inicial:
+  - `experimental`.
+
+### 2.6. Variantes iniciais, campos e cardinalidades
+
+#### 2.6.1. `hero.standard`
+
+- Lifecycle: `experimental`.
+- Estrutura:
+  - `eyebrow`: 0–1, papel `eyebrow`;
+  - `title`: exatamente 1, papel `h1`;
+  - `subtitle`: exatamente 1, papel `paragraph`;
+  - `primaryCta`: exatamente 1;
+  - `secondaryCta`: 0–1;
+  - `proofShort`: 0–1, papel `paragraph`;
+  - `media`: 0–1 referência.
+- Uso:
+  - abertura textual com mídia opcional.
+- Não representa produto único, portfólio, canal ou funil.
+
+#### 2.6.2. `hero.media_split`
+
+- Lifecycle: `experimental`.
+- Estrutura:
+  - mesmos campos de `hero.standard`;
+  - `media`: exatamente 1.
+- Diferença estrutural:
+  - mídia é parte obrigatória da execução do Hero.
+- Não deve ser criada apenas porque o conteúdo possui imagem.
+
+#### 2.6.3. `media.gallery`
+
+- Lifecycle: `experimental`.
+- Estrutura:
+  - `eyebrow`: 0–1;
+  - `title`: 0–1, papel `h2`;
+  - `items`: 1–12 referências de mídia;
+  - cada item exige `altText`;
+  - cada item admite `caption` 0–1.
+- Não autoriza carrossel automático ou autoplay.
+
+#### 2.6.4. `media.external_tour`
+
+- Lifecycle: `experimental`.
+- Estrutura:
+  - `eyebrow`: 0–1;
+  - `title`: 0–1;
+  - `previewMedia`: exatamente 1;
+  - `tourCta`: exatamente 1, `actionRole = resource`.
+- O destino externo é valor operacional.
+- O contrato não autoriza embed.
+
+#### 2.6.5. `benefits.cards`
+
+- Lifecycle: `experimental`.
+- Estrutura:
+  - `eyebrow`: 0–1;
+  - `title`: exatamente 1, papel `h2`;
+  - `items`: 2–6;
+  - item:
+    - `title`: exatamente 1, papel `card_title`;
+    - `body`: exatamente 1, papel `card_body`;
+    - `iconRef`: 0–1 referência abstrata.
+- Não usar ícone concreto, classe ou token no registry.
+
+#### 2.6.6. `benefits.list`
+
+- Lifecycle: `experimental`.
+- Estrutura:
+  - `eyebrow`: 0–1;
+  - `title`: exatamente 1;
+  - `items`: 3–8;
+  - item `text`: exatamente 1, papel `benefit_item`.
+- A diferença para cards é estrutural, não apenas visual.
+
+#### 2.6.7. `offer.summary`
+
+- Lifecycle: `experimental`.
+- Estrutura:
+  - `eyebrow`: 0–1;
+  - `title`: exatamente 1, papel `h2`;
+  - `description`: exatamente 1, papel `paragraph`;
+  - `highlights`: 0–6, papel `benefit_item`;
+  - `priceText`: 0–1, valor operacional obrigatório;
+  - `primaryCta`: 0–1;
+  - `secondaryCta`: 0–1;
+  - `disclaimer`: 0–1, papel `privacy_note`.
+- Preço, desconto, condição e prazo não podem ser inferidos da pesquisa.
+
+#### 2.6.8. `proof.metrics`
+
+- Lifecycle: `candidate`.
+- Estrutura:
+  - `eyebrow`: 0–1;
+  - `title`: 0–1;
+  - `items`: 1–4;
+  - item:
+    - `value`: exatamente 1, operacional e verificável;
+    - `label`: exatamente 1, papel `card_title`;
+    - `context`: 0–1, papel `card_body`;
+    - `evidenceRef`: exatamente 1 no snapshot futuro.
+- Não pode entrar em composição enquanto permanecer `candidate`.
+
+#### 2.6.9. `proof.testimonials`
+
+- Lifecycle: `candidate`.
+- Estrutura:
+  - `eyebrow`: 0–1;
+  - `title`: 0–1;
+  - `items`: 1–6;
+  - item:
+    - `quote`: exatamente 1, operacional;
+    - `authorName`: exatamente 1, operacional;
+    - `authorContext`: 0–1, operacional;
+    - `media`: 0–1;
+    - `evidenceRef`: exatamente 1 no snapshot futuro.
+- Depoimento não pode ser gerado a partir de pesquisa.
+
+#### 2.6.10. `proof.authority`
+
+- Lifecycle: `experimental`.
+- Estrutura:
+  - `eyebrow`: 0–1;
+  - `title`: 0–1;
+  - `description`: 0–1;
+  - `credentials`: 1–6 valores operacionais;
+  - `identityMedia`: 0–1.
+- Credencial, registro e certificação exigem valor real.
+
+#### 2.6.11. `location.summary`
+
+- Lifecycle: `experimental`.
+- Estrutura:
+  - `eyebrow`: 0–1;
+  - `title`: exatamente 1;
+  - `description`: 0–1;
+  - `highlights`: 1–8;
+  - `media`: 0–1;
+  - `mapCta`: 0–1, `actionRole = resource | internal_navigation`.
+- Endereço, mapa e rota são valores operacionais.
+
+#### 2.6.12. `qualification.simple_form`
+
+- Lifecycle: `experimental`.
+- Estrutura:
+  - `eyebrow`: 0–1;
+  - `title`: exatamente 1;
+  - `description`: 0–1;
+  - `fieldSlots`: 1–4;
+  - `submitCta`: exatamente 1;
+  - `privacyNote`: exatamente 1;
+  - `consentSlot`: 0–1.
+- Todos os campos são exibidos em uma etapa.
+- O contrato não cria formulário funcional.
+
+#### 2.6.13. `qualification.progressive_form`
+
+- Lifecycle: `experimental`.
+- Estrutura:
+  - `eyebrow`: 0–1;
+  - `title`: exatamente 1;
+  - `description`: 0–1;
+  - `steps`: 2–5;
+  - total de `fieldSlots`: 2–8;
+  - cada etapa contém 1–4 slots;
+  - `submitCta`: exatamente 1;
+  - `privacyNote`: exatamente 1;
+  - `consentSlot`: 0–1.
+- A variante existe por mudança reutilizável de comportamento em etapas.
+- Não representa financiamento, imóvel ou qualquer taxon.
+
+#### 2.6.14. `how_it_works.steps`
+
+- Lifecycle: `experimental`.
+- Estrutura:
+  - `eyebrow`: 0–1;
+  - `title`: exatamente 1;
+  - `steps`: 2–6;
+  - item:
+    - `label`: exatamente 1, papel `step_label`;
+    - `title`: exatamente 1, papel `step_title`;
+    - `body`: exatamente 1, papel `step_body`.
+
+#### 2.6.15. `faq.accordion`
+
+- Lifecycle: `experimental`.
+- Estrutura:
+  - `eyebrow`: 0–1;
+  - `title`: exatamente 1;
+  - `questions`: 2–8;
+  - item:
+    - `question`: exatamente 1, papel `faq_question`;
+    - `answer`: exatamente 1, papel `faq_answer`.
+- `accordion` descreve comportamento estrutural de expansão.
+- Não autoriza FAQ inventada.
+
+#### 2.6.16. `final_cta.simple`
+
+- Lifecycle: `experimental`.
+- Estrutura:
+  - `eyebrow`: 0–1;
+  - `title`: exatamente 1;
+  - `description`: exatamente 1;
+  - `primaryCta`: exatamente 1;
+  - `proofShort`: 0–1;
+  - `privacyNote`: 0–1.
+
+#### 2.6.17. `final_cta.contact_options`
+
+- Lifecycle: `candidate`.
+- Estrutura:
+  - `eyebrow`: 0–1;
+  - `title`: exatamente 1;
+  - `description`: 0–1;
+  - `options`: 2–3;
+  - cada opção contém `label` exatamente 1 e `actionRole = contact`;
+  - `privacyNote`: 0–1.
+- Os canais e destinos reais vêm das entradas operacionais.
+- Não pode entrar em composição enquanto permanecer `candidate`.
+
+#### 2.6.18. `trust.compliance`
+
+- Lifecycle: `experimental`.
+- Estrutura:
+  - `title`: 0–1;
+  - `identityItems`: 1–8 valores operacionais;
+  - `privacyNote`: exatamente 1;
+  - `contactOptions`: 0–3;
+  - `legalLinks`: 0–3 referências operacionais.
+- Não declara conformidade jurídica integral.
+- Não cria política de privacidade ou texto regulatório automaticamente.
+
+### 2.7. Especializações sobre a raiz
+
+- Regra geral:
+  - campo sem especialização herda integralmente a raiz;
+  - módulo pode restringir a raiz;
+  - variante pode restringir o módulo;
+  - variante não pode ampliar regra efetiva do módulo;
+  - nenhuma camada pode ampliar limite absoluto da raiz.
+- Limite técnico absoluto efetivo:
+  - menor valor entre raiz, módulo e variante.
+- Faixa recomendada efetiva:
+  - especialização mais específica válida;
+  - mínimo maior ou igual a 1;
+  - mínimo menor ou igual ao máximo;
+  - máximo menor ou igual ao limite absoluto efetivo.
+- Especializações v1 sustentadas pelo blueprint:
+  - `hero.title`, papel `h1`: recomendado 45–80, absoluto herdado;
+  - `hero.subtitle`, papel `paragraph`: recomendado 90–160, absoluto herdado;
+  - CTA primário de Hero, papel `cta_label`: recomendado 14–28, absoluto herdado;
+  - CTA secundário de Hero, papel `cta_label`: recomendado 14–30, absoluto herdado;
+  - `proofShort`, papel `paragraph`: recomendado 40–90, absoluto herdado;
+  - títulos de seção, papel `h2`: recomendado 25–60, absoluto herdado;
+  - `benefits.cards.items.body`, papel `card_body`: recomendado 60–120, absoluto herdado;
+  - `faq.question`: recomendado 45–90, absoluto herdado;
+  - `faq.answer`: recomendado 90–220, absoluto herdado;
+  - `privacyNote`: recomendado 80–180, absoluto herdado.
+- Não criar outras especializações numéricas na v1 sem evidência ou decisão humana.
+- Opções de `spacing`:
+  - todas as variantes herdam `compact`, `default` e `spacious`;
+  - nenhuma restrição própria entra na v1 por falta de evidência suficiente;
+  - escolha por ocorrência pertence à composição futura.
+
+### 2.8. Contrato de `copy_source_map`
+
+- Cada referência deve declarar:
+  - `audienceScope`;
+  - `researchBlock`;
+  - `itemKey`;
+  - `sourceRole = primary | auxiliary`.
+- `audienceScope` permitido:
+  - `end_customer`;
+  - `business_buyer`.
+- Regra padrão:
+  - copy destinada ao visitante usa `end_customer` como fonte primária;
+  - `business_buyer` pode ser auxiliar apenas para autoridade do fornecedor, processo de atendimento, posicionamento do negócio e prova institucional;
+  - `business_buyer` não substitui dor, desejo, objeção, intenção de busca ou vocabulário do `end_customer`.
+- Limite por campo:
+  - até 2 referências primárias;
+  - até 1 referência auxiliar.
+- Seleção dos itens:
+  - maior `priority`;
+  - depois menor `sort_order`;
+  - sem mistura de versões ou conjuntos fora do contrato da E10.8.
+- Blocos permitidos no mapa de campo:
+  - `strategic_core`;
+  - `seo`.
+- `lp_overview`:
+  - contexto de transformação e direção;
+  - não fonte factual de copy.
+- `lp_sections`:
+  - fonte estrutural da futura composição E20;
+  - proibido como fonte fixa de copy por campo.
+- Chave desconhecida deve falhar fechado.
+- Campo marcado como operacional não pode ter seu valor factual preenchido por pesquisa.
+
+### 2.9. Mapa inicial de fontes de copy
+
+#### 2.9.1. Hero
+
+- `eyebrow`:
+  - primária: `end_customer.seo.search_intent`;
+  - auxiliar: `end_customer.strategic_core.positioning_opportunity`.
+- `title`:
+  - primárias:
+    - `end_customer.strategic_core.positioning_opportunity`;
+    - `end_customer.strategic_core.desire`;
+  - auxiliar: `end_customer.seo.commercial_keywords`.
+- `subtitle`:
+  - primárias:
+    - `end_customer.strategic_core.pain`;
+    - `end_customer.strategic_core.desire`;
+  - auxiliar: `end_customer.strategic_core.belief`.
+- CTAs:
+  - primária: `end_customer.strategic_core.trigger`;
+  - auxiliar: `end_customer.seo.search_intent`.
+- `proofShort`:
+  - primária: `end_customer.strategic_core.proof_type`;
+  - auxiliar: `end_customer.strategic_core.objection`.
+
+#### 2.9.2. Media
+
+- `title` e `caption`:
+  - primárias:
+    - `end_customer.strategic_core.desire`;
+    - `end_customer.strategic_core.vocabulary`.
+- O tipo, a seleção e o valor do ativo são operacionais.
+- `lp_overview.image_style` orienta transformação futura, mas não entra como fonte factual.
+
+#### 2.9.3. Benefits
+
+- `title`:
+  - primárias:
+    - `end_customer.strategic_core.desire`;
+    - `end_customer.strategic_core.positioning_opportunity`;
+  - auxiliar: `end_customer.strategic_core.pain`.
+- Itens:
+  - primárias:
+    - `end_customer.strategic_core.desire`;
+    - `end_customer.strategic_core.pain`;
+  - auxiliar: `end_customer.strategic_core.objection`.
+
+#### 2.9.4. Offer
+
+- `title` e `description`:
+  - primárias:
+    - `end_customer.strategic_core.desire`;
+    - `end_customer.strategic_core.trigger`;
+  - auxiliar: `end_customer.strategic_core.positioning_opportunity`.
+- `highlights`:
+  - primárias:
+    - `end_customer.strategic_core.desire`;
+    - `end_customer.strategic_core.proof_type`;
+  - auxiliar: `end_customer.strategic_core.trend`.
+- `priceText` e disclaimer factual:
+  - valores operacionais obrigatórios.
+
+#### 2.9.5. Proof
+
+- Título e introdução:
+  - primárias:
+    - `end_customer.strategic_core.proof_type`;
+    - `end_customer.strategic_core.belief`;
+  - auxiliar: `end_customer.strategic_core.fear`.
+- Rótulo de métrica:
+  - primária: `end_customer.strategic_core.proof_type`;
+  - auxiliar: `end_customer.strategic_core.positioning_opportunity`.
+- Título de autoridade:
+  - primárias:
+    - `business_buyer.strategic_core.proof_type`;
+    - `business_buyer.strategic_core.positioning_opportunity`;
+  - auxiliar: `end_customer.strategic_core.belief`.
+- Métricas, depoimentos, nomes, credenciais e evidências:
+  - valores operacionais obrigatórios.
+
+#### 2.9.6. Location
+
+- `title` e `description`:
+  - primárias:
+    - `end_customer.seo.local_terms`;
+    - `end_customer.seo.search_intent`;
+  - auxiliar: `end_customer.strategic_core.desire`.
+- `highlights`:
+  - primárias:
+    - `end_customer.seo.local_terms`;
+    - `end_customer.strategic_core.desire`;
+  - auxiliar: `end_customer.strategic_core.pain`.
+- Endereço, mapa e rota são operacionais.
+
+#### 2.9.7. Qualification
+
+- `title` e `description`:
+  - primárias:
+    - `end_customer.strategic_core.objection`;
+    - `end_customer.strategic_core.fear`;
+  - auxiliar: `end_customer.strategic_core.awareness_level`.
+- Rótulos e perguntas:
+  - primárias:
+    - `end_customer.strategic_core.objection`;
+    - `end_customer.strategic_core.fear`;
+  - auxiliar: `end_customer.strategic_core.vocabulary`.
+- `submitCta.label`:
+  - primária: `end_customer.strategic_core.trigger`;
+  - auxiliar: `end_customer.strategic_core.desire`.
+- `privacyNote`:
+  - primárias:
+    - `end_customer.strategic_core.fear`;
+    - `end_customer.strategic_core.belief`;
+  - auxiliar: `end_customer.strategic_core.proof_type`.
+
+#### 2.9.8. How it works
+
+- Título e campos dos passos:
+  - primárias:
+    - `end_customer.strategic_core.objection`;
+    - `business_buyer.strategic_core.belief`;
+  - auxiliar: `end_customer.strategic_core.fear`.
+- O processo factual deve vir de valor operacional do negócio.
+
+#### 2.9.9. FAQ
+
+- `question`:
+  - primárias:
+    - `end_customer.seo.faq_questions`;
+    - `end_customer.strategic_core.objection`;
+  - auxiliar: `end_customer.strategic_core.fear`.
+- `answer`:
+  - primárias:
+    - `end_customer.strategic_core.objection`;
+    - `end_customer.strategic_core.belief`;
+  - auxiliar: `end_customer.strategic_core.proof_type`.
+- Resposta factual, legal, financeira ou regulatória exige valor operacional ou fonte própria do recorte futuro.
+
+#### 2.9.10. Final CTA
+
+- `title`:
+  - primárias:
+    - `end_customer.strategic_core.trigger`;
+    - `end_customer.strategic_core.desire`;
+  - auxiliar: `end_customer.strategic_core.positioning_opportunity`.
+- `description`:
+  - primárias:
+    - `end_customer.strategic_core.objection`;
+    - `end_customer.strategic_core.desire`;
+  - auxiliar: `end_customer.strategic_core.proof_type`.
+- CTA:
+  - primária: `end_customer.strategic_core.trigger`;
+  - auxiliar: `end_customer.seo.search_intent`.
+
+#### 2.9.11. Trust
+
+- Título e rótulos:
+  - primárias:
+    - `business_buyer.strategic_core.proof_type`;
+    - `business_buyer.strategic_core.belief`;
+  - auxiliar: `end_customer.strategic_core.fear`.
+- Identidade, registro, política, contato e links:
+  - valores operacionais obrigatórios.
+
+### 2.10. Contexto de `lp_overview`
+
+- O resolver deve expor, como referências contextuais aceitas para consumidores futuros:
+  - `narrative_arc`;
+  - `visual_tone`;
+  - `color_direction`;
+  - `page_length`;
+  - `image_style`;
+  - `visual_density`;
+  - `typography_direction`;
+  - `mobile_priority`.
+- Essas chaves orientam transformação, composição e futura renderização, mas não autorizam fatos, não alteram o design system, não criam variantes e não sobrescrevem raiz, módulo ou variante.
+
+### 2.11. `funnel_copy_profile`
+
+- Perfis permitidos:
+  - `bofu`;
+  - `mofu`;
+  - `tofu`.
+- O perfil é selecionado por intenção informada no fluxo futuro.
+- O perfil não é canal, módulo, variante, taxon ou composição.
+- O perfil deve declarar objetivo de comunicação, nível presumido de consciência, intensidade da conversão, profundidade explicativa, fricção máxima de qualificação e tratamentos.
+- O módulo adapta o perfil à sua função.
+- A variante pode apenas restringir ou tornar mais específico; nunca promover tratamento proibido a permitido.
+- O perfil não pode ampliar limite técnico ou cardinalidade.
+
+#### 2.11.1. BOFU
+
+- Objetivo:
+  - conversão direta ou microconversão de alta intenção.
+- Consciência presumida:
+  - média a alta.
+- Direção:
+  - recorte específico;
+  - benefício concreto;
+  - prova;
+  - objeção;
+  - CTA direto.
+- Qualificação:
+  - simples ou progressiva, quando aplicável.
+- Módulos mais adequados:
+  - Hero;
+  - Offer;
+  - Proof;
+  - Qualification;
+  - FAQ;
+  - Final CTA;
+  - Trust.
+
+#### 2.11.2. MOFU
+
+- Objetivo:
+  - avaliação, comparação e avanço de consideração.
+- Consciência presumida:
+  - média.
+- Direção:
+  - explicar;
+  - diferenciar;
+  - demonstrar;
+  - responder riscos;
+  - oferecer próximo passo proporcional.
+- Qualificação:
+  - baixa a moderada.
+- Módulos mais adequados:
+  - Hero;
+  - Media;
+  - Benefits;
+  - Proof;
+  - Location;
+  - How it works;
+  - FAQ;
+  - Final CTA;
+  - Trust.
+- Oferta e CTA direto:
+  - permitidos com intensidade restrita.
+
+#### 2.11.3. TOFU
+
+- Objetivo:
+  - descoberta, consciência e primeiro avanço.
+- Consciência presumida:
+  - baixa a média.
+- Direção:
+  - contexto;
+  - dor;
+  - desejo;
+  - educação;
+  - prova de relevância;
+  - CTA de baixa fricção.
+- Qualificação:
+  - apenas simples e curta, quando necessária.
+- Módulos mais adequados:
+  - Hero;
+  - Media;
+  - Benefits;
+  - Location;
+  - How it works;
+  - FAQ;
+  - Trust.
+- Offer e Final CTA:
+  - somente em forma proporcional e não agressiva.
+- Qualificação progressiva:
+  - proibida na v1 para TOFU.
+
+### 2.12. Matriz de tratamentos comerciais
+
+- Estados:
+  - `allowed`;
+  - `restricted`;
+  - `prohibited`.
+- Regra global:
+  - tratamento sem fonte real é sempre `prohibited`, mesmo quando a matriz indicar `allowed`.
+
+| Tratamento | BOFU | MOFU | TOFU | Condição |
+|---|---|---|---|---|
+| CTA direto de conversão | allowed | restricted | restricted | coerente com intenção e ação disponível |
+| CTA educacional ou recurso | allowed | allowed | allowed | recurso real e destino válido |
+| preço explícito | allowed | restricted | prohibited | valor operacional atual |
+| oferta transacional | allowed | restricted | restricted | condição real; em TOFU apenas baixa pressão |
+| urgência | restricted | prohibited | prohibited | prazo ou evento real |
+| escassez | restricted | prohibited | prohibited | disponibilidade real e verificável |
+| garantia | restricted | restricted | prohibited | garantia formal e condições disponíveis |
+| prova ou resultado | allowed | allowed | allowed | evidência real e rastreável |
+| comparação | allowed | allowed | restricted | critério objetivo, sem alegação enganosa |
+| credencial | allowed | allowed | allowed | credencial real e vigente |
+| autoridade | allowed | allowed | allowed | identidade e especialização reais |
+| formulário simples | allowed | allowed | restricted | fricção proporcional |
+| formulário progressivo | allowed | restricted | prohibited | necessidade real de qualificação |
+| enquadramento de risco ou medo | restricted | restricted | restricted | sem alarmismo ou manipulação |
+| superlativo ou promessa forte | restricted | restricted | restricted | sustentação explícita e linguagem não absoluta |
+
+- Proibições permanentes:
+  - prova inventada;
+  - depoimento gerado;
+  - resultado garantido sem contrato;
+  - escassez artificial;
+  - urgência artificial;
+  - comparação sem base objetiva;
+  - preço estimado apresentado como real;
+  - credencial inexistente;
+  - autoridade simulada;
+  - keyword stuffing;
+  - omissão deliberada de condição relevante;
+  - linguagem discriminatória;
+  - manipulação por medo.
+
+### 2.13. Adaptação do perfil por módulo
+
+- Hero:
+  - adapta intensidade da proposta e do CTA;
+  - não muda estrutura pelo funil.
+- Media:
+  - BOFU prioriza demonstração;
+  - MOFU prioriza avaliação;
+  - TOFU prioriza descoberta.
+- Benefits:
+  - BOFU prioriza ganho concreto;
+  - MOFU prioriza diferenciação;
+  - TOFU prioriza compreensão.
+- Offer:
+  - BOFU admite oferta transacional sustentada;
+  - MOFU usa explicação e próximo passo;
+  - TOFU restringe pressão comercial.
+- Proof:
+  - BOFU prioriza redução de risco;
+  - MOFU prioriza comparação e confiança;
+  - TOFU prioriza legitimidade.
+- Location:
+  - adapta a relevância, sem criar fatos geográficos.
+- Qualification:
+  - BOFU permite maior profundidade;
+  - MOFU limita fricção;
+  - TOFU admite somente `simple_form`.
+- How it works:
+  - BOFU remove incerteza operacional;
+  - MOFU explica processo;
+  - TOFU educa sobre jornada.
+- FAQ:
+  - BOFU responde objeções de decisão;
+  - MOFU responde dúvidas de avaliação;
+  - TOFU responde dúvidas introdutórias.
+- Final CTA:
+  - BOFU direto;
+  - MOFU proporcional;
+  - TOFU de baixa fricção.
+- Trust:
+  - invariantes factuais e de privacidade em todos os perfis.
+
+### 2.14. Contrato de resolução
+
+- Resolver público previsto:
+  - `resolveLandingPageModuleVariant(...)`.
+- Entrada mínima:
+  - `rootVersion`;
+  - `moduleCatalogVersion`;
+  - `moduleKey`;
+  - `variantKey`;
+  - `purpose`.
+- `purpose` permitido:
+  - `controlled_test`;
+  - `new_use`;
+  - `historical_read`.
+- Comportamento:
+  - resolver primeiro a raiz;
+  - validar compatibilidade do catálogo com a raiz;
+  - resolver módulo;
+  - resolver variante;
+  - aplicar precedência raiz → módulo → variante;
+  - calcular limites efetivos;
+  - validar lifecycle contra o propósito;
+  - retornar payload profundamente imutável.
+- Elegibilidade:
+  - `controlled_test`: aceita `experimental` e `validated`;
+  - `new_use`: aceita somente `validated`;
+  - `historical_read`: aceita `experimental`, `validated` e `deprecated` por versão exata;
+  - `candidate`: não é resolvível para uso.
+- Não existe fallback de catálogo, módulo, variante, versão ou lifecycle.
+- Erros mínimos:
+  - `UNKNOWN_ROOT_VERSION`;
+  - `UNKNOWN_MODULE_CATALOG_VERSION`;
+  - `ROOT_CATALOG_INCOMPATIBLE`;
+  - `UNKNOWN_MODULE`;
+  - `UNKNOWN_VARIANT`;
+  - `MODULE_VARIANT_MISMATCH`;
+  - `INVALID_MODULE_CONTRACT`;
+  - `INVALID_VARIANT_CONTRACT`;
+  - `LIFECYCLE_NOT_ELIGIBLE`;
+  - `INVALID_SPECIALIZATION`;
+  - `INVALID_COPY_SOURCE_MAP`;
+  - `INVALID_FUNNEL_PROFILE`.
+
+### 2.15. Compatibilidade histórica
+
+- O contrato resolvido deve expor:
+  - `rootVersion`;
+  - `moduleCatalogVersion`;
+  - `moduleKey`;
+  - `moduleVersion`;
+  - `variantKey`;
+  - `variantVersion`;
+  - lifecycle;
+  - contrato efetivo.
+- Consumidores futuros devem persistir essas identidades no snapshot da LP.
+- A E18.5 não altera agora `account_landing_pages` nem `content_artifacts`.
+- Uma variante `deprecated`:
+  - não entra em novas composições;
+  - não entra em novas gerações;
+  - continua resolvível em `historical_read`.
+- Uma variante só pode deixar de existir em código quando nenhum artefato publicado depender dela ou houver plano de migração aprovado e executado.
+- Remover a variante do catálogo atual não autoriza apagar a definição das versões antigas.
+- A renderer futura deve resolver o contrato exato do snapshot, não o catálogo mais recente.
+- Migração automática de LP existente é proibida sem plano próprio.
+
+### 2.16. Validações executáveis mínimas
+
+- Catálogo v1 válido.
+- Todos os módulos têm chave única e função estrutural não vazia.
+- Todas as variantes têm chave única e prefixo correspondente ao módulo.
+- Chave do catálogo corresponde a `moduleCatalogVersion`.
+- `rootVersion` compatível existe.
+- Lifecycle válido.
+- Módulo desconhecido falha fechado.
+- Variante desconhecida falha fechado.
+- Variante vinculada ao módulo errado falha fechado.
+- `candidate` rejeitada em todos os propósitos de uso.
+- `experimental` aceita em `controlled_test` e rejeitada em `new_use`.
+- `validated` aceita em todos os propósitos aplicáveis.
+- `deprecated` aceita somente em `historical_read`.
+- Campo obrigatório ausente falha.
+- Campo desconhecido falha.
+- Cardinalidade mínima e máxima inválidas falham.
+- `minItems > maxItems` falha.
+- Papel semântico desconhecido falha.
+- Opção de spacing fora da raiz falha.
+- Especialização com mínimo menor que 1 falha.
+- Especialização com mínimo maior que máximo falha.
+- Especialização acima do limite absoluto efetivo falha.
+- Variante que amplia restrição do módulo falha.
+- `copy_source_map` com mais de 2 fontes primárias falha.
+- `copy_source_map` com mais de 1 auxiliar falha.
+- `researchBlock` desconhecido falha.
+- `itemKey` desconhecido no bloco fixo falha.
+- `lp_sections` como fonte de copy falha.
+- `business_buyer` usado como fonte primária de dor, desejo, objeção, SEO ou vocabulário do visitante falha.
+- Campo operacional sem marcação obrigatória falha.
+- Métrica, depoimento, credencial, preço, endereço ou compliance com origem de pesquisa como valor factual falha.
+- Perfil de funil desconhecido falha.
+- Override de variante que promove tratamento proibido falha.
+- Tratamento sem fonte real permanece proibido.
+- TOFU com `qualification.progressive_form` falha.
+- Resultado resolvido é profundamente imutável.
+- Chamadas diferentes não compartilham referência mutável.
+- Nova versão de catálogo pode ser adicionada sem alterar a v1.
+- Versão antiga permanece resolvível.
+- Registry não contém taxon, campaign, account, composition, sortOrder, isRequired, conteúdo concreto, URL concreta ou preço concreto.
+- Ausência de imports de banco, Supabase, env, API, renderer, rota ou Admin.
+
+### 2.17. Fluxo operacional
+
+- Gatilho:
+  - plano-base v2 consolidado e mergeado;
+  - fase atual instruída pelo Estrategista.
+- Entrada:
+  - parametrização raiz v1;
+  - plano-base E18.5;
+  - catálogo inicial aprovado;
+  - `item_key` oficiais;
+  - evidência parcial do blueprint.
+- Processamento:
+  - criar contratos públicos;
+  - criar registry versionado;
+  - criar schema estrito;
+  - criar resolver;
+  - calcular especializações efetivas;
+  - validar mapas e perfis;
+  - criar casos executáveis;
+  - ajustar exports e script.
+- Validação:
+  - `npm ci`;
+  - `npm run validate:landing-page-root`;
+  - `npm run validate:landing-page-modules`;
+  - `npm run validate:commercial-activation`;
+  - `npm run check`;
+  - `git diff --check`;
+  - checks do PR.
+- Persistência:
+  - arquivos versionados no repositório;
+  - sem banco.
+- Consumo:
+  - E20 e E19 em fases futuras.
+- Fallback:
+  - falha fechada;
+  - sem versão ou variante implícita;
+  - conflito ou necessidade de escopo novo retorna ao Estrategista.
+
+### 2.18. Relatório documental
+
+- Usar relatório consolidado somente ao final do plano.
+- O relatório final deve informar ao Gestor de Docs:
+  - catálogo inicial;
+  - variantes e lifecycle;
+  - boundary e arquivos;
+  - especializações efetivas;
+  - `copy_source_map`;
+  - `funnel_copy_profile`;
+  - matriz de tratamentos;
+  - compatibilidade histórica;
+  - checks;
+  - ausência de banco, composição, geração e Admin.
+- Atualizações duráveis previstas:
+  - `docs/roadmap.md`;
+  - `docs/base-tecnica.md`;
+  - referências comprovadamente afetadas em `docs/lp-planejamento.md`, apenas se houver delta real.
+- `docs/schema.md`:
+  - N/A se não houver mudança de banco.
+
+## 3. Fases e próxima ação
+
+### 3.1. E18.5.3–E18.5.9 — Catálogo versionado de módulos e variantes v1
+
+- Status:
+  - pendente;
+  - bloqueada até consolidação v2 e merge do plano-base.
+- Automação:
+  - não.
+- Risco:
+  - médio controlado.
+- Objetivo:
+  - implementar atomicamente o contrato repo-only completo de módulos e variantes v1.
+- Artefatos a criar:
+  - `lib/conversion-content/landing-page/module-catalog/contracts.ts`;
+  - `lib/conversion-content/landing-page/module-catalog/registry.ts`;
+  - `lib/conversion-content/landing-page/module-catalog/schema.ts`;
+  - `lib/conversion-content/landing-page/module-catalog/resolver.ts`;
+  - `lib/conversion-content/landing-page/module-catalog/validation-cases.ts`;
+  - `lib/conversion-content/landing-page/module-catalog/index.ts`.
+- Artefatos a ajustar:
+  - `lib/conversion-content/index.ts`;
+  - `package.json`;
+  - `docs/lousa-plano-base-e18-5.md`, somente estado e evidências da fase.
+- Implementação:
+  - catálogo e versões;
+  - módulos e variantes;
+  - campos, estruturas e cardinalidades;
+  - especializações sobre a raiz;
+  - mapas de fontes;
+  - perfis de funil;
+  - matriz de tratamentos;
+  - lifecycle;
+  - compatibilidade;
+  - resolver;
+  - validações.
+- Critérios de aceite:
+  - todos os contratos da seção 2 implementados;
+  - raiz preservada;
+  - catálogo v1 imutável;
+  - resolver fail-closed;
+  - módulos e variantes não representam taxon, conteúdo, campanha ou composição;
+  - fontes de copy usam apenas chaves autorizadas;
+  - fatos operacionais não são inferidos da pesquisa;
+  - lifecycle e propósito de uso aplicados;
+  - versões antigas preserváveis;
+  - nenhum renderer, schema final de LP ou geração antecipada;
+  - nenhuma mudança de banco;
+  - validações concluídas.
+- Próxima ação após execução:
+  - avaliação do Analista;
+  - se aprovado, encerrar a implementação material e emitir relatório final ao Gestor de Docs;
+  - se precisar de ajuste, retornar à mesma fase.
+
+## 4. Escopo negativo e critérios de parada
+
+### 4.1. Fora do escopo
+
+- Catálogo de entradas.
+- Valores reais das entradas.
+- Resolução de pesquisas.
+- Nova regra de herança de `business_buyer`.
+- Taxonomia.
+- Composição base.
+- Composição por taxon.
+- Ordem ou obrigatoriedade das seções.
+- Herança concreta de composição.
+- Prontidão do taxon.
+- Autorização de conta de teste.
+- Entitlement.
+- Geração de LP.
+- IA de geração.
+- Prompt de geração.
+- Structured Output de conteúdo final.
+- Schema final de conteúdo da LP.
+- Renderer.
+- Render model.
+- Rota pública.
+- Publicação.
+- Tracking.
+- Analytics.
+- Teste A/B.
+- Admin.
+- LP Builder.
+- Editor visual.
+- Banco.
+- Migration.
+- RPC.
+- Policy.
+- Grant.
+- Trigger.
+- Nova tabela ou coluna.
+- Storage.
+- Upload.
+- CRM.
+- Webhook.
+- Job.
+- Agente.
+- Automação.
+- Workflow.
+- Nova infraestrutura.
+- Nova dependência.
+- Configuração de bundler.
+- Alteração em `commercial_activation`.
+
+### 4.2. Critérios de parada
+
+- Parar e devolver ao Estrategista se:
+  - a implementação exigir banco;
+  - surgir necessidade de registrar composição;
+  - surgir necessidade de gerar ou renderizar conteúdo;
+  - faltar `item_key` oficial necessário;
+  - uma variante depender de taxon, campanha ou entrada específica;
+  - uma diferença puder ser atendida por parâmetro já existente;
+  - houver necessidade de ampliar limite absoluto da raiz;
+  - houver conflito com a E18.4;
+  - houver conflito com E20 ou E19;
+  - a implementação exigir mudança de `commercial_activation`;
+  - a implementação exigir nova dependência;
+  - a implementação exigir URL, rota, formulário funcional ou integração;
+  - a preservação histórica não puder ser garantida no contrato repo-only;
+  - o diff ultrapassar os artefatos autorizados sem decisão humana.
+
+### 4.3. Decisão atual
+
+- Plano-base v1 criado para avaliação única dos especialistas.
+- Nenhuma fase autorizada ao Executor.
+- Próxima ação:
+  - abrir PR vivo apenas com este plano-base;
+  - solicitar avaliação do Analista, Gestor Estrutural e Gestor de Updates;
+  - consolidar todos os retornos no mesmo PR como v2;
+  - solicitar merge humano;
+  - somente após confirmação do merge, instruir a fase 3.1 ao Executor.

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -4,7 +4,7 @@ Fontes: chat, `README.md`, `AGENTS.md`, `docs/roadmap.md`, `docs/base-tecnica.md
 
 Versão: v1 em ajuste.
 
-Status: plano simplificado; nove módulos mantidos no escopo; `hero`, `hero.standard@v1`, `trust_bar`, `trust_bar.standard@v1`, `problem_solution`, `problem_solution.standard@v1`, `offer`, `offer.standard@v1`, `process` e `process.standard@v1` conceitualmente fechados; quatro módulos pendentes; nenhuma implementação autorizada neste PR.
+Status: plano simplificado; nove módulos mantidos no escopo; `hero`, `hero.standard@v1`, `trust_bar`, `trust_bar.standard@v1`, `problem_solution`, `problem_solution.standard@v1`, `offer`, `offer.standard@v1`, `process`, `process.standard@v1`, `technical_assurance` e `technical_assurance.standard@v1` conceitualmente fechados; três módulos pendentes; nenhuma implementação autorizada neste PR.
 
 Path: `docs/lousa-plano-base-e18-5.md`.
 
@@ -48,7 +48,7 @@ Regras:
 - `item_key` é evidência de pesquisa, não identidade canônica do módulo.
 - Os módulos são transversais e não recebem identidade de taxon.
 - Formatos curto, médio e longo pertencem à composição e à extensão da LP.
-- O próximo módulo para análise é `technical_assurance`.
+- O próximo módulo para análise é `social_proof`.
 
 ### 1.4. Escopo positivo
 
@@ -698,13 +698,107 @@ Estado:
 - propósito `controlled_test`;
 - implementação ainda não autorizada por este ajuste documental.
 
+### 3.11. Módulo `technical_assurance`
+
+- `moduleKey = technical_assurance`.
+- `moduleVersion = 1`.
+- Função:
+  - explicar salvaguardas, critérios, documentos, credenciais ou verificações técnicas relevantes para a decisão;
+  - transformar sinais abstratos de confiança em fundamentos compreensíveis;
+  - reduzir risco percebido sem prometer eliminação de risco ou emitir conclusão técnica ou jurídica.
+- Invariantes:
+  - cada item descreve uma salvaguarda, evidência ou critério real e verificável;
+  - o conteúdo distingue orientação geral de afirmação factual sobre a operação;
+  - toda credencial, documento, método, verificação ou capacidade apresentada possui sustentação operacional;
+  - nenhum item implica aprovação, regularidade integral, ausência de risco, certificação, garantia ou resultado sem comprovação específica;
+  - ausência de identidade de taxon, plano, campanha ou funil no contrato.
+- Fronteiras:
+  - não substitui sinais curtos de `trust_bar`;
+  - não contém depoimento, avaliação de cliente, caso real ou métrica de resultado;
+  - não descreve etapas do processo, catálogo de ofertas ou respostas de FAQ;
+  - não presta consultoria técnica ou jurídica individualizada;
+  - não contém CTA, mídia, download, link de verificação, formulário ou interação na execução inicial.
+- Evidências principais:
+  - `prova_tecnica_documental`, pesquisa ativa de `lp_sections`, taxon `Corretor Imóveis`;
+  - itens `proof_type`, `belief`, `fear`, `objection` e `positioning_opportunity` de `strategic_core`;
+  - `narrative_arc` de `lp_overview`, que recomenda provar regularidade e autoridade;
+  - Blueprint do corretor, especialmente compliance, identificação profissional, documentação e segurança da decisão;
+  - catálogo de entradas vigente, somente para sustentar credenciais e capacidades reais quando aplicáveis.
+- Variantes futuras podem usar outra execução estrutural ou referências verificáveis sem alterar `technical_assurance.standard@v1`.
+
+### 3.12. Variante `technical_assurance.standard@v1`
+
+Identidade:
+
+- `variantKey = technical_assurance.standard`.
+- `variantVersion = 1`.
+- Compatível com `technical_assurance@v1` e com a versão vigente da raiz utilizada na implementação inicial.
+- Única variante inicial.
+
+Campos:
+
+- `title`:
+  - texto, papel `h2`, cardinalidade `1..1`, policy `research_guided`.
+- `items`:
+  - coleção, cardinalidade `1..4`, policy `not_copy`;
+  - item fechado com `assuranceTitle` e `assuranceBody`;
+  - `assuranceTitle`: texto, papel `card_title`, cardinalidade `1..1`, policy `hybrid`, suporte `when_present`;
+  - `assuranceBody`: texto, papel `card_body`, cardinalidade `1..1`, policy `hybrid`, suporte `when_present`.
+
+Copy:
+
+- `title`: primárias `proof_type` e `belief`; auxiliar `objection`.
+- `assuranceTitle`: primária `proof_type`; auxiliar `belief`.
+- `assuranceBody`: primárias `proof_type` e `positioning_opportunity`; auxiliar `objection`.
+
+Regras específicas:
+
+- uma ocorrência válida contém de um a quatro itens completos;
+- cada item contém exatamente `assuranceTitle` e `assuranceBody`;
+- cada item representa salvaguarda, credencial, documento, checklist, método, verificação ou critério técnico efetivamente aplicável;
+- todo item exige suporte operacional real e rastreável;
+- o contrato transversal não fixa chaves de um taxon específico;
+- no primeiro taxon, exemplos de sustentação incluem credencial profissional, orientação documental e apoio em financiamento, quando aplicáveis e reais;
+- pesquisa e Blueprint orientam seleção e redação, mas não comprovam credencial, documento, certificação, verificação, regularidade, aprovação, garantia ou resultado;
+- conteúdo não pode afirmar conclusão jurídica, técnica ou financeira individualizada;
+- os papéis `h2`, `card_title` e `card_body` usam as faixas da raiz sem especialização na v1;
+- a coleção não admite item aninhado;
+- não possui subtítulo, CTA, mídia, ícone, link, download, depoimento, caso, métrica, preço, processo ou resposta de FAQ;
+- diferenças de copy, quantidade dentro de `1..4`, ordem dos itens e funil não criam variante;
+- o tratamento da ausência de item válido depende da obrigatoriedade definida pela composição da E20 e será especificado pela E19.
+
+Funil:
+
+- BOFU prioriza evidências concretas, aplicabilidade e limites da salvaguarda apresentada.
+- MOFU prioriza explicação dos critérios e de como reduzem incerteza.
+- TOFU prioriza educação geral, sem aconselhamento técnico ou jurídico individualizado.
+- O funil altera seleção, profundidade e redação, sem alterar campos, cardinalidades, variante ou ordem estrutural da LP.
+
+Validações estruturais:
+
+- exigir `title` e `items`;
+- exigir cardinalidade `1..4` em `items`;
+- exigir exatamente `assuranceTitle` e `assuranceBody` em cada item;
+- rejeitar coleção aninhada e campos extras;
+- validar os papéis semânticos e as policies declaradas;
+- exigir suporte `when_present` em `assuranceTitle` e `assuranceBody`;
+- rejeitar item sem sustentação operacional rastreável;
+- rejeitar CTA, mídia, ação, link, download, depoimento, caso, métrica, preço, processo, FAQ ou referência técnica concreta na variante;
+- resolver de forma fail-closed e imutável.
+
+Estado:
+
+- contrato conceitualmente fechado;
+- lifecycle `experimental`;
+- propósito `controlled_test`;
+- implementação ainda não autorizada por este ajuste documental.
+
 ## 4. Módulos pendentes
 
 ### 4.1. Estado
 
 Permanecem pendentes:
 
-- `technical_assurance`;
 - `social_proof`;
 - `faq`;
 - `final_cta`.
@@ -730,8 +824,8 @@ A etapa seguinte só deve reproduzir o contrato compartilhado após ele estar va
 
 ### 4.3. Próxima ação
 
-- Analisar `technical_assurance` pelo checklist mínimo da seção 2.9.
-- Separar `technical_assurance` de `technical_assurance.standard@v1`.
+- Analisar `social_proof` pelo checklist mínimo da seção 2.9.
+- Separar `social_proof` de `social_proof.standard@v1`.
 - Não alterar o arquivo novamente sem decisão humana sobre o contrato proposto.
 - Não implementar código durante o fechamento conceitual.
 

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -134,6 +134,8 @@ Não criam variante isoladamente:
 - Necessidade acima do limite da raiz exige evolução versionada da raiz.
 - Capability da raiz só bloqueia a implementação quando for indispensável à variante `standard@v1` em implementação.
 - Capability opcional ou destinada a variante futura permanece evolução posterior.
+- Variante deve declarar compatibilidade explícita com a versão da raiz usada por seu contrato.
+- O comportamento de uma variante imutável não muda pela disponibilidade posterior de nova capability da raiz.
 - Não existe fallback silencioso.
 - Contrato ausente, incompatível ou inválido falha fechado.
 - Resultado resolvido deve ser completo e imutável.
@@ -153,7 +155,7 @@ Cada campo usado por uma variante declara:
 Regras:
 
 - cardinalidade representa obrigatoriedade;
-- texto visível usa papel semântico existente na raiz;
+- texto visível usa papel semântico existente na raiz compatível;
 - coleção possui contrato fechado do item;
 - coleção aninhada não integra a v1;
 - ação não armazena canal, URL, telefone, e-mail ou destino concreto;
@@ -164,11 +166,11 @@ Regras:
 
 - `copySourceMap` define até duas fontes primárias e uma auxiliar por campo textual, salvo decisão humana registrada.
 - `funnelCopyProfile` adapta seleção e redação para BOFU, MOFU e TOFU.
-- Funil altera copy, seleção e ordem permitida; não cria módulo ou variante.
+- O funil orienta copy e seleção e pode influenciar a escolha entre ordens previamente permitidas pela composição da E20; não redefine sozinho a estrutura da LP.
 - Pesquisa orienta copy, mas não comprova fatos sobre a operação.
 - Credencial, capacidade, condição, preço, prazo, parceria, resultado, garantia ou ação concreta exige suporte operacional real.
 - A E18.5 declara a exigência estrutural.
-- A E19 resolve valores, omissões e validação final da instância concreta.
+- A E19 resolve valores e valida a instância concreta conforme a composição recebida.
 - Nenhum módulo pode inventar prova, certificação, garantia ou resultado.
 
 Policies iniciais devem ser limitadas às efetivamente consumidas pelas variantes aprovadas:
@@ -217,7 +219,8 @@ E20:
 E19:
 
 - recebe pesquisas, composição e entradas;
-- resolve conteúdo, ativos, vínculos e omissões;
+- resolve conteúdo, ativos e vínculos;
+- trata ausência ou invalidade de dados conforme a obrigatoriedade definida pela E20 e seu próprio contrato;
 - gera e administra a LP real;
 - preserva as versões utilizadas.
 
@@ -298,7 +301,7 @@ Identidade:
 
 - `variantKey = hero.standard`.
 - `variantVersion = 1`.
-- Compatível com `hero@v1`.
+- Compatível com `hero@v1` e com a versão vigente da raiz utilizada na implementação inicial.
 - Única variante inicial.
 
 Campos:
@@ -334,9 +337,10 @@ Regras específicas:
 - Canal e destino concretos ficam fora do registry.
 - Imagem informativa exige alternativa acessível.
 - Imagem decorativa não transporta informação essencial.
-- Visibilidade `desktop_only` pode ser selecionada pela E20 somente para imagem complementar, decorativa ou redundante.
-- A capability técnica de `desktop_only` depende de evolução da raiz; sua ausência não bloqueia a implementação básica com `all_viewports`.
-- `subtitle` usa `body.editorialEmphasis` quando disponível; `body.base` é alternativa explícita, não fallback do renderer.
+- Visibilidade da mídia em `hero.standard@v1` é `all_viewports`.
+- `subtitle` usa `body.base` na versão inicial.
+- `desktop_only` e `body.editorialEmphasis` não integram `hero.standard@v1` enquanto não houver evolução versionada e compatibilidade explícita.
+- A adoção futura dessas capacidades exige nova `variantVersion` ou novo contrato compatível, sem alterar LPs existentes.
 - Não pertencem a `hero.standard@v1`:
   - CTA secundário;
   - vídeo;
@@ -405,8 +409,9 @@ Regras específicas:
 - a coleção não admite item aninhado;
 - não possui título, subtítulo, CTA, ícone ou mídia;
 - disposição horizontal, quebra e empilhamento são responsabilidade responsiva do renderer;
-- TOFU, MOFU e BOFU alteram seleção, ordem e redação, não o contrato;
-- futura E19 omite a ocorrência quando não houver ao menos dois sinais válidos.
+- TOFU, MOFU e BOFU alteram seleção e redação, não o contrato nem a ordem estrutural da LP;
+- uma ocorrência válida de `trust_bar.standard@v1` exige de dois a quatro sinais sustentados;
+- o tratamento da ausência de dados depende da obrigatoriedade definida pela composição da E20 e será especificado pela E19.
 
 Estado:
 

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -1,10 +1,10 @@
 14/07/2026 — Plano-base E18.5 — Parametrização de módulos e variantes `landing_page`
 
-Fontes: chat, `README.md`, `AGENTS.md`, `docs/prompt-estrategista.md`, `docs/template-roadmap.md`, `docs/template-briefing-codex.md`, `docs/prompt-executor.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/schema.md`, `docs/lp-planejamento.md`, `docs/lousa-plano-base-e18-4.md`, `docs/template-blueprint.md`, `docs/blueprint-corretor-imoveis-end-customer.md`, `docs/prompt-nicho-itens-estruturados.md`, `lib/conversion-content/landing-page/`, contratos atuais de templates, compositions e módulos, PRs #559, #563, #564, #566, #567 e #577, avaliações do Analista e decisões humanas de 14 e 15/07/2026.
+Fontes: chat, `README.md`, `AGENTS.md`, `docs/prompt-estrategista.md`, `docs/template-roadmap.md`, `docs/prompt-executor.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/schema.md`, `docs/lp-planejamento.md`, `docs/lousa-plano-base-e18-4.md`, `docs/template-blueprint.md`, `docs/blueprint-corretor-imoveis-end-customer.md`, `docs/prompt-nicho-itens-estruturados.md`, consulta read-only ao Supabase dos itens ativos de `lp_sections`, `lib/conversion-content/landing-page/`, PRs #559, #563, #564, #566, #567 e #577, avaliações do Analista e decisões humanas de 14 e 15/07/2026.
 
 Versão: v1 em ajuste.
 
-Status: PR vivo para debate e avaliação; decisões conceituais aprovadas incorporadas nesta v1; plano-base v2 ainda não consolidado; definição material da E18.5 bloqueada até a evolução versionada da raiz que garanta o tratamento editorial requerido pelo Hero e até o merge humano da v2 do PR #577.
+Status: PR vivo para debate; grade inicial de nove módulos definida a partir de `Corretor Imóveis`, `audience_scope = end_customer`, `lp_sections` v1 ativa; os contratos serão fechados um a um antes da avaliação única dos especialistas; nenhuma implementação autorizada.
 
 Path: `docs/lousa-plano-base-e18-5.md`.
 
@@ -14,251 +14,186 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 
 ### 1.1. Pré-requisitos confirmados
 
-- O PR #559 foi mergeado na `main` em 13/07/2026.
-- A E18.4 foi concluída, aprovada, documentada e formalmente encerrada.
-- A parametrização raiz v1 está implementada em `lib/conversion-content/landing-page/`.
-- A raiz v1 possui registry versionado, schema estrito, resolver fail-closed, saída profundamente imutável, papéis semânticos, faixas editoriais recomendadas, limites técnicos absolutos, opções comuns de espaçamento, critérios visuais e presets.
+- A E18.4 está concluída e a parametrização raiz v1 existe em `lib/conversion-content/landing-page/`.
+- A raiz possui registry versionado, schema estrito, resolver fail-closed, saída imutável, papéis semânticos, limites, critérios visuais e presets.
 - A raiz v1 não garante `body.editorialEmphasis` em todos os presets:
-  - o tratamento é opcional no contrato compartilhado;
-  - o preset `balanced` o possui;
-  - o preset `compact` não o possui.
-- A decisão de produto é que o subtítulo do Hero normalmente use maior ênfase, sem fallback automático para texto-base.
-- Essa garantia exige evolução versionada da raiz em recorte e PR próprios, preservando integralmente a `rootVersion 1`.
-- A precedência obrigatória é:
-  - parametrização raiz;
-  - módulo;
-  - variante.
-- `commercial_activation`, E18.2 e E18.3 permanecem integralmente preservados.
+  - `balanced` possui o tratamento;
+  - `compact` não possui;
+  - o contrato compartilhado o mantém opcional.
+- O subtítulo do Hero deve usar maior ênfase por padrão, sem fallback automático para `body.base`.
+- A garantia exige evolução versionada da raiz em recorte e PR próprios, preservando a `rootVersion 1`.
+- A consulta ao banco confirmou como fonte estrutural principal:
+  - taxon: `Corretor Imóveis`;
+  - nível: `niche`;
+  - público: `end_customer`;
+  - bloco: `lp_sections`;
+  - versão 1 ativa.
+- O ultranicho `Corretor de imóveis de médio padrão` será somente fonte complementar posterior.
+- Os módulos serão transversais e reutilizáveis dentro da família `landing_page`; não representarão nicho, profissão, campanha ou conteúdo concreto.
+- A precedência permanece `raiz → módulo → variante`.
+- `commercial_activation`, E18.2 e E18.3 permanecem preservados.
 
 ### 1.2. Estado processual
 
 - O plano-base v1 e o PR #577 já existem.
-- O debate conceitual permanece aberto para fechar o contrato da E18.5.
-- As decisões aprovadas neste debate devem ser incorporadas no mesmo PR.
-- Não reiniciar o fluxo em novo arquivo ou novo PR.
-- A evolução da raiz será planejada e implementada em recorte e PR próprios.
-- O PR #577 registra somente a dependência e o contrato esperado; não incorpora tamanhos concretos nem detalhes internos da nova raiz.
-- A versão v2 será declarada somente após:
-  - conclusão do debate necessário;
-  - recebimento dos pareceres aplicáveis;
-  - consolidação única dos retornos;
-  - decisão humana sobre os pontos pendentes;
-  - confirmação da evolução versionada da raiz necessária para o Hero.
-- O Executor da E18.5 não pode ser instruído antes do merge humano da evolução da raiz e da v2 do PR #577.
+- As decisões do debate são incorporadas no mesmo PR; não criar arquivo paralelo.
+- A v1 permanecerá aberta até definir, um a um, os nove módulos e suas variantes iniciais.
+- Para cada módulo, fechar:
+  - função estrutural;
+  - campos e cardinalidades;
+  - herança e exceções;
+  - variante inicial e deltas;
+  - fontes de copy;
+  - perfis BOFU, MOFU e TOFU;
+  - lifecycle e limites.
+- O Hero é o módulo-piloto; os demais seguem a ordem da grade inicial.
+- Depois da grade completa, o plano será dividido em fases executáveis específicas.
+- A avaliação única do Analista, Gestor Estrutural e Gestor de Updates ocorrerá somente com a v1 estável.
+- A v2 será consolidada no mesmo PR após os pareceres.
+- O Executor só poderá ser instruído após o merge humano da evolução da raiz e da v2 do PR #577.
 
 ### 1.3. Princípio canônico de herança
 
-- A raiz contém todas as regras comuns da família `landing_page`.
-- O módulo não repete valores da raiz.
-- O módulo declara:
-  - função estrutural;
-  - catálogo fechado de campos;
-  - associação de cada campo a um papel semântico da raiz;
-  - cardinalidade;
-  - fontes de copy;
-  - política de valor operacional;
-  - tratamento tipográfico padrão e alternativas permitidas somente quando disponibilizados pela raiz;
-  - somente exceções próprias e justificadas.
-- A variante não repete o módulo.
-- A variante declara somente deltas fechados e tipados sobre campos já previstos pelo módulo.
-- A composição futura pode selecionar, por ocorrência, somente opções previamente autorizadas pelo módulo ou variante.
-- O resolver aplica:
-  - raiz;
-  - módulo;
-  - variante;
-  - seleção válida por ocorrência quando o contrato futuro da composição a fornecer.
-- O consumidor recebe o contrato efetivo completo e profundamente imutável.
-- E20, E19, geração, validação e renderer futuros não podem reaplicar a herança por conta própria.
-- O renderer executa o tratamento resolvido; não escolhe fallback nem corrige ausência de capability.
+- A raiz contém regras comuns da família.
+- O módulo declara apenas função estrutural, campos, cardinalidades, fontes, políticas e exceções justificadas.
+- O módulo não repete valores concretos da raiz.
+- A variante registra somente deltas fechados sobre campos já previstos.
+- A composição futura pode selecionar por ocorrência apenas opções previamente autorizadas.
+- O resolver aplica a precedência e entrega contrato efetivo completo e imutável.
+- E20, E19, geração e renderer não podem reaplicar a herança.
+- O renderer executa o contrato resolvido; não escolhe fallback.
 
 ### 1.4. Regras de exceção
 
-- Campo sem exceção herda integralmente a raiz.
-- Módulo pode restringir ou selecionar capacidades da raiz quando a função estrutural justificar.
-- Variante pode restringir o módulo quando sua execução reutilizável justificar.
-- Escolha por ocorrência não cria variante quando já estiver autorizada no contrato do módulo.
-- Módulo ou variante não pode ampliar limite técnico absoluto da raiz.
-- Necessidade acima do limite absoluto deve primeiro avaliar:
-  - revisão do texto;
-  - divisão do conteúdo;
-  - mudança do papel semântico;
-  - nova estrutura do módulo.
-- Nova `rootVersion` só deve ser avaliada quando a necessidade comum e comprovada não puder ser atendida pelas alternativas anteriores.
-- Ultrapassar faixa recomendada, permanecendo dentro do limite absoluto, não torna o conteúdo inválido e não cria variante automaticamente.
-- Diferença apenas de taxon, conteúdo, campanha, entrada da conta, origem de tráfego, funil ou composição não cria módulo nem variante.
+- Campo sem exceção herda a raiz.
+- Módulo pode restringir ou selecionar capacidades da raiz quando sua função justificar.
+- Variante pode restringir o módulo quando houver mudança reutilizável de execução ou comportamento.
+- Escolha por ocorrência já autorizada não cria variante.
+- Módulo ou variante não pode ampliar limite técnico absoluto.
+- Necessidade acima do limite deve avaliar antes revisão de texto, divisão de conteúdo, mudança semântica ou nova estrutura.
+- Diferença apenas de taxon, conteúdo, campanha, conta, tráfego, funil ou composição não cria módulo nem variante.
 
 ### 1.5. Decisões técnicas incorporadas
 
-- Valores já existentes na raiz não serão copiados para módulos ou variantes.
-- Especializações numéricas gerais observadas apenas no primeiro Blueprint não entram automaticamente no contrato.
-- Obrigatoriedade e quantidade serão representadas somente por cardinalidade:
-  - `{ min: 1, max: 1 }` para campo único obrigatório;
-  - `{ min: 0, max: 1 }` para campo único opcional;
-  - `{ min, max }` para coleções.
-- Não haverá propriedade `required` separada.
-- Não haverá objeto livre `structuralRules`.
-- Não haverá `addedFields` livre em variantes.
-- Campo realmente novo exige nova versão do contrato do módulo.
-- `structuralBehavior`, caso necessário, deverá ser união fechada, aprovada e validável.
-- Deltas de variante são internos ao registry e ao resolver.
-- O contrato público resolvido não expõe operações de delta para o consumidor aplicar.
-- A E18.5 não cria mapeamento tipográfico geral como `paragraph → body.base` para toda a família.
-- A E18.5 pode selecionar tratamento tipográfico disponibilizado e garantido pela raiz para um campo específico do módulo.
-- O Hero define para `subtitle`:
+- Cardinalidade substitui propriedade `required` separada.
+- Não haverá `structuralRules` aberto nem `addedFields` livre.
+- Campo novo exige nova versão do contrato do módulo.
+- Comportamento estrutural, quando necessário, será união fechada.
+- O consumidor não recebe operações de delta para aplicar.
+- A grade inicial v1 possui nove módulos candidatos:
+  - `hero`, derivado de `hero_segmentado`;
+  - `trust_bar`, derivado de `barra_de_confianca`;
+  - `problem_solution`, derivado de `dores_e_solucoes`;
+  - `offer`, derivado de `servicos_por_intencao`;
+  - `process`, derivado de `processo_de_atendimento`;
+  - `technical_assurance`, derivado de `prova_tecnica_documental`;
+  - `social_proof`, derivado de `prova_social`;
+  - `faq`, derivado de `faq_objeções`;
+  - `final_cta`, derivado de `cta_final_qualificado`.
+- Os `item_key` de `lp_sections` são evidência da função, não identidade permanente do módulo.
+- Cada candidato só será aprovado após confirmar função reutilizável e diferença real em relação aos demais.
+- `formato_curto`, `formato_medio` e `formato_longo` orientam composição e extensão; não são módulos nem variantes.
+- O catálogo inicial fica limitado a nove módulos; ampliação exige decisão posterior.
+- Para `hero.subtitle`:
   - `semanticRole = paragraph`;
-  - tratamento padrão `body.editorialEmphasis`;
-  - tratamentos permitidos `body.editorialEmphasis` e `body.base`.
-- `body.base` é alternativa explícita autorizada, nunca fallback automático.
-- A E20 poderá selecionar `body.base` por ocorrência concreta do Hero quando houver justificativa.
-- A E18.5 dependerá explicitamente da versão da raiz que garanta `body.editorialEmphasis` em todos os presets compatíveis.
-- A forma concreta de preservar contratos da versão 1 e garantir a capability na versão seguinte pertence ao plano e ao PR próprios da evolução da raiz.
-- O futuro renderer deverá consumir o contrato resolvido, sem hardcode independente e sem escolher tratamento.
+  - padrão: `body.editorialEmphasis`;
+  - alternativa autorizada: `body.base`;
+  - ausência da capability falha fechado;
+  - E20 poderá selecionar a alternativa por ocorrência.
 - `hero.media_split` não está aprovada.
-- Mídia obrigatória, isoladamente, não comprova uma variante.
-- O catálogo inicial pode ter apenas uma variante para determinado módulo.
+- `hero.standard` é a única variante inicial aprovada do Hero.
 
 ### 1.6. Estado técnico confirmado
 
-- Boundary raiz atual:
-  - `lib/conversion-content/landing-page/`.
-- Namespace público atual:
-  - `landingPageRoot`.
-- Não existem atualmente para `landing_page`:
-  - catálogo de módulos;
-  - variantes;
-  - schemas finais de conteúdo;
-  - composição;
-  - renderer;
-  - render model.
-- O banco possui estruturas transversais de templates e compositions, mas elas não autorizam registros de `landing_page` nesta fase.
+- Boundary atual: `lib/conversion-content/landing-page/`.
+- Namespace público: `landingPageRoot`.
+- Ainda não existem catálogo de módulos, variantes, composição, renderer ou render model de `landing_page`.
 - A E18.5 será repo-only.
-- Composição concreta e registros por taxon pertencem à E20.
-- Seleção por ocorrência entre tratamentos previamente autorizados pertence à E20.
-- Geração, snapshot, persistência e ciclo das LPs por conta pertencem à E19.
-- `account_landing_pages` não será alterada neste recorte.
+- A leitura dos itens estruturados serve como evidência; este recorte não altera banco.
+- Composição e seleção por ocorrência pertencem à E20.
+- Geração, snapshot e persistência por conta pertencem à E19.
+- `account_landing_pages` não será alterada.
 
 ### 1.7. Pontos ainda em debate
 
-- Conjunto inicial exato de módulos.
-- Ordem de definição dos módulos.
-- Uso do Hero como módulo-piloto antes de ampliar o catálogo.
-- Critério mínimo de evidência para:
-  - criar módulo;
-  - criar variante;
-  - criar exceção estrutural.
-- Necessidade real de múltiplas variantes no primeiro catálogo.
-- Contratos fechados de comportamento estrutural que forem efetivamente necessários.
-- Mapa de fontes de copy de cada módulo.
-- Adaptação dos perfis BOFU, MOFU e TOFU por módulo.
-- Lifecycle inicial de cada módulo e variante.
-- Validação necessária para promoção de `experimental` para `validated`.
+- Confirmação individual dos oito módulos restantes.
+- Campos, cardinalidades e papéis semânticos de cada módulo.
+- Variante inicial e deltas de cada módulo.
+- Critério mínimo para nova variante e exceção estrutural.
+- Mapas de fontes de copy.
+- Perfis BOFU, MOFU e TOFU.
+- Lifecycle inicial.
+- Critério de promoção de `experimental` para `validated`.
+- Divisão final em fases executáveis.
 
 ## 2. Contrato do caso
 
 ### 2.1. Problema
 
-- A raiz já define as regras comuns, mas ainda não existe contrato aprovado para:
-  - funções estruturais dos módulos;
-  - campos e cardinalidades;
-  - variantes reutilizáveis;
-  - exceções justificadas;
-  - `copy_source_map`;
-  - `funnel_copy_profile`;
-  - tratamentos por BOFU, MOFU e TOFU;
-  - lifecycle e compatibilidade histórica.
-- A raiz v1 não garante o tratamento editorial definido como padrão do subtítulo do Hero em todos os presets.
-- Repetir parâmetros da raiz nos módulos criaria múltiplas fontes da verdade.
-- Permitir variantes abertas criaria especializações por taxon, campanha ou conteúdo.
-- Entregar deltas aos consumidores faria cada camada reimplementar a precedência.
-- Usar `body.base` como fallback ocultaria a ausência da capability e transformaria exceção deliberada em degradação silenciosa.
+- A raiz existe, mas ainda faltam contratos aprovados para módulos, variantes, campos, fontes, perfis de funil e lifecycle.
+- Os nove itens estruturais do primeiro recorte não podem virar módulos automaticamente.
+- O catálogo precisa generalizar funções reais sem transportar identidade imobiliária.
+- A raiz v1 não garante o tratamento editorial exigido pelo Hero.
+- Repetição de valores da raiz ou deltas aplicados por consumidores criaria múltiplas fontes da verdade.
+- Fallback para `body.base` esconderia capability ausente.
 
 ### 2.2. Resultado esperado
 
-- Criar fonte repo-only versionada para módulos e variantes.
-- Definir catálogo inicial pequeno e sustentado por evidência.
-- Fazer módulos herdarem a raiz sem repetição.
-- Fazer variantes registrarem apenas deltas.
-- Fazer o resolver retornar contrato efetivo completo e imutável.
-- Fazer a E18.5 depender somente de raiz compatível com as capabilities tipográficas que selecionar.
-- Definir no Hero a ênfase como padrão do subtítulo e `body.base` como alternativa explícita.
-- Deixar a escolha por ocorrência para a composição futura, dentro das opções autorizadas.
-- Definir fontes de copy usando apenas `item_key` oficiais.
-- Separar valores factuais operacionais de orientação de pesquisa.
-- Definir BOFU, MOFU e TOFU como perfis de transformação, não como variantes.
-- Preservar versões antigas para leitura histórica.
-- Entregar validação executável sem banco, composição, geração ou renderer.
+- Criar catálogo repo-only versionado com nove módulos transversais.
+- Usar `Corretor Imóveis`, `end_customer`, `lp_sections` v1 ativa como evidência estrutural principal.
+- Confirmar cada módulo e variante inicial individualmente.
+- Resolver `raiz → módulo → variante` em contrato final imutável.
+- Definir fontes somente com `item_key` oficiais.
+- Separar pesquisa orientadora de valores factuais operacionais.
+- Tratar BOFU, MOFU e TOFU como perfis, não variantes.
+- Preservar versões históricas.
+- Não criar banco, composição, geração ou renderer.
 
 ### 2.3. Fonte e critério para parametrização
 
-A decisão sobre módulo, variante ou exceção deve seguir esta ordem de evidência:
+Ordem de evidência:
 
-1. Parametrização raiz:
-   - contrato comum obrigatório;
-   - fonte dos papéis, limites, treatments e opções permitidas.
-2. `docs/lp-planejamento.md`:
-   - fronteiras entre raiz, módulo, variante, composição, conteúdo e entradas.
-3. Itens estruturados oficiais:
-   - `strategic_core`;
-   - `lp_overview`;
-   - `lp_sections`;
-   - `seo`.
-4. Blueprints e referências reais:
-   - evidência para funções, estruturas, campos e riscos;
-   - recomendação sem sustentação suficiente permanece hipótese.
-5. Decisão interna de produto:
-   - pode definir padrão funcional próprio do LP Factory 10;
-   - não deve ser apresentada como regra universal da web.
-6. LP real validada:
-   - evidência posterior para promover, restringir, substituir ou depreciar contratos.
+1. parametrização raiz;
+2. `docs/lp-planejamento.md`;
+3. itens estruturados oficiais;
+4. Blueprints e referências reais;
+5. decisão interna de produto;
+6. LP real validada.
 
-Critérios:
+Regras específicas:
 
-- Criar módulo somente quando existir função estrutural reutilizável não coberta.
-- Criar variante somente quando existir mudança reutilizável de estrutura, execução ou comportamento dentro da mesma função.
-- Não criar variante quando a diferença puder ser atendida por:
-  - conteúdo;
-  - parâmetro herdado;
-  - escolha de ocorrência autorizada;
-  - composição;
-  - fonte de copy;
-  - perfil de funil;
-  - valor operacional.
-- Não generalizar para toda a família um valor observado apenas em um nicho.
-- Não usar fallback para mascarar ausência de capability requerida pelo módulo.
+- A grade inicial usa `Corretor Imóveis`, `end_customer`, `lp_sections` v1 ativa.
+- O ultranicho de médio padrão não restringe o catálogo transversal.
+- Item de `lp_sections` não cria módulo automaticamente.
+- Módulo exige função estrutural reutilizável ainda não coberta.
+- Variante exige mudança reutilizável de estrutura, execução ou comportamento.
+- Conteúdo, parâmetro herdado, escolha de ocorrência, composição, fonte, funil ou valor operacional não criam variante.
+- Identidade do módulo não pode carregar taxon, profissão ou campanha.
+- Itens de extensão de página não pertencem ao catálogo.
 
 ### 2.4. Identidade e versionamento previstos
 
-- Identidade inicial prevista:
-  - `family = landing_page`;
-  - `rootVersion = versão que garanta body.editorialEmphasis em todos os presets compatíveis`, prevista como evolução da versão 1 em recorte próprio;
-  - `moduleCatalogVersion = 1`.
-- O registry deve ser explícito:
-  - `moduleCatalogVersion → catálogo imutável`.
-- Módulo:
-  - `moduleKey`;
-  - `moduleVersion`;
-  - `lifecycle`;
-  - `structuralFunction`;
-  - `fieldCatalog`.
-- Variante:
-  - `variantKey`;
-  - `variantVersion`;
-  - `moduleKey`;
-  - `lifecycle`;
-  - deltas fechados.
-- Regras:
-  - `rootVersion` e `moduleCatalogVersion` obrigatórios;
-  - compatibilidade explícita entre catálogo e raiz;
-  - a E18.5 não aceita raiz sem a capability requerida pelo Hero;
-  - sem catálogo padrão implícito;
-  - sem fallback silencioso;
-  - versões publicadas imutáveis;
-  - mudança incompatível cria nova versão aplicável;
-  - a forma tipada de preservar a versão 1 e exigir a capability na nova versão será definida no recorte próprio da raiz.
+- `family = landing_page`.
+- `rootVersion` será a versão que garanta as capabilities requeridas.
+- `moduleCatalogVersion = 1`.
+- Grade candidata de `moduleKey`:
+  - `hero`;
+  - `trust_bar`;
+  - `problem_solution`;
+  - `offer`;
+  - `process`;
+  - `technical_assurance`;
+  - `social_proof`;
+  - `faq`;
+  - `final_cta`.
+- O registry será explícito e imutável por versão.
+- Módulo: chave, versão, lifecycle, função e catálogo de campos.
+- Variante: chave, versão, módulo, lifecycle e deltas fechados.
+- Não haverá versão ou catálogo implícito nem fallback silencioso.
 
 ### 2.5. Contrato-base de campo
 
-Cada campo do módulo deve declarar:
+Cada campo declara:
 
 - `fieldKey`;
 - `semanticRole`;
@@ -266,316 +201,129 @@ Cada campo do módulo deve declarar:
 - `copySourceMap`;
 - `operationalValuePolicy`.
 
-Quando o módulo selecionar tratamento tipográfico garantido pela raiz, o campo também pode declarar:
+Quando aplicável:
 
 - `defaultTypographyTreatment`;
 - `allowedTypographyTreatments`.
 
 Regras:
 
-- `semanticRole` referencia papel existente na raiz.
-- `cardinality` contém apenas `min` e `max`.
-- `min` deve ser maior ou igual a zero.
-- `max` deve ser maior ou igual a `min`.
-- Campo único usa `max = 1`.
-- Coleção usa `max > 1`.
-- Nenhum limite ou tamanho da raiz é copiado.
-- Exceção opcional só entra com justificativa:
-  - `recommendedRangeOverride`;
-  - `absoluteMaxRestriction`.
-- `recommendedRangeOverride` deve respeitar o limite absoluto efetivo.
-- `absoluteMaxRestriction` só pode reduzir o teto herdado.
-- `defaultTypographyTreatment` deve referenciar capability garantida pela raiz compatível.
-- `defaultTypographyTreatment` deve pertencer a `allowedTypographyTreatments`.
-- `allowedTypographyTreatments` deve ser lista fechada de referências válidas da raiz.
-- A ausência da capability requerida falha fechado; não aciona fallback.
-- Esse contrato não cria um mapeamento tipográfico geral para todos os papéis semânticos.
-- Campo factual deve declarar política operacional e não pode ser preenchido como fato por pesquisa.
+- papéis e tratamentos devem existir na raiz;
+- cardinalidade contém somente `min` e `max`;
+- nenhum valor concreto da raiz é copiado;
+- exceção de faixa ou limite deve ser justificada e só pode restringir o teto herdado;
+- tratamento padrão deve pertencer à lista permitida;
+- capability ausente falha fechado;
+- fato operacional não pode ser preenchido como fato por pesquisa.
 
 ### 2.6. Contrato de variante
 
-A variante referencia apenas campos existentes no `fieldCatalog` do módulo.
+Deltas permitidos quando aprovados:
 
-Deltas permitidos, quando aprovados:
-
-- mudança de cardinalidade;
+- cardinalidade;
 - remoção de campo opcional;
-- ativação obrigatória de campo já previsto;
-- restrição de faixa recomendada;
-- restrição de limite absoluto;
-- restrição de tratamentos tipográficos já autorizados pelo módulo;
-- comportamento estrutural enumerado e fechado.
+- ativação de campo previsto;
+- restrição de faixa ou limite;
+- restrição de tratamentos permitidos;
+- comportamento estrutural enumerado.
 
 Deltas proibidos:
 
-- campo livre novo;
-- papel semântico inexistente;
-- tratamento tipográfico inexistente ou não autorizado pelo módulo;
-- ampliação do limite absoluto;
+- campo livre;
+- papel ou tratamento desconhecido;
+- ampliação de limite;
 - regra arbitrária;
-- taxon;
-- campanha;
-- conteúdo concreto;
-- valor de conta;
-- composição;
-- ordem global da LP;
-- URL ou destino real;
-- classe, token ou componente visual concreto.
+- taxon, campanha ou conteúdo;
+- valor de conta ou composição;
+- URL, classe ou componente visual concreto.
 
-O resolver deve validar o delta e retornar apenas o contrato efetivo final.
+O resolver valida o delta e retorna somente o contrato final.
 
 ### 2.7. Módulo-piloto `hero`
 
 #### 2.7.1. Função estrutural
 
-- Apresentar o recorte da LP, a proposta de valor e a principal ação esperada.
-- Não representar:
-  - taxon;
-  - campanha;
-  - origem de tráfego;
-  - BOFU, MOFU ou TOFU;
-  - composição.
+- Apresentar o recorte da LP, a proposta de valor e a principal ação.
+- A evidência inicial é `hero_segmentado`, sem transportar para o contrato as intenções ou a profissão do recorte.
+- Não representa taxon, campanha, tráfego, funil ou composição.
 
 #### 2.7.2. Catálogo fechado de campos proposto
 
-- `eyebrow`:
-  - papel: `eyebrow`;
-  - cardinalidade: `{ min: 0, max: 1 }`.
-- `title`:
-  - papel: `h1`;
-  - cardinalidade: `{ min: 1, max: 1 }`.
-- `subtitle`:
-  - papel: `paragraph`;
-  - cardinalidade: `{ min: 1, max: 1 }`;
-  - `defaultTypographyTreatment: body.editorialEmphasis`;
-  - `allowedTypographyTreatments`:
-    - `body.editorialEmphasis`;
-    - `body.base`.
-- `primaryCta.label`:
-  - papel: `cta_label`;
-  - cardinalidade: `{ min: 1, max: 1 }`.
-- `secondaryCta.label`:
-  - papel: `cta_label`;
-  - cardinalidade: `{ min: 0, max: 1 }`.
-- `proofShort`:
-  - papel: `paragraph`;
-  - cardinalidade: `{ min: 0, max: 1 }`.
-- `media`:
-  - referência abstrata de mídia;
-  - cardinalidade: `{ min: 0, max: 1 }`.
+- `eyebrow`: `eyebrow`, `{ min: 0, max: 1 }`.
+- `title`: `h1`, `{ min: 1, max: 1 }`.
+- `subtitle`: `paragraph`, `{ min: 1, max: 1 }`, padrão `body.editorialEmphasis`, permitidos `body.editorialEmphasis` e `body.base`.
+- `primaryCta.label`: `cta_label`, `{ min: 1, max: 1 }`.
+- `secondaryCta.label`: `cta_label`, `{ min: 0, max: 1 }`.
+- `proofShort`: `paragraph`, `{ min: 0, max: 1 }`.
+- `media`: referência abstrata, `{ min: 0, max: 1 }`.
 
 #### 2.7.3. Herança e exceções
 
-- Todos os campos textuais herdam faixas, limites e valores concretos da raiz.
-- Não há na proposta atual:
-  - faixa numérica própria;
-  - limite absoluto próprio;
-  - tamanho de fonte próprio;
-  - spacing próprio.
-- `subtitle` permanece semanticamente `paragraph`.
-- `subtitle` seleciona `body.editorialEmphasis` como tratamento padrão disponibilizado pela raiz compatível.
-- `body.base` é alternativa permitida para seleção explícita por ocorrência futura.
-- A ausência de `body.editorialEmphasis` no preset é incompatibilidade, não autorização para fallback.
-- A existência de mídia não define sozinha nova variante.
+- Campos textuais herdam faixas, limites e valores da raiz.
+- Não há tamanho, limite ou spacing próprio.
+- `subtitle` permanece `paragraph` e usa tratamento da raiz.
+- `body.base` é alternativa explícita, não fallback.
+- Mídia opcional não comprova variante.
 
-#### 2.7.4. Variante inicial em debate
+#### 2.7.4. Variante inicial definida
 
-- `hero.standard`:
-  - usa o contrato-base do Hero;
-  - herda `body.editorialEmphasis` como padrão do subtítulo;
-  - não possui delta numérico;
-  - mídia permanece opcional.
-- `hero.media_split`:
-  - rejeitada como variante aprovada no estado atual;
-  - pode voltar ao debate somente com mudança estrutural reutilizável e contratualmente fechada.
-- Variante criada apenas para trocar `body.editorialEmphasis` por `body.base`:
-  - proibida;
-  - a escolha pertence à ocorrência futura da composição, dentro das opções do módulo.
-- Variante específica de nicho:
-  - proibida.
+- `hero.standard` usa o contrato-base, mantém mídia opcional e não possui delta numérico.
+- É a única variante inicial aprovada do Hero.
+- `hero.media_split` permanece rejeitada.
+- Troca isolada para `body.base` não cria variante.
+- Variante específica de nicho é proibida.
 
 ### 2.8. `copy_source_map`
 
-Cada referência deve declarar:
-
-- `audienceScope`;
-- `researchBlock`;
-- `itemKey`;
-- `sourceRole`.
-
-Regras:
-
-- `sourceRole`:
-  - `primary`;
-  - `auxiliary`.
-- Até 2 fontes primárias e 1 auxiliar por campo.
+- Cada referência declara público, bloco, `itemKey` e papel primário ou auxiliar.
+- Cada campo usa até duas fontes primárias e uma auxiliar.
 - Copy para visitante usa `end_customer` como fonte primária.
-- `business_buyer` só pode auxiliar quando o campo tratar:
-  - autoridade do fornecedor;
-  - processo real;
-  - posicionamento do negócio;
-  - prova institucional.
-- `business_buyer` não substitui dor, desejo, objeção, intenção de busca ou vocabulário do visitante.
-- Blocos factuais de copy:
-  - `strategic_core`;
-  - `seo`.
-- `lp_overview` pode orientar contexto de transformação, sem fornecer fato.
-- `lp_sections` orienta composição futura, sem virar fonte fixa de campo.
-- Chave desconhecida falha fechado.
-- Valor operacional não pode ser inferido como fato a partir da pesquisa.
+- `business_buyer` pode auxiliar somente autoridade, processo, posicionamento ou prova institucional.
+- `strategic_core` e `seo` fornecem insumos factuais de pesquisa.
+- `lp_overview` orienta transformação.
+- `lp_sections` comprova funções estruturais, mas não vira fonte fixa de copy.
+- Chave desconhecida e fato operacional inferido falham fechado.
 
-Mapa inicial do Hero para debate:
+Mapa inicial do Hero:
 
-- `title`:
-  - primárias:
-    - `end_customer.strategic_core.positioning_opportunity`;
-    - `end_customer.strategic_core.desire`;
-  - auxiliar:
-    - `end_customer.seo.commercial_keywords`.
-- `subtitle`:
-  - primárias:
-    - `end_customer.strategic_core.pain`;
-    - `end_customer.strategic_core.desire`;
-  - auxiliar:
-    - `end_customer.strategic_core.belief`.
-- CTAs:
-  - primária:
-    - `end_customer.strategic_core.trigger`;
-  - auxiliar:
-    - `end_customer.seo.search_intent`.
-- `proofShort`:
-  - primária:
-    - `end_customer.strategic_core.proof_type`;
-  - auxiliar:
-    - `end_customer.strategic_core.objection`.
+- `title`: `positioning_opportunity`, `desire`; auxiliar `commercial_keywords`.
+- `subtitle`: `pain`, `desire`; auxiliar `belief`.
+- CTAs: `trigger`; auxiliar `search_intent`.
+- `proofShort`: `proof_type`; auxiliar `objection`.
 
 ### 2.9. `funnel_copy_profile`
 
-Perfis previstos:
-
-- `bofu`;
-- `mofu`;
-- `tofu`.
-
-Regras:
-
-- Perfil não é canal, módulo, variante, taxon ou composição.
-- O perfil orienta transformação da copy.
-- O perfil não altera:
-  - schema;
-  - cardinalidade;
-  - limite absoluto;
-  - estrutura aprovada.
-- Módulo adapta o perfil à sua função.
-- Variante pode apenas restringir ou especializar comportamento permitido.
-- Tratamento proibido não pode ser promovido por variante.
-
-Direção do Hero:
-
-- BOFU:
-  - recorte específico;
-  - benefício concreto sustentado;
-  - objeção direta;
-  - CTA de maior intenção.
-- MOFU:
-  - diferenciação;
-  - explicação;
-  - prova contextual;
-  - CTA proporcional.
-- TOFU:
-  - contexto;
-  - dor e desejo;
-  - baixa pressão;
-  - CTA de baixa fricção.
+- Perfis: `bofu`, `mofu`, `tofu`.
+- Perfil orienta transformação, sem alterar schema, cardinalidade, limite ou estrutura.
+- Módulo adapta o perfil à função.
+- Variante apenas restringe ou especializa tratamento permitido.
+- Hero:
+  - BOFU: recorte específico, benefício sustentado, objeção direta e CTA de maior intenção;
+  - MOFU: diferenciação, explicação, prova contextual e CTA proporcional;
+  - TOFU: contexto, dor e desejo, baixa pressão e CTA de baixa fricção.
 
 ### 2.10. Tratamentos comerciais
 
-Tratamento comercial só pode ser usado com fonte real aplicável.
-
-Tratamentos a governar:
-
-- promessa;
-- prova;
-- autoridade;
-- credencial;
-- comparação;
-- preço;
-- oferta;
-- desconto;
-- garantia;
-- urgência;
-- escassez;
-- resultado;
-- depoimento;
-- métrica.
-
-Regras gerais:
-
-- Pesquisa pode orientar tema, objeção, desejo, posicionamento e tipo de prova.
-- Pesquisa não fornece como fato:
-  - preço;
-  - condição;
-  - prazo;
-  - disponibilidade;
-  - garantia;
-  - credencial;
-  - depoimento;
-  - métrica;
-  - registro;
-  - contato;
-  - endereço;
-  - URL;
-  - informação legal específica.
-- Valor factual exige entrada operacional ou fonte própria futura.
-- BOFU admite maior intensidade apenas quando sustentada.
-- MOFU restringe pressão e prioriza comparação e explicação.
-- TOFU proíbe urgência, escassez e pressão artificial.
+- Promessa, prova, autoridade, credencial, comparação, preço, oferta, desconto, garantia, urgência, escassez, resultado, depoimento e métrica exigem fonte real aplicável.
+- Pesquisa não fornece como fato preço, condição, prazo, disponibilidade, garantia, credencial, depoimento, métrica, contato, endereço, URL ou informação legal específica.
+- Valor factual exige entrada operacional futura.
+- TOFU não admite pressão artificial.
 
 ### 2.11. Lifecycle e compatibilidade
 
-Lifecycle previsto:
-
-- `candidate`;
-- `experimental`;
-- `validated`;
-- `deprecated`.
-
-Significado:
-
-- `candidate`:
-  - em avaliação;
-  - não pode entrar em composição ou geração.
-- `experimental`:
-  - uso apenas em teste controlado.
-- `validated`:
-  - aprovado por LP real e decisão humana.
-- `deprecated`:
-  - não entra em novo uso;
-  - permanece resolvível para histórico.
-
-Propósitos previstos:
-
-- `controlled_test`;
-- `new_use`;
-- `historical_read`.
-
-Regras:
-
-- `controlled_test` aceita `experimental` e `validated`.
-- `new_use` aceita somente `validated`.
-- `historical_read` aceita versão exata `experimental`, `validated` ou `deprecated`.
-- `candidate` não é resolvível para uso.
-- LP futura deve preservar snapshot das versões efetivas.
-- Renderer futuro deve resolver o contrato exato do snapshot.
-- Remoção física exige ausência de dependência publicada ou plano de migração aprovado.
+- Lifecycle: `candidate`, `experimental`, `validated`, `deprecated`.
+- `candidate` não entra em composição ou geração.
+- `experimental` serve a teste controlado.
+- `validated` exige LP real e decisão humana.
+- `deprecated` não entra em novo uso, mas permanece resolvível.
+- Propósitos: `controlled_test`, `new_use`, `historical_read`.
+- Versões efetivas serão preservadas em snapshot futuro.
 
 ### 2.12. Contrato de resolução previsto
 
-Resolver público previsto:
+Resolver previsto: `resolveLandingPageModuleVariant(...)`.
 
-- `resolveLandingPageModuleVariant(...)`.
-
-Entrada mínima:
+Entrada:
 
 - `rootVersion`;
 - `moduleCatalogVersion`;
@@ -586,119 +334,67 @@ Entrada mínima:
 Processamento:
 
 1. resolver raiz;
-2. validar compatibilidade e capabilities do catálogo;
+2. validar compatibilidade;
 3. resolver módulo;
-4. validar referências tipográficas do módulo;
-5. validar delta da variante;
+4. validar referências;
+5. validar variante;
 6. aplicar precedência;
-7. aplicar seleção por ocorrência quando fornecida por contrato futuro compatível;
-8. calcular contrato efetivo;
-9. validar lifecycle e propósito;
-10. retornar resultado profundamente imutável.
+7. calcular contrato final;
+8. validar lifecycle;
+9. retornar resultado imutável.
 
-Saída pública:
-
-- identidades e versões;
-- lifecycle;
-- função estrutural;
-- campos finais;
-- cardinalidades finais;
-- papéis semânticos;
-- fontes finais;
-- políticas operacionais;
-- tratamentos tipográficos finais;
-- limites efetivos quando houver exceção;
-- comportamento estrutural efetivo quando aprovado.
-
-A saída não contém operações de delta nem fallback para o consumidor executar.
+A saída contém identidades, versões, lifecycle, função, campos, cardinalidades, papéis, fontes, políticas, tratamentos e limites efetivos; não contém deltas ou fallback para o consumidor.
 
 ### 2.13. Artefatos previstos
 
-Criar somente após a evolução da raiz e a v2 deste plano serem mergeadas:
+Após a evolução da raiz e o merge da v2:
 
 - `lib/conversion-content/landing-page/module-catalog/contracts.ts`;
-- `lib/conversion-content/landing-page/module-catalog/registry.ts`;
-- `lib/conversion-content/landing-page/module-catalog/schema.ts`;
-- `lib/conversion-content/landing-page/module-catalog/resolver.ts`;
-- `lib/conversion-content/landing-page/module-catalog/validation-cases.ts`;
-- `lib/conversion-content/landing-page/module-catalog/index.ts`.
+- `registry.ts`;
+- `schema.ts`;
+- `resolver.ts`;
+- `validation-cases.ts`;
+- `index.ts`.
 
-Ajustar:
+Ajustar somente `lib/conversion-content/index.ts`, `package.json` e o estado deste plano.
 
-- `lib/conversion-content/index.ts`;
-- `package.json`;
-- `docs/lousa-plano-base-e18-5.md`, somente para estado e evidências da fase.
+Preservar `landingPageRoot`, versões históricas e `commercial_activation`.
 
-Preservar:
+Interface prevista: `landingPageModules`.
 
-- `landingPageRoot` e versões históricas da raiz;
-- `commercial_activation`.
-
-Interface pública agregada prevista:
-
-- `landingPageModules`.
-
-Script previsto:
-
-- `validate:landing-page-modules`.
-
-Não adicionar dependência npm.
+Script previsto: `validate:landing-page-modules`.
 
 ### 2.14. Validações mínimas previstas
 
 - Catálogo e versões válidos.
-- Compatibilidade explícita com a raiz.
-- Capability tipográfica requerida pelo módulo presente na raiz compatível.
-- Referência tipográfica desconhecida falha.
-- Tratamento padrão fora da lista permitida falha.
-- Ausência de `body.editorialEmphasis` em preset compatível falha.
-- Fallback automático para `body.base` falha.
-- Seleção por ocorrência fora da lista autorizada falha.
-- Módulo desconhecido falha fechado.
-- Variante desconhecida falha fechado.
-- Variante vinculada ao módulo errado falha fechado.
-- Campo da variante fora do catálogo do módulo falha.
-- Cardinalidade inválida falha.
-- Papel semântico desconhecido falha.
-- Valor da raiz não é duplicado no módulo.
-- Exceção acima do limite absoluto falha.
-- Ampliação de restrição pelo nível filho falha.
-- Regra estrutural não enumerada falha.
-- `copy_source_map` excedendo fontes permitidas falha.
-- `itemKey` desconhecido falha.
-- Fonte de `business_buyer` usada indevidamente falha.
-- Fato operacional originado da pesquisa falha.
-- Perfil de funil desconhecido falha.
-- Tratamento proibido promovido por variante falha.
-- Lifecycle incompatível com propósito falha.
-- Resultado resolvido é profundamente imutável.
-- Chamadas não compartilham referências mutáveis.
+- Exatamente nove módulos aprovados.
+- Nenhum módulo carrega identidade de taxon.
+- Compatibilidade e capabilities da raiz validadas.
+- Referência, tratamento, módulo, variante ou campo desconhecido falha.
+- Tratamento padrão deve estar na lista permitida.
+- Ausência de `body.editorialEmphasis` e fallback automático falham.
+- Cardinalidade, faixa, limite e comportamento inválidos falham.
+- Valor da raiz não é duplicado.
+- Fontes excedentes ou `itemKey` desconhecido falham.
+- `business_buyer` indevido e fato operacional inferido falham.
+- Lifecycle incompatível falha.
+- Resultado é profundamente imutável.
 - Versão antiga permanece resolvível.
-- Ausência de imports de banco, Supabase, env, API, renderer, rota ou Admin.
+- Sem imports de banco, Supabase, env, API, renderer, rota ou Admin.
 
 ### 2.15. Fluxo operacional
 
 - Gatilho:
-  - evolução versionada da raiz mergeada;
-  - plano-base v2 consolidado e mergeado;
-  - fase instruída pelo Estrategista.
+  - evolução da raiz mergeada;
+  - plano v2 mergeado;
+  - fase instruída.
 - Entrada:
-  - raiz versionada compatível com a capability requerida;
-  - plano-base E18.5;
-  - catálogo aprovado;
-  - `item_key` oficiais;
-  - evidências aprovadas.
+  - raiz compatível;
+  - plano E18.5;
+  - nove módulos aprovados;
+  - `item_key` oficiais.
 - Processamento:
-  - contratos;
-  - registry;
-  - schema;
-  - resolver;
-  - validação de deltas;
-  - tratamentos tipográficos autorizados;
-  - mapas;
-  - perfis;
-  - lifecycle;
-  - casos executáveis.
+  - contratos, registry, schema, resolver, deltas, mapas, perfis, lifecycle e casos executáveis.
 - Validação:
   - `npm ci`;
   - `npm run validate:landing-page-root`;
@@ -707,15 +403,9 @@ Não adicionar dependência npm.
   - `npm run check`;
   - `git diff --check`;
   - checks do PR.
-- Persistência:
-  - repositório;
-  - sem banco.
-- Consumo:
-  - E20 e E19 em fases futuras.
-- Fallback:
-  - falha fechada;
-  - sem versão, capability, módulo, variante ou tratamento implícito;
-  - conflito retorna ao Estrategista.
+- Persistência: repositório, sem banco.
+- Consumo: E20 e E19 futuramente.
+- Fallback: falha fechada.
 
 ## 3. Fases e próxima ação
 
@@ -723,143 +413,74 @@ Não adicionar dependência npm.
 
 - Status:
   - pendente;
-  - bloqueada até o merge da evolução versionada da raiz, consolidação v2 e merge humano do plano-base.
-- Automação:
-  - não.
-- Risco:
-  - médio controlado.
-- Objetivo:
-  - implementar atomicamente o contrato repo-only aprovado para módulos e variantes.
-- Escopo material previsto:
-  - identidade e versões;
-  - compatibilidade com capabilities da raiz;
-  - módulos aprovados;
-  - variantes aprovadas;
-  - campos e cardinalidades;
-  - tratamentos tipográficos autorizados;
-  - deltas fechados;
-  - resolução efetiva;
-  - `copy_source_map`;
-  - `funnel_copy_profile`;
-  - tratamentos comerciais;
-  - lifecycle;
-  - compatibilidade histórica;
-  - validações.
+  - bloqueada até fechar a grade, mergear a evolução da raiz e consolidar a v2.
+- Automação: não.
+- Risco: médio controlado.
+- Objetivo: implementar o contrato repo-only dos nove módulos e variantes iniciais.
 - Critérios de aceite:
-  - nenhum valor comum da raiz duplicado;
-  - versões históricas da raiz preservadas;
-  - capability requerida validada;
-  - `body.editorialEmphasis` padrão no subtítulo do Hero;
-  - `body.base` somente como alternativa explícita autorizada;
-  - nenhum fallback silencioso;
-  - catálogo imutável;
-  - resolver fail-closed;
-  - consumidor recebe contrato efetivo;
-  - variante não cria campo livre;
-  - módulo e variante não representam taxon, campanha, conteúdo ou composição;
-  - fatos operacionais não são inferidos da pesquisa;
-  - nenhuma mudança de banco;
-  - nenhum renderer, geração ou schema final de LP;
-  - validações concluídas.
+  - nove módulos transversais;
+  - nenhuma duplicação da raiz;
+  - compatibilidade e capability validadas;
+  - `hero.subtitle` com ênfase padrão e alternativa explícita;
+  - catálogo imutável e resolver fail-closed;
+  - nenhum taxon, composição, banco, renderer ou geração.
 - Próxima ação:
-  - abrir e concluir o recorte próprio da evolução da raiz;
-  - continuar o debate do catálogo inicial;
-  - consolidar os pareceres aplicáveis;
-  - produzir v2 no mesmo PR;
-  - solicitar merge humano;
-  - somente depois instruir o Executor.
+  - debater `trust_bar` e sua variante inicial;
+  - seguir módulo por módulo na ordem da grade;
+  - dividir depois em fases executáveis;
+  - concluir a evolução da raiz;
+  - realizar avaliação única dos especialistas;
+  - consolidar v2 e solicitar merge humano.
 
 ## 4. Escopo negativo e critérios de parada
 
 ### 4.1. Fora do escopo
 
 - Implementação da evolução da raiz no PR #577.
-- Valores tipográficos concretos da nova raiz.
-- Forma interna de discriminar contratos das versões da raiz.
-- Catálogo de entradas.
-- Valores reais das entradas.
-- Resolução de pesquisas.
-- Nova regra de herança de `business_buyer`.
-- Taxonomia.
-- Composição base.
-- Composição por taxon.
-- Escolha concreta de tratamento por ocorrência.
-- Ordem ou obrigatoriedade global das seções.
-- Herança concreta de composição.
-- Prontidão do taxon.
-- Autorização de conta de teste.
-- Entitlement.
-- Geração de LP.
-- IA de geração.
-- Prompt de geração.
-- Structured Output de conteúdo final.
-- Schema final de conteúdo da LP.
-- Renderer.
-- Render model.
-- Rota pública.
-- Publicação.
-- Tracking.
-- Analytics.
-- Teste A/B.
-- Admin.
-- LP Builder.
-- Editor visual.
-- Banco.
-- Migration.
-- RPC.
-- Policy.
-- Grant.
-- Trigger.
-- Nova tabela ou coluna.
-- Storage.
-- Upload.
-- CRM.
-- Webhook.
-- Job.
-- Agente.
-- Automação.
-- Workflow.
-- Nova infraestrutura.
-- Nova dependência.
-- Configuração de bundler.
-- Alteração em `commercial_activation`.
+- Valores concretos da nova raiz.
+- Módulos identificados por corretor, imóveis, médio padrão ou outro taxon.
+- Implementação específica dos taxons usados como evidência.
+- Catálogo de entradas, valores reais, taxonomia ou resolução de pesquisas.
+- Composição, ordem global, prontidão de taxon ou conta de teste.
+- Geração, IA, prompt, schema final, renderer, render model ou publicação.
+- Tracking, analytics, teste A/B, Admin, Builder ou editor visual.
+- Banco, migration, RPC, policy, grant, trigger, storage ou upload.
+- CRM, webhook, job, agente, automação, workflow ou nova infraestrutura.
+- Nova dependência, bundler ou alteração em `commercial_activation`.
 
 ### 4.2. Critérios de parada
 
-Parar e devolver ao Estrategista se:
+Parar se:
 
-- a evolução versionada da raiz não estiver mergeada;
-- a raiz compatível não garantir a capability requerida;
-- a implementação tentar aplicar fallback automático para `body.base`;
-- a implementação exigir banco;
-- surgir necessidade de registrar composição;
-- surgir necessidade de escolher concretamente tratamento por ocorrência;
-- surgir necessidade de gerar ou renderizar conteúdo;
-- faltar `item_key` oficial necessário;
-- uma variante depender de taxon, campanha ou entrada específica;
-- uma diferença puder ser atendida por parâmetro, conteúdo ou composição;
-- houver necessidade de ampliar limite absoluto da raiz;
-- houver conflito com E18.4, E20 ou E19;
-- a implementação exigir mudança de `commercial_activation`;
-- a implementação exigir nova dependência;
-- a implementação exigir URL, rota, formulário funcional ou integração;
-- a preservação histórica não puder ser garantida;
-- o diff ultrapassar os artefatos autorizados sem decisão humana.
+- a raiz compatível não estiver mergeada ou não garantir a capability;
+- surgir fallback automático;
+- módulo ou variante depender do taxon usado como evidência;
+- surgir necessidade de banco, composição, geração ou renderer;
+- faltar `item_key` oficial;
+- diferença puder ser atendida por conteúdo, parâmetro ou composição;
+- houver ampliação de limite absoluto;
+- houver conflito com E18.4, E20, E19 ou `commercial_activation`;
+- surgir nova dependência ou artefato fora do escopo;
+- preservação histórica não puder ser garantida.
 
 ### 4.3. Decisão atual
 
-- PR #577 preservado.
-- Plano-base permanece v1 em ajuste.
-- Parecer do Analista aprovado.
-- A evolução da raiz será tratada em recorte e PR próprios.
-- A definição material da E18.5 fica bloqueada até essa evolução ser mergeada.
-- O padrão de `hero.subtitle` será `body.editorialEmphasis`.
-- `body.base` será alternativa explícita autorizada para futura escolha por ocorrência na E20.
-- Fallback automático fica proibido.
-- `hero.media_split` não aprovada.
-- `hero.standard` permanece exemplo inicial em debate.
-- Próxima decisão humana:
-  - abrir o recorte próprio da evolução da raiz;
-  - fechar a estrutura mínima do Hero;
-  - decidir se o catálogo inicial será construído módulo a módulo;
-  - definir o próximo módulo a debater.
+- PR #577 preservado e plano-base mantido em v1.
+- Fonte principal: `Corretor Imóveis`, `end_customer`, `lp_sections` v1 ativa.
+- Fonte complementar: `Corretor de imóveis de médio padrão`.
+- Grade inicial limitada a:
+  - `hero`;
+  - `trust_bar`;
+  - `problem_solution`;
+  - `offer`;
+  - `process`;
+  - `technical_assurance`;
+  - `social_proof`;
+  - `faq`;
+  - `final_cta`.
+- Os módulos serão transversais e reutilizáveis na família `landing_page`.
+- `formato_curto`, `formato_medio` e `formato_longo` não são módulos.
+- Hero e `hero.standard` estão fechados para a v1.
+- `body.editorialEmphasis` é padrão; `body.base` é alternativa explícita; fallback é proibido.
+- A implementação permanece bloqueada.
+- Próxima decisão humana: contrato e variante inicial de `trust_bar`.

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -524,7 +524,7 @@ Quando autorizada:
 - rejeitar campos, policies, capabilities e deltas desconhecidos;
 - garantir resolução fail-closed e resultado imutável;
 - validar combinações efetivamente utilizadas;
-- executar casos próprios e integração dos nove módulos e das duas variantes de FAQ;
+- executar casos próprios e integração dos nove módulos, das nove variantes `standard@v1` e de `faq.accordion@v1`;
 - executar `npm ci`, validações aplicáveis, `npm run check` e `git diff --check`.
 
 Alteração exclusivamente documental:

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -70,7 +70,7 @@ Aceito:
 
 Rejeitado:
 
-- novas fases/variantes, banco, renderer, tracking, automação e updates de Supabase/Vercel/GitHub;
+- fases fora das subseções 18.5.3 a 18.5.9, variantes adicionais, banco, renderer, tracking, automação e updates de Supabase/Vercel/GitHub;
 - conformidade WCAG integral e validação comportamental real;
 - aliases aceitos pelo registry ou resolução pública por injeção de objetos de catálogo/raiz.
 
@@ -81,7 +81,7 @@ Pendente sem bloquear:
 Decisão humana de 19/07/2026:
 
 - este patch final está aprovado;
-- a implementação manual comparativa da fase 3.1 pode começar em branch filha criada do head atualizado do PR #585;
+- a implementação manual comparativa pode começar pela fase 18.5.3 em branch filha criada do head atualizado do PR #585;
 - a aprovação não autoriza merge do PR #585, do PR #577 ou de qualquer entrega experimental;
 - a integração na `main` será decidida somente após a comparação manual versus automatizada.
 

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -4,7 +4,7 @@ Fontes: chat, `README.md`, `AGENTS.md`, `docs/roadmap.md`, `docs/base-tecnica.md
 
 Versão: v1 em ajuste.
 
-Status: plano simplificado; nove módulos mantidos no escopo; `hero`, `hero.standard@v1`, `trust_bar`, `trust_bar.standard@v1`, `problem_solution`, `problem_solution.standard@v1`, `offer`, `offer.standard@v1`, `process`, `process.standard@v1`, `technical_assurance` e `technical_assurance.standard@v1` conceitualmente fechados; três módulos pendentes; nenhuma implementação autorizada neste PR.
+Status: plano simplificado; nove módulos mantidos no escopo; `hero`, `hero.standard@v1`, `trust_bar`, `trust_bar.standard@v1`, `problem_solution`, `problem_solution.standard@v1`, `offer`, `offer.standard@v1`, `process`, `process.standard@v1`, `technical_assurance`, `technical_assurance.standard@v1`, `social_proof` e `social_proof.standard@v1` conceitualmente fechados; dois módulos pendentes; nenhuma implementação autorizada neste PR.
 
 Path: `docs/lousa-plano-base-e18-5.md`.
 
@@ -48,7 +48,7 @@ Regras:
 - `item_key` é evidência de pesquisa, não identidade canônica do módulo.
 - Os módulos são transversais e não recebem identidade de taxon.
 - Formatos curto, médio e longo pertencem à composição e à extensão da LP.
-- O próximo módulo para análise é `social_proof`.
+- O próximo módulo para análise é `faq`.
 
 ### 1.4. Escopo positivo
 
@@ -177,8 +177,11 @@ Policies iniciais devem ser limitadas às efetivamente consumidas pelas variante
 
 - `research_guided`;
 - `hybrid`;
+- `operational_required`;
 - `technical_reference`;
 - `not_copy`.
+
+`operational_required` exige valor originado de evidência operacional real e impede geração a partir da pesquisa.
 
 Novas policies somente entram quando outro módulo aprovado exigir comportamento não representável pelas existentes.
 
@@ -793,13 +796,60 @@ Estado:
 - propósito `controlled_test`;
 - implementação ainda não autorizada por este ajuste documental.
 
+### 3.13. Módulo `social_proof`
+
+- `moduleKey = social_proof`; `moduleVersion = 1`.
+- Função: apresentar experiências reais de terceiros que reduzam incerteza sobre atendimento, entrega ou relação com a operação.
+- Invariantes:
+  - toda prova é real, rastreável e autorizada para uso;
+  - conteúdo e atribuição correspondem à mesma evidência;
+  - não há fabricação, alteração material, resultado garantido ou generalização indevida.
+- Fronteiras: não substitui `trust_bar` ou `technical_assurance`; não contém oferta, processo, FAQ, CTA, rating agregado, métrica, logo, caso detalhado ou mídia na execução inicial.
+- Evidências: `prova_social` de `lp_sections`, `proof_type`, `belief` e `objection` de `strategic_core`, `narrative_arc` de `lp_overview` e Blueprint do corretor.
+- Variantes futuras podem usar outra execução estrutural sem alterar `social_proof.standard@v1`.
+
+### 3.14. Variante `social_proof.standard@v1`
+
+Identidade:
+
+- `variantKey = social_proof.standard`; `variantVersion = 1`.
+- Compatível com `social_proof@v1` e com a versão vigente da raiz utilizada na implementação inicial; única variante inicial.
+
+Campos:
+
+- `title`: texto, papel `h2`, cardinalidade `1..1`, policy `research_guided`.
+- `items`: coleção `1..3`, policy `not_copy`; item fechado com:
+  - `quote`: texto, papel `card_body`, `1..1`, policy `operational_required`;
+  - `attribution`: texto, papel `card_title`, `1..1`, policy `operational_required`;
+  - `evidenceRef`: referência técnica, `1..1`, policy `technical_reference`.
+
+Copy:
+
+- `title`: primárias `proof_type` e `belief`; auxiliar `objection`.
+- `quote` e `attribution`: sem fonte de pesquisa; derivam exclusivamente da evidência operacional referenciada.
+
+Regras e validações:
+
+- exigir de um a três itens completos e exatamente `quote`, `attribution` e `evidenceRef` em cada item;
+- impedir geração, composição ou alteração material do depoimento e exigir referência rastreável;
+- atribuição pública identificável depende de autorização; atribuição reduzida não elimina a rastreabilidade interna;
+- os papéis `h2`, `card_title` e `card_body` usam as faixas da raiz sem especialização;
+- rejeitar coleção aninhada, campos extras, CTA, mídia, rating, métrica, logo, caso detalhado ou prova sem suporte;
+- BOFU, MOFU e TOFU alteram seleção e título, não o conteúdo factual da prova nem o contrato;
+- ausência de item válido depende da obrigatoriedade da E20 e será tratada pela E19;
+- resolver de forma fail-closed e imutável.
+
+Estado:
+
+- contrato conceitualmente fechado; lifecycle `experimental`; propósito `controlled_test`;
+- implementação ainda não autorizada por este ajuste documental.
+
 ## 4. Módulos pendentes
 
 ### 4.1. Estado
 
 Permanecem pendentes:
 
-- `social_proof`;
 - `faq`;
 - `final_cta`.
 
@@ -824,8 +874,8 @@ A etapa seguinte só deve reproduzir o contrato compartilhado após ele estar va
 
 ### 4.3. Próxima ação
 
-- Analisar `social_proof` pelo checklist mínimo da seção 2.9.
-- Separar `social_proof` de `social_proof.standard@v1`.
+- Analisar `faq` pelo checklist mínimo da seção 2.9.
+- Separar `faq` de `faq.standard@v1`.
 - Não alterar o arquivo novamente sem decisão humana sobre o contrato proposto.
 - Não implementar código durante o fechamento conceitual.
 

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -1,6 +1,6 @@
 14/07/2026 — Plano-base E18.5 — Parametrização de módulos e variantes `landing_page`
 
-Fontes: chat, `README.md`, `AGENTS.md`, `docs/prompt-estrategista.md`, `docs/template-roadmap.md`, `docs/prompt-executor.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/schema.md`, `docs/lp-planejamento.md`, `docs/lousa-plano-base-e18-4.md`, `docs/template-blueprint.md`, `docs/blueprint-corretor-imoveis-end-customer.md`, `docs/prompt-nicho-itens-estruturados.md`, consulta read-only ao Supabase dos itens ativos de `lp_sections`, `lib/conversion-content/landing-page/`, PRs #559, #563, #564, #566, #567 e #577, avaliações do Analista e decisões humanas de 14 e 15/07/2026.
+Fontes: chat, `README.md`, `AGENTS.md`, `docs/prompt-estrategista.md`, `docs/template-roadmap.md`, `docs/prompt-executor.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/schema.md`, `docs/lp-planejamento.md`, `docs/lousa-plano-base-e18-4.md`, `docs/template-blueprint.md`, `docs/blueprint-corretor-imoveis-end-customer.md`, `docs/prompt-nicho-itens-estruturados.md`, consulta read-only ao Supabase dos itens ativos de `lp_sections`, `lib/conversion-content/landing-page/`, PRs #559, #563, #564, #566, #567 e #577, avaliações do Analista e decisões humanas de 14, 15 e 16/07/2026.
 
 Versão: v1 em ajuste.
 
@@ -364,6 +364,38 @@ Interface prevista: `landingPageModules`.
 
 Script previsto: `validate:landing-page-modules`.
 
+#### 2.13.1. Evolução futura do catálogo
+
+- A operação comum de criação de módulo ou variante será declarativa e versionada no repositório.
+- Novo módulo que use campos, deltas, papéis e capabilities já suportados exigirá normalmente:
+  - registrar o módulo, sua versão e sua variante inicial em `registry.ts`;
+  - adicionar casos positivos e negativos em `validation-cases.ts`;
+  - publicar nova `moduleCatalogVersion` que preserve integralmente os catálogos anteriores.
+- Nova variante que use deltas já suportados exigirá normalmente:
+  - registrar a variante e sua versão em `registry.ts`;
+  - vinculá-la explicitamente ao módulo e à versão compatíveis;
+  - adicionar os respectivos casos em `validation-cases.ts`;
+  - publicar nova `moduleCatalogVersion` sem alterar versões anteriores.
+- `contracts.ts`, `schema.ts` e `resolver.ts` não devem ser alterados quando a necessidade puder ser expressa pelo contrato fechado existente.
+- Campo novo em módulo já publicado exige nova `moduleVersion`; não autoriza editar silenciosamente a versão publicada.
+- Novo tipo de delta, novo comportamento estrutural ou nova forma de resolução exige:
+  - evolução explícita de `contracts.ts`;
+  - ajuste correspondente de `schema.ts` e `resolver.ts`;
+  - atualização do registry e dos casos de validação;
+  - nova versão compatível do catálogo.
+- Capability comum ausente, como novo papel semântico, tratamento ou opção aplicável à família, não deve ser criada no módulo:
+  - exige evolução própria da raiz;
+  - cria nova `rootVersion`;
+  - somente depois autoriza catálogo compatível.
+- A inclusão do novo módulo ou variante em um taxon, sua ordem, obrigatoriedade e escolhas por ocorrência pertencem à composição futura da E20; não são efeito automático do registry.
+- Toda evolução ocorrerá por branch, PR, revisão e validações executáveis.
+- No MVP não haverá:
+  - cadastro dinâmico de módulos ou variantes no banco;
+  - Admin para editar contratos;
+  - mutação de versão publicada em runtime;
+  - criação automática de módulo ou variante a partir de taxon ou pesquisa.
+- A alteração de infraestrutura será exceção; a extensão rotineira deverá limitar-se ao registry, aos casos de validação e ao novo versionamento aplicável.
+
 ### 2.14. Validações mínimas previstas
 
 - Catálogo e versões válidos.
@@ -380,6 +412,9 @@ Script previsto: `validate:landing-page-modules`.
 - Lifecycle incompatível falha.
 - Resultado é profundamente imutável.
 - Versão antiga permanece resolvível.
+- Versão publicada de catálogo, módulo ou variante não pode ser sobrescrita.
+- Extensão declarativa compatível não exige alteração do contrato, schema ou resolver.
+- Mudança de contrato sem nova versão aplicável falha.
 - Sem imports de banco, Supabase, env, API, renderer, rota ou Admin.
 
 ### 2.15. Fluxo operacional
@@ -423,6 +458,8 @@ Script previsto: `validate:landing-page-modules`.
   - compatibilidade e capability validadas;
   - `hero.subtitle` com ênfase padrão e alternativa explícita;
   - catálogo imutável e resolver fail-closed;
+  - extensão futura comum pelo registry e casos de validação;
+  - evolução de infraestrutura somente quando o contrato fechado não atender;
   - nenhum taxon, composição, banco, renderer ou geração.
 - Próxima ação:
   - debater `trust_bar` e sua variante inicial;
@@ -440,6 +477,7 @@ Script previsto: `validate:landing-page-modules`.
 - Valores concretos da nova raiz.
 - Módulos identificados por corretor, imóveis, médio padrão ou outro taxon.
 - Implementação específica dos taxons usados como evidência.
+- Cadastro dinâmico de módulos ou variantes no banco ou Admin.
 - Catálogo de entradas, valores reais, taxonomia ou resolução de pesquisas.
 - Composição, ordem global, prontidão de taxon ou conta de teste.
 - Geração, IA, prompt, schema final, renderer, render model ou publicação.
@@ -459,6 +497,8 @@ Parar se:
 - faltar `item_key` oficial;
 - diferença puder ser atendida por conteúdo, parâmetro ou composição;
 - houver ampliação de limite absoluto;
+- houver tentativa de sobrescrever catálogo, módulo ou variante já publicado;
+- uma necessidade nova exigir alteração de contrato sem versionamento próprio;
 - houver conflito com E18.4, E20, E19 ou `commercial_activation`;
 - surgir nova dependência ou artefato fora do escopo;
 - preservação histórica não puder ser garantida.
@@ -482,5 +522,9 @@ Parar se:
 - `formato_curto`, `formato_medio` e `formato_longo` não são módulos.
 - Hero e `hero.standard` estão fechados para a v1.
 - `body.editorialEmphasis` é padrão; `body.base` é alternativa explícita; fallback é proibido.
+- A criação futura comum de módulos e variantes será declarativa em `registry.ts`, acompanhada de casos em `validation-cases.ts` e nova versão aplicável.
+- `contracts.ts`, `schema.ts` e `resolver.ts` só serão alterados quando a necessidade não couber no contrato fechado existente.
+- Versões publicadas são imutáveis; campo novo exige nova `moduleVersion` e capability comum exige nova `rootVersion`.
+- Uso por taxon pertence à composição da E20.
 - A implementação permanece bloqueada.
 - Próxima decisão humana: contrato e variante inicial de `trust_bar`.

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -4,7 +4,7 @@ Fontes: chat, `README.md`, `AGENTS.md`, `docs/roadmap.md`, `docs/base-tecnica.md
 
 Versão: v1 em ajuste.
 
-Status: PR vivo para debate; grade metodológica comum registrada; `hero` e `hero.standard` permanecem como proposta consolidada com pendências; nove módulos candidatos preservados; nenhuma implementação autorizada.
+Status: PR vivo para debate; grade metodológica comum registrada; `hero` e `hero.standard` conceitualmente fechados na v1; oito módulos candidatos ainda pendentes; nenhuma implementação autorizada.
 
 Path: `docs/lousa-plano-base-e18-5.md`.
 
@@ -17,6 +17,7 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 - A E18.4 está concluída e a raiz versionada existe em `lib/conversion-content/landing-page/`.
 - A raiz v1 não garante `body.editorialEmphasis` em todos os presets nem possui capability fechada de visibilidade responsiva por campo.
 - Ambas as necessidades exigem evolução versionada própria, preservando `rootVersion 1`.
+- Essas necessidades bloqueiam implementação, não o fechamento conceitual do módulo.
 - Fonte estrutural principal confirmada:
   - taxon `Corretor Imóveis`;
   - `taxonId = c7952d16-678c-4615-9483-a003e57d94aa`;
@@ -43,7 +44,8 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
   - responsividade e acessibilidade aplicáveis;
   - variante, versões, lifecycle e compatibilidades;
   - casos da E18.5 e invariantes futuras da E19.
-- O Hero é o piloto; `trust_bar` só começa após seu fechamento.
+- O Hero é o piloto e está conceitualmente fechado na v1.
+- O próximo candidato é `trust_bar`.
 - Implementação somente após evolução da raiz, v2 estável, pareceres e merge humano.
 
 ### 1.3. Princípio canônico de herança
@@ -59,6 +61,7 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 - Tipo de mídia, ativo, taxon, campanha, funil, conteúdo ou visibilidade responsiva autorizada não criam variante isoladamente.
 - Módulo e variante não ampliam limite absoluto da raiz.
 - Campo novo exige nova versão do módulo.
+- Reintrodução de vídeo, formulário ou CTA secundário no Hero exige nova `moduleVersion`.
 
 ### 1.5. Decisões técnicas incorporadas
 
@@ -81,19 +84,27 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
   - padrão `body.editorialEmphasis`;
   - alternativa `body.base`;
   - sem fallback.
-- `hero.standard` é a única variante inicial e pode ter delta vazio.
+- `hero.standard` é a única variante inicial e possui delta vazio.
 - Canal e destino concretos de CTA permanecem fora do registry do módulo.
 - Nenhum `actionRole` está aprovado sem contrato fechado.
 - `moduleCatalogVersion` possui versão e compatibilidade; lifecycle próprio do catálogo não está aprovado.
-- Decisão humana de 16/07/2026:
-  - autorizar conceitualmente `desktop_only` como opção responsiva de `hero.media`;
-  - condicionar seu uso à evolução versionada da raiz;
+- Decisão humana de 16/07/2026 sobre `desktop_only`:
+  - autorizar conceitualmente a opção para `hero.media`;
+  - condicionar sua implementação à evolução versionada da raiz;
   - proibir a ocultação de informação essencial.
 - A relação entre lifecycle da raiz e propósito é política nova da E18.5; não é comportamento já implementado pelo resolver da raiz.
 - Decisão humana de 16/07/2026 sobre `secondaryCta`:
   - retirar o campo da v1 de `hero` e de `hero.standard`;
   - não criar entrada operacional para sustentá-lo;
   - permitir reavaliação futura somente com evidência real, contrato fechado e nova `moduleVersion`.
+- Decisão humana de 16/07/2026 sobre mídia:
+  - restringir `hero.media` da v1 a imagem;
+  - retirar vídeo da v1;
+  - permitir vídeo futuramente somente com contrato de acessibilidade fechado e nova `moduleVersion`.
+- Decisão humana de 16/07/2026 sobre CTA para formulário:
+  - restringir a v1 a `whatsapp`, `phone`, `email` e `external_url`;
+  - retirar `form` do contrato do Hero v1;
+  - permitir suporte futuro somente após contrato de composição E20/E19 e nova `moduleVersion`.
 
 ### 1.6. Estado técnico confirmado
 
@@ -105,8 +116,6 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 
 ### 1.7. Pontos ainda em debate
 
-- Contrato exato de acessibilidade para vídeo.
-- Contrato futuro de vínculo entre CTA principal e ocorrência de formulário na composição.
 - Confirmação dos oito candidatos restantes.
 - Evolução tipográfica e responsiva da raiz.
 - Divisão final em fases.
@@ -115,7 +124,7 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 
 ### 2.1. Problema
 
-- Faltam contratos aprovados para todos os módulos e variantes.
+- Faltam contratos aprovados para oito módulos e suas variantes.
 - O catálogo deve generalizar funções sem carregar identidade imobiliária.
 - CTA não pode duplicar canal ou destino da E20.2.
 - Campos híbridos precisam representar declarativamente quando suporte operacional é exigido.
@@ -153,6 +162,7 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 - resolve hipóteses e ambiguidades;
 - pode rejeitar evidência insuficiente;
 - pode aprovar padrão funcional do produto;
+- pode reduzir a v1 para preservar fechamento e avanço seguro;
 - não viola contrato vigente sem evolução versionada.
 
 #### 2.3.4. Validação posterior
@@ -241,7 +251,7 @@ Regras:
 - valor operacional não pode ser inferido como fato;
 - referência técnica não é copy;
 - somente cardinalidade representa obrigatoriedade;
-- capability ausente falha fechado.
+- capability ausente falha fechado na implementação.
 
 #### 2.5.1. Política fechada de origem do valor
 
@@ -356,7 +366,7 @@ Nova chave operacional não pode ser criada implicitamente pela E18.5.
 #### 2.7.1. Identidade e função estrutural
 
 - `moduleKey = hero`.
-- `moduleVersion = 1` proposto.
+- `moduleVersion = 1`.
 - Função:
   - apresentar recorte;
   - comunicar proposta principal;
@@ -394,11 +404,13 @@ Pertencem:
 - explicação curta;
 - CTA principal;
 - microprova opcional;
-- uma mídia opcional.
+- uma imagem opcional.
 
 Não pertencem:
 
 - CTA secundário na v1;
+- vídeo na v1;
+- CTA para formulário na v1;
 - trust bar completa;
 - oferta;
 - processo;
@@ -414,7 +426,7 @@ Não pertencem:
 - navegação;
 - ordem global.
 
-#### 2.7.4. Catálogo de campos proposto
+#### 2.7.4. Catálogo de campos v1
 
 - `eyebrow`:
   - `fieldKind = text`;
@@ -447,6 +459,11 @@ Não pertencem:
     - policy `hybrid`;
     - `operationalSupportRequirement = when_present`;
   - `operationalBindingRequirement.catalogFieldKey = primary_conversion_channel`;
+  - canais admitidos na v1:
+    - `whatsapp`;
+    - `phone`;
+    - `email`;
+    - `external_url`;
   - vínculo obrigatório quando a ação estiver presente;
   - canal e destino concretos ficam fora do registry.
 - `proofShort`:
@@ -461,7 +478,7 @@ Não pertencem:
   - `fieldKind = media`;
   - cardinalidade `0..1`;
   - policy `technical_reference`;
-  - `mediaKind = image | video`;
+  - `mediaKind = image`;
   - referência do ativo pertence à instância futura;
   - `accessibilityMode = informative | decorative`;
   - acessibilidade usa contrato próprio de mídia, não policy textual;
@@ -469,28 +486,20 @@ Não pertencem:
   - imagem decorativa exige ausência de descrição semântica, normalizada pelo contrato final;
   - conteúdo da alternativa acessível deriva do ativo, função e contexto reais;
   - legenda não integra o contrato inicial e não se confunde com alternativa acessível;
-  - vídeo exige alternativa acessível própria;
-  - contrato exato de vídeo ainda pendente;
   - mídia decorativa não transporta informação essencial.
 
 Estado dos campos:
 
-- a v1 do Hero contém seis campos no catálogo publicável:
+- a v1 do Hero contém seis campos publicáveis:
   - `eyebrow`;
   - `title`;
   - `subtitle`;
   - `primaryCta`;
   - `proofShort`;
   - `media`;
-- quatro possuem contrato interno definido:
-  - `eyebrow`;
-  - `title`;
-  - `subtitle`;
-  - `proofShort`;
-- `primaryCta` permanece parcialmente pendente para o canal `form`;
-- `media` permanece parcialmente pendente para acessibilidade de vídeo;
-- `secondaryCta` foi retirado da v1 por decisão humana;
-- as capabilities tipográfica e responsiva da raiz são dependências externas, não pendências internas desses campos.
+- os seis possuem contrato interno conceitualmente fechado;
+- `secondaryCta`, vídeo e `form` foram retirados da v1 por decisão humana;
+- as capabilities tipográfica e responsiva da raiz são dependências externas de implementação.
 
 #### 2.7.5. Herança e exceção tipográfica
 
@@ -498,11 +507,12 @@ Estado dos campos:
 - A E18.5 autoriza `body.editorialEmphasis` e `body.base`; a E20 seleciona.
 - Exceção exige decisão humana documentada, sem presumir persistência nova.
 - O renderer não escolhe nem aplica fallback.
-- A capability tipográfica ainda depende de nova `rootVersion`.
+- A capability tipográfica ainda depende de nova `rootVersion` para implementação.
 
 #### 2.7.6. Mídia e comportamento responsivo
 
-- Imagem e vídeo no mesmo slot usam `hero.standard`.
+- A v1 admite apenas imagem no slot de mídia de `hero.standard`.
+- Vídeo exige nova `moduleVersion` e contrato de acessibilidade próprio.
 - Galeria, carrossel e tour ficam fora.
 - Opções conceitualmente autorizadas:
   - `all_viewports`;
@@ -511,12 +521,12 @@ Estado dos campos:
   - `desktop_only` é opção responsiva aprovada para `hero.media`;
   - pertence à escolha por ocorrência da E20;
   - não cria variante;
-  - só pode ser usada quando a mídia for decorativa, complementar ou redundante;
+  - só pode ser usada quando a imagem for decorativa, complementar ou redundante;
   - não pode ocultar informação essencial.
 - Aprovação conceitual não equivale a capability técnica disponível.
 - A raiz v1 não possui a capability necessária.
 - A implementação de `desktop_only` permanece bloqueada até evolução versionada da raiz.
-- A E19 valida a mídia concreta e a preservação da informação.
+- A E19 valida a imagem concreta e a preservação da informação.
 
 #### 2.7.7. Fronteira com formulário
 
@@ -530,13 +540,12 @@ Estado dos campos:
     - a E19 resolve `email_destination`;
   - `external_url`:
     - a E19 resolve `external_url_destination`.
-- Quando `primary_conversion_channel = form`:
-  - `privacy_policy_url` comprova requisito de privacidade, mas não identifica a ocorrência concreta do formulário;
-  - o CTA depende de futura ocorrência de módulo de formulário aprovada na composição;
-  - a E20 deverá compor o Hero com essa ocorrência;
-  - a E19 deverá vincular o CTA à ocorrência composta;
-  - esse vínculo ainda não possui contrato aprovado;
-  - o caso `form` não é considerado completamente resolvido pelo Hero.
+- `primary_conversion_channel = form` é inválido para `hero` v1.
+- Suporte futuro a formulário exige:
+  - ocorrência de módulo de formulário aprovada na composição;
+  - contrato E20 para composição;
+  - contrato E19 para vínculo;
+  - nova `moduleVersion` do Hero.
 - Não criar agora:
   - nova entrada operacional;
   - identificador de formulário;
@@ -556,7 +565,7 @@ Estado dos campos:
 - `subtitle`:
   - primárias `pain` e `desire`;
   - auxiliar `belief`.
-- labels:
+- label:
   - primária `trigger`;
   - auxiliar `search_intent`;
   - ação concreta exige vínculo operacional.
@@ -564,11 +573,11 @@ Estado dos campos:
   - primária `proof_type`;
   - auxiliar `objection`;
   - suporte operacional obrigatório quando presente.
-- Alternativa acessível de mídia:
+- Alternativa acessível de imagem:
   - não usa `copySourceMap`;
   - não usa `operationalValuePolicy`;
   - a E19 a produz a partir do ativo e contexto sob o contrato de acessibilidade.
-- Ativo, tipo de mídia, modo de acessibilidade, visibilidade, canal e destino não recebem `copySourceMap`.
+- Ativo, modo de acessibilidade, visibilidade, canal e destino não recebem `copySourceMap`.
 
 #### 2.7.9. Perfis de funil do Hero
 
@@ -592,19 +601,19 @@ Estado dos campos:
 - `variantVersion = 1`.
 - Compatível com `moduleVersion = 1`.
 - Execução-base com delta vazio.
-- Mídia permanece opcional.
-- `secondaryCta` não pertence à v1.
-- Inclusão futura de `secondaryCta` exige nova `moduleVersion`, vínculo operacional aprovado e casos próprios.
-- Imagem, vídeo, funil, visibilidade e troca para `body.base` não criam variante.
+- Imagem permanece opcional.
+- `secondaryCta`, vídeo e `form` não pertencem à v1.
+- Inclusão futura de qualquer um deles exige nova `moduleVersion`, contrato aprovado e casos próprios.
+- Funil, visibilidade e troca para `body.base` não criam variante.
 - `hero.media_split` permanece rejeitada.
+- A variante está conceitualmente fechada na v1.
 
 #### 2.7.11. Lifecycle e compatibilidade do Hero
 
 - `moduleCatalogVersion = 1` proposto.
-- `moduleVersion = 1` proposto.
-- `variantVersion = 1` proposto.
+- `moduleVersion = 1` fechado conceitualmente.
+- `variantVersion = 1` fechada conceitualmente.
 - `moduleCatalogVersion` não possui lifecycle próprio aprovado; declara apenas versão e compatibilidade com a raiz.
-- `rootVersion` depende das capabilities tipográfica e responsiva.
 - Lifecycle da raiz disponível no contrato atual:
   - `hypothesis`;
   - `validated`;
@@ -632,15 +641,16 @@ Estado dos campos:
 - Validar identidade, evidência, proveniência e interpretação editorial de `hero_segmentado`.
 - Aceitar exatamente os seis campos publicáveis da v1.
 - Rejeitar `secondaryCta` em `moduleVersion = 1`.
-- Exigir nova `moduleVersion` para inclusão futura de `secondaryCta`.
+- Rejeitar `mediaKind = video` em `moduleVersion = 1`.
+- Rejeitar `primary_conversion_channel = form` no Hero v1.
+- Exigir nova `moduleVersion` para inclusão futura desses recursos.
 - Rejeitar campo, cardinalidade, policy, fonte, tratamento ou variante inválidos.
 - Rejeitar combinação ausente da allowlist.
 - Validar `operationalSupportRequirement` e sua compatibilidade com policy e campo.
 - Validar vínculo abstrato do CTA principal com `primary_conversion_channel`.
 - Garantir que CTA não armazene canal ou destino concreto.
-- Registrar o caso `form` como vínculo de composição ainda pendente.
-- Validar contrato abstrato de mídia, acessibilidade e responsividade.
-- Falhar sem capabilities exigidas e sem fallback.
+- Validar contrato abstrato de imagem, acessibilidade e responsividade.
+- Falhar na implementação sem capabilities exigidas e sem fallback.
 - Incluir raiz na elegibilidade sem exigir lifecycle do catálogo.
 - Tratar lifecycle–propósito como política da E18.5.
 - Retornar resultado imutável.
@@ -651,27 +661,25 @@ Não criam agora schema ou validador de conteúdo na E18.5:
 
 - título, subtítulo e CTA principal concretos conforme cardinalidade;
 - label compatível com canal, ação e destino resolvidos;
-- CTA para formulário vinculado à ocorrência composta quando esse contrato existir;
+- canal limitado ao conjunto autorizado pela v1;
 - suporte operacional exigido disponível;
 - prova concreta sustentada;
-- ativo de mídia válido;
+- ativo de imagem válido;
 - imagem informativa com alternativa acessível;
 - imagem decorativa sem descrição semântica;
-- vídeo com alternativa acessível;
 - `desktop_only` sem ocultar informação essencial;
-- ausência de CTA secundário, formulário completo, seletor interativo, galeria, carrossel ou tour dentro de `hero.standard` v1.
+- ausência de CTA secundário, vídeo, formulário completo, seletor interativo, galeria, carrossel ou tour dentro de `hero.standard` v1.
 
-#### 2.7.14. Critérios de fechamento do Hero
+#### 2.7.14. Fechamento do Hero
 
-Fechar após aprovação de:
+Contrato conceitual aprovado na v1:
 
 - identidade, evidência, interpretação da segmentação e fronteiras;
 - seis campos publicáveis e cardinalidades;
 - allowlist de policies e `operationalSupportRequirement`;
-- vínculo do CTA principal;
-- contrato do caso `form`;
-- mídia e acessibilidade, inclusive vídeo;
-- visibilidade responsiva e nova raiz;
+- vínculo do CTA principal aos quatro canais autorizados;
+- imagem e acessibilidade abstrata;
+- visibilidade responsiva conceitual;
 - variante, versões, lifecycle e compatibilidades;
 - casos E18.5 e invariantes E19.
 
@@ -683,14 +691,16 @@ Estado:
 - labels e `proofShort` usam `hybrid` com suporte declarativo;
 - CTA principal referencia somente a chave operacional aprovada;
 - destinos concretos permanecem fora do registry;
-- caso `form` delimitado como vínculo futuro de composição;
+- `form` foi retirado da v1;
+- mídia foi restringida a imagem;
 - alternativa acessível saiu de `operationalValuePolicy`;
 - `desktop_only` possui aprovação humana conceitual, mas capability técnica ainda não existe;
 - lifecycle próprio do catálogo foi retirado;
 - lifecycle–propósito foi identificado como política nova da E18.5;
-- `secondaryCta` foi retirado da v1;
-- acessibilidade de vídeo ainda está pendente;
-- Hero ainda não fechado e implementação bloqueada.
+- `secondaryCta` e vídeo foram retirados da v1;
+- `hero` está conceitualmente fechado na v1;
+- `hero.standard` está conceitualmente fechada na v1;
+- implementação permanece bloqueada até evolução tipográfica e responsiva da raiz.
 
 ### 2.8. `copy_source_map`
 
@@ -772,17 +782,17 @@ Validações E18.5:
 - allowlist de policy e suporte operacional respeitada;
 - vínculo de ação referencia apenas `fieldKey` aprovado do catálogo operacional;
 - nenhum destino concreto de CTA no registry;
-- `secondaryCta` rejeitado na v1;
-- capabilities exigidas sem fallback;
+- `secondaryCta`, vídeo e canal `form` rejeitados no Hero v1;
+- capabilities exigidas sem fallback na implementação;
 - delta vazio somente na base autorizada;
-- contrato abstrato de mídia e acessibilidade válido;
+- contrato abstrato de imagem e acessibilidade válido;
 - formulário ou seletor interativo não adicionados ao Hero;
 - resultado imutável, versões históricas preservadas e sem imports fora do boundary.
 
 #### 2.14.1. Invariantes futuras para E19
 
 - presença e consistência do conteúdo concreto;
-- CTA vinculado à operação real;
+- CTA vinculado à operação real e a canal autorizado;
 - suporte operacional exigido resolvido;
 - prova sustentada;
 - ativo e acessibilidade válidos;
@@ -803,12 +813,15 @@ Validações E18.5:
 
 - Status pendente e bloqueado até grade fechada, raiz evoluída e v2 consolidada.
 - Automação: não. Risco: médio controlado.
-- Aceite: módulos aprovados, sem duplicação da raiz ou E20.2, compatibilidade validada, Hero conforme contrato, resolver fail-closed e separação E18.5/E19.
+- Aceite: módulos aprovados, sem duplicação da raiz ou E20.2, compatibilidade validada, resolver fail-closed e separação E18.5/E19.
+- Hero:
+  - contrato conceitual fechado;
+  - implementação bloqueada pela raiz.
 - Próxima ação:
-  - fechar acessibilidade de vídeo;
-  - reavaliar Hero;
-  - depois iniciar `trust_bar` e seguir a grade;
-  - concluir raiz, pareceres, v2 e merge humano.
+  - iniciar análise de `trust_bar` pela grade metodológica comum;
+  - seguir os oito candidatos restantes;
+  - evoluir a raiz antes da implementação;
+  - concluir pareceres, v2 e merge humano.
 
 ## 4. Escopo negativo e critérios de parada
 
@@ -817,7 +830,7 @@ Validações E18.5:
 - Implementação da raiz no PR #577.
 - Banco, composição, geração, renderer, Admin, Builder, tracking, automação ou nova infraestrutura.
 - Nova entrada operacional para sustentar `secondaryCta`.
-- `secondaryCta` na v1 do Hero.
+- `secondaryCta`, vídeo ou CTA para formulário na v1 do Hero.
 - Módulo de formulário, seletor interativo, galeria, carrossel ou tour neste recorte.
 - Persistência nova para justificativa da composição.
 
@@ -825,13 +838,13 @@ Validações E18.5:
 
 Parar se:
 
-- raiz, capability ou lifecycle aplicável não estiverem resolvidos;
+- raiz, capability ou lifecycle aplicável não estiverem resolvidos na implementação;
 - surgir lifecycle próprio de catálogo sem decisão explícita;
 - surgir fallback, dependência de taxon ou ampliação de limite;
 - faltar evidência oficial;
 - destino concreto entrar no registry;
 - campo híbrido depender de regra hardcoded por `fieldKey`;
-- `secondaryCta` for reintroduzido na v1;
+- `secondaryCta`, vídeo ou `form` forem reintroduzidos na v1;
 - formulário, seletor interativo ou mídia essencial forem tratados incorretamente;
 - validação de conteúdo for antecipada na E18.5;
 - houver conflito de fronteiras ou perda histórica.
@@ -841,16 +854,16 @@ Parar se:
 - PR #577 permanece em v1 e sem implementação autorizada.
 - `hero_segmentado` está comprovado com `itemId` e interpretado editorialmente na v1.
 - Grade comum e nove candidatos permanecem.
-- Hero possui seis campos publicáveis na v1.
-- Quatro campos têm contrato interno definido; `primaryCta` permanece pendente para `form` e `media` para vídeo.
-- `secondaryCta` foi retirado da v1; eventual retorno exige nova `moduleVersion` e contrato aprovado.
-- `hero.standard` permanece a única variante inicial, com delta vazio.
+- Hero possui seis campos publicáveis com contrato conceitualmente fechado.
+- `secondaryCta`, vídeo e canal `form` foram retirados da v1; eventual retorno exige nova `moduleVersion` e contrato aprovado.
+- `hero.standard` permanece a única variante inicial, com delta vazio, e está conceitualmente fechada.
 - Labels e `proofShort` usam `hybrid` com exigência declarativa de suporte.
 - CTA principal referencia `primary_conversion_channel`, sem canal ou destino concreto no registry.
-- Alternativa acessível da mídia usa contrato próprio, não policy textual.
-- Imagem, vídeo e visibilidade responsiva não criam variante.
+- Alternativa acessível da imagem usa contrato próprio, não policy textual.
+- Visibilidade responsiva não cria variante.
 - Formulário completo e seletor interativo ficam fora do Hero.
 - Elegibilidade inclui a raiz e não presume lifecycle do catálogo.
 - E18.5 e E19 permanecem separadas.
-- Hero ainda não está fechado por acessibilidade de vídeo, vínculo futuro do caso `form` e evolução da raiz.
-- Próxima decisão humana: fechar acessibilidade de vídeo e reavaliar o Hero antes de `trust_bar`.
+- Hero e `hero.standard` estão finalizados conceitualmente na v1.
+- A implementação continua bloqueada pela evolução tipográfica e responsiva da raiz.
+- Próxima ação humana: iniciar `trust_bar` e seguir a grade dos oito módulos restantes.

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -4,7 +4,7 @@ Fontes: chat, `README.md`, `AGENTS.md`, `docs/roadmap.md`, `docs/base-tecnica.md
 
 Versão: v1 em ajuste.
 
-Status: PR vivo para debate; grade metodológica comum registrada; `hero` e `hero.standard` conceitualmente fechados na v1; oito módulos candidatos ainda pendentes; nenhuma implementação autorizada.
+Status: PR vivo para debate; grade metodológica comum registrada; `hero`, `hero.standard`, `trust_bar` e `trust_bar.standard` conceitualmente fechados na v1; sete módulos candidatos ainda pendentes; nenhuma implementação autorizada.
 
 Path: `docs/lousa-plano-base-e18-5.md`.
 
@@ -44,8 +44,9 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
   - responsividade e acessibilidade aplicáveis;
   - variante, versões, lifecycle e compatibilidades;
   - casos da E18.5 e invariantes futuras da E19.
-- O Hero é o piloto e está conceitualmente fechado na v1.
-- O próximo candidato é `trust_bar`.
+- O Hero permanece como piloto metodológico e está conceitualmente fechado na v1.
+- `trust_bar` e `trust_bar.standard` estão conceitualmente fechados na v1.
+- O próximo candidato é `problem_solution`.
 - Implementação somente após evolução da raiz, v2 estável, pareceres e merge humano.
 
 ### 1.3. Princípio canônico de herança
@@ -105,6 +106,11 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
   - restringir a v1 a `whatsapp`, `phone`, `email` e `external_url`;
   - retirar `form` do contrato do Hero v1;
   - permitir suporte futuro somente após contrato de composição E20/E19 e nova `moduleVersion`.
+- Decisão humana de 16/07/2026 sobre `trust_bar`:
+  - aprovar coleção de dois a quatro sinais curtos de confiança;
+  - exigir suporte operacional real para cada sinal;
+  - manter TOFU, MOFU e BOFU como perfis de seleção e redação, sem alterar estrutura ou variante;
+  - aprovar `trust_bar.standard` como única variante inicial, com delta vazio.
 
 ### 1.6. Estado técnico confirmado
 
@@ -116,7 +122,7 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 
 ### 1.7. Pontos ainda em debate
 
-- Confirmação dos oito candidatos restantes.
+- Confirmação dos sete candidatos restantes.
 - Evolução tipográfica e responsiva da raiz.
 - Divisão final em fases.
 
@@ -124,7 +130,7 @@ Recorte do roadmap: `18.5 — Parametrização de módulos e variantes landing_p
 
 ### 2.1. Problema
 
-- Faltam contratos aprovados para oito módulos e suas variantes.
+- Faltam contratos aprovados para sete módulos e suas variantes.
 - O catálogo deve generalizar funções sem carregar identidade imobiliária.
 - CTA não pode duplicar canal ou destino da E20.2.
 - Campos híbridos precisam representar declarativamente quando suporte operacional é exigido.
@@ -807,6 +813,157 @@ Validações E18.5:
 - Validação: `npm ci`, validações da raiz, módulos e commercial activation, `npm run check`, `git diff --check` e checks do PR.
 - Persistência: repositório; consumo futuro: E20 e E19; fallback: falha fechada.
 
+### 2.16. Módulo `trust_bar`
+
+#### 2.16.1. Identidade e função estrutural
+
+- `moduleKey = trust_bar`.
+- `moduleVersion = 1`.
+- Função:
+  - apresentar sinais curtos e verificáveis de confiança;
+  - reduzir a insegurança inicial;
+  - sustentar a continuidade da leitura ou a aproximação do CTA.
+- O módulo é opcional na composição.
+- Sua posição mais comum é após o Hero, mas ordem e ocorrência pertencem à E20.
+
+#### 2.16.2. Evidência e equivalência
+
+- Evidência estrutural:
+  - candidato `barra_de_confianca` da grade de `lp_sections`;
+  - blueprint imobiliário com prova curta imediata;
+  - exemplos documentados: especialização, registro profissional, privacidade e marca parceira.
+- Função transversal:
+  - responder rapidamente se a empresa, profissional ou oferta possui sinais reais de confiança.
+- A evidência imobiliária orienta o primeiro caso, mas o módulo não carrega identidade de taxon.
+
+#### 2.16.3. Fronteiras
+
+Pertencem:
+
+- credencial ou registro verificável;
+- especialização real;
+- capacidade operacional concreta;
+- informação curta de segurança ou privacidade;
+- parceria ou vínculo real;
+- outro sinal curto sustentado por dado operacional.
+
+Não pertencem:
+
+- depoimentos ou avaliações;
+- prova social extensa;
+- explicação institucional;
+- política de privacidade completa;
+- prova técnica detalhada;
+- CTA;
+- formulário;
+- mídia;
+- selo, certificação, parceria, experiência ou resultado inventado.
+
+#### 2.16.4. Catálogo de campos v1
+
+- `items`:
+  - `fieldKind = collection`;
+  - cardinalidade `2..4`;
+  - policy `not_copy` no contêiner;
+  - contrato fechado do item:
+    - `text`:
+      - `fieldKind = text`;
+      - `semanticRole = benefit_item`;
+      - cardinalidade `1..1`;
+      - policy `hybrid`;
+      - `operationalSupportRequirement = when_present`.
+- A coleção não admite item aninhado.
+- A v1 não possui título, subtítulo, CTA, ícone ou mídia próprios.
+- A redação herda as faixas da raiz para `benefit_item`, sem especialização própria.
+
+#### 2.16.5. Fontes de copy e suporte
+
+- `copySourceMap` de `items.text`:
+  - primárias:
+    - `proof_type`;
+    - `belief`;
+  - auxiliar:
+    - `objection`.
+- Pesquisa orienta seleção, relevância e redação.
+- Pesquisa e `copySourceMap` não comprovam o sinal exibido.
+- Cada item presente exige suporte operacional real aplicável.
+- A E19 deve omitir o módulo quando não conseguir resolver ao menos dois sinais válidos.
+
+#### 2.16.6. Perfis de funil
+
+- BOFU:
+  - prioriza credencial, parceria, capacidade concreta e segurança verificável;
+  - usa redação direta e decisória.
+- MOFU:
+  - prioriza especialização, processo, orientação e suporte oferecido;
+  - reduz risco sem pressão excessiva.
+- TOFU:
+  - prioriza identificação clara, privacidade, atendimento humano e transparência;
+  - usa confiança leve e baixa fricção.
+- O perfil altera seleção, ordem e redação dos itens.
+- O perfil não altera campos, cardinalidade, módulo ou variante.
+
+#### 2.16.7. Variante `trust_bar.standard`
+
+- `variantKey = trust_bar.standard`.
+- `variantVersion = 1`.
+- Compatível com `moduleVersion = 1`.
+- Execução-base com delta vazio.
+- Única variante inicial.
+- Disposição horizontal, quebra de linha ou empilhamento mobile são comportamento responsivo do renderer, não novas variantes.
+- A variante está conceitualmente fechada na v1.
+
+#### 2.16.8. Lifecycle e compatibilidade
+
+- `moduleCatalogVersion = 1` proposto.
+- `moduleVersion = 1` fechado conceitualmente.
+- `variantVersion = 1` fechada conceitualmente.
+- Módulo e variante começam `experimental`.
+- Propósito inicial: `controlled_test`.
+- Promoção exige uso em LP real, revisão e decisão humanas.
+
+#### 2.16.9. Casos executáveis da E18.5
+
+- Validar identidade e função transversal.
+- Aceitar somente o campo `items` na v1.
+- Validar cardinalidade `2..4`.
+- Validar o contrato fechado de `items.text`.
+- Validar policy `hybrid` com `operationalSupportRequirement = when_present`.
+- Validar `copySourceMap` dentro do limite comum.
+- Rejeitar CTA, mídia, item aninhado, campo adicional ou variante não aprovada.
+- Confirmar que TOFU, MOFU e BOFU não alteram schema ou variante.
+- Retornar contrato imutável.
+
+#### 2.16.10. Invariantes futuras de conteúdo para E19
+
+- Resolver de dois a quatro itens válidos.
+- Exigir suporte operacional real para cada item.
+- Proibir credencial, parceria, experiência, certificação, capacidade ou resultado inventado.
+- Não tratar pesquisa como comprovação factual.
+- Evitar duplicidade material entre itens.
+- Manter os textos curtos, claros e relevantes para o público e o funil.
+- Omitir o módulo quando houver menos de dois sinais válidos.
+- Não inserir CTA, mídia, depoimento ou explicação extensa.
+
+#### 2.16.11. Fechamento da `trust_bar`
+
+Contrato conceitual aprovado na v1:
+
+- função e fronteiras;
+- coleção `items` com cardinalidade `2..4`;
+- contrato fechado de `items.text`;
+- fontes de copy e suporte operacional;
+- perfis BOFU, MOFU e TOFU;
+- variante única `trust_bar.standard`;
+- lifecycle inicial e propósito de teste;
+- casos E18.5 e invariantes E19.
+
+Estado:
+
+- `trust_bar` está conceitualmente fechada na v1;
+- `trust_bar.standard` está conceitualmente fechada na v1;
+- implementação permanece condicionada ao catálogo de módulos e ao fluxo futuro da E19.
+
 ## 3. Fases e próxima ação
 
 ### 3.1. E18.5.3–E18.5.9 — Catálogo versionado de módulos e variantes v1
@@ -817,9 +974,13 @@ Validações E18.5:
 - Hero:
   - contrato conceitual fechado;
   - implementação bloqueada pela raiz.
+- `trust_bar`:
+  - contrato conceitual fechado;
+  - variante `trust_bar.standard` fechada;
+  - implementação condicionada ao catálogo de módulos e à E19.
 - Próxima ação:
-  - iniciar análise de `trust_bar` pela grade metodológica comum;
-  - seguir os oito candidatos restantes;
+  - iniciar análise de `problem_solution` pela grade metodológica comum;
+  - seguir os sete candidatos restantes;
   - evoluir a raiz antes da implementação;
   - concluir pareceres, v2 e merge humano.
 
@@ -865,5 +1026,10 @@ Parar se:
 - Elegibilidade inclui a raiz e não presume lifecycle do catálogo.
 - E18.5 e E19 permanecem separadas.
 - Hero e `hero.standard` estão finalizados conceitualmente na v1.
+- `trust_bar` possui coleção de dois a quatro sinais reais de confiança.
+- TOFU, MOFU e BOFU alteram somente seleção, ordem e redação dos itens.
+- `trust_bar.standard` é a única variante inicial, com delta vazio.
+- `trust_bar` e `trust_bar.standard` estão finalizadas conceitualmente na v1.
+- Sete módulos candidatos permanecem pendentes.
 - A implementação continua bloqueada pela evolução tipográfica e responsiva da raiz.
-- Próxima ação humana: iniciar `trust_bar` e seguir a grade dos oito módulos restantes.
+- Próxima ação humana: iniciar `problem_solution`.

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -4,7 +4,7 @@ Fontes: chat, `README.md`, `AGENTS.md`, `docs/roadmap.md`, `docs/base-tecnica.md
 
 Versão: v1 em ajuste.
 
-Status: plano simplificado; nove módulos mantidos no escopo; `hero`, `hero.standard@v1`, `trust_bar` e `trust_bar.standard@v1` conceitualmente fechados; sete módulos pendentes; nenhuma implementação autorizada neste PR.
+Status: plano simplificado; nove módulos mantidos no escopo; `hero`, `hero.standard@v1`, `trust_bar`, `trust_bar.standard@v1`, `problem_solution` e `problem_solution.standard@v1` conceitualmente fechados; seis módulos pendentes; nenhuma implementação autorizada neste PR.
 
 Path: `docs/lousa-plano-base-e18-5.md`.
 
@@ -48,7 +48,7 @@ Regras:
 - `item_key` é evidência de pesquisa, não identidade canônica do módulo.
 - Os módulos são transversais e não recebem identidade de taxon.
 - Formatos curto, médio e longo pertencem à composição e à extensão da LP.
-- O próximo módulo para análise é `problem_solution`.
+- O próximo módulo para análise é `offer`.
 
 ### 1.4. Escopo positivo
 
@@ -420,13 +420,102 @@ Estado:
 - propósito `controlled_test`;
 - implementação ainda não autorizada por este ajuste documental.
 
+### 3.5. Módulo `problem_solution`
+
+- `moduleKey = problem_solution`.
+- `moduleVersion = 1`.
+- Função:
+  - apresentar problemas, fricções ou riscos reconhecíveis pelo público;
+  - relacionar cada problema a uma resposta prática e coerente;
+  - transformar posicionamento abstrato em relevância concreta antes da oferta ou do processo.
+- Invariantes:
+  - cada problema possui uma solução diretamente correspondente;
+  - problema e solução permanecem distinguíveis;
+  - o problema não usa alarmismo, medo artificial ou alegação não sustentada;
+  - a solução não promete resultado, garantia ou capacidade inexistente;
+  - ausência de identidade de taxon, plano, campanha ou funil no contrato.
+- Fronteiras:
+  - não substitui proposta principal da Hero;
+  - não detalha catálogo de serviços, preço, condição comercial ou oferta;
+  - não descreve sequência de atendimento;
+  - não apresenta prova técnica, depoimento, credencial, FAQ ou CTA;
+  - não contém mídia, formulário ou interação na execução inicial.
+- Evidências principais:
+  - `dores_e_solucoes`, pesquisa ativa de `lp_sections`, taxon `Corretor Imóveis`;
+  - itens `pain`, `fear`, `objection`, `desire`, `belief` e `positioning_opportunity` de `strategic_core`;
+  - Blueprint do corretor, especialmente dores, objeções, riscos percebidos e diferenciais objetivos.
+- Variantes futuras podem usar outra execução estrutural sem alterar `problem_solution.standard@v1`.
+
+### 3.6. Variante `problem_solution.standard@v1`
+
+Identidade:
+
+- `variantKey = problem_solution.standard`.
+- `variantVersion = 1`.
+- Compatível com `problem_solution@v1` e com a versão vigente da raiz utilizada na implementação inicial.
+- Única variante inicial.
+
+Campos:
+
+- `title`:
+  - texto, papel `h2`, cardinalidade `1..1`, policy `research_guided`.
+- `items`:
+  - coleção, cardinalidade `2..4`, policy `not_copy`;
+  - item fechado com `problem` e `solution`;
+  - `problem`: texto, papel `card_title`, cardinalidade `1..1`, policy `research_guided`;
+  - `solution`: texto, papel `card_body`, cardinalidade `1..1`, policy `hybrid`, suporte `when_present`.
+
+Copy:
+
+- `title`: primárias `pain` e `desire`; auxiliar `positioning_opportunity`.
+- `problem`: primárias `pain` e `fear`; auxiliar `objection`.
+- `solution`: primárias `positioning_opportunity` e `desire`; auxiliar `belief`.
+
+Regras específicas:
+
+- uma ocorrência válida contém de dois a quatro pares completos;
+- cada item contém exatamente um `problem` e uma `solution`;
+- a solução responde diretamente ao problema do mesmo item;
+- problemas devem ser concretos, reconhecíveis e proporcionais, sem amplificação artificial;
+- toda solução apresentada exige suporte operacional real;
+- a pesquisa orienta a solução, mas não comprova serviço, método, prazo, condição, garantia ou resultado;
+- os papéis `h2`, `card_title` e `card_body` usam as faixas da raiz sem especialização na v1;
+- a coleção não admite item aninhado;
+- não possui subtítulo, CTA, mídia, ícone, prova, preço, lista detalhada de serviços ou etapas de processo;
+- diferenças de copy, quantidade dentro de `2..4`, ordem dos pares e funil não criam variante;
+- o tratamento da ausência de pares válidos depende da obrigatoriedade definida pela composição da E20 e será especificado pela E19.
+
+Funil:
+
+- BOFU prioriza fricções decisórias e respostas operacionais diretas.
+- MOFU prioriza compreensão, comparação e redução de objeções.
+- TOFU prioriza problemas amplos e respostas educativas de baixa pressão.
+- O funil altera seleção, prioridade e redação dos pares, sem alterar campos, cardinalidades, variante ou ordem estrutural da LP.
+
+Validações estruturais:
+
+- exigir `title` e `items`;
+- exigir cardinalidade `2..4` em `items`;
+- exigir exatamente `problem` e `solution` em cada item;
+- rejeitar coleção aninhada e campos extras;
+- validar os papéis semânticos e as policies declaradas;
+- exigir suporte `when_present` em `solution`;
+- rejeitar CTA, mídia, ação, prova, preço, processo ou referência técnica na variante;
+- resolver de forma fail-closed e imutável.
+
+Estado:
+
+- contrato conceitualmente fechado;
+- lifecycle `experimental`;
+- propósito `controlled_test`;
+- implementação ainda não autorizada por este ajuste documental.
+
 ## 4. Módulos pendentes
 
 ### 4.1. Estado
 
 Permanecem pendentes:
 
-- `problem_solution`;
 - `offer`;
 - `process`;
 - `technical_assurance`;
@@ -455,8 +544,8 @@ A etapa seguinte só deve reproduzir o contrato compartilhado após ele estar va
 
 ### 4.3. Próxima ação
 
-- Analisar `problem_solution` pelo checklist mínimo da seção 2.9.
-- Separar `problem_solution` de `problem_solution.standard@v1`.
+- Analisar `offer` pelo checklist mínimo da seção 2.9.
+- Separar `offer` de `offer.standard@v1`.
 - Não alterar o arquivo novamente sem decisão humana sobre o contrato proposto.
 - Não implementar código durante o fechamento conceitual.
 

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -144,6 +144,12 @@ Cada campo usado por uma variante declara:
 - suporte operacional, quando aplicável;
 - capability específica, quando aplicável.
 
+Notação da seção 3:
+
+- campo textual usa `fieldKey: semanticRole, cardinalidade, policy[, suporte]`; somente nessa notação `fieldKind = text` fica implícito;
+- coleção, ação, mídia e referência técnica declaram o `fieldKind` explicitamente;
+- campos internos de coleção declaram sua própria cardinalidade, sem inferência por omissão.
+
 Regras:
 
 - cardinalidade representa obrigatoriedade;
@@ -245,6 +251,12 @@ Um módulo está implementado na E18.5 quando existem:
 
 Isso não inclui seção visual funcional.
 
+Compatibilidade comum da seção 3:
+
+- salvo indicação contrária, cada variante `standard@v1` é compatível exclusivamente com o respectivo módulo `@v1` e com a versão da raiz declarada pelo catálogo inicial;
+- `faq.accordion@v1` possui a mesma compatibilidade explícita com `faq@v1` e com essa versão da raiz;
+- definições compartilhadas podem ser reutilizadas na implementação, mas uma variante não herda semanticamente o contrato de uma variante irmã.
+
 ## 3. Contratos conceitualmente fechados
 
 ### 3.1. Módulo `hero`
@@ -261,7 +273,7 @@ Isso não inclui seção visual funcional.
   - `eyebrow`: `eyebrow`, `0..1`, `research_guided`;
   - `title`: `h1`, `1..1`, `hybrid`, suporte `when_factual`;
   - `subtitle`: `paragraph`, `1..1`, `hybrid`, suporte `when_factual`;
-  - `primaryCta`: ação `1..1`, `not_copy`, label `cta_label`, `hybrid`, suporte `when_present`, vínculo obrigatório com `primary_conversion_channel`;
+  - `primaryCta`: ação `1..1`, `not_copy`, label `cta_label`, `1..1`, `hybrid`, suporte `when_present`, vínculo obrigatório com `primary_conversion_channel`;
   - `proofShort`: `paragraph`, `0..1`, `hybrid`, suporte `when_present`;
   - `media`: imagem `0..1`, `technical_reference`, modo `informative` ou `decorative`.
 - Copy:
@@ -289,7 +301,7 @@ Isso não inclui seção visual funcional.
 
 ### 3.4. Variante `trust_bar.standard@v1`
 
-- Campo `items`: coleção `2..4`, `not_copy`, item `text` com papel `benefit_item`, `hybrid`, suporte `when_present`.
+- Campo `items`: coleção `2..4`, `not_copy`, com `text`: `benefit_item`, `1..1`, `hybrid`, suporte `when_present`.
 - Copy: `proof_type` e `belief`; auxiliar `objection`.
 - Regras:
   - cada item exige suporte operacional real;
@@ -310,7 +322,9 @@ Isso não inclui seção visual funcional.
 
 - Campos:
   - `title`: `h2`, `1..1`, `research_guided`;
-  - `items`: coleção `2..4`, `not_copy`, com `problem` (`card_title`, `research_guided`) e `solution` (`card_body`, `hybrid`, suporte `when_present`).
+  - `items`: coleção `2..4`, `not_copy`, com:
+    - `problem`: `card_title`, `1..1`, `research_guided`;
+    - `solution`: `card_body`, `1..1`, `hybrid`, suporte `when_present`.
 - Copy:
   - `title`: `pain` e `desire`; auxiliar `positioning_opportunity`;
   - `problem`: `pain` e `fear`; auxiliar `objection`;
@@ -333,7 +347,9 @@ Isso não inclui seção visual funcional.
 
 - Campos:
   - `title`: `h2`, `1..1`, `research_guided`;
-  - `items`: coleção `1..4`, `not_copy`, com `itemTitle` (`card_title`, `hybrid`) e `description` (`card_body`, `hybrid`), ambos com suporte `when_present`.
+  - `items`: coleção `1..4`, `not_copy`, com:
+    - `itemTitle`: `card_title`, `1..1`, `hybrid`, suporte `when_present`;
+    - `description`: `card_body`, `1..1`, `hybrid`, suporte `when_present`.
 - Copy:
   - `title`: `desire` e `trigger`; auxiliar `positioning_opportunity`;
   - `itemTitle`: `trigger` e `desire`;
@@ -356,7 +372,9 @@ Isso não inclui seção visual funcional.
 
 - Campos:
   - `title`: `h2`, `1..1`, `research_guided`;
-  - `steps`: coleção ordenada `2..6`, `not_copy`, com `stepTitle` (`step_title`, `hybrid`) e `stepBody` (`step_body`, `hybrid`), ambos com suporte `when_present`.
+  - `steps`: coleção ordenada `2..6`, `not_copy`, com:
+    - `stepTitle`: `step_title`, `1..1`, `hybrid`, suporte `when_present`;
+    - `stepBody`: `step_body`, `1..1`, `hybrid`, suporte `when_present`.
 - Copy:
   - `title`: `belief` e `desire`; auxiliar `positioning_opportunity`;
   - `stepTitle`: `trigger` e `positioning_opportunity`; auxiliar `desire`;
@@ -379,7 +397,9 @@ Isso não inclui seção visual funcional.
 
 - Campos:
   - `title`: `h2`, `1..1`, `research_guided`;
-  - `items`: coleção `1..4`, `not_copy`, com `assuranceTitle` (`card_title`, `hybrid`) e `assuranceBody` (`card_body`, `hybrid`), ambos com suporte `when_present`.
+  - `items`: coleção `1..4`, `not_copy`, com:
+    - `assuranceTitle`: `card_title`, `1..1`, `hybrid`, suporte `when_present`;
+    - `assuranceBody`: `card_body`, `1..1`, `hybrid`, suporte `when_present`.
 - Copy:
   - `title`: `proof_type` e `belief`; auxiliar `objection`;
   - `assuranceTitle`: `proof_type`; auxiliar `belief`;
@@ -402,7 +422,10 @@ Isso não inclui seção visual funcional.
 
 - Campos:
   - `title`: `h2`, `1..1`, `research_guided`;
-  - `items`: coleção `1..3`, `not_copy`, com `quote` (`card_body`, `operational_required`), `attribution` (`card_title`, `operational_required`) e `evidenceRef` (`technical_reference`).
+  - `items`: coleção `1..3`, `not_copy`, com:
+    - `quote`: `card_body`, `1..1`, `operational_required`;
+    - `attribution`: `card_title`, `1..1`, `operational_required`;
+    - `evidenceRef`: referência técnica, `1..1`, `technical_reference`.
 - Copy:
   - `title`: `proof_type` e `belief`; auxiliar `objection`;
   - `quote` e `attribution`: exclusivamente da evidência operacional referenciada.
@@ -424,7 +447,9 @@ Isso não inclui seção visual funcional.
 
 - Campos:
   - `title`: `h2`, `1..1`, `research_guided`;
-  - `items`: coleção `2..6`, `not_copy`, com `question` (`faq_question`, `research_guided`) e `answer` (`faq_answer`, `hybrid`, suporte `when_factual`).
+  - `items`: coleção `2..6`, `not_copy`, com:
+    - `question`: `faq_question`, `1..1`, `research_guided`;
+    - `answer`: `faq_answer`, `1..1`, `hybrid`, suporte `when_factual`.
 - Copy:
   - `title`: `objection` e `awareness_level`; auxiliar `search_intent`;
   - `question`: `objection` e `fear`; auxiliar `faq_questions`;
@@ -441,7 +466,8 @@ Isso não inclui seção visual funcional.
 - Identidade: `faq.accordion@v1`, compatível com `faq@v1` e com a raiz vigente.
 - Finalidade: validar duas variantes do mesmo módulo e oferecer apresentação compacta, especialmente no mobile.
 - Conteúdo:
-  - reutiliza integralmente `title`, `items`, `question` e `answer` de `faq.standard@v1`;
+  - declara o mesmo contrato de campos de `faq.standard@v1`;
+  - a implementação pode reutilizar definições imutáveis compartilhadas, sem estabelecer herança entre variantes;
   - mantém cardinalidades, semantic roles, policies, copy e sustentação factual;
   - não adiciona campo de conteúdo.
 - Capability: interação de acordeão e requisitos de acessibilidade associados.
@@ -456,7 +482,7 @@ Isso não inclui seção visual funcional.
   - foco preservado no controle acionado.
 - Limites:
   - não define elemento HTML, componente, ícone, animação ou visual do renderer;
-  - não altera conteúdo, cardinalidade, copy ou sustentação factual herdados.
+  - não altera conteúdo, cardinalidade, copy ou sustentação factual declarados em seu próprio contrato.
 - Estado: `experimental`, `controlled_test`, candidata à primeira composição controlada.
 
 ### 3.18. Módulo `final_cta`
@@ -471,13 +497,13 @@ Isso não inclui seção visual funcional.
 
 - Identidade: `final_cta.standard@v1`, compatível com `final_cta@v1` e com a raiz vigente; única variante inicial.
 - Campos:
-  - `title`: texto, papel `h2`, `1..1`, policy `hybrid`, suporte `when_factual`;
-  - `body`: texto, papel `paragraph`, `1..1`, policy `hybrid`, suporte `when_factual`;
-  - `primaryCta`: ação `1..1`, policy `not_copy`, com label `cta_label`, `1..1`, `hybrid`, suporte `when_present`, e vínculo obrigatório com `primary_conversion_channel`.
+  - `title`: `h2`, `1..1`, `hybrid`, suporte `when_factual`;
+  - `body`: `paragraph`, `1..1`, `hybrid`, suporte `when_factual`;
+  - `primaryCta`: ação `1..1`, `not_copy`, com label `cta_label`, `1..1`, `hybrid`, suporte `when_present`, e vínculo obrigatório com `primary_conversion_channel`.
 - Copy:
-  - `title`: primárias `trigger` e `desire`; auxiliar `positioning_opportunity`;
-  - `body`: primárias `desire` e `objection`; auxiliar `belief`;
-  - `primaryCta.label`: primária `trigger`; auxiliar `search_intent`.
+  - `title`: `trigger` e `desire`; auxiliar `positioning_opportunity`;
+  - `body`: `desire` e `objection`; auxiliar `belief`;
+  - `primaryCta.label`: `trigger`; auxiliar `search_intent`.
 - Regras:
   - uma única ação principal;
   - canais permitidos: `whatsapp`, `phone`, `email` e `external_url`;


### PR DESCRIPTION
## 1. Escopo

Plano-base v2 da E18.5, consolidado com os pareceres e com a execução corrigida para as subseções previstas do roadmap.

## 2. Estado

- plano aprovado humanamente em 19/07/2026 para implementação manual comparativa;
- sete fases executáveis: `18.5.3` a `18.5.9`;
- o Executor recebe somente a fase atual, uma por vez;
- PR documental e draft;
- base: `docs/e18-5-modules-variants`;
- head: `codex-app/e18-5-v2-processo-atual`;
- próxima entrega ocorrerá em nova branch filha do head deste PR, iniciando por `18.5.3`.

## 3. Ajustes finais

- somente literais nas policies, treatments e `ctaMode`;
- `absoluteMax` aplicado com helpers canônicos da raiz;
- resolver e payload validator com assinaturas fechadas;
- lifecycle da raiz, módulo, variante e efetivo;
- fases alinhadas a `18.5.3`–`18.5.9` conforme `docs/lp-planejamento.md`;
- `18.5.10` permanece limite documental, sem fase administrativa;
- fluxo experimental definido para comparação manual versus automatizada.

## 4. Limites

- nenhum PR experimental deve ser mergeado antes da comparação;
- sem banco, rota, composição, renderer, persistência, tracking ou automação;
- sem variante adicional além de `faq.accordion@v1`.