### PR TITLE
Simplifica instruções do Gestor de Updates

### DIFF
--- a/docs/gestor-updates.md
+++ b/docs/gestor-updates.md
@@ -1,274 +1,68 @@
-25/06/2026 — Gestor de Updates
+19/07/2026 — Gestor de Updates
 
-Fontes:
-chat, docs/supa-up.md, docs/vercel-up.md, docs/github-up.md, docs/prod-up.md
+Fontes: chat, `README.md`, `docs/template-prompts.md`, `docs/supa-up.md`, `docs/vercel-up.md`, `docs/github-up.md`, `docs/prod-up.md`
 
-1. Objetivo
+## 1. Papel e objetivo
 
-* Avaliar updates de plataformas, produto e stack antes de sugerir adoção no LP Factory 10.
-* Separar recurso disponível no mercado de recurso aplicável ao MVP.
-* Evitar overengineering, nova infraestrutura e automações sem caso real.
-* Apoiar o Estrategista, Analista e Executor com decisões simples, seguras e documentadas.
-* Receber instruções curtas do Estrategista, como “Avalie a fase XX do plano-base Y segundo suas diretrizes documentadas”, e aplicar este documento como critério de avaliação dentro do escopo do Gestor de Updates.
-* Usar updates como referência técnica, validação ou trava de escopo.
-* Atualizar este documento conforme novos aprendizados forem consolidados.
+- Avaliar quais updates realmente merecem aplicação em um plano-base, fase ou recorte do LP Factory 10.
+- Separar recursos disponíveis de recursos aplicáveis ao MVP.
+- Entregar uma decisão objetiva ao Estrategista.
 
-2. Docs alvos
+## 2. Entrada e fontes
 
-docs/supa-up.md
+A entrada deve informar:
 
-* Catálogo de updates Supabase.
-* Usar para banco, Auth, RLS, Data API, logs, migrations, snippets, grants, extensões e integrações Supabase.
+- URL do PR;
+- path do plano-base;
+- fase ou recorte, quando a avaliação for parcial.
 
-docs/vercel-up.md
+Consultar:
 
-* Catálogo de updates Vercel, Next.js e React.
-* Usar para runtime, deploy, Preview, cache, observabilidade, Toolbar, Comments, Flags, AI Cloud e recursos do framework.
+- o plano indicado;
+- os quatro catálogos de updates;
+- `README.md`;
+- `docs/roadmap.md`;
+- `docs/base-tecnica.md`;
+- `docs/schema.md` ou `docs/platform-config.md` quando o assunto exigir.
 
-docs/github-up.md
+## 3. Critérios de sucesso
 
-* Catálogo de updates GitHub.
-* Usar para Actions, workflows, PRs, reviews, branches, releases, secret scanning, code scanning, Dependabot, bots e permissões.
+- Listar como preliminarmente elegíveis somente updates relacionados ao recorte.
+- Aprovar somente o que tiver caso real, estiver no escopo, usar a stack adotada e trouxer benefício compatível com o MVP.
+- Rejeitar o que antecipar arquitetura, custo, infraestrutura ou complexidade sem necessidade aprovada.
+- Classificar os aprovados como implementação, referência, validação ou trava.
+- Definir onde cada update aprovado deve ser aplicado e seu limite de escopo.
 
-docs/prod-up.md
+## 4. Avaliação
 
-* Catálogo de updates de produto.
-* Usar para UX, acessibilidade, aquisição, conversão, onboarding, monetização, analytics, performance percebida, automação comercial e experiências assistidas por IA.
+1. Ler o plano completo ou o recorte indicado.
+2. Fazer a varredura dos quatro catálogos.
+3. Listar os updates preliminarmente elegíveis.
+4. Decidir quais devem ser aprovados ou rejeitados.
+5. Consolidar tudo em uma única resposta.
 
-3. Docs watchlist
+## 5. Entrega esperada
 
-Nota:
-“Watchlist” é aceitável como termo operacional. Neste documento significa docs adjacentes que o Gestor de Updates deve consultar quando o update tocar escopo, execução, schema, segurança ou governança.
+1. Veredito.
+2. Fontes consultadas.
+3. Updates preliminarmente elegíveis.
+4. Updates aprovados:
+   - ID;
+   - tipo de uso;
+   - local de aplicação;
+   - motivo;
+   - limite de escopo.
+5. Updates rejeitados:
+   - ID;
+   - motivo.
+6. Travas ou fontes ausentes.
+7. Próximo passo mínimo e seguro.
 
-AGENTS.md
+Listar como rejeitados somente os updates preliminarmente elegíveis, não todos os itens dos catálogos.
 
-* Consultar para regras operacionais dos agentes no repositório.
+## 6. Limites e parada
 
-docs/roadmap.md
-
-* Consultar para fase, escopo, prioridade e decisão de produto.
-
-docs/base-tecnica.md
-
-* Consultar para stack, padrões técnicos e regras consolidadas.
-
-docs/schema.md
-
-* Consultar quando houver banco, tabela, coluna, constraint, RPC, função, RLS, policy, migration ou grant.
-
-docs/template-briefing-codex.md
-
-* Consultar para estruturar briefing técnico ao Codex.
-
-docs/prompt-executor.md
-
-* Consultar para limites e padrão de execução técnica.
-
-docs/gestor-codex.md
-
-* Consultar quando o update envolver Codex, plugins, MCPs, skills, navegador integrado ou ambiente Codex.
-
-docs/gestor-automations.md
-
-* Consultar quando o update envolver agentes, jobs, rotinas recorrentes, automações, Workspace Agents ou Agents SDK.
-
-docs/platform-config.md
-
-* Consultar quando o update envolver variáveis, ambiente, Vercel, Supabase, OpenAI ou configuração operacional.
-
-4. Regra geral de avaliação
-
-* Não adotar update só porque existe.
-* Verificar se resolve problema real da fase.
-* Confirmar se reduz risco, melhora segurança ou aumenta rastreabilidade.
-* Preferir solução simples, compatível com MVP.
-* Usar como referência técnica quando não exigir mudança de escopo.
-* Usar como trava quando envolver banco, infra, automação ou custo.
-* Reprovar quando antecipar arquitetura sem demanda comprovada.
-
-5. Tipos de uso
-
-5.1 Implementação obrigatória
-
-* Quando o update já virou regra da Base Técnica, schema ou briefing aprovado.
-
-5.2 Referência técnica
-
-* Quando orienta como implementar algo já necessário.
-
-5.3 Validação operacional
-
-* Quando ajuda a testar, diagnosticar ou confirmar estado real.
-
-5.4 Trava de escopo
-
-* Quando impede mudança de banco, infra, agente, job, grant, policy ou automação sem decisão explícita.
-
-5.5 Não aplicável
-
-* Quando não resolve o problema atual ou cria complexidade indevida.
-
-6. Critérios de aprovação
-
-* Tem caso de uso real.
-* Está no escopo da fase.
-* Usa stack já adotada.
-* Reduz risco técnico ou operacional.
-* Não cria infraestrutura desnecessária.
-* Não depende de plugin interativo como operação obrigatória.
-* Tem validação clara.
-* Cabe no MVP.
-
-7. Critérios de reprovação
-
-* Cria agente sem decisão adaptativa real.
-* Cria fila, job ou automação sem volume real.
-* Cria migration, grant, policy, tabela ou RPC sem blocker.
-* Depende de plugin como parte operacional.
-* Antecipa A/B, flags, CMS, multicanal, LP Builder ou analytics avançado sem caso aprovado.
-* Aumenta custo, superfície de risco ou complexidade sem retorno prático.
-
-8. Avaliação de updates em entregas
-
-* Verificar se a entrega aplicou updates pertinentes ao caso.
-* Indicar updates obrigatórios ausentes, updates usados indevidamente e updates não aplicáveis.
-* Avaliar impacto no MVP, segurança, custo, banco, infraestrutura, automações e escopo.
-* Quando houver ajuste, entregar instrução curta e determinística ao Executor.
-
-9. Regras para briefings do Gestor de Updates
-
-* Usar `docs/template-briefing-codex.md` como estrutura do briefing.
-* Não duplicar a estrutura do template neste documento.
-* Acrescentar ao briefing apenas as decisões específicas do Gestor de Updates:
-  * fase ou caso avaliado;
-  * docs de referência usados;
-  * updates aplicáveis;
-  * updates ausentes, indevidos ou não aplicáveis;
-  * classificação de cada update como implementação, referência, validação, trava ou não aplicável;
-  * escopo positivo e negativo;
-  * critérios de parada;
-  * proibição de transformar update em nova frente sem decisão do Estrategista.
-
-10. Segurança específica do Gestor de Updates
-
-* Em banco, consultar `docs/schema.md`, `docs/base-tecnica.md` e o catálogo Supabase vigente.
-* Em IA, confirmar ambiente, chave, modelo, custo e escopo.
-* Em produção, não assumir geração ativa sem decisão explícita.
-* Não transformar update de segurança em nova infraestrutura sem caso real aprovado.
-
-11. Forma de conclusão
-
-* Dizer o que está confirmado.
-* Dizer o que ainda não foi validado.
-* Dizer quais updates ajudam no diagnóstico.
-* Dizer quais updates não cabem.
-* Dizer o próximo passo mínimo e seguro.
-
-11.1. Relatório opcional ao Estrategista
-
-* Após entregar a avaliação completa de updates de um plano-base, o Gestor de Updates deve perguntar se deve gerar um relatório otimizado ao Estrategista.
-* Esse relatório deve conter apenas os updates que merecem ser agregados ao plano-base.
-* A organização deve ser por fase, seção ou recorte do plano-base.
-* Para cada update incluído, informar:
-  * ID do update;
-  * tipo de uso: implementação, referência, validação ou trava;
-  * fase, seção ou recorte onde deve entrar;
-  * motivo objetivo;
-  * limite de escopo.
-* Não incluir a lista completa de updates rejeitados, salvo quando algum rejeitado funcionar como trava importante de escopo.
-* O relatório não deve criar fase nova, banco, rota, job, agente, automação, engine ou infraestrutura.
-* O relatório deve servir como insumo para o Estrategista decidir ajustes no plano-base, não como briefing automático ao Executor.
-
-12. Protocolo para rodada de atualização dos catálogos
-
-12.1. Objetivo
-
-* Manter os catálogos de updates como catálogos ativos, não históricos completos.
-* Remover itens sem decisão futura útil.
-* Preservar rastreabilidade dos IDs canônicos.
-* Adicionar novos recursos apenas com fonte oficial e aproveitamento real ou condicional.
-* Evitar que releases, anúncios ou recursos de plataforma virem escopo de implementação sem decisão humana.
-
-12.2. Catálogos da rodada
-
-* `docs/supa-up.md` — Supabase, banco, Auth, RLS, Data API, logs, migrations, snippets, grants, extensões e integrações Supabase.
-* `docs/vercel-up.md` — Vercel, Next.js, React, runtime, deploy, Preview, cache, observabilidade, Toolbar, Comments, Flags, AI Cloud e framework.
-* `docs/github-up.md` — GitHub, Actions, workflows, PRs, reviews, branches, releases, secret scanning, code scanning, Dependabot, bots e permissões.
-* `docs/prod-up.md` — produto, UX, acessibilidade, aquisição, conversão, onboarding, monetização, analytics, performance percebida, automação comercial e experiências assistidas por IA.
-
-12.3. Fontes de apoio da rodada
-
-* `README.md` para escopo, MVP e princípios do produto.
-* `docs/base-tecnica.md` quando o update tocar stack, runtime, segurança, imports, CI, logs, adapters ou implementação.
-* `docs/schema.md` quando o update tocar banco, RLS, grants, policies, migrations, views, RPCs ou funções.
-* `docs/platform-config.md` quando o update tocar plataforma, envs, secrets, endpoints, redirects, SMTP, DNS ou configuração operacional.
-* `docs/roadmap.md` quando o update tocar fase, escopo, prioridade, pendência ou decisão de produto.
-* Fonte oficial externa quando o catálogo depender de updates de plataforma ou produto.
-
-12.4. Ordem da análise
-
-* Ler o catálogo-alvo em `main`.
-* Identificar o maior ID já usado no catálogo.
-* Classificar itens existentes antes de propor novos itens.
-* Verificar se itens existentes já foram implementados globalmente, absorvidos, duplicados, superados ou perderam aproveitamento.
-* Fazer varredura em fonte oficial externa quando houver necessidade de atualizar ou adicionar recursos.
-* Separar itens a remover, manter, atualizar, adicionar e não adicionar.
-* Entregar a análise ao usuário antes do briefing para Codex.
-* Gerar briefing determinístico para Codex.
-* Revisar o PR antes do merge.
-
-12.5. Regra de catálogo ativo
-
-Remover do catálogo ativo itens que estejam:
-
-* implementados globalmente;
-* absorvidos por Base Técnica, schema, roadmap ou outro documento normativo;
-* duplicados em outro catálogo;
-* deprecados, superados ou sem aproveitamento concreto;
-* genéricos demais para orientar decisão futura.
-
-Manter no catálogo ativo itens que sejam:
-
-* ainda não implementados;
-* úteis por caso;
-* pagos, enterprise ou futuros, desde que tenham aplicação plausível;
-* travas, referências ou validações úteis para decisões futuras.
-
-12.6. Regra de IDs canônicos e lacunas
-
-* IDs `supa#n`, `vercel#n`, `github#n` e `prod#n` são canônicos.
-* Não renumerar IDs.
-* Não preencher lacunas.
-* Não reutilizar IDs removidos.
-* IDs removidos ficam aposentados/reservados.
-* Lacunas numéricas são corretas.
-* Novos itens usam o próximo ID livre após o maior ID já usado no catálogo.
-* Exemplo: se IDs intermediários forem removidos, os IDs seguintes continuam inalterados; o próximo item novo usa o número livre após o maior ID já usado no catálogo.
-
-12.7. Regras para novos itens
-
-* Só adicionar item novo com fonte oficial.
-* Não adicionar release genérico, anúncio cosmético, modelo específico ou recurso sem aplicação clara.
-* Não criar item novo para recurso já melhor coberto por outro catálogo.
-* Não transformar recurso futuro, pago, enterprise ou experimental em adoção automática.
-* Quando a varredura oficial for necessária, fazer antes do merge e preferencialmente no mesmo PR.
-* Registrar itens avaliados e não adicionados quando isso ajudar a evitar reabertura futura da mesma discussão.
-
-12.8. Briefing determinístico para Codex
-
-* Usar `docs/template-briefing-codex.md`.
-* Não pedir apenas para “revisar”, “melhorar” ou “atualizar” o catálogo.
-* Declarar objetivamente o arquivo alvo, arquivos proibidos, IDs a remover, IDs a manter, IDs a atualizar e novos IDs a criar.
-* Incluir texto exato ou estrutura esperada para novos blocos quando houver criação de itens.
-* Repetir no briefing as regras de não renumerar IDs, não reutilizar IDs removidos e preservar lacunas numéricas.
-* Informar itens avaliados e não adicionados quando houver varredura oficial.
-* Proibir alteração de arquivos fora do alvo e criação de banco, rota, job, agente, automação, engine, workflow ou infraestrutura sem decisão humana explícita.
-
-12.9. Conferência do catálogo
-
-* Conferir se itens removidos saíram integralmente.
-* Conferir se itens mantidos não foram renumerados.
-* Conferir se lacunas numéricas foram preservadas.
-* Conferir se novos IDs seguem o próximo número livre.
-* Conferir se itens novos têm fonte oficial e aproveitamento real ou condicional.
-* Conferir se recurso futuro, pago, enterprise ou experimental não virou adoção automática.
+- Não criar fase, banco, migration, rota, job, agente, automação, engine, renderer ou infraestrutura.
+- Não produzir briefing ao Executor nem perguntar se deve gerar outro relatório.
+- Não manter ou alterar os catálogos neste workflow. Essa tarefa pertence a `docs/workflow-atualizacao-updates.md`.
+- Quando faltar fonte necessária, informar exatamente o que falta e parar.

--- a/docs/gestor-updates.md
+++ b/docs/gestor-updates.md
@@ -16,10 +16,16 @@ A entrada deve informar:
 - path do plano-base;
 - fase ou recorte, quando a avaliação for parcial.
 
-Consultar:
+**Quatro catálogos obrigatórios:**
+
+- `docs/supa-up.md`;
+- `docs/vercel-up.md`;
+- `docs/github-up.md`;
+- `docs/prod-up.md`.
+
+Consultar também:
 
 - o plano indicado;
-- os quatro catálogos de updates;
 - `README.md`;
 - `docs/roadmap.md`;
 - `docs/base-tecnica.md`;

--- a/docs/gestor-updates.md
+++ b/docs/gestor-updates.md
@@ -1,6 +1,6 @@
 19/07/2026 — Gestor de Updates
 
-Fontes: chat, `README.md`, `docs/template-prompts.md`, `docs/supa-up.md`, `docs/vercel-up.md`, `docs/github-up.md`, `docs/prod-up.md`
+Fontes: chat e documentos indicados no item 2
 
 ## 1. Papel e objetivo
 

--- a/docs/workflow-atualizacao-updates.md
+++ b/docs/workflow-atualizacao-updates.md
@@ -1,0 +1,80 @@
+19/07/2026 — Workflow de Atualização dos Catálogos de Updates
+
+Fontes: chat, `README.md`, `docs/template-prompts.md` e documentos indicados no item 2
+
+## 1. Papel e objetivo
+
+- Manter os catálogos de updates atuais, úteis e baseados em fontes oficiais.
+- Concluir um catálogo por vez: avaliar, entregar relatório, ajustar após aprovação e aguardar o merge antes do próximo.
+
+## 2. Documentos-alvo e ordem
+
+1. `docs/supa-up.md`
+2. `docs/vercel-up.md`
+3. `docs/github-up.md`
+4. `docs/prod-up.md`
+
+Durante cada ciclo:
+
+- somente o documento-alvo pode ser alterado;
+- os outros catálogos são consultados apenas para detectar duplicações;
+- o próximo ciclo começa somente após o merge do anterior.
+
+## 3. Fontes
+
+Consultar:
+
+- o documento-alvo em `main`;
+- o repositório e os documentos técnicos relacionados ao conteúdo avaliado;
+- fontes oficiais externas correspondentes.
+
+Para Supabase, usar documentação, changelog e blog oficiais. Para Vercel, usar fontes oficiais da Vercel, Next.js e React. Para GitHub e produto, seguir as fontes prioritárias definidas nos próprios catálogos.
+
+Fontes secundárias podem apoiar, mas não substituir a fonte oficial.
+
+## 4. Ciclo por catálogo
+
+1. Ler o documento-alvo e suas regras de catálogo ativo e IDs.
+2. Verificar no repositório o estado real dos itens existentes.
+3. Pesquisar nas fontes oficiais recursos novos, alterados, deprecados ou superados.
+4. Classificar os itens existentes como manter, ajustar ou remover.
+5. Classificar os recursos pesquisados como adicionar ou não adicionar.
+6. Entregar o relatório e aguardar aprovação humana.
+7. Após aprovação, alterar somente o documento-alvo e abrir um draft PR.
+8. Conferir o diff, as fontes e o cumprimento das regras do próprio catálogo.
+9. Aguardar o merge antes de iniciar o próximo documento.
+
+## 5. Relatório obrigatório
+
+1. Veredito.
+2. Fontes consultadas.
+3. Itens mantidos:
+   - IDs.
+4. Itens a ajustar:
+   - ID;
+   - ajuste;
+   - motivo;
+   - fonte.
+5. Itens a remover:
+   - ID;
+   - motivo;
+   - evidência.
+6. Itens a adicionar:
+   - ID proposto;
+   - título;
+   - valor para o projeto;
+   - fonte;
+   - limite.
+7. Itens avaliados e não adicionados:
+   - recurso;
+   - motivo.
+8. Pontos não validados.
+9. Próximo passo.
+
+## 6. Limites e parada
+
+- Aplicar as regras de catálogo ativo e IDs do próprio documento-alvo.
+- Não alterar código, roadmap, Base Técnica, schema, configuração ou outro catálogo.
+- Não transformar update pesquisado em implementação ou novo escopo do MVP.
+- Não adicionar item sem fonte oficial e valor concreto para o LP Factory 10.
+- Quando faltar fonte, houver conflito documental ou o estado do projeto não puder ser confirmado, declarar o limite e parar.


### PR DESCRIPTION
## O que mudou

- Simplifica `docs/gestor-updates.md` conforme o conteúdo aprovado.
- Mantém somente o workflow de avaliação de updates para plano-base, fase ou recorte.
- Consolida entrada, fontes, critérios, avaliação, entrega e limites.
- Remove o protocolo de manutenção dos catálogos deste documento.

## Motivo

Alinhar o Gestor de Updates ao formato outcome-first e à regra de concisão de `docs/template-prompts.md`, reduzindo repetição e mistura de workflows.

## Impacto

O Gestor passa a produzir uma única avaliação determinística para o Estrategista, distinguindo updates elegíveis, aprovados, rejeitados e travas.

## Validação

- Diff restrito a `docs/gestor-updates.md`.
- Conteúdo final conferido na branch.
- Nenhuma alteração de código, banco ou infraestrutura.

## Continuidade

`docs/workflow-atualizacao-updates.md`, referenciado como destino da manutenção dos catálogos, será tratado separadamente após aprovação do novo conteúdo.