### PR TITLE
feat: implementa E18.5.3 a E18.5.9 do catálogo

### DIFF
--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -618,7 +618,8 @@ Validações:
 
 Estado da fase:
 
-- fase `18.5.4` em execução;
+- fase `18.5.4` aguardando reavaliação após o ajuste;
+- fase `18.5.5` ainda não autorizada;
 - PR experimental permanece draft e sem merge.
 
 ### 4.3. Fase 3 — E18.5.5 — Variantes e critérios de criação

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -583,6 +583,12 @@ Validações:
 - `npm run check`;
 - `git diff --check`.
 
+Estado da fase:
+
+- definições estruturais do registry revisadas e ratificadas pelo Estrategista como contrato da v1;
+- ajuste solicitado e implementado para proteger os valores exatos de `function`, `boundaries` e `invariants` da v1;
+- fase `18.5.3` ainda aguardando reavaliação do Analista.
+
 ### 4.2. Fase 2 — E18.5.4 — Campos, estruturas e cardinalidades
 
 - Automação: não.

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -621,7 +621,8 @@ Estado da fase:
 - fase `18.5.4` concluída e aprovada;
 - fase `18.5.5` concluída e aprovada;
 - fase `18.5.6` concluída e aprovada;
-- fase `18.5.7` em execução;
+- fase `18.5.7` concluída e aprovada;
+- fase `18.5.8` em execução;
 - PR experimental permanece draft e sem merge.
 
 ### 4.3. Fase 3 — E18.5.5 — Variantes e critérios de criação

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -619,7 +619,8 @@ Validações:
 Estado da fase:
 
 - fase `18.5.4` concluída e aprovada;
-- fase `18.5.5` em execução;
+- fase `18.5.5` concluída e aprovada;
+- fase `18.5.6` em execução;
 - PR experimental permanece draft e sem merge.
 
 ### 4.3. Fase 3 — E18.5.5 — Variantes e critérios de criação

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -587,7 +587,7 @@ Estado da fase:
 
 - definições estruturais do registry revisadas e ratificadas pelo Estrategista como contrato da v1;
 - ajuste solicitado e implementado para proteger os valores exatos de `function`, `boundaries` e `invariants` da v1;
-- fase `18.5.3` ainda aguardando reavaliação do Analista.
+- fase `18.5.3` concluída e aprovada.
 
 ### 4.2. Fase 2 — E18.5.4 — Campos, estruturas e cardinalidades
 
@@ -615,6 +615,11 @@ Validações:
 - `npm run validate:landing-page-module-catalog`;
 - `npm run check`;
 - `git diff --check`.
+
+Estado da fase:
+
+- fase `18.5.4` em execução;
+- PR experimental permanece draft e sem merge.
 
 ### 4.3. Fase 3 — E18.5.5 — Variantes e critérios de criação
 

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -620,7 +620,8 @@ Estado da fase:
 
 - fase `18.5.4` concluída e aprovada;
 - fase `18.5.5` concluída e aprovada;
-- fase `18.5.6` em execução;
+- fase `18.5.6` concluída e aprovada;
+- fase `18.5.7` em execução;
 - PR experimental permanece draft e sem merge.
 
 ### 4.3. Fase 3 — E18.5.5 — Variantes e critérios de criação

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -622,7 +622,8 @@ Estado da fase:
 - fase `18.5.5` concluída e aprovada;
 - fase `18.5.6` concluída e aprovada;
 - fase `18.5.7` concluída e aprovada;
-- fase `18.5.8` em execução;
+- fase `18.5.8` concluída e aprovada;
+- fase `18.5.9` em execução;
 - PR experimental permanece draft e sem merge.
 
 ### 4.3. Fase 3 — E18.5.5 — Variantes e critérios de criação

--- a/docs/lousa-plano-base-e18-5.md
+++ b/docs/lousa-plano-base-e18-5.md
@@ -618,8 +618,8 @@ Validações:
 
 Estado da fase:
 
-- fase `18.5.4` aguardando reavaliação após o ajuste;
-- fase `18.5.5` ainda não autorizada;
+- fase `18.5.4` concluída e aprovada;
+- fase `18.5.5` em execução;
 - PR experimental permanece draft e sem merge.
 
 ### 4.3. Fase 3 — E18.5.5 — Variantes e critérios de criação

--- a/lib/conversion-content/index.ts
+++ b/lib/conversion-content/index.ts
@@ -4,6 +4,7 @@ export * from "./commercial-activation";
 export * as landingPageRoot from "./landing-page";
 export * as landingPageResearch from "./landing-page/research-resolution";
 export * as landingPageInputCatalog from "./landing-page/input-catalog";
+export * as landingPageModuleCatalog from "./landing-page/module-catalog";
 export {
   getCommercialActivationBundle,
   getCommercialActivationHierarchicalBundle,

--- a/lib/conversion-content/landing-page/index.ts
+++ b/lib/conversion-content/landing-page/index.ts
@@ -20,3 +20,7 @@ export type {
   ResolveLandingPageRootParametersResult,
 } from "./contracts";
 export { resolveLandingPageRootParameters } from "./root-resolver";
+export {
+  countLandingPageRootTextCharacters,
+  normalizeLandingPageRootText,
+} from "./root-schema";

--- a/lib/conversion-content/landing-page/module-catalog/contracts.ts
+++ b/lib/conversion-content/landing-page/module-catalog/contracts.ts
@@ -1,4 +1,8 @@
-import type { LandingPageRootSemanticRoleKey } from "../contracts";
+import type {
+  LandingPageRootLifecycleStatus,
+  LandingPageRootParameters,
+  LandingPageRootSemanticRoleKey,
+} from "../contracts";
 
 export const landingPageModuleKeys = [
   "hero",
@@ -340,3 +344,73 @@ export type LandingPageModuleVariantCatalogEntry = Readonly<{
 export type LandingPageModuleVariantCatalogRegistry = Readonly<
   Record<number, LandingPageModuleVariantCatalogEntry>
 >;
+
+export const landingPageModuleCatalogErrorCodes = [
+  "UNKNOWN_MODULE_CATALOG_VERSION",
+  "INVALID_MODULE_CATALOG_CONTRACT",
+  "ROOT_RESOLUTION_FAILED",
+  "INCOMPATIBLE_ROOT_VERSION",
+  "UNKNOWN_MODULE",
+  "UNKNOWN_MODULE_VERSION",
+  "UNKNOWN_VARIANT",
+  "UNKNOWN_VARIANT_VERSION",
+  "INCOMPATIBLE_REFERENCE",
+  "INVALID_VARIANT_PAYLOAD",
+] as const;
+
+export type LandingPageModuleCatalogErrorCode =
+  (typeof landingPageModuleCatalogErrorCodes)[number];
+
+export type LandingPageModuleCatalogError = Readonly<{
+  code: LandingPageModuleCatalogErrorCode;
+  message: string;
+}>;
+
+export type LandingPageModuleVariantReference = Readonly<{
+  family: "landing_page";
+  moduleCatalogVersion: number;
+  rootVersion: number;
+  moduleKey: LandingPageModuleKey;
+  moduleVersion: number;
+  variantKey: LandingPageVariantKey;
+  variantVersion: number;
+}>;
+
+export type LandingPageEffectiveFunnelCopyProfile =
+  LandingPageFunnelCopyProfile &
+    Readonly<{
+      emphasized: readonly LandingPageCopyTreatment[];
+    }>;
+
+export type LandingPageEffectiveFunnelCopyProfileRegistry = Readonly<
+  Record<LandingPageFunnelStage, LandingPageEffectiveFunnelCopyProfile>
+>;
+
+export type ResolvedLandingPageModuleVariant = Readonly<{
+  reference: LandingPageModuleVariantReference;
+  rootParameters: LandingPageRootParameters;
+  module: LandingPageModuleDefinition;
+  variant: LandingPageModuleVariantDefinition;
+  fields: Readonly<Record<string, LandingPageFieldDefinition>>;
+  capabilities: readonly LandingPageCapabilityDefinition[];
+  copySourceMap: LandingPageCopySourceMap;
+  funnelCopyProfile: LandingPageEffectiveFunnelCopyProfileRegistry;
+  rootLifecycleStatus: LandingPageRootLifecycleStatus;
+  moduleLifecycleStatus: LandingPageModuleLifecycleStatus;
+  variantLifecycleStatus: LandingPageModuleLifecycleStatus;
+  effectiveLifecycleStatus: LandingPageModuleLifecycleStatus;
+  modulePurpose: LandingPageModulePurpose;
+  variantPurpose: LandingPageModulePurpose;
+}>;
+
+export type ResolveLandingPageModuleVariantOptions = Readonly<{
+  presetKey?: string;
+}>;
+
+export type ResolveLandingPageModuleVariantResult =
+  | Readonly<{ ok: true; value: ResolvedLandingPageModuleVariant }>
+  | Readonly<{ ok: false; error: LandingPageModuleCatalogError }>;
+
+export type ValidateLandingPageVariantPayloadResult =
+  | Readonly<{ ok: true }>
+  | Readonly<{ ok: false; error: LandingPageModuleCatalogError }>;

--- a/lib/conversion-content/landing-page/module-catalog/contracts.ts
+++ b/lib/conversion-content/landing-page/module-catalog/contracts.ts
@@ -1,3 +1,5 @@
+import type { LandingPageRootSemanticRoleKey } from "../contracts";
+
 export const landingPageModuleKeys = [
   "hero",
   "trust_bar",
@@ -40,4 +42,103 @@ export type LandingPageModuleCatalogEntry = Readonly<{
 
 export type LandingPageModuleCatalogRegistry = Readonly<
   Record<number, LandingPageModuleCatalogEntry>
+>;
+
+export const landingPageFieldKinds = [
+  "text",
+  "collection",
+  "action",
+  "image",
+  "reference",
+] as const;
+
+export const landingPageFieldPolicies = [
+  "research_guided",
+  "hybrid",
+  "operational_required",
+  "technical_reference",
+  "not_copy",
+] as const;
+
+export const landingPageFieldSupports = [
+  "none",
+  "when_factual",
+  "when_present",
+] as const;
+
+export type LandingPageFieldKind = (typeof landingPageFieldKinds)[number];
+export type LandingPageFieldPolicy = (typeof landingPageFieldPolicies)[number];
+export type LandingPageFieldSupport = (typeof landingPageFieldSupports)[number];
+export type LandingPageFieldCardinality = Readonly<{
+  min: number;
+  max: number;
+}>;
+
+type LandingPageFieldDefinitionBase = Readonly<{
+  path: string;
+  cardinality: LandingPageFieldCardinality;
+}>;
+
+export type LandingPageTextFieldDefinition =
+  LandingPageFieldDefinitionBase &
+    Readonly<{
+      fieldKind: "text";
+      semanticRole: LandingPageRootSemanticRoleKey;
+      policy: "research_guided" | "hybrid" | "operational_required";
+      support: LandingPageFieldSupport;
+    }>;
+
+export type LandingPageCollectionFieldDefinition =
+  LandingPageFieldDefinitionBase &
+    Readonly<{
+      fieldKind: "collection";
+      policy: "not_copy";
+      ordered?: true;
+    }>;
+
+export type LandingPageActionFieldDefinition =
+  LandingPageFieldDefinitionBase &
+    Readonly<{
+      fieldKind: "action";
+      policy: "not_copy";
+    }>;
+
+export type LandingPageImageFieldDefinition =
+  LandingPageFieldDefinitionBase &
+    Readonly<{
+      fieldKind: "image";
+      policy: "technical_reference";
+      visibility: "all_viewports";
+    }>;
+
+export type LandingPageReferenceFieldDefinition =
+  LandingPageFieldDefinitionBase &
+    Readonly<{
+      fieldKind: "reference";
+      policy: "technical_reference";
+      referenceKind: "operational_evidence";
+    }>;
+
+export type LandingPageFieldDefinition =
+  | LandingPageTextFieldDefinition
+  | LandingPageCollectionFieldDefinition
+  | LandingPageActionFieldDefinition
+  | LandingPageImageFieldDefinition
+  | LandingPageReferenceFieldDefinition;
+
+export type LandingPageModuleFieldDefinition = Readonly<{
+  moduleKey: LandingPageModuleKey;
+  moduleVersion: number;
+  fields: Readonly<Record<string, LandingPageFieldDefinition>>;
+}>;
+
+export type LandingPageModuleFieldCatalogEntry = Readonly<{
+  moduleCatalogVersion: number;
+  modules: Readonly<
+    Record<LandingPageModuleKey, LandingPageModuleFieldDefinition>
+  >;
+}>;
+
+export type LandingPageModuleFieldCatalogRegistry = Readonly<
+  Record<number, LandingPageModuleFieldCatalogEntry>
 >;

--- a/lib/conversion-content/landing-page/module-catalog/contracts.ts
+++ b/lib/conversion-content/landing-page/module-catalog/contracts.ts
@@ -153,9 +153,56 @@ export const landingPageCapabilityKeys = [
   "accordion_interaction",
 ] as const;
 
+export const landingPageCopySourceModes = [
+  "research",
+  "operational_evidence",
+] as const;
+
+export const landingPageCopySourceItemKeyCatalog = {
+  strategic_core: [
+    "pain",
+    "objection",
+    "desire",
+    "belief",
+    "fear",
+    "awareness_level",
+    "trigger",
+    "proof_type",
+    "positioning_opportunity",
+  ],
+  seo: ["search_intent", "commercial_keywords", "faq_questions"],
+} as const;
+
+export const landingPageCopySourceItemKeys = [
+  ...landingPageCopySourceItemKeyCatalog.strategic_core,
+  ...landingPageCopySourceItemKeyCatalog.seo,
+] as const;
+
 export type LandingPageVariantKey = (typeof landingPageVariantKeys)[number];
 export type LandingPageCapabilityKey =
   (typeof landingPageCapabilityKeys)[number];
+export type LandingPageCopySourceMode =
+  (typeof landingPageCopySourceModes)[number];
+export type LandingPageCopySourceItemKey =
+  (typeof landingPageCopySourceItemKeys)[number];
+
+export type LandingPageResearchCopySource = Readonly<{
+  sourceMode: "research";
+  primaryItemKeys: readonly LandingPageCopySourceItemKey[];
+  auxiliaryItemKey?: LandingPageCopySourceItemKey;
+}>;
+
+export type LandingPageOperationalEvidenceCopySource = Readonly<{
+  sourceMode: "operational_evidence";
+}>;
+
+export type LandingPageCopySource =
+  | LandingPageResearchCopySource
+  | LandingPageOperationalEvidenceCopySource;
+
+export type LandingPageCopySourceMap = Readonly<
+  Record<string, LandingPageCopySource>
+>;
 
 export type LandingPagePrimaryActionCapability = Readonly<{
   capabilityKey: "primary_action";
@@ -196,6 +243,7 @@ export type LandingPageModuleVariantDefinition = Readonly<{
   purpose: LandingPageModulePurpose;
   compatibleModuleVersion: number;
   fields: Readonly<Record<string, LandingPageFieldDefinition>>;
+  copySourceMap: LandingPageCopySourceMap;
   capabilities: readonly LandingPageCapabilityKey[];
   rootDelta: LandingPageRootDelta;
 }>;

--- a/lib/conversion-content/landing-page/module-catalog/contracts.ts
+++ b/lib/conversion-content/landing-page/module-catalog/contracts.ts
@@ -142,3 +142,77 @@ export type LandingPageModuleFieldCatalogEntry = Readonly<{
 export type LandingPageModuleFieldCatalogRegistry = Readonly<
   Record<number, LandingPageModuleFieldCatalogEntry>
 >;
+
+export const landingPageVariantKeys = ["standard", "accordion"] as const;
+
+export const landingPageCapabilityKeys = [
+  "primary_action",
+  "image_asset",
+  "accordion_interaction",
+] as const;
+
+export type LandingPageVariantKey = (typeof landingPageVariantKeys)[number];
+export type LandingPageCapabilityKey =
+  (typeof landingPageCapabilityKeys)[number];
+
+export type LandingPagePrimaryActionCapability = Readonly<{
+  capabilityKey: "primary_action";
+  bindingFieldKey: "primary_conversion_channel";
+  allowedValues: readonly ["whatsapp", "phone", "email", "external_url"];
+}>;
+
+export type LandingPageImageAssetCapability = Readonly<{
+  capabilityKey: "image_asset";
+  modes: readonly ["informative", "decorative"];
+  visibility: "all_viewports";
+  informativeRequiresAltText: true;
+  decorativeRequiresEmptyAltText: true;
+}>;
+
+export type LandingPageAccordionInteractionCapability = Readonly<{
+  capabilityKey: "accordion_interaction";
+  initialState: "all_closed";
+  expansionMode: "single";
+  toggleMode: "own_control";
+  keyboardRequired: true;
+  stateExposed: true;
+  controlContentAssociationRequired: true;
+  focusPreserved: true;
+  focusVisible: "inherited_from_root";
+  wcagBaseline: "2.2";
+}>;
+
+export type LandingPageCapabilityDefinition =
+  | LandingPagePrimaryActionCapability
+  | LandingPageImageAssetCapability
+  | LandingPageAccordionInteractionCapability;
+
+export type LandingPageModuleVariantDefinition = Readonly<{
+  variantKey: LandingPageVariantKey;
+  variantVersion: number;
+  lifecycleStatus: LandingPageModuleLifecycleStatus;
+  purpose: LandingPageModulePurpose;
+  compatibleModuleVersion: number;
+  fields: Readonly<Record<string, LandingPageFieldDefinition>>;
+  capabilities: readonly LandingPageCapabilityKey[];
+}>;
+
+export type LandingPageModuleVariantCatalogModuleEntry = Readonly<{
+  moduleKey: LandingPageModuleKey;
+  moduleVersion: number;
+  variants: Readonly<Record<string, LandingPageModuleVariantDefinition>>;
+}>;
+
+export type LandingPageModuleVariantCatalogEntry = Readonly<{
+  moduleCatalogVersion: number;
+  capabilities: Readonly<
+    Record<LandingPageCapabilityKey, LandingPageCapabilityDefinition>
+  >;
+  modules: Readonly<
+    Record<LandingPageModuleKey, LandingPageModuleVariantCatalogModuleEntry>
+  >;
+}>;
+
+export type LandingPageModuleVariantCatalogRegistry = Readonly<
+  Record<number, LandingPageModuleVariantCatalogEntry>
+>;

--- a/lib/conversion-content/landing-page/module-catalog/contracts.ts
+++ b/lib/conversion-content/landing-page/module-catalog/contracts.ts
@@ -22,6 +22,7 @@ export type LandingPageModuleKey = (typeof landingPageModuleKeys)[number];
 export type LandingPageModuleLifecycleStatus =
   (typeof landingPageModuleLifecycleStatuses)[number];
 export type LandingPageModulePurpose = "controlled_test";
+export type LandingPageRootDelta = Readonly<Record<string, never>>;
 
 export type LandingPageModuleDefinition = Readonly<{
   moduleKey: LandingPageModuleKey;
@@ -31,6 +32,7 @@ export type LandingPageModuleDefinition = Readonly<{
   function: string;
   boundaries: readonly string[];
   invariants: readonly string[];
+  rootDelta: LandingPageRootDelta;
 }>;
 
 export type LandingPageModuleCatalogEntry = Readonly<{
@@ -195,11 +197,13 @@ export type LandingPageModuleVariantDefinition = Readonly<{
   compatibleModuleVersion: number;
   fields: Readonly<Record<string, LandingPageFieldDefinition>>;
   capabilities: readonly LandingPageCapabilityKey[];
+  rootDelta: LandingPageRootDelta;
 }>;
 
 export type LandingPageModuleVariantCatalogModuleEntry = Readonly<{
   moduleKey: LandingPageModuleKey;
   moduleVersion: number;
+  rootDelta: LandingPageRootDelta;
   variants: Readonly<Record<string, LandingPageModuleVariantDefinition>>;
 }>;
 

--- a/lib/conversion-content/landing-page/module-catalog/contracts.ts
+++ b/lib/conversion-content/landing-page/module-catalog/contracts.ts
@@ -178,6 +178,38 @@ export const landingPageCopySourceItemKeys = [
   ...landingPageCopySourceItemKeyCatalog.seo,
 ] as const;
 
+export const landingPageFunnelStages = ["bofu", "mofu", "tofu"] as const;
+
+export const landingPageCopyTreatments = [
+  "direct_action",
+  "qualified_action",
+  "low_friction_action",
+  "educational_context",
+  "problem_emphasis",
+  "offer_specificity",
+  "proof",
+  "comparison",
+  "price",
+  "promise",
+  "credential",
+  "authority",
+  "urgency",
+  "scarcity",
+  "guarantee",
+] as const;
+
+export const landingPageCtaModes = [
+  "direct",
+  "qualified",
+  "low_friction",
+] as const;
+
+export const landingPageCtaModeTreatmentMap = {
+  direct: "direct_action",
+  qualified: "qualified_action",
+  low_friction: "low_friction_action",
+} as const;
+
 export type LandingPageVariantKey = (typeof landingPageVariantKeys)[number];
 export type LandingPageCapabilityKey =
   (typeof landingPageCapabilityKeys)[number];
@@ -185,6 +217,10 @@ export type LandingPageCopySourceMode =
   (typeof landingPageCopySourceModes)[number];
 export type LandingPageCopySourceItemKey =
   (typeof landingPageCopySourceItemKeys)[number];
+export type LandingPageFunnelStage = (typeof landingPageFunnelStages)[number];
+export type LandingPageCopyTreatment =
+  (typeof landingPageCopyTreatments)[number];
+export type LandingPageCtaMode = (typeof landingPageCtaModes)[number];
 
 export type LandingPageResearchCopySource = Readonly<{
   sourceMode: "research";
@@ -202,6 +238,39 @@ export type LandingPageCopySource =
 
 export type LandingPageCopySourceMap = Readonly<
   Record<string, LandingPageCopySource>
+>;
+
+export type LandingPageFunnelCopyProfile = Readonly<{
+  allowed: readonly LandingPageCopyTreatment[];
+  restricted: readonly LandingPageCopyTreatment[];
+  prohibited: readonly LandingPageCopyTreatment[];
+  ctaMode: LandingPageCtaMode;
+}>;
+
+export type LandingPageFunnelCopyProfileRegistry = Readonly<
+  Record<LandingPageFunnelStage, LandingPageFunnelCopyProfile>
+>;
+
+export type LandingPageTreatmentSupportRequirement = Readonly<{
+  fieldPaths: readonly string[];
+  policies: readonly ("hybrid" | "operational_required")[];
+  supports: readonly ("when_factual" | "when_present")[];
+  sourceModes: readonly ("research" | "operational_evidence")[];
+}>;
+
+export type LandingPageFunnelProfileStageDelta = Readonly<{
+  restricted: readonly LandingPageCopyTreatment[];
+  prohibited: readonly LandingPageCopyTreatment[];
+  emphasized: readonly LandingPageCopyTreatment[];
+  supportRequirements: Readonly<
+    Partial<
+      Record<LandingPageCopyTreatment, LandingPageTreatmentSupportRequirement>
+    >
+  >;
+}>;
+
+export type LandingPageFunnelProfileDelta = Readonly<
+  Record<LandingPageFunnelStage, LandingPageFunnelProfileStageDelta>
 >;
 
 export type LandingPagePrimaryActionCapability = Readonly<{
@@ -244,6 +313,7 @@ export type LandingPageModuleVariantDefinition = Readonly<{
   compatibleModuleVersion: number;
   fields: Readonly<Record<string, LandingPageFieldDefinition>>;
   copySourceMap: LandingPageCopySourceMap;
+  funnelProfileDelta: LandingPageFunnelProfileDelta;
   capabilities: readonly LandingPageCapabilityKey[];
   rootDelta: LandingPageRootDelta;
 }>;
@@ -252,11 +322,13 @@ export type LandingPageModuleVariantCatalogModuleEntry = Readonly<{
   moduleKey: LandingPageModuleKey;
   moduleVersion: number;
   rootDelta: LandingPageRootDelta;
+  funnelProfileDelta: LandingPageFunnelProfileDelta;
   variants: Readonly<Record<string, LandingPageModuleVariantDefinition>>;
 }>;
 
 export type LandingPageModuleVariantCatalogEntry = Readonly<{
   moduleCatalogVersion: number;
+  funnelCopyProfiles: LandingPageFunnelCopyProfileRegistry;
   capabilities: Readonly<
     Record<LandingPageCapabilityKey, LandingPageCapabilityDefinition>
   >;

--- a/lib/conversion-content/landing-page/module-catalog/contracts.ts
+++ b/lib/conversion-content/landing-page/module-catalog/contracts.ts
@@ -1,0 +1,43 @@
+export const landingPageModuleKeys = [
+  "hero",
+  "trust_bar",
+  "problem_solution",
+  "offer",
+  "process",
+  "technical_assurance",
+  "social_proof",
+  "faq",
+  "final_cta",
+] as const;
+
+export const landingPageModuleLifecycleStatuses = [
+  "hypothesis",
+  "validated",
+  "deprecated",
+] as const;
+
+export type LandingPageModuleKey = (typeof landingPageModuleKeys)[number];
+export type LandingPageModuleLifecycleStatus =
+  (typeof landingPageModuleLifecycleStatuses)[number];
+export type LandingPageModulePurpose = "controlled_test";
+
+export type LandingPageModuleDefinition = Readonly<{
+  moduleKey: LandingPageModuleKey;
+  moduleVersion: number;
+  lifecycleStatus: LandingPageModuleLifecycleStatus;
+  purpose: LandingPageModulePurpose;
+  function: string;
+  boundaries: readonly string[];
+  invariants: readonly string[];
+}>;
+
+export type LandingPageModuleCatalogEntry = Readonly<{
+  family: "landing_page";
+  moduleCatalogVersion: number;
+  compatibleRootVersions: readonly number[];
+  modules: Readonly<Record<LandingPageModuleKey, LandingPageModuleDefinition>>;
+}>;
+
+export type LandingPageModuleCatalogRegistry = Readonly<
+  Record<number, LandingPageModuleCatalogEntry>
+>;

--- a/lib/conversion-content/landing-page/module-catalog/index.ts
+++ b/lib/conversion-content/landing-page/module-catalog/index.ts
@@ -1,0 +1,53 @@
+export {
+  landingPageModuleCatalogErrorCodes,
+} from "./contracts";
+export type {
+  LandingPageCapabilityDefinition,
+  LandingPageCapabilityKey,
+  LandingPageCopySource,
+  LandingPageCopySourceMap,
+  LandingPageCopySourceMode,
+  LandingPageCopyTreatment,
+  LandingPageCtaMode,
+  LandingPageEffectiveFunnelCopyProfile,
+  LandingPageEffectiveFunnelCopyProfileRegistry,
+  LandingPageFieldDefinition,
+  LandingPageFieldKind,
+  LandingPageFieldPolicy,
+  LandingPageFieldSupport,
+  LandingPageFunnelCopyProfile,
+  LandingPageFunnelCopyProfileRegistry,
+  LandingPageFunnelStage,
+  LandingPageModuleCatalogEntry,
+  LandingPageModuleCatalogError,
+  LandingPageModuleCatalogErrorCode,
+  LandingPageModuleCatalogRegistry,
+  LandingPageModuleDefinition,
+  LandingPageModuleFieldCatalogEntry,
+  LandingPageModuleFieldCatalogRegistry,
+  LandingPageModuleKey,
+  LandingPageModuleLifecycleStatus,
+  LandingPageModulePurpose,
+  LandingPageModuleVariantCatalogEntry,
+  LandingPageModuleVariantCatalogRegistry,
+  LandingPageModuleVariantDefinition,
+  LandingPageModuleVariantReference,
+  LandingPageVariantKey,
+  ResolvedLandingPageModuleVariant,
+  ResolveLandingPageModuleVariantOptions,
+  ResolveLandingPageModuleVariantResult,
+  ValidateLandingPageVariantPayloadResult,
+} from "./contracts";
+export {
+  landingPageModuleCatalogRegistry,
+  landingPageModuleFieldCatalogRegistry,
+  landingPageModuleVariantCatalogRegistry,
+} from "./registry";
+export {
+  landingPageModuleCatalogEntrySchema,
+  landingPageModuleFieldCatalogEntrySchema,
+  landingPageModuleVariantCatalogEntrySchema,
+  landingPageModuleVariantReferenceSchema,
+} from "./schema";
+export { resolveLandingPageModuleVariant } from "./resolver";
+export { validateLandingPageVariantPayload } from "./payload-validator";

--- a/lib/conversion-content/landing-page/module-catalog/payload-validator.ts
+++ b/lib/conversion-content/landing-page/module-catalog/payload-validator.ts
@@ -1,0 +1,163 @@
+import type {
+  LandingPageFieldDefinition,
+  LandingPageModuleKey,
+} from "./contracts";
+import { landingPageModuleFieldCatalogRegistry } from "./registry";
+
+export type LandingPageModuleFieldPayloadValidationResult =
+  | Readonly<{ ok: true }>
+  | Readonly<{ ok: false }>;
+
+export function validateLandingPageModuleFieldPayload(
+  moduleKey: LandingPageModuleKey,
+  payload: unknown,
+): LandingPageModuleFieldPayloadValidationResult {
+  const moduleDefinition =
+    landingPageModuleFieldCatalogRegistry[1].modules[moduleKey];
+
+  return validatePayloadObject(payload, moduleDefinition.fields)
+    ? { ok: true }
+    : { ok: false };
+}
+
+function validatePayloadObject(
+  payload: unknown,
+  fields: Readonly<Record<string, LandingPageFieldDefinition>>,
+): boolean {
+  if (!isPlainObject(payload)) return false;
+
+  const rootFields = Object.values(fields).filter(
+    (field) => !field.path.includes(".") && !field.path.includes("[]"),
+  );
+  const allowedKeys = new Set(rootFields.map((field) => field.path));
+
+  if (Object.keys(payload).some((key) => !allowedKeys.has(key))) return false;
+
+  for (const field of rootFields) {
+    const hasValue = Object.hasOwn(payload, field.path);
+    if (!hasValue && field.cardinality.min > 0) return false;
+    if (!hasValue) continue;
+    if (!validateFieldValue(field, payload[field.path], fields)) return false;
+  }
+
+  return true;
+}
+
+function validateFieldValue(
+  field: LandingPageFieldDefinition,
+  value: unknown,
+  fields: Readonly<Record<string, LandingPageFieldDefinition>>,
+): boolean {
+  switch (field.fieldKind) {
+    case "text":
+      return typeof value === "string";
+    case "collection":
+      return validateCollection(field, value, fields);
+    case "action":
+      return validateChildObject(field.path, value, fields, ".");
+    case "image":
+      return validateImage(value);
+    case "reference":
+      return validateReference(value);
+  }
+}
+
+function validateCollection(
+  field: Extract<LandingPageFieldDefinition, { fieldKind: "collection" }>,
+  value: unknown,
+  fields: Readonly<Record<string, LandingPageFieldDefinition>>,
+): boolean {
+  if (!Array.isArray(value)) return false;
+  if (
+    value.length < field.cardinality.min ||
+    value.length > field.cardinality.max
+  ) {
+    return false;
+  }
+
+  return value.every((item) =>
+    validateChildObject(field.path, item, fields, "[]."),
+  );
+}
+
+function validateChildObject(
+  parentPath: string,
+  value: unknown,
+  fields: Readonly<Record<string, LandingPageFieldDefinition>>,
+  separator: "." | "[].",
+): boolean {
+  if (!isPlainObject(value)) return false;
+
+  const prefix = `${parentPath}${separator}`;
+  const childFields = Object.values(fields).filter((field) =>
+    field.path.startsWith(prefix),
+  );
+  const childByKey = new Map(
+    childFields.map((field) => [field.path.slice(prefix.length), field]),
+  );
+
+  if (
+    childFields.length === 0 ||
+    Object.keys(value).some((key) => !childByKey.has(key))
+  ) {
+    return false;
+  }
+
+  for (const [key, childField] of childByKey) {
+    if (key.includes(".")) return false;
+    const hasValue = Object.hasOwn(value, key);
+    if (!hasValue && childField.cardinality.min > 0) return false;
+    if (!hasValue) continue;
+    if (!validateFieldValue(childField, value[key], fields)) return false;
+  }
+
+  return true;
+}
+
+function validateImage(value: unknown): boolean {
+  if (
+    !hasExactKeys(value, ["assetRef", "mode", "altText", "visibility"])
+  ) {
+    return false;
+  }
+
+  if (
+    typeof value.assetRef !== "string" ||
+    value.assetRef.trim().length === 0 ||
+    typeof value.altText !== "string" ||
+    value.visibility !== "all_viewports"
+  ) {
+    return false;
+  }
+
+  if (value.mode === "informative") return value.altText.trim().length > 0;
+  if (value.mode === "decorative") return value.altText.length === 0;
+  return false;
+}
+
+function validateReference(value: unknown): boolean {
+  return (
+    hasExactKeys(value, ["referenceKind", "evidenceRef"]) &&
+    value.referenceKind === "operational_evidence" &&
+    typeof value.evidenceRef === "string" &&
+    value.evidenceRef.trim().length > 0 &&
+    !/^[a-z][a-z0-9+.-]*:\/\//i.test(value.evidenceRef)
+  );
+}
+
+function hasExactKeys<T extends string>(
+  value: unknown,
+  expectedKeys: readonly T[],
+): value is Record<T, unknown> {
+  if (!isPlainObject(value)) return false;
+  const actualKeys = Object.keys(value).sort();
+  const sortedExpectedKeys = [...expectedKeys].sort();
+  return (
+    actualKeys.length === sortedExpectedKeys.length &&
+    actualKeys.every((key, index) => key === sortedExpectedKeys[index])
+  );
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/lib/conversion-content/landing-page/module-catalog/payload-validator.ts
+++ b/lib/conversion-content/landing-page/module-catalog/payload-validator.ts
@@ -14,6 +14,7 @@ export function validateLandingPageModuleFieldPayload(
 ): LandingPageModuleFieldPayloadValidationResult {
   const moduleDefinition =
     landingPageModuleFieldCatalogRegistry[1].modules[moduleKey];
+  if (!moduleDefinition) return { ok: false };
 
   return validatePayloadObject(payload, moduleDefinition.fields)
     ? { ok: true }

--- a/lib/conversion-content/landing-page/module-catalog/payload-validator.ts
+++ b/lib/conversion-content/landing-page/module-catalog/payload-validator.ts
@@ -2,21 +2,60 @@ import type {
   LandingPageFieldDefinition,
   LandingPageModuleKey,
 } from "./contracts";
-import { landingPageModuleFieldCatalogRegistry } from "./registry";
+import {
+  countLandingPageRootTextCharacters,
+  normalizeLandingPageRootText,
+  resolveLandingPageRootParameters,
+  type LandingPageRootParameters,
+} from "../index";
+import {
+  landingPageModuleCatalogRegistry,
+  landingPageModuleFieldCatalogRegistry,
+} from "./registry";
+
+export type LandingPageModuleFieldPayloadValidationErrorCode =
+  "ROOT_RESOLUTION_FAILED";
 
 export type LandingPageModuleFieldPayloadValidationResult =
   | Readonly<{ ok: true }>
-  | Readonly<{ ok: false }>;
+  | Readonly<{
+      ok: false;
+      error?: Readonly<{
+        code: LandingPageModuleFieldPayloadValidationErrorCode;
+      }>;
+    }>;
+
+type LandingPageModuleFieldPayloadValidationOptions = Readonly<{
+  rootVersion?: number;
+  presetKey?: string;
+}>;
 
 export function validateLandingPageModuleFieldPayload(
   moduleKey: LandingPageModuleKey,
   payload: unknown,
+  options: LandingPageModuleFieldPayloadValidationOptions = {},
 ): LandingPageModuleFieldPayloadValidationResult {
   const moduleDefinition =
     landingPageModuleFieldCatalogRegistry[1].modules[moduleKey];
   if (!moduleDefinition) return { ok: false };
 
-  return validatePayloadObject(payload, moduleDefinition.fields)
+  const rootResolution = resolveLandingPageRootParameters({
+    rootVersion:
+      options.rootVersion ??
+      landingPageModuleCatalogRegistry[1].compatibleRootVersions[0],
+    ...(options.presetKey === undefined
+      ? {}
+      : { presetKey: options.presetKey }),
+  });
+  if (!rootResolution.ok) {
+    return { ok: false, error: { code: "ROOT_RESOLUTION_FAILED" } };
+  }
+
+  return validatePayloadObject(
+    payload,
+    moduleDefinition.fields,
+    rootResolution.value,
+  )
     ? { ok: true }
     : { ok: false };
 }
@@ -24,6 +63,7 @@ export function validateLandingPageModuleFieldPayload(
 function validatePayloadObject(
   payload: unknown,
   fields: Readonly<Record<string, LandingPageFieldDefinition>>,
+  rootParameters: LandingPageRootParameters,
 ): boolean {
   if (!isPlainObject(payload)) return false;
 
@@ -38,7 +78,12 @@ function validatePayloadObject(
     const hasValue = Object.hasOwn(payload, field.path);
     if (!hasValue && field.cardinality.min > 0) return false;
     if (!hasValue) continue;
-    if (!validateFieldValue(field, payload[field.path], fields)) return false;
+    if (!validateFieldValue(
+      field,
+      payload[field.path],
+      fields,
+      rootParameters,
+    )) return false;
   }
 
   return true;
@@ -48,14 +93,21 @@ function validateFieldValue(
   field: LandingPageFieldDefinition,
   value: unknown,
   fields: Readonly<Record<string, LandingPageFieldDefinition>>,
+  rootParameters: LandingPageRootParameters,
 ): boolean {
   switch (field.fieldKind) {
     case "text":
-      return typeof value === "string";
+      return validateText(field, value, rootParameters);
     case "collection":
-      return validateCollection(field, value, fields);
+      return validateCollection(field, value, fields, rootParameters);
     case "action":
-      return validateChildObject(field.path, value, fields, ".");
+      return validateChildObject(
+        field.path,
+        value,
+        fields,
+        ".",
+        rootParameters,
+      );
     case "image":
       return validateImage(value);
     case "reference":
@@ -63,10 +115,29 @@ function validateFieldValue(
   }
 }
 
+function validateText(
+  field: Extract<LandingPageFieldDefinition, { fieldKind: "text" }>,
+  value: unknown,
+  rootParameters: LandingPageRootParameters,
+): boolean {
+  if (typeof value !== "string") return false;
+
+  const normalizedValue = normalizeLandingPageRootText(value);
+  if (normalizedValue.length === 0) return false;
+
+  const semanticRole = rootParameters.semanticRoles[field.semanticRole];
+  return (
+    semanticRole !== undefined &&
+    countLandingPageRootTextCharacters(normalizedValue) <=
+      semanticRole.textRange.absoluteMax
+  );
+}
+
 function validateCollection(
   field: Extract<LandingPageFieldDefinition, { fieldKind: "collection" }>,
   value: unknown,
   fields: Readonly<Record<string, LandingPageFieldDefinition>>,
+  rootParameters: LandingPageRootParameters,
 ): boolean {
   if (!Array.isArray(value)) return false;
   if (
@@ -77,7 +148,7 @@ function validateCollection(
   }
 
   return value.every((item) =>
-    validateChildObject(field.path, item, fields, "[]."),
+    validateChildObject(field.path, item, fields, "[].", rootParameters),
   );
 }
 
@@ -86,6 +157,7 @@ function validateChildObject(
   value: unknown,
   fields: Readonly<Record<string, LandingPageFieldDefinition>>,
   separator: "." | "[].",
+  rootParameters: LandingPageRootParameters,
 ): boolean {
   if (!isPlainObject(value)) return false;
 
@@ -109,7 +181,9 @@ function validateChildObject(
     const hasValue = Object.hasOwn(value, key);
     if (!hasValue && childField.cardinality.min > 0) return false;
     if (!hasValue) continue;
-    if (!validateFieldValue(childField, value[key], fields)) return false;
+    if (!validateFieldValue(childField, value[key], fields, rootParameters)) {
+      return false;
+    }
   }
 
   return true;

--- a/lib/conversion-content/landing-page/module-catalog/payload-validator.ts
+++ b/lib/conversion-content/landing-page/module-catalog/payload-validator.ts
@@ -1,6 +1,9 @@
 import type {
   LandingPageFieldDefinition,
   LandingPageModuleKey,
+  LandingPageModuleVariantReference,
+  ResolveLandingPageModuleVariantOptions,
+  ValidateLandingPageVariantPayloadResult,
 } from "./contracts";
 import {
   countLandingPageRootTextCharacters,
@@ -12,6 +15,7 @@ import {
   landingPageModuleCatalogRegistry,
   landingPageModuleFieldCatalogRegistry,
 } from "./registry";
+import { resolveLandingPageModuleVariant } from "./resolver";
 
 export type LandingPageModuleFieldPayloadValidationErrorCode =
   "ROOT_RESOLUTION_FAILED";
@@ -58,6 +62,33 @@ export function validateLandingPageModuleFieldPayload(
   )
     ? { ok: true }
     : { ok: false };
+}
+
+export function validateLandingPageVariantPayload(
+  reference: LandingPageModuleVariantReference,
+  payload: unknown,
+  options: ResolveLandingPageModuleVariantOptions = {},
+): ValidateLandingPageVariantPayloadResult {
+  const resolution = resolveLandingPageModuleVariant(reference, options);
+  if (!resolution.ok) return deepFreeze(cloneJson(resolution));
+
+  if (
+    !validatePayloadObject(
+      payload,
+      resolution.value.fields,
+      resolution.value.rootParameters,
+    )
+  ) {
+    return deepFreeze({
+      ok: false,
+      error: {
+        code: "INVALID_VARIANT_PAYLOAD",
+        message: "Invalid landing page variant payload.",
+      },
+    });
+  }
+
+  return deepFreeze({ ok: true });
 }
 
 function validatePayloadObject(
@@ -235,4 +266,21 @@ function hasExactKeys<T extends string>(
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === "object") {
+    for (const property of Object.getOwnPropertyNames(value)) {
+      const nested = value[property as keyof T];
+      if (nested && typeof nested === "object" && !Object.isFrozen(nested)) {
+        deepFreeze(nested);
+      }
+    }
+    Object.freeze(value);
+  }
+  return value;
 }

--- a/lib/conversion-content/landing-page/module-catalog/registry.ts
+++ b/lib/conversion-content/landing-page/module-catalog/registry.ts
@@ -1,0 +1,167 @@
+import type { LandingPageModuleCatalogRegistry } from "./contracts";
+
+export const landingPageModuleCatalogRegistry = deepFreeze({
+  1: {
+    family: "landing_page",
+    moduleCatalogVersion: 1,
+    compatibleRootVersions: [1],
+    modules: {
+      hero: moduleDefinition({
+        moduleKey: "hero",
+        function: "establish_primary_value_proposition",
+        boundaries: [
+          "opening_section_only",
+          "no_full_offer_detail",
+          "no_proof_collection",
+        ],
+        invariants: [
+          "one_primary_value_proposition",
+          "one_primary_conversion_intent",
+          "no_concrete_destination",
+        ],
+      }),
+      trust_bar: moduleDefinition({
+        moduleKey: "trust_bar",
+        function: "surface_compact_trust_signals",
+        boundaries: [
+          "compact_signals_only",
+          "no_testimonial_narrative",
+          "no_conversion_action",
+        ],
+        invariants: [
+          "support_required_for_every_signal",
+          "no_fabricated_signal",
+          "no_material_evidence_change",
+        ],
+      }),
+      problem_solution: moduleDefinition({
+        moduleKey: "problem_solution",
+        function: "connect_problem_to_solution_approach",
+        boundaries: [
+          "problem_and_solution_only",
+          "no_offer_detail",
+          "no_conversion_action",
+        ],
+        invariants: [
+          "problem_precedes_solution",
+          "no_alarmist_framing",
+          "solution_matches_declared_problem",
+        ],
+      }),
+      offer: moduleDefinition({
+        moduleKey: "offer",
+        function: "present_offer_structure",
+        boundaries: [
+          "offer_components_only",
+          "no_social_evidence",
+          "no_conversion_action",
+        ],
+        invariants: [
+          "operational_capacity_required",
+          "no_unsupported_commercial_term",
+          "no_concrete_destination",
+        ],
+      }),
+      process: moduleDefinition({
+        moduleKey: "process",
+        function: "explain_ordered_operational_steps",
+        boundaries: [
+          "process_explanation_only",
+          "no_offer_detail",
+          "no_conversion_action",
+        ],
+        invariants: [
+          "steps_form_coherent_sequence",
+          "no_unverified_step",
+          "no_concrete_destination",
+        ],
+      }),
+      technical_assurance: moduleDefinition({
+        moduleKey: "technical_assurance",
+        function: "clarify_supported_technical_assurances",
+        boundaries: [
+          "technical_assurance_only",
+          "no_testimonial_narrative",
+          "no_conversion_action",
+        ],
+        invariants: [
+          "traceable_support_required",
+          "no_fabricated_assurance",
+          "no_material_evidence_change",
+        ],
+      }),
+      social_proof: moduleDefinition({
+        moduleKey: "social_proof",
+        function: "present_supported_social_evidence",
+        boundaries: [
+          "social_evidence_only",
+          "no_general_trust_signal",
+          "no_conversion_action",
+        ],
+        invariants: [
+          "traceable_evidence_required",
+          "no_fabricated_evidence",
+          "no_material_evidence_change",
+        ],
+      }),
+      faq: moduleDefinition({
+        moduleKey: "faq",
+        function: "answer_recurring_questions_and_objections",
+        boundaries: [
+          "question_and_answer_only",
+          "no_offer_expansion",
+          "no_conversion_action",
+        ],
+        invariants: [
+          "questions_are_not_duplicated",
+          "factual_answers_require_support",
+          "answers_match_declared_questions",
+        ],
+      }),
+      final_cta: moduleDefinition({
+        moduleKey: "final_cta",
+        function: "close_with_primary_conversion_intent",
+        boundaries: [
+          "closing_section_only",
+          "no_new_argument",
+          "no_secondary_conversion_action",
+        ],
+        invariants: [
+          "one_primary_conversion_intent",
+          "no_concrete_destination",
+          "action_matches_preceding_proposition",
+        ],
+      }),
+    },
+  },
+} satisfies LandingPageModuleCatalogRegistry);
+
+function moduleDefinition(input: {
+  moduleKey: keyof LandingPageModuleCatalogRegistry[1]["modules"];
+  function: string;
+  boundaries: readonly string[];
+  invariants: readonly string[];
+}) {
+  return {
+    moduleKey: input.moduleKey,
+    moduleVersion: 1,
+    lifecycleStatus: "hypothesis" as const,
+    purpose: "controlled_test" as const,
+    function: input.function,
+    boundaries: input.boundaries,
+    invariants: input.invariants,
+  };
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === "object") {
+    for (const property of Object.getOwnPropertyNames(value)) {
+      const nested = value[property as keyof T];
+      if (nested && typeof nested === "object" && !Object.isFrozen(nested)) {
+        deepFreeze(nested);
+      }
+    }
+    Object.freeze(value);
+  }
+  return value;
+}

--- a/lib/conversion-content/landing-page/module-catalog/registry.ts
+++ b/lib/conversion-content/landing-page/module-catalog/registry.ts
@@ -5,6 +5,13 @@ import type {
   LandingPageCapabilityKey,
   LandingPageCopySourceItemKey,
   LandingPageCopySourceMap,
+  LandingPageCopyTreatment,
+  LandingPageCtaMode,
+  LandingPageFunnelCopyProfile,
+  LandingPageFunnelCopyProfileRegistry,
+  LandingPageFunnelProfileDelta,
+  LandingPageFunnelProfileStageDelta,
+  LandingPageFunnelStage,
   LandingPageModuleCatalogRegistry,
   LandingPageModuleFieldCatalogRegistry,
   LandingPageModuleKey,
@@ -12,7 +19,20 @@ import type {
   LandingPageModuleVariantDefinition,
   LandingPageReferenceFieldDefinition,
   LandingPageTextFieldDefinition,
+  LandingPageTreatmentSupportRequirement,
 } from "./contracts";
+import {
+  landingPageCopyTreatments,
+  landingPageCtaModeTreatmentMap,
+  landingPageFunnelStages,
+} from "./contracts";
+
+type ModuleFunnelPolicy = Readonly<{
+  prohibited: readonly LandingPageCopyTreatment[];
+  restricted: readonly LandingPageCopyTreatment[];
+  emphasized: readonly LandingPageCopyTreatment[];
+  effectiveActionOnly: boolean;
+}>;
 
 export const landingPageModuleCatalogRegistry = deepFreeze({
   1: {
@@ -351,6 +371,165 @@ export const landingPageModuleFieldCatalogRegistry = deepFreeze({
   },
 } satisfies LandingPageModuleFieldCatalogRegistry);
 
+const approvedFunnelCopyProfiles = {
+  bofu: {
+    allowed: [
+      "direct_action",
+      "qualified_action",
+      "low_friction_action",
+      "educational_context",
+      "problem_emphasis",
+      "offer_specificity",
+    ],
+    restricted: [
+      "proof",
+      "comparison",
+      "price",
+      "promise",
+      "credential",
+      "authority",
+      "urgency",
+      "scarcity",
+      "guarantee",
+    ],
+    prohibited: [],
+    ctaMode: "direct",
+  },
+  mofu: {
+    allowed: [
+      "qualified_action",
+      "low_friction_action",
+      "educational_context",
+      "problem_emphasis",
+      "offer_specificity",
+    ],
+    restricted: [
+      "direct_action",
+      "proof",
+      "comparison",
+      "price",
+      "promise",
+      "credential",
+      "authority",
+      "urgency",
+      "scarcity",
+      "guarantee",
+    ],
+    prohibited: [],
+    ctaMode: "qualified",
+  },
+  tofu: {
+    allowed: [
+      "low_friction_action",
+      "educational_context",
+      "problem_emphasis",
+    ],
+    restricted: [
+      "qualified_action",
+      "offer_specificity",
+      "proof",
+      "credential",
+      "authority",
+    ],
+    prohibited: [
+      "direct_action",
+      "comparison",
+      "price",
+      "promise",
+      "urgency",
+      "scarcity",
+      "guarantee",
+    ],
+    ctaMode: "low_friction",
+  },
+} satisfies LandingPageFunnelCopyProfileRegistry;
+
+const actionTreatments = [
+  "direct_action",
+  "qualified_action",
+  "low_friction_action",
+] as const satisfies readonly LandingPageCopyTreatment[];
+
+const moduleFunnelPolicies = {
+  hero: {
+    prohibited: [
+      "comparison",
+      "price",
+      "guarantee",
+      "urgency",
+      "scarcity",
+    ],
+    restricted: [],
+    emphasized: [],
+    effectiveActionOnly: true,
+  },
+  trust_bar: {
+    prohibited: [
+      ...actionTreatments,
+      "educational_context",
+      "problem_emphasis",
+      "offer_specificity",
+      "comparison",
+      "price",
+      "promise",
+      "urgency",
+      "scarcity",
+      "guarantee",
+    ],
+    restricted: [],
+    emphasized: [],
+    effectiveActionOnly: false,
+  },
+  problem_solution: policyAllowingOnly([
+    "educational_context",
+    "problem_emphasis",
+  ]),
+  offer: {
+    prohibited: [
+      ...actionTreatments,
+      "proof",
+      "comparison",
+      "price",
+      "promise",
+      "credential",
+      "authority",
+      "urgency",
+      "scarcity",
+      "guarantee",
+    ],
+    restricted: ["offer_specificity"],
+    emphasized: [],
+    effectiveActionOnly: false,
+  },
+  process: policyAllowingOnly(["educational_context"]),
+  technical_assurance: {
+    prohibited: [
+      ...actionTreatments,
+      "problem_emphasis",
+      "offer_specificity",
+      "comparison",
+      "price",
+      "promise",
+      "urgency",
+      "scarcity",
+      "guarantee",
+    ],
+    restricted: [],
+    emphasized: ["educational_context"],
+    effectiveActionOnly: false,
+  },
+  social_proof: policyAllowingOnly(["proof"]),
+  faq: policyAllowingOnly(["educational_context", "problem_emphasis"]),
+  final_cta: {
+    prohibited: landingPageCopyTreatments.filter(
+      (treatment) => !actionTreatments.includes(treatment as never),
+    ),
+    restricted: [],
+    emphasized: [],
+    effectiveActionOnly: true,
+  },
+} satisfies Readonly<Record<LandingPageModuleKey, ModuleFunnelPolicy>>;
+
 const approvedCopySourceMaps = {
   hero: {
     eyebrow: researchSource(["positioning_opportunity"], "search_intent"),
@@ -420,6 +599,7 @@ const approvedCopySourceMaps = {
 export const landingPageModuleVariantCatalogRegistry = deepFreeze({
   1: {
     moduleCatalogVersion: 1,
+    funnelCopyProfiles: approvedFunnelCopyProfiles,
     capabilities: {
       primary_action: {
         capabilityKey: "primary_action",
@@ -535,7 +715,13 @@ function moduleVariants(
   moduleKey: LandingPageModuleKey,
   variants: Readonly<Record<string, LandingPageModuleVariantDefinition>>,
 ) {
-  return { moduleKey, moduleVersion: 1, rootDelta: {}, variants };
+  return {
+    moduleKey,
+    moduleVersion: 1,
+    rootDelta: {},
+    funnelProfileDelta: createModuleFunnelProfileDelta(moduleKey),
+    variants,
+  };
 }
 
 function variantDefinition(
@@ -551,9 +737,183 @@ function variantDefinition(
     compatibleModuleVersion: 1,
     fields: copyApprovedModuleFields(moduleKey),
     copySourceMap: copyApprovedCopySourceMap(moduleKey),
+    funnelProfileDelta: createModuleFunnelProfileDelta(moduleKey),
     capabilities,
     rootDelta: {},
   };
+}
+
+export function applyLandingPageFunnelProfileDeltaInternal(
+  profile: LandingPageFunnelCopyProfile,
+  delta: LandingPageFunnelProfileStageDelta,
+): LandingPageFunnelCopyProfile | undefined {
+  const knownTreatments = new Set<string>(landingPageCopyTreatments);
+  const profileTreatments = [
+    ...profile.allowed,
+    ...profile.restricted,
+    ...profile.prohibited,
+  ];
+  const deltaTreatments = [
+    ...delta.restricted,
+    ...delta.prohibited,
+    ...delta.emphasized,
+  ];
+  if (
+    profileTreatments.length !== landingPageCopyTreatments.length ||
+    new Set(profileTreatments).size !== landingPageCopyTreatments.length ||
+    [...profileTreatments, ...deltaTreatments].some(
+      (treatment) => !knownTreatments.has(treatment),
+    )
+  ) {
+    return undefined;
+  }
+
+  const restricted = new Set(delta.restricted);
+  const prohibited = new Set(delta.prohibited);
+  const classification = new Map<
+    LandingPageCopyTreatment,
+    "allowed" | "restricted" | "prohibited"
+  >();
+
+  for (const treatment of profile.allowed) classification.set(treatment, "allowed");
+  for (const treatment of profile.restricted) {
+    classification.set(treatment, "restricted");
+  }
+  for (const treatment of profile.prohibited) {
+    classification.set(treatment, "prohibited");
+  }
+  for (const treatment of landingPageCopyTreatments) {
+    if (restricted.has(treatment) && classification.get(treatment) === "allowed") {
+      classification.set(treatment, "restricted");
+    }
+    if (prohibited.has(treatment)) classification.set(treatment, "prohibited");
+  }
+
+  return {
+    allowed: landingPageCopyTreatments.filter(
+      (treatment) => classification.get(treatment) === "allowed",
+    ),
+    restricted: landingPageCopyTreatments.filter(
+      (treatment) => classification.get(treatment) === "restricted",
+    ),
+    prohibited: landingPageCopyTreatments.filter(
+      (treatment) => classification.get(treatment) === "prohibited",
+    ),
+    ctaMode: profile.ctaMode,
+  };
+}
+
+function createModuleFunnelProfileDelta(
+  moduleKey: LandingPageModuleKey,
+): LandingPageFunnelProfileDelta {
+  return Object.fromEntries(
+    landingPageFunnelStages.map((stage) => {
+      const profile = approvedFunnelCopyProfiles[stage];
+      const policy = moduleFunnelPolicies[moduleKey];
+      const effectiveAction = landingPageCtaModeTreatmentMap[profile.ctaMode];
+      const prohibited = new Set<LandingPageCopyTreatment>(policy.prohibited);
+      if (policy.effectiveActionOnly) {
+        for (const treatment of actionTreatments) {
+          if (treatment !== effectiveAction) prohibited.add(treatment);
+        }
+      }
+
+      const restricted = policy.restricted.filter(
+        (treatment) => !prohibited.has(treatment),
+      );
+      const emphasized = [
+        ...policy.emphasized,
+        ...(policy.effectiveActionOnly ? [effectiveAction] : []),
+      ].filter((treatment) => !prohibited.has(treatment));
+      const partialDelta = {
+        restricted,
+        prohibited: landingPageCopyTreatments.filter((treatment) =>
+          prohibited.has(treatment),
+        ),
+        emphasized,
+        supportRequirements: {},
+      } satisfies LandingPageFunnelProfileStageDelta;
+      const result = applyLandingPageFunnelProfileDeltaInternal(
+        profile,
+        partialDelta,
+      );
+      if (!result) throw new Error("invalid internal funnel profile delta");
+
+      const supportRequirements = Object.fromEntries(
+        result.restricted.map((treatment) => [
+          treatment,
+          treatmentSupportRequirement(moduleKey, treatment),
+        ]),
+      );
+      return [stage, { ...partialDelta, supportRequirements }];
+    }),
+  ) as unknown as LandingPageFunnelProfileDelta;
+}
+
+function policyAllowingOnly(
+  emphasized: readonly LandingPageCopyTreatment[],
+): ModuleFunnelPolicy {
+  return {
+    prohibited: landingPageCopyTreatments.filter(
+      (treatment) => !emphasized.includes(treatment),
+    ),
+    restricted: [],
+    emphasized,
+    effectiveActionOnly: false,
+  };
+}
+
+function treatmentSupportRequirement(
+  moduleKey: LandingPageModuleKey,
+  treatment: LandingPageCopyTreatment,
+): LandingPageTreatmentSupportRequirement {
+  const researchSupport = (
+    fieldPaths: readonly string[],
+  ): LandingPageTreatmentSupportRequirement => ({
+    fieldPaths,
+    policies: ["hybrid"],
+    supports: ["when_factual", "when_present"],
+    sourceModes: ["research"],
+  });
+
+  if (moduleKey === "hero") {
+    if (treatment === "proof" || treatment === "credential" || treatment === "authority") {
+      return researchSupport(["proofShort"]);
+    }
+    if (treatment === "promise" || treatment === "offer_specificity") {
+      return researchSupport(["title", "subtitle"]);
+    }
+  }
+  if (
+    moduleKey === "trust_bar" &&
+    ["proof", "credential", "authority"].includes(treatment)
+  ) {
+    return researchSupport(["items[].text"]);
+  }
+  if (moduleKey === "offer" && treatment === "offer_specificity") {
+    return researchSupport(["items[].itemTitle", "items[].description"]);
+  }
+  if (
+    moduleKey === "technical_assurance" &&
+    ["proof", "credential", "authority"].includes(treatment)
+  ) {
+    return researchSupport([
+      "items[].assuranceTitle",
+      "items[].assuranceBody",
+    ]);
+  }
+  if (moduleKey === "social_proof" && treatment === "proof") {
+    return {
+      fieldPaths: ["items[].quote", "items[].attribution"],
+      policies: ["operational_required"],
+      supports: ["when_present"],
+      sourceModes: ["operational_evidence"],
+    };
+  }
+
+  throw new Error(
+    `missing internal support requirement for ${moduleKey}.${treatment}`,
+  );
 }
 
 function copyApprovedCopySourceMap(

--- a/lib/conversion-content/landing-page/module-catalog/registry.ts
+++ b/lib/conversion-content/landing-page/module-catalog/registry.ts
@@ -1,4 +1,12 @@
-import type { LandingPageModuleCatalogRegistry } from "./contracts";
+import type {
+  LandingPageActionFieldDefinition,
+  LandingPageCollectionFieldDefinition,
+  LandingPageImageFieldDefinition,
+  LandingPageModuleCatalogRegistry,
+  LandingPageModuleFieldCatalogRegistry,
+  LandingPageReferenceFieldDefinition,
+  LandingPageTextFieldDefinition,
+} from "./contracts";
 
 export const landingPageModuleCatalogRegistry = deepFreeze({
   1: {
@@ -136,6 +144,207 @@ export const landingPageModuleCatalogRegistry = deepFreeze({
   },
 } satisfies LandingPageModuleCatalogRegistry);
 
+export const landingPageModuleFieldCatalogRegistry = deepFreeze({
+  1: {
+    moduleCatalogVersion: 1,
+    modules: {
+      hero: moduleFields("hero", {
+        eyebrow: textField(
+          "eyebrow",
+          "eyebrow",
+          0,
+          1,
+          "research_guided",
+          "none",
+        ),
+        title: textField("title", "h1", 1, 1, "hybrid", "when_factual"),
+        subtitle: textField(
+          "subtitle",
+          "paragraph",
+          1,
+          1,
+          "hybrid",
+          "when_factual",
+        ),
+        primaryCta: actionField("primaryCta", 1, 1),
+        "primaryCta.label": textField(
+          "primaryCta.label",
+          "cta_label",
+          1,
+          1,
+          "hybrid",
+          "when_present",
+        ),
+        proofShort: textField(
+          "proofShort",
+          "paragraph",
+          0,
+          1,
+          "hybrid",
+          "when_present",
+        ),
+        media: imageField("media", 0, 1),
+      }),
+      trust_bar: moduleFields("trust_bar", {
+        items: collectionField("items", 2, 4),
+        "items[].text": textField(
+          "items[].text",
+          "benefit_item",
+          1,
+          1,
+          "hybrid",
+          "when_present",
+        ),
+      }),
+      problem_solution: moduleFields("problem_solution", {
+        title: textField("title", "h2", 1, 1, "research_guided", "none"),
+        items: collectionField("items", 2, 4),
+        "items[].problem": textField(
+          "items[].problem",
+          "card_title",
+          1,
+          1,
+          "research_guided",
+          "none",
+        ),
+        "items[].solution": textField(
+          "items[].solution",
+          "card_body",
+          1,
+          1,
+          "hybrid",
+          "when_present",
+        ),
+      }),
+      offer: moduleFields("offer", {
+        title: textField("title", "h2", 1, 1, "research_guided", "none"),
+        items: collectionField("items", 1, 4),
+        "items[].itemTitle": textField(
+          "items[].itemTitle",
+          "card_title",
+          1,
+          1,
+          "hybrid",
+          "when_present",
+        ),
+        "items[].description": textField(
+          "items[].description",
+          "card_body",
+          1,
+          1,
+          "hybrid",
+          "when_present",
+        ),
+      }),
+      process: moduleFields("process", {
+        title: textField("title", "h2", 1, 1, "research_guided", "none"),
+        steps: collectionField("steps", 2, 6, true),
+        "steps[].stepTitle": textField(
+          "steps[].stepTitle",
+          "step_title",
+          1,
+          1,
+          "hybrid",
+          "when_present",
+        ),
+        "steps[].stepBody": textField(
+          "steps[].stepBody",
+          "step_body",
+          1,
+          1,
+          "hybrid",
+          "when_present",
+        ),
+      }),
+      technical_assurance: moduleFields("technical_assurance", {
+        title: textField("title", "h2", 1, 1, "research_guided", "none"),
+        items: collectionField("items", 1, 4),
+        "items[].assuranceTitle": textField(
+          "items[].assuranceTitle",
+          "card_title",
+          1,
+          1,
+          "hybrid",
+          "when_present",
+        ),
+        "items[].assuranceBody": textField(
+          "items[].assuranceBody",
+          "card_body",
+          1,
+          1,
+          "hybrid",
+          "when_present",
+        ),
+      }),
+      social_proof: moduleFields("social_proof", {
+        title: textField("title", "h2", 1, 1, "research_guided", "none"),
+        items: collectionField("items", 1, 3),
+        "items[].quote": textField(
+          "items[].quote",
+          "card_body",
+          1,
+          1,
+          "operational_required",
+          "when_present",
+        ),
+        "items[].attribution": textField(
+          "items[].attribution",
+          "card_title",
+          1,
+          1,
+          "operational_required",
+          "when_present",
+        ),
+        "items[].evidenceRef": referenceField(
+          "items[].evidenceRef",
+          1,
+          1,
+        ),
+      }),
+      faq: moduleFields("faq", {
+        title: textField("title", "h2", 1, 1, "research_guided", "none"),
+        items: collectionField("items", 2, 6),
+        "items[].question": textField(
+          "items[].question",
+          "faq_question",
+          1,
+          1,
+          "research_guided",
+          "none",
+        ),
+        "items[].answer": textField(
+          "items[].answer",
+          "faq_answer",
+          1,
+          1,
+          "hybrid",
+          "when_factual",
+        ),
+      }),
+      final_cta: moduleFields("final_cta", {
+        title: textField("title", "h2", 1, 1, "hybrid", "when_factual"),
+        body: textField(
+          "body",
+          "paragraph",
+          1,
+          1,
+          "hybrid",
+          "when_factual",
+        ),
+        primaryCta: actionField("primaryCta", 1, 1),
+        "primaryCta.label": textField(
+          "primaryCta.label",
+          "cta_label",
+          1,
+          1,
+          "hybrid",
+          "when_present",
+        ),
+      }),
+    },
+  },
+} satisfies LandingPageModuleFieldCatalogRegistry);
+
 function moduleDefinition(input: {
   moduleKey: keyof LandingPageModuleCatalogRegistry[1]["modules"];
   function: string;
@@ -150,6 +359,87 @@ function moduleDefinition(input: {
     function: input.function,
     boundaries: input.boundaries,
     invariants: input.invariants,
+  };
+}
+
+function moduleFields(
+  moduleKey: keyof LandingPageModuleFieldCatalogRegistry[1]["modules"],
+  fields: LandingPageModuleFieldCatalogRegistry[1]["modules"][typeof moduleKey]["fields"],
+) {
+  return { moduleKey, moduleVersion: 1, fields };
+}
+
+function textField(
+  path: string,
+  semanticRole: LandingPageTextFieldDefinition["semanticRole"],
+  min: number,
+  max: number,
+  policy: LandingPageTextFieldDefinition["policy"],
+  support: LandingPageTextFieldDefinition["support"],
+): LandingPageTextFieldDefinition {
+  return {
+    path,
+    fieldKind: "text",
+    semanticRole,
+    cardinality: { min, max },
+    policy,
+    support,
+  };
+}
+
+function collectionField(
+  path: string,
+  min: number,
+  max: number,
+  ordered?: true,
+): LandingPageCollectionFieldDefinition {
+  return {
+    path,
+    fieldKind: "collection",
+    cardinality: { min, max },
+    policy: "not_copy",
+    ...(ordered ? { ordered } : {}),
+  };
+}
+
+function actionField(
+  path: string,
+  min: number,
+  max: number,
+): LandingPageActionFieldDefinition {
+  return {
+    path,
+    fieldKind: "action",
+    cardinality: { min, max },
+    policy: "not_copy",
+  };
+}
+
+function imageField(
+  path: string,
+  min: number,
+  max: number,
+): LandingPageImageFieldDefinition {
+  return {
+    path,
+    fieldKind: "image",
+    cardinality: { min, max },
+    policy: "technical_reference",
+    visibility: "all_viewports",
+  };
+}
+
+function referenceField(
+  path: string,
+  min: number,
+  max: number,
+): LandingPageReferenceFieldDefinition {
+  return {
+    path,
+    fieldKind: "reference",
+    cardinality: { min, max },
+    policy: "technical_reference",
+    referenceKind: "operational_evidence",
   };
 }
 

--- a/lib/conversion-content/landing-page/module-catalog/registry.ts
+++ b/lib/conversion-content/landing-page/module-catalog/registry.ts
@@ -3,6 +3,8 @@ import type {
   LandingPageCollectionFieldDefinition,
   LandingPageImageFieldDefinition,
   LandingPageCapabilityKey,
+  LandingPageCopySourceItemKey,
+  LandingPageCopySourceMap,
   LandingPageModuleCatalogRegistry,
   LandingPageModuleFieldCatalogRegistry,
   LandingPageModuleKey,
@@ -349,6 +351,72 @@ export const landingPageModuleFieldCatalogRegistry = deepFreeze({
   },
 } satisfies LandingPageModuleFieldCatalogRegistry);
 
+const approvedCopySourceMaps = {
+  hero: {
+    eyebrow: researchSource(["positioning_opportunity"], "search_intent"),
+    title: researchSource(
+      ["positioning_opportunity", "desire"],
+      "commercial_keywords",
+    ),
+    subtitle: researchSource(["pain", "desire"], "belief"),
+    "primaryCta.label": researchSource(["trigger"], "search_intent"),
+    proofShort: researchSource(["proof_type"], "objection"),
+  },
+  trust_bar: {
+    "items[].text": researchSource(["proof_type", "belief"], "objection"),
+  },
+  problem_solution: {
+    title: researchSource(["pain", "desire"], "positioning_opportunity"),
+    "items[].problem": researchSource(["pain", "fear"], "objection"),
+    "items[].solution": researchSource(
+      ["positioning_opportunity", "desire"],
+      "belief",
+    ),
+  },
+  offer: {
+    title: researchSource(["desire", "trigger"], "positioning_opportunity"),
+    "items[].itemTitle": researchSource(["trigger", "desire"]),
+    "items[].description": researchSource(
+      ["positioning_opportunity", "belief"],
+      "objection",
+    ),
+  },
+  process: {
+    title: researchSource(["belief", "desire"], "positioning_opportunity"),
+    "steps[].stepTitle": researchSource(
+      ["trigger", "positioning_opportunity"],
+      "desire",
+    ),
+    "steps[].stepBody": researchSource(["belief", "desire"], "objection"),
+  },
+  technical_assurance: {
+    title: researchSource(["proof_type", "belief"], "objection"),
+    "items[].assuranceTitle": researchSource(["proof_type"], "belief"),
+    "items[].assuranceBody": researchSource(
+      ["proof_type", "positioning_opportunity"],
+      "objection",
+    ),
+  },
+  social_proof: {
+    title: researchSource(["proof_type", "belief"], "objection"),
+    "items[].quote": operationalEvidenceSource(),
+    "items[].attribution": operationalEvidenceSource(),
+  },
+  faq: {
+    title: researchSource(["objection", "awareness_level"], "search_intent"),
+    "items[].question": researchSource(["objection", "fear"], "faq_questions"),
+    "items[].answer": researchSource(
+      ["belief", "positioning_opportunity"],
+      "desire",
+    ),
+  },
+  final_cta: {
+    title: researchSource(["trigger", "desire"], "positioning_opportunity"),
+    body: researchSource(["desire", "objection"], "belief"),
+    "primaryCta.label": researchSource(["trigger"], "search_intent"),
+  },
+} satisfies Readonly<Record<LandingPageModuleKey, LandingPageCopySourceMap>>;
+
 export const landingPageModuleVariantCatalogRegistry = deepFreeze({
   1: {
     moduleCatalogVersion: 1,
@@ -482,9 +550,44 @@ function variantDefinition(
     purpose: "controlled_test",
     compatibleModuleVersion: 1,
     fields: copyApprovedModuleFields(moduleKey),
+    copySourceMap: copyApprovedCopySourceMap(moduleKey),
     capabilities,
     rootDelta: {},
   };
+}
+
+function copyApprovedCopySourceMap(
+  moduleKey: LandingPageModuleKey,
+): LandingPageCopySourceMap {
+  return Object.fromEntries(
+    Object.entries(approvedCopySourceMaps[moduleKey]).map(([path, source]) => [
+      path,
+      source.sourceMode === "research"
+        ? {
+            sourceMode: source.sourceMode,
+            primaryItemKeys: [...source.primaryItemKeys],
+            ...(source.auxiliaryItemKey === undefined
+              ? {}
+              : { auxiliaryItemKey: source.auxiliaryItemKey }),
+          }
+        : { sourceMode: source.sourceMode },
+    ]),
+  );
+}
+
+function researchSource(
+  primaryItemKeys: readonly LandingPageCopySourceItemKey[],
+  auxiliaryItemKey?: LandingPageCopySourceItemKey,
+) {
+  return {
+    sourceMode: "research" as const,
+    primaryItemKeys,
+    ...(auxiliaryItemKey === undefined ? {} : { auxiliaryItemKey }),
+  };
+}
+
+function operationalEvidenceSource() {
+  return { sourceMode: "operational_evidence" as const };
 }
 
 function copyApprovedModuleFields(moduleKey: LandingPageModuleKey) {

--- a/lib/conversion-content/landing-page/module-catalog/registry.ts
+++ b/lib/conversion-content/landing-page/module-catalog/registry.ts
@@ -2,8 +2,12 @@ import type {
   LandingPageActionFieldDefinition,
   LandingPageCollectionFieldDefinition,
   LandingPageImageFieldDefinition,
+  LandingPageCapabilityKey,
   LandingPageModuleCatalogRegistry,
   LandingPageModuleFieldCatalogRegistry,
+  LandingPageModuleKey,
+  LandingPageModuleVariantCatalogRegistry,
+  LandingPageModuleVariantDefinition,
   LandingPageReferenceFieldDefinition,
   LandingPageTextFieldDefinition,
 } from "./contracts";
@@ -345,6 +349,95 @@ export const landingPageModuleFieldCatalogRegistry = deepFreeze({
   },
 } satisfies LandingPageModuleFieldCatalogRegistry);
 
+export const landingPageModuleVariantCatalogRegistry = deepFreeze({
+  1: {
+    moduleCatalogVersion: 1,
+    capabilities: {
+      primary_action: {
+        capabilityKey: "primary_action",
+        bindingFieldKey: "primary_conversion_channel",
+        allowedValues: ["whatsapp", "phone", "email", "external_url"],
+      },
+      image_asset: {
+        capabilityKey: "image_asset",
+        modes: ["informative", "decorative"],
+        visibility: "all_viewports",
+        informativeRequiresAltText: true,
+        decorativeRequiresEmptyAltText: true,
+      },
+      accordion_interaction: {
+        capabilityKey: "accordion_interaction",
+        initialState: "all_closed",
+        expansionMode: "single",
+        toggleMode: "own_control",
+        keyboardRequired: true,
+        stateExposed: true,
+        controlContentAssociationRequired: true,
+        focusPreserved: true,
+        focusVisible: "inherited_from_root",
+        wcagBaseline: "2.2",
+      },
+    },
+    modules: {
+      hero: moduleVariants("hero", {
+        standard: variantDefinition("hero", "standard", [
+          "primary_action",
+          "image_asset",
+        ]),
+      }),
+      trust_bar: moduleVariants("trust_bar", {
+        standard: variantDefinition("trust_bar", "standard"),
+      }),
+      problem_solution: moduleVariants("problem_solution", {
+        standard: variantDefinition("problem_solution", "standard"),
+      }),
+      offer: moduleVariants("offer", {
+        standard: variantDefinition("offer", "standard"),
+      }),
+      process: moduleVariants("process", {
+        standard: variantDefinition("process", "standard"),
+      }),
+      technical_assurance: moduleVariants("technical_assurance", {
+        standard: variantDefinition("technical_assurance", "standard"),
+      }),
+      social_proof: moduleVariants("social_proof", {
+        standard: variantDefinition("social_proof", "standard"),
+      }),
+      faq: moduleVariants("faq", {
+        standard: variantDefinition("faq", "standard"),
+        accordion: variantDefinition("faq", "accordion", [
+          "accordion_interaction",
+        ]),
+      }),
+      final_cta: moduleVariants("final_cta", {
+        standard: variantDefinition("final_cta", "standard", [
+          "primary_action",
+        ]),
+      }),
+    },
+  },
+} satisfies LandingPageModuleVariantCatalogRegistry);
+
+export function resolveLandingPageModuleVariantDefinitionInternal(input: {
+  moduleKey: string;
+  moduleVersion: number;
+  variantKey: string;
+  variantVersion: number;
+}): LandingPageModuleVariantDefinition | undefined {
+  const catalog = landingPageModuleVariantCatalogRegistry[1];
+  const moduleEntry = catalog.modules[input.moduleKey as LandingPageModuleKey];
+  if (!moduleEntry || moduleEntry.moduleVersion !== input.moduleVersion) {
+    return undefined;
+  }
+
+  const variant = moduleEntry.variants[input.variantKey];
+  if (!variant || variant.variantVersion !== input.variantVersion) {
+    return undefined;
+  }
+
+  return variant;
+}
+
 function moduleDefinition(input: {
   moduleKey: keyof LandingPageModuleCatalogRegistry[1]["modules"];
   function: string;
@@ -367,6 +460,40 @@ function moduleFields(
   fields: LandingPageModuleFieldCatalogRegistry[1]["modules"][typeof moduleKey]["fields"],
 ) {
   return { moduleKey, moduleVersion: 1, fields };
+}
+
+function moduleVariants(
+  moduleKey: LandingPageModuleKey,
+  variants: Readonly<Record<string, LandingPageModuleVariantDefinition>>,
+) {
+  return { moduleKey, moduleVersion: 1, variants };
+}
+
+function variantDefinition(
+  moduleKey: LandingPageModuleKey,
+  variantKey: LandingPageModuleVariantDefinition["variantKey"],
+  capabilities: readonly LandingPageCapabilityKey[] = [],
+): LandingPageModuleVariantDefinition {
+  return {
+    variantKey,
+    variantVersion: 1,
+    lifecycleStatus: "hypothesis",
+    purpose: "controlled_test",
+    compatibleModuleVersion: 1,
+    fields: copyApprovedModuleFields(moduleKey),
+    capabilities,
+  };
+}
+
+function copyApprovedModuleFields(moduleKey: LandingPageModuleKey) {
+  return Object.fromEntries(
+    Object.entries(
+      landingPageModuleFieldCatalogRegistry[1].modules[moduleKey].fields,
+    ).map(([path, field]) => [
+      path,
+      { ...field, cardinality: { ...field.cardinality } },
+    ]),
+  ) as LandingPageModuleVariantDefinition["fields"];
 }
 
 function textField(

--- a/lib/conversion-content/landing-page/module-catalog/registry.ts
+++ b/lib/conversion-content/landing-page/module-catalog/registry.ts
@@ -452,6 +452,7 @@ function moduleDefinition(input: {
     function: input.function,
     boundaries: input.boundaries,
     invariants: input.invariants,
+    rootDelta: {},
   };
 }
 
@@ -466,7 +467,7 @@ function moduleVariants(
   moduleKey: LandingPageModuleKey,
   variants: Readonly<Record<string, LandingPageModuleVariantDefinition>>,
 ) {
-  return { moduleKey, moduleVersion: 1, variants };
+  return { moduleKey, moduleVersion: 1, rootDelta: {}, variants };
 }
 
 function variantDefinition(
@@ -482,6 +483,7 @@ function variantDefinition(
     compatibleModuleVersion: 1,
     fields: copyApprovedModuleFields(moduleKey),
     capabilities,
+    rootDelta: {},
   };
 }
 

--- a/lib/conversion-content/landing-page/module-catalog/registry.ts
+++ b/lib/conversion-content/landing-page/module-catalog/registry.ts
@@ -30,7 +30,6 @@ import {
 type ModuleFunnelPolicy = Readonly<{
   prohibited: readonly LandingPageCopyTreatment[];
   restricted: readonly LandingPageCopyTreatment[];
-  emphasized: readonly LandingPageCopyTreatment[];
   effectiveActionOnly: boolean;
 }>;
 
@@ -460,7 +459,6 @@ const moduleFunnelPolicies = {
       "scarcity",
     ],
     restricted: [],
-    emphasized: [],
     effectiveActionOnly: true,
   },
   trust_bar: {
@@ -477,10 +475,9 @@ const moduleFunnelPolicies = {
       "guarantee",
     ],
     restricted: [],
-    emphasized: [],
     effectiveActionOnly: false,
   },
-  problem_solution: policyAllowingOnly([
+  problem_solution: policyPermittingOnly([
     "educational_context",
     "problem_emphasis",
   ]),
@@ -498,10 +495,9 @@ const moduleFunnelPolicies = {
       "guarantee",
     ],
     restricted: ["offer_specificity"],
-    emphasized: [],
     effectiveActionOnly: false,
   },
-  process: policyAllowingOnly(["educational_context"]),
+  process: policyPermittingOnly(["educational_context"]),
   technical_assurance: {
     prohibited: [
       ...actionTreatments,
@@ -515,17 +511,15 @@ const moduleFunnelPolicies = {
       "guarantee",
     ],
     restricted: [],
-    emphasized: ["educational_context"],
     effectiveActionOnly: false,
   },
-  social_proof: policyAllowingOnly(["proof"]),
-  faq: policyAllowingOnly(["educational_context", "problem_emphasis"]),
+  social_proof: policyPermittingOnly(["proof"]),
+  faq: policyPermittingOnly(["educational_context", "problem_emphasis"]),
   final_cta: {
     prohibited: landingPageCopyTreatments.filter(
       (treatment) => !actionTreatments.includes(treatment as never),
     ),
     restricted: [],
-    emphasized: [],
     effectiveActionOnly: true,
   },
 } satisfies Readonly<Record<LandingPageModuleKey, ModuleFunnelPolicy>>;
@@ -821,16 +815,12 @@ function createModuleFunnelProfileDelta(
       const restricted = policy.restricted.filter(
         (treatment) => !prohibited.has(treatment),
       );
-      const emphasized = [
-        ...policy.emphasized,
-        ...(policy.effectiveActionOnly ? [effectiveAction] : []),
-      ].filter((treatment) => !prohibited.has(treatment));
       const partialDelta = {
         restricted,
         prohibited: landingPageCopyTreatments.filter((treatment) =>
           prohibited.has(treatment),
         ),
-        emphasized,
+        emphasized: [],
         supportRequirements: {},
       } satisfies LandingPageFunnelProfileStageDelta;
       const result = applyLandingPageFunnelProfileDeltaInternal(
@@ -850,15 +840,14 @@ function createModuleFunnelProfileDelta(
   ) as unknown as LandingPageFunnelProfileDelta;
 }
 
-function policyAllowingOnly(
-  emphasized: readonly LandingPageCopyTreatment[],
+function policyPermittingOnly(
+  allowed: readonly LandingPageCopyTreatment[],
 ): ModuleFunnelPolicy {
   return {
     prohibited: landingPageCopyTreatments.filter(
-      (treatment) => !emphasized.includes(treatment),
+      (treatment) => !allowed.includes(treatment),
     ),
     restricted: [],
-    emphasized,
     effectiveActionOnly: false,
   };
 }

--- a/lib/conversion-content/landing-page/module-catalog/resolver.ts
+++ b/lib/conversion-content/landing-page/module-catalog/resolver.ts
@@ -1,0 +1,265 @@
+import {
+  resolveLandingPageRootParameters,
+  type ResolveLandingPageRootParametersInput,
+  type ResolveLandingPageRootParametersResult,
+} from "../index";
+import {
+  landingPageFunnelStages,
+  landingPageModuleLifecycleStatuses,
+  type LandingPageEffectiveFunnelCopyProfileRegistry,
+  type LandingPageModuleCatalogErrorCode,
+  type LandingPageModuleCatalogRegistry,
+  type LandingPageModuleFieldCatalogRegistry,
+  type LandingPageModuleKey,
+  type LandingPageModuleLifecycleStatus,
+  type LandingPageModuleVariantCatalogRegistry,
+  type LandingPageModuleVariantReference,
+  type ResolveLandingPageModuleVariantOptions,
+  type ResolveLandingPageModuleVariantResult,
+} from "./contracts";
+import {
+  applyLandingPageFunnelProfileDeltaInternal,
+  landingPageModuleCatalogRegistry,
+  landingPageModuleFieldCatalogRegistry,
+  landingPageModuleVariantCatalogRegistry,
+} from "./registry";
+import {
+  landingPageModuleCatalogEntrySchema,
+  landingPageModuleFieldCatalogEntrySchema,
+  landingPageModuleVariantCatalogEntrySchema,
+  landingPageModuleVariantReferenceSchema,
+} from "./schema";
+
+export type LandingPageModuleResolverDependenciesInternal = Readonly<{
+  moduleCatalogRegistry: LandingPageModuleCatalogRegistry;
+  fieldCatalogRegistry: LandingPageModuleFieldCatalogRegistry;
+  variantCatalogRegistry: LandingPageModuleVariantCatalogRegistry;
+  resolveRootParameters: (
+    input: ResolveLandingPageRootParametersInput,
+  ) => ResolveLandingPageRootParametersResult;
+}>;
+
+const canonicalDependencies: LandingPageModuleResolverDependenciesInternal = {
+  moduleCatalogRegistry: landingPageModuleCatalogRegistry,
+  fieldCatalogRegistry: landingPageModuleFieldCatalogRegistry,
+  variantCatalogRegistry: landingPageModuleVariantCatalogRegistry,
+  resolveRootParameters: resolveLandingPageRootParameters,
+};
+
+const safeMessages = {
+  UNKNOWN_MODULE_CATALOG_VERSION: "Unknown module catalog version.",
+  INVALID_MODULE_CATALOG_CONTRACT: "Invalid module catalog contract.",
+  ROOT_RESOLUTION_FAILED: "Landing page root resolution failed.",
+  INCOMPATIBLE_ROOT_VERSION: "Incompatible landing page root version.",
+  UNKNOWN_MODULE: "Unknown landing page module.",
+  UNKNOWN_MODULE_VERSION: "Unknown landing page module version.",
+  UNKNOWN_VARIANT: "Unknown landing page module variant.",
+  UNKNOWN_VARIANT_VERSION: "Unknown landing page module variant version.",
+  INCOMPATIBLE_REFERENCE: "Incompatible landing page module variant reference.",
+  INVALID_VARIANT_PAYLOAD: "Invalid landing page variant payload.",
+} as const satisfies Readonly<Record<LandingPageModuleCatalogErrorCode, string>>;
+
+export function resolveLandingPageModuleVariant(
+  reference: LandingPageModuleVariantReference,
+  options: ResolveLandingPageModuleVariantOptions = {},
+): ResolveLandingPageModuleVariantResult {
+  return resolveLandingPageModuleVariantWithDependenciesInternal(
+    reference,
+    options,
+    canonicalDependencies,
+  );
+}
+
+export function resolveLandingPageModuleVariantWithDependenciesInternal(
+  reference: LandingPageModuleVariantReference,
+  options: ResolveLandingPageModuleVariantOptions,
+  dependencies: LandingPageModuleResolverDependenciesInternal,
+): ResolveLandingPageModuleVariantResult {
+  const parsedReference = landingPageModuleVariantReferenceSchema.safeParse(reference);
+  if (!parsedReference.success) return failure("INCOMPATIBLE_REFERENCE");
+
+  const requested = parsedReference.data;
+  const catalog = dependencies.moduleCatalogRegistry[requested.moduleCatalogVersion];
+  const fieldCatalog =
+    dependencies.fieldCatalogRegistry[requested.moduleCatalogVersion];
+  const variantCatalog =
+    dependencies.variantCatalogRegistry[requested.moduleCatalogVersion];
+  if (!catalog || !fieldCatalog || !variantCatalog) {
+    return failure("UNKNOWN_MODULE_CATALOG_VERSION");
+  }
+
+  if (
+    !landingPageModuleCatalogEntrySchema.safeParse(catalog).success ||
+    !landingPageModuleFieldCatalogEntrySchema.safeParse(fieldCatalog).success ||
+    !landingPageModuleVariantCatalogEntrySchema.safeParse(variantCatalog).success ||
+    catalog.moduleCatalogVersion !== requested.moduleCatalogVersion ||
+    fieldCatalog.moduleCatalogVersion !== requested.moduleCatalogVersion ||
+    variantCatalog.moduleCatalogVersion !== requested.moduleCatalogVersion
+  ) {
+    return failure("INVALID_MODULE_CATALOG_CONTRACT");
+  }
+
+  if (!catalog.compatibleRootVersions.includes(requested.rootVersion)) {
+    return failure("INCOMPATIBLE_ROOT_VERSION");
+  }
+
+  const moduleDefinition = catalog.modules[requested.moduleKey as LandingPageModuleKey];
+  const fieldModule = fieldCatalog.modules[requested.moduleKey as LandingPageModuleKey];
+  const variantModule = variantCatalog.modules[requested.moduleKey as LandingPageModuleKey];
+  if (!moduleDefinition || !fieldModule || !variantModule) {
+    return failure("UNKNOWN_MODULE");
+  }
+  if (
+    moduleDefinition.moduleVersion !== requested.moduleVersion ||
+    fieldModule.moduleVersion !== requested.moduleVersion ||
+    variantModule.moduleVersion !== requested.moduleVersion
+  ) {
+    return failure("UNKNOWN_MODULE_VERSION");
+  }
+
+  const variant = variantModule.variants[requested.variantKey];
+  if (!variant) return failure("UNKNOWN_VARIANT");
+  if (variant.variantVersion !== requested.variantVersion) {
+    return failure("UNKNOWN_VARIANT_VERSION");
+  }
+  if (
+    moduleDefinition.moduleKey !== requested.moduleKey ||
+    fieldModule.moduleKey !== requested.moduleKey ||
+    variantModule.moduleKey !== requested.moduleKey ||
+    variant.variantKey !== requested.variantKey ||
+    variant.compatibleModuleVersion !== requested.moduleVersion
+  ) {
+    return failure("INCOMPATIBLE_REFERENCE");
+  }
+  const validReference = requested as LandingPageModuleVariantReference;
+
+  const rootResolution = dependencies.resolveRootParameters({
+    rootVersion: requested.rootVersion,
+    ...(options.presetKey === undefined ? {} : { presetKey: options.presetKey }),
+  });
+  if (!rootResolution.ok) return failure("ROOT_RESOLUTION_FAILED");
+  if (rootResolution.value.rootVersion !== requested.rootVersion) {
+    return failure("INCOMPATIBLE_REFERENCE");
+  }
+
+  const effectiveLifecycleStatus =
+    calculateLandingPageEffectiveLifecycleStatusInternal(
+      rootResolution.value.lifecycleStatus,
+      moduleDefinition.lifecycleStatus,
+      variant.lifecycleStatus,
+    );
+  if (!effectiveLifecycleStatus) {
+    return failure("INVALID_MODULE_CATALOG_CONTRACT");
+  }
+
+  const funnelCopyProfile = composeFunnelCopyProfiles(
+    variantCatalog.funnelCopyProfiles,
+    variantModule.funnelProfileDelta,
+    variant.funnelProfileDelta,
+  );
+  if (!funnelCopyProfile) return failure("INVALID_MODULE_CATALOG_CONTRACT");
+
+  const capabilities = variant.capabilities.map(
+    (capabilityKey) => variantCatalog.capabilities[capabilityKey],
+  );
+  if (capabilities.some((capability) => capability === undefined)) {
+    return failure("INVALID_MODULE_CATALOG_CONTRACT");
+  }
+
+  return deepFreeze(cloneJson({
+    ok: true,
+    value: {
+      reference: validReference,
+      rootParameters: rootResolution.value,
+      module: moduleDefinition,
+      variant,
+      fields: variant.fields,
+      capabilities,
+      copySourceMap: variant.copySourceMap,
+      funnelCopyProfile,
+      rootLifecycleStatus: rootResolution.value.lifecycleStatus,
+      moduleLifecycleStatus: moduleDefinition.lifecycleStatus,
+      variantLifecycleStatus: variant.lifecycleStatus,
+      effectiveLifecycleStatus,
+      modulePurpose: moduleDefinition.purpose,
+      variantPurpose: variant.purpose,
+    },
+  } satisfies ResolveLandingPageModuleVariantResult));
+}
+
+export function calculateLandingPageEffectiveLifecycleStatusInternal(
+  rootStatus: string,
+  moduleStatus: string,
+  variantStatus: string,
+): LandingPageModuleLifecycleStatus | undefined {
+  const statuses = [rootStatus, moduleStatus, variantStatus];
+  if (
+    statuses.some(
+      (status) =>
+        !landingPageModuleLifecycleStatuses.includes(
+          status as LandingPageModuleLifecycleStatus,
+        ),
+    )
+  ) {
+    return undefined;
+  }
+  if (statuses.includes("deprecated")) return "deprecated";
+  if (statuses.includes("hypothesis")) return "hypothesis";
+  return "validated";
+}
+
+function composeFunnelCopyProfiles(
+  profiles: LandingPageModuleVariantCatalogRegistry[1]["funnelCopyProfiles"],
+  moduleDelta: LandingPageModuleVariantCatalogRegistry[1]["modules"][LandingPageModuleKey]["funnelProfileDelta"],
+  variantDelta: LandingPageModuleVariantCatalogRegistry[1]["modules"][LandingPageModuleKey]["funnelProfileDelta"],
+): LandingPageEffectiveFunnelCopyProfileRegistry | undefined {
+  const result = {} as Record<
+    (typeof landingPageFunnelStages)[number],
+    LandingPageEffectiveFunnelCopyProfileRegistry[(typeof landingPageFunnelStages)[number]]
+  >;
+  for (const stage of landingPageFunnelStages) {
+    const moduleProfile = applyLandingPageFunnelProfileDeltaInternal(
+      profiles[stage],
+      moduleDelta[stage],
+    );
+    if (!moduleProfile) return undefined;
+    const variantProfile = applyLandingPageFunnelProfileDeltaInternal(
+      moduleProfile,
+      variantDelta[stage],
+    );
+    if (!variantProfile) return undefined;
+
+    const emphasized = [...new Set([
+      ...moduleDelta[stage].emphasized,
+      ...variantDelta[stage].emphasized,
+    ])];
+    if (emphasized.some((treatment) => variantProfile.prohibited.includes(treatment))) {
+      return undefined;
+    }
+    result[stage] = { ...variantProfile, emphasized };
+  }
+  return result;
+}
+
+function failure(
+  code: LandingPageModuleCatalogErrorCode,
+): ResolveLandingPageModuleVariantResult {
+  return deepFreeze({ ok: false, error: { code, message: safeMessages[code] } });
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === "object") {
+    for (const property of Object.getOwnPropertyNames(value)) {
+      const nested = value[property as keyof T];
+      if (nested && typeof nested === "object" && !Object.isFrozen(nested)) {
+        deepFreeze(nested);
+      }
+    }
+    Object.freeze(value);
+  }
+  return value;
+}

--- a/lib/conversion-content/landing-page/module-catalog/schema.ts
+++ b/lib/conversion-content/landing-page/module-catalog/schema.ts
@@ -1,12 +1,21 @@
 import { z } from "zod";
 
 import {
+  landingPageFieldKinds,
+  landingPageFieldPolicies,
+  landingPageFieldSupports,
   landingPageModuleKeys,
   landingPageModuleLifecycleStatuses,
+  type LandingPageFieldDefinition,
   type LandingPageModuleDefinition,
+  type LandingPageModuleFieldDefinition,
   type LandingPageModuleKey,
 } from "./contracts";
-import { landingPageModuleCatalogRegistry } from "./registry";
+import {
+  landingPageModuleCatalogRegistry,
+  landingPageModuleFieldCatalogRegistry,
+} from "./registry";
+import { landingPageRootSemanticRoleKeys } from "../root-schema";
 
 const identifierSchema = z.string().regex(/^[a-z][a-z0-9_]*$/);
 const uniqueIdentifiersSchema = z
@@ -18,6 +27,162 @@ const uniqueIdentifiersSchema = z
         code: "custom",
         message: "structural identifiers must be unique",
       });
+    }
+  });
+
+const fieldPathSchema = z
+  .string()
+  .regex(/^[a-z][a-zA-Z0-9]*(?:\[\])?(?:\.[a-z][a-zA-Z0-9]*)?$/);
+const cardinalitySchema = z
+  .object({
+    min: z.number().int().min(0),
+    max: z.number().int().min(0),
+  })
+  .strict()
+  .superRefine((cardinality, context) => {
+    if (cardinality.min > cardinality.max) {
+      context.addIssue({
+        code: "custom",
+        message: "field cardinality is inverted",
+      });
+    }
+  });
+
+const textFieldDefinitionSchema = z
+  .object({
+    path: fieldPathSchema,
+    fieldKind: z.literal(landingPageFieldKinds[0]),
+    semanticRole: z.enum(landingPageRootSemanticRoleKeys),
+    cardinality: cardinalitySchema,
+    policy: z.enum([
+      landingPageFieldPolicies[0],
+      landingPageFieldPolicies[1],
+      landingPageFieldPolicies[2],
+    ]),
+    support: z.enum(landingPageFieldSupports),
+  })
+  .strict()
+  .superRefine((field, context) => {
+    if (
+      field.policy === "operational_required" &&
+      field.support !== "when_present"
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["support"],
+        message: "operational required text needs when_present support",
+      });
+    }
+  });
+
+const collectionFieldDefinitionSchema = z
+  .object({
+    path: fieldPathSchema,
+    fieldKind: z.literal(landingPageFieldKinds[1]),
+    cardinality: cardinalitySchema,
+    policy: z.literal("not_copy"),
+    ordered: z.literal(true).optional(),
+  })
+  .strict();
+
+const actionFieldDefinitionSchema = z
+  .object({
+    path: fieldPathSchema,
+    fieldKind: z.literal(landingPageFieldKinds[2]),
+    cardinality: cardinalitySchema,
+    policy: z.literal("not_copy"),
+  })
+  .strict();
+
+const imageFieldDefinitionSchema = z
+  .object({
+    path: fieldPathSchema,
+    fieldKind: z.literal(landingPageFieldKinds[3]),
+    cardinality: cardinalitySchema,
+    policy: z.literal("technical_reference"),
+    visibility: z.literal("all_viewports"),
+  })
+  .strict();
+
+const referenceFieldDefinitionSchema = z
+  .object({
+    path: fieldPathSchema,
+    fieldKind: z.literal(landingPageFieldKinds[4]),
+    cardinality: cardinalitySchema,
+    policy: z.literal("technical_reference"),
+    referenceKind: z.literal("operational_evidence"),
+  })
+  .strict();
+
+const fieldDefinitionSchema = z
+  .discriminatedUnion("fieldKind", [
+    textFieldDefinitionSchema,
+    collectionFieldDefinitionSchema,
+    actionFieldDefinitionSchema,
+    imageFieldDefinitionSchema,
+    referenceFieldDefinitionSchema,
+  ])
+  .superRefine((field, context) => {
+    if (field.fieldKind !== "collection" && field.cardinality.max > 1) {
+      context.addIssue({
+        code: "custom",
+        path: ["cardinality", "max"],
+        message: "non-collection fields allow at most one value",
+      });
+    }
+  });
+
+const moduleFieldDefinitionSchema = z
+  .object({
+    moduleKey: z.enum(landingPageModuleKeys),
+    moduleVersion: z.literal(1),
+    fields: z.record(z.string(), fieldDefinitionSchema),
+  })
+  .strict()
+  .superRefine((moduleDefinition, context) => {
+    validateFieldPaths(moduleDefinition, context);
+  });
+
+export const landingPageModuleFieldCatalogEntrySchema = z
+  .object({
+    moduleCatalogVersion: z.literal(1),
+    modules: z.record(z.string(), moduleFieldDefinitionSchema),
+  })
+  .strict()
+  .superRefine((catalog, context) => {
+    validateExactValues({
+      context,
+      path: ["modules"],
+      actual: Object.keys(catalog.modules),
+      expected: landingPageModuleKeys,
+    });
+
+    for (const [moduleKey, moduleDefinition] of Object.entries(
+      catalog.modules,
+    )) {
+      if (moduleDefinition.moduleKey !== moduleKey) {
+        context.addIssue({
+          code: "custom",
+          path: ["modules", moduleKey, "moduleKey"],
+          message: "module field identity must match its registry key",
+        });
+      }
+
+      const canonicalModule =
+        landingPageModuleFieldCatalogRegistry[1].modules[
+          moduleKey as LandingPageModuleKey
+        ];
+      if (
+        moduleDefinition.moduleVersion === 1 &&
+        canonicalModule &&
+        !isDeepEqual(moduleDefinition.fields, canonicalModule.fields)
+      ) {
+        context.addIssue({
+          code: "custom",
+          path: ["modules", moduleKey, "fields"],
+          message: "module fields must match the approved v1 contract",
+        });
+      }
     }
   });
 
@@ -134,6 +299,114 @@ function validateExactModuleV1Structure(input: {
     actual: input.actual.invariants,
     expected: input.expected.invariants,
   });
+}
+
+function validateFieldPaths(
+  moduleDefinition: LandingPageModuleFieldDefinition,
+  context: z.RefinementCtx,
+) {
+  const fields = moduleDefinition.fields;
+
+  for (const [fieldPath, fieldDefinition] of Object.entries(fields)) {
+    if (fieldDefinition.path !== fieldPath) {
+      context.addIssue({
+        code: "custom",
+        path: ["fields", fieldPath, "path"],
+        message: "field path must match its registry key",
+      });
+    }
+
+    const collectionChild = fieldPath.match(
+      /^([a-z][a-zA-Z0-9]*)\[\]\.([a-z][a-zA-Z0-9]*)$/,
+    );
+    const objectChild = fieldPath.match(
+      /^([a-z][a-zA-Z0-9]*)\.([a-z][a-zA-Z0-9]*)$/,
+    );
+
+    if (collectionChild) {
+      const parent = fields[collectionChild[1]];
+      if (!parent || parent.fieldKind !== "collection") {
+        context.addIssue({
+          code: "custom",
+          path: ["fields", fieldPath],
+          message: "collection child requires a declared collection parent",
+        });
+      }
+      if (fieldDefinition.fieldKind === "collection") {
+        context.addIssue({
+          code: "custom",
+          path: ["fields", fieldPath, "fieldKind"],
+          message: "nested collections are not allowed",
+        });
+      }
+    } else if (objectChild) {
+      const parent = fields[objectChild[1]];
+      if (!parent || parent.fieldKind !== "action") {
+        context.addIssue({
+          code: "custom",
+          path: ["fields", fieldPath],
+          message: "object child requires a declared action parent",
+        });
+      }
+    } else if (fieldPath.includes(".") || fieldPath.includes("[]")) {
+      context.addIssue({
+        code: "custom",
+        path: ["fields", fieldPath],
+        message: "unknown field path structure",
+      });
+    }
+  }
+
+  for (const [fieldPath, fieldDefinition] of Object.entries(fields)) {
+    if (
+      fieldDefinition.fieldKind === "collection" &&
+      !Object.keys(fields).some((path) => path.startsWith(`${fieldPath}[].`))
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["fields", fieldPath],
+        message: "collection requires a closed item contract",
+      });
+    }
+    if (
+      fieldDefinition.fieldKind === "action" &&
+      !Object.keys(fields).some((path) => path.startsWith(`${fieldPath}.`))
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["fields", fieldPath],
+        message: "action requires a closed child contract",
+      });
+    }
+  }
+}
+
+function isDeepEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) return true;
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return (
+      Array.isArray(left) &&
+      Array.isArray(right) &&
+      left.length === right.length &&
+      left.every((value, index) => isDeepEqual(value, right[index]))
+    );
+  }
+  if (isPlainObject(left) && isPlainObject(right)) {
+    const leftKeys = Object.keys(left).sort();
+    const rightKeys = Object.keys(right).sort();
+    return (
+      leftKeys.length === rightKeys.length &&
+      leftKeys.every(
+        (key, index) =>
+          key === rightKeys[index] && isDeepEqual(left[key], right[key]),
+      )
+    );
+  }
+  return false;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function validateExactOrderedIdentifiers(input: {

--- a/lib/conversion-content/landing-page/module-catalog/schema.ts
+++ b/lib/conversion-content/landing-page/module-catalog/schema.ts
@@ -1,0 +1,119 @@
+import { z } from "zod";
+
+import {
+  landingPageModuleKeys,
+  landingPageModuleLifecycleStatuses,
+} from "./contracts";
+
+const identifierSchema = z.string().regex(/^[a-z][a-z0-9_]*$/);
+const uniqueIdentifiersSchema = z
+  .array(identifierSchema)
+  .min(1)
+  .superRefine((values, context) => {
+    if (new Set(values).size !== values.length) {
+      context.addIssue({
+        code: "custom",
+        message: "structural identifiers must be unique",
+      });
+    }
+  });
+
+export const landingPageModuleDefinitionSchema = z
+  .object({
+    moduleKey: z.enum(landingPageModuleKeys),
+    moduleVersion: z.number().int().min(1),
+    lifecycleStatus: z.enum(landingPageModuleLifecycleStatuses),
+    purpose: z.literal("controlled_test"),
+    function: identifierSchema,
+    boundaries: uniqueIdentifiersSchema,
+    invariants: uniqueIdentifiersSchema,
+  })
+  .strict();
+
+export const landingPageModuleCatalogEntrySchema = z
+  .object({
+    family: z.literal("landing_page"),
+    moduleCatalogVersion: z.number().int().min(1),
+    compatibleRootVersions: z.array(z.number().int().min(1)).min(1),
+    modules: z.record(z.string(), landingPageModuleDefinitionSchema),
+  })
+  .strict()
+  .superRefine((catalog, context) => {
+    if (
+      new Set(catalog.compatibleRootVersions).size !==
+      catalog.compatibleRootVersions.length
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["compatibleRootVersions"],
+        message: "compatible root versions must be unique",
+      });
+    }
+
+    if (catalog.moduleCatalogVersion === 1) {
+      validateExactValues({
+        context,
+        path: ["compatibleRootVersions"],
+        actual: catalog.compatibleRootVersions,
+        expected: [1],
+      });
+      validateExactValues({
+        context,
+        path: ["modules"],
+        actual: Object.keys(catalog.modules),
+        expected: landingPageModuleKeys,
+      });
+
+      for (const [moduleKey, moduleDefinition] of Object.entries(
+        catalog.modules,
+      )) {
+        if (moduleDefinition.moduleKey !== moduleKey) {
+          context.addIssue({
+            code: "custom",
+            path: ["modules", moduleKey, "moduleKey"],
+            message: "module identity must match its registry key",
+          });
+        }
+        if (moduleDefinition.moduleVersion !== 1) {
+          context.addIssue({
+            code: "custom",
+            path: ["modules", moduleKey, "moduleVersion"],
+            message: "module catalog v1 requires module version 1",
+          });
+        }
+        if (moduleDefinition.lifecycleStatus !== "hypothesis") {
+          context.addIssue({
+            code: "custom",
+            path: ["modules", moduleKey, "lifecycleStatus"],
+            message: "module catalog v1 starts as hypothesis",
+          });
+        }
+      }
+    }
+  });
+
+function validateExactValues(input: {
+  context: z.RefinementCtx;
+  path: (string | number)[];
+  actual: readonly (string | number)[];
+  expected: readonly (string | number)[];
+}) {
+  for (const value of input.actual) {
+    if (!input.expected.includes(value)) {
+      input.context.addIssue({
+        code: "custom",
+        path: input.path,
+        message: "unknown required value",
+      });
+    }
+  }
+  for (const value of input.expected) {
+    if (!input.actual.includes(value)) {
+      input.context.addIssue({
+        code: "custom",
+        path: input.path,
+        message: "required value missing",
+      });
+    }
+  }
+}

--- a/lib/conversion-content/landing-page/module-catalog/schema.ts
+++ b/lib/conversion-content/landing-page/module-catalog/schema.ts
@@ -20,6 +20,7 @@ import {
 import { landingPageRootSemanticRoleKeys } from "../root-schema";
 
 const identifierSchema = z.string().regex(/^[a-z][a-z0-9_]*$/);
+const rootDeltaSchema = z.object({}).strict();
 const uniqueIdentifiersSchema = z
   .array(identifierSchema)
   .min(1)
@@ -241,6 +242,7 @@ const moduleVariantDefinitionSchema = z
     compatibleModuleVersion: z.literal(1),
     fields: z.record(z.string(), fieldDefinitionSchema),
     capabilities: z.array(z.enum(landingPageCapabilityKeys)),
+    rootDelta: rootDeltaSchema,
   })
   .strict()
   .superRefine((variant, context) => {
@@ -258,6 +260,7 @@ const moduleVariantCatalogModuleEntrySchema = z
   .object({
     moduleKey: z.enum(landingPageModuleKeys),
     moduleVersion: z.literal(1),
+    rootDelta: rootDeltaSchema,
     variants: z.record(z.string(), moduleVariantDefinitionSchema),
   })
   .strict();
@@ -362,6 +365,7 @@ export const landingPageModuleDefinitionSchema = z
     function: identifierSchema,
     boundaries: uniqueIdentifiersSchema,
     invariants: uniqueIdentifiersSchema,
+    rootDelta: rootDeltaSchema,
   })
   .strict();
 

--- a/lib/conversion-content/landing-page/module-catalog/schema.ts
+++ b/lib/conversion-content/landing-page/module-catalog/schema.ts
@@ -2,15 +2,22 @@ import { z } from "zod";
 
 import {
   landingPageCapabilityKeys,
+  landingPageCopySourceModes,
   landingPageCopySourceItemKeys,
+  landingPageCopyTreatments,
+  landingPageCtaModes,
+  landingPageCtaModeTreatmentMap,
   landingPageFieldKinds,
   landingPageFieldPolicies,
   landingPageFieldSupports,
+  landingPageFunnelStages,
   landingPageModuleKeys,
   landingPageModuleLifecycleStatuses,
   landingPageVariantKeys,
   type LandingPageCopySourceMap,
   type LandingPageFieldDefinition,
+  type LandingPageFunnelCopyProfile,
+  type LandingPageFunnelProfileStageDelta,
   type LandingPageModuleDefinition,
   type LandingPageModuleKey,
 } from "./contracts";
@@ -18,6 +25,7 @@ import {
   landingPageModuleCatalogRegistry,
   landingPageModuleFieldCatalogRegistry,
   landingPageModuleVariantCatalogRegistry,
+  applyLandingPageFunnelProfileDeltaInternal,
 } from "./registry";
 import { landingPageRootSemanticRoleKeys } from "../root-schema";
 
@@ -270,6 +278,73 @@ const copySourceSchema = z.discriminatedUnion("sourceMode", [
   z.object({ sourceMode: z.literal("operational_evidence") }).strict(),
 ]);
 
+const treatmentArraySchema = z
+  .array(z.enum(landingPageCopyTreatments))
+  .superRefine((treatments, context) => {
+    if (new Set(treatments).size !== treatments.length) {
+      context.addIssue({
+        code: "custom",
+        message: "copy treatments must be unique",
+      });
+    }
+  });
+
+const funnelCopyProfileSchema = z
+  .object({
+    allowed: treatmentArraySchema,
+    restricted: treatmentArraySchema,
+    prohibited: treatmentArraySchema,
+    ctaMode: z.enum(landingPageCtaModes),
+  })
+  .strict()
+  .superRefine((profile, context) => {
+    validateFunnelCopyProfile(profile, context);
+  });
+
+const treatmentSupportRequirementSchema = z
+  .object({
+    fieldPaths: z.array(fieldPathSchema).min(1),
+    policies: z.array(z.enum(["hybrid", "operational_required"])).min(1),
+    supports: z.array(z.enum(["when_factual", "when_present"])).min(1),
+    sourceModes: z.array(z.enum(landingPageCopySourceModes)).min(1),
+  })
+  .strict()
+  .superRefine((requirement, context) => {
+    for (const values of [
+      requirement.fieldPaths,
+      requirement.policies,
+      requirement.supports,
+      requirement.sourceModes,
+    ]) {
+      if (new Set(values).size !== values.length) {
+        context.addIssue({
+          code: "custom",
+          message: "treatment support values must be unique",
+        });
+      }
+    }
+  });
+
+const funnelProfileStageDeltaSchema = z
+  .object({
+    restricted: treatmentArraySchema,
+    prohibited: treatmentArraySchema,
+    emphasized: treatmentArraySchema,
+    supportRequirements: z.partialRecord(
+      z.enum(landingPageCopyTreatments),
+      treatmentSupportRequirementSchema,
+    ),
+  })
+  .strict();
+
+const funnelProfileDeltaSchema = z
+  .object({
+    bofu: funnelProfileStageDeltaSchema,
+    mofu: funnelProfileStageDeltaSchema,
+    tofu: funnelProfileStageDeltaSchema,
+  })
+  .strict();
+
 const moduleVariantDefinitionSchema = z
   .object({
     variantKey: z.enum(landingPageVariantKeys),
@@ -279,6 +354,7 @@ const moduleVariantDefinitionSchema = z
     compatibleModuleVersion: z.literal(1),
     fields: z.record(z.string(), fieldDefinitionSchema),
     copySourceMap: z.record(z.string(), copySourceSchema),
+    funnelProfileDelta: funnelProfileDeltaSchema,
     capabilities: z.array(z.enum(landingPageCapabilityKeys)),
     rootDelta: rootDeltaSchema,
   })
@@ -300,6 +376,7 @@ const moduleVariantCatalogModuleEntrySchema = z
     moduleKey: z.enum(landingPageModuleKeys),
     moduleVersion: z.literal(1),
     rootDelta: rootDeltaSchema,
+    funnelProfileDelta: funnelProfileDeltaSchema,
     variants: z.record(z.string(), moduleVariantDefinitionSchema),
   })
   .strict();
@@ -307,11 +384,34 @@ const moduleVariantCatalogModuleEntrySchema = z
 export const landingPageModuleVariantCatalogEntrySchema = z
   .object({
     moduleCatalogVersion: z.literal(1),
+    funnelCopyProfiles: z.object({
+      bofu: funnelCopyProfileSchema,
+      mofu: funnelCopyProfileSchema,
+      tofu: funnelCopyProfileSchema,
+    }).strict(),
     capabilities: z.record(z.string(), capabilityDefinitionSchema),
     modules: z.record(z.string(), moduleVariantCatalogModuleEntrySchema),
   })
   .strict()
   .superRefine((catalog, context) => {
+    validateExactValues({
+      context,
+      path: ["funnelCopyProfiles"],
+      actual: Object.keys(catalog.funnelCopyProfiles),
+      expected: landingPageFunnelStages,
+    });
+    if (
+      !isDeepEqual(
+        catalog.funnelCopyProfiles,
+        landingPageModuleVariantCatalogRegistry[1].funnelCopyProfiles,
+      )
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["funnelCopyProfiles"],
+        message: "funnel copy profiles must match the approved v1 contract",
+      });
+    }
     validateExactValues({
       context,
       path: ["capabilities"],
@@ -362,6 +462,29 @@ export const landingPageModuleVariantCatalogEntrySchema = z
       }
       if (!canonicalModule) continue;
 
+      if (
+        !isDeepEqual(
+          moduleEntry.funnelProfileDelta,
+          canonicalModule.funnelProfileDelta,
+        )
+      ) {
+        context.addIssue({
+          code: "custom",
+          path: ["modules", moduleKey, "funnelProfileDelta"],
+          message: "module funnel delta must match the approved v1 contract",
+        });
+      }
+
+      validateFunnelProfileDelta({
+        moduleKey,
+        variantKey: undefined,
+        fields: canonicalModule.variants.standard.fields,
+        copySourceMap: canonicalModule.variants.standard.copySourceMap,
+        delta: moduleEntry.funnelProfileDelta,
+        profiles: catalog.funnelCopyProfiles,
+        context,
+      });
+
       validateExactValues({
         context,
         path: ["modules", moduleKey, "variants"],
@@ -389,6 +512,15 @@ export const landingPageModuleVariantCatalogEntrySchema = z
           moduleKey,
           variantKey,
           variant,
+          context,
+        });
+        validateFunnelProfileDelta({
+          moduleKey,
+          variantKey,
+          fields: variant.fields,
+          copySourceMap: variant.copySourceMap,
+          delta: variant.funnelProfileDelta,
+          profiles: catalog.funnelCopyProfiles,
           context,
         });
       }
@@ -674,6 +806,159 @@ function validateCapabilityBindings(input: {
       ],
       message: "accordion interaction belongs only to faq accordion",
     });
+  }
+}
+
+function validateFunnelCopyProfile(
+  profile: LandingPageFunnelCopyProfile,
+  context: z.RefinementCtx,
+) {
+  const classified = [
+    ...profile.allowed,
+    ...profile.restricted,
+    ...profile.prohibited,
+  ];
+  if (
+    classified.length !== landingPageCopyTreatments.length ||
+    new Set(classified).size !== landingPageCopyTreatments.length ||
+    landingPageCopyTreatments.some(
+      (treatment) => !classified.includes(treatment),
+    )
+  ) {
+    context.addIssue({
+      code: "custom",
+      message: "every copy treatment must have exactly one classification",
+    });
+  }
+
+  const actionTreatment = landingPageCtaModeTreatmentMap[profile.ctaMode];
+  if (!profile.allowed.includes(actionTreatment)) {
+    context.addIssue({
+      code: "custom",
+      path: ["ctaMode"],
+      message: "cta mode action treatment must be allowed",
+    });
+  }
+}
+
+function validateFunnelProfileDelta(input: {
+  moduleKey: string;
+  variantKey: string | undefined;
+  fields: Readonly<Record<string, LandingPageFieldDefinition>>;
+  copySourceMap: LandingPageCopySourceMap;
+  delta: Readonly<Record<string, LandingPageFunnelProfileStageDelta>>;
+  profiles: Readonly<Record<string, LandingPageFunnelCopyProfile>>;
+  context: z.RefinementCtx;
+}) {
+  const basePath = input.variantKey === undefined
+    ? ["modules", input.moduleKey, "funnelProfileDelta"]
+    : [
+        "modules",
+        input.moduleKey,
+        "variants",
+        input.variantKey,
+        "funnelProfileDelta",
+      ];
+
+  validateExactValues({
+    context: input.context,
+    path: basePath,
+    actual: Object.keys(input.delta),
+    expected: landingPageFunnelStages,
+  });
+
+  for (const stage of landingPageFunnelStages) {
+    const profile = input.profiles[stage];
+    const delta = input.delta[stage];
+    if (!profile || !delta) continue;
+
+    const result = applyLandingPageFunnelProfileDeltaInternal(profile, delta);
+    if (!result) {
+      input.context.addIssue({
+        code: "custom",
+        path: [...basePath, stage],
+        message: "funnel profile delta is invalid",
+      });
+      continue;
+    }
+
+    const actionTreatment = landingPageCtaModeTreatmentMap[result.ctaMode];
+    const hasPrimaryAction = input.fields.primaryCta?.fieldKind === "action";
+    if (hasPrimaryAction && !result.allowed.includes(actionTreatment)) {
+      input.context.addIssue({
+        code: "custom",
+        path: [...basePath, stage],
+        message: "delta must preserve the effective cta action treatment",
+      });
+    }
+
+    const classificationRank = (
+      candidate: LandingPageFunnelCopyProfile,
+      treatment: (typeof landingPageCopyTreatments)[number],
+    ) => candidate.prohibited.includes(treatment)
+      ? 2
+      : candidate.restricted.includes(treatment)
+        ? 1
+        : 0;
+    for (const treatment of landingPageCopyTreatments) {
+      if (
+        classificationRank(result, treatment) <
+        classificationRank(profile, treatment)
+      ) {
+        input.context.addIssue({
+          code: "custom",
+          path: [...basePath, stage],
+          message: "delta cannot expand the family profile permissions",
+        });
+      }
+    }
+
+    for (const treatment of delta.emphasized) {
+      if (result.prohibited.includes(treatment)) {
+        input.context.addIssue({
+          code: "custom",
+          path: [...basePath, stage, "emphasized"],
+          message: "a prohibited treatment cannot be emphasized",
+        });
+      }
+    }
+
+    validateExactValues({
+      context: input.context,
+      path: [...basePath, stage, "supportRequirements"],
+      actual: Object.keys(delta.supportRequirements),
+      expected: result.restricted,
+    });
+
+    for (const [treatment, requirement] of Object.entries(
+      delta.supportRequirements,
+    )) {
+      if (!requirement) continue;
+      for (const fieldPath of requirement.fieldPaths) {
+        const field = input.fields[fieldPath];
+        const source = input.copySourceMap[fieldPath];
+        if (
+          !field ||
+          field.fieldKind !== "text" ||
+          !requirement.policies.includes(field.policy as never) ||
+          !requirement.supports.includes(field.support as never) ||
+          !source ||
+          !requirement.sourceModes.includes(source.sourceMode)
+        ) {
+          input.context.addIssue({
+            code: "custom",
+            path: [
+              ...basePath,
+              stage,
+              "supportRequirements",
+              treatment,
+              "fieldPaths",
+            ],
+            message: "restricted treatment requires a compatible supported field",
+          });
+        }
+      }
+    }
   }
 }
 

--- a/lib/conversion-content/landing-page/module-catalog/schema.ts
+++ b/lib/conversion-content/landing-page/module-catalog/schema.ts
@@ -1,19 +1,21 @@
 import { z } from "zod";
 
 import {
+  landingPageCapabilityKeys,
   landingPageFieldKinds,
   landingPageFieldPolicies,
   landingPageFieldSupports,
   landingPageModuleKeys,
   landingPageModuleLifecycleStatuses,
+  landingPageVariantKeys,
   type LandingPageFieldDefinition,
   type LandingPageModuleDefinition,
-  type LandingPageModuleFieldDefinition,
   type LandingPageModuleKey,
 } from "./contracts";
 import {
   landingPageModuleCatalogRegistry,
   landingPageModuleFieldCatalogRegistry,
+  landingPageModuleVariantCatalogRegistry,
 } from "./registry";
 import { landingPageRootSemanticRoleKeys } from "../root-schema";
 
@@ -140,7 +142,7 @@ const moduleFieldDefinitionSchema = z
   })
   .strict()
   .superRefine((moduleDefinition, context) => {
-    validateFieldPaths(moduleDefinition, context);
+    validateFieldPaths(moduleDefinition.fields, context);
   });
 
 export const landingPageModuleFieldCatalogEntrySchema = z
@@ -181,6 +183,171 @@ export const landingPageModuleFieldCatalogEntrySchema = z
           code: "custom",
           path: ["modules", moduleKey, "fields"],
           message: "module fields must match the approved v1 contract",
+        });
+      }
+    }
+  });
+
+const primaryActionCapabilitySchema = z
+  .object({
+    capabilityKey: z.literal("primary_action"),
+    bindingFieldKey: z.literal("primary_conversion_channel"),
+    allowedValues: z.tuple([
+      z.literal("whatsapp"),
+      z.literal("phone"),
+      z.literal("email"),
+      z.literal("external_url"),
+    ]),
+  })
+  .strict();
+
+const imageAssetCapabilitySchema = z
+  .object({
+    capabilityKey: z.literal("image_asset"),
+    modes: z.tuple([z.literal("informative"), z.literal("decorative")]),
+    visibility: z.literal("all_viewports"),
+    informativeRequiresAltText: z.literal(true),
+    decorativeRequiresEmptyAltText: z.literal(true),
+  })
+  .strict();
+
+const accordionInteractionCapabilitySchema = z
+  .object({
+    capabilityKey: z.literal("accordion_interaction"),
+    initialState: z.literal("all_closed"),
+    expansionMode: z.literal("single"),
+    toggleMode: z.literal("own_control"),
+    keyboardRequired: z.literal(true),
+    stateExposed: z.literal(true),
+    controlContentAssociationRequired: z.literal(true),
+    focusPreserved: z.literal(true),
+    focusVisible: z.literal("inherited_from_root"),
+    wcagBaseline: z.literal("2.2"),
+  })
+  .strict();
+
+const capabilityDefinitionSchema = z.discriminatedUnion("capabilityKey", [
+  primaryActionCapabilitySchema,
+  imageAssetCapabilitySchema,
+  accordionInteractionCapabilitySchema,
+]);
+
+const moduleVariantDefinitionSchema = z
+  .object({
+    variantKey: z.enum(landingPageVariantKeys),
+    variantVersion: z.literal(1),
+    lifecycleStatus: z.literal("hypothesis"),
+    purpose: z.literal("controlled_test"),
+    compatibleModuleVersion: z.literal(1),
+    fields: z.record(z.string(), fieldDefinitionSchema),
+    capabilities: z.array(z.enum(landingPageCapabilityKeys)),
+  })
+  .strict()
+  .superRefine((variant, context) => {
+    validateFieldPaths(variant.fields, context);
+    if (new Set(variant.capabilities).size !== variant.capabilities.length) {
+      context.addIssue({
+        code: "custom",
+        path: ["capabilities"],
+        message: "variant capabilities must be unique",
+      });
+    }
+  });
+
+const moduleVariantCatalogModuleEntrySchema = z
+  .object({
+    moduleKey: z.enum(landingPageModuleKeys),
+    moduleVersion: z.literal(1),
+    variants: z.record(z.string(), moduleVariantDefinitionSchema),
+  })
+  .strict();
+
+export const landingPageModuleVariantCatalogEntrySchema = z
+  .object({
+    moduleCatalogVersion: z.literal(1),
+    capabilities: z.record(z.string(), capabilityDefinitionSchema),
+    modules: z.record(z.string(), moduleVariantCatalogModuleEntrySchema),
+  })
+  .strict()
+  .superRefine((catalog, context) => {
+    validateExactValues({
+      context,
+      path: ["capabilities"],
+      actual: Object.keys(catalog.capabilities),
+      expected: landingPageCapabilityKeys,
+    });
+    validateExactValues({
+      context,
+      path: ["modules"],
+      actual: Object.keys(catalog.modules),
+      expected: landingPageModuleKeys,
+    });
+
+    for (const [capabilityKey, capability] of Object.entries(
+      catalog.capabilities,
+    )) {
+      const canonicalCapability =
+        landingPageModuleVariantCatalogRegistry[1].capabilities[
+          capabilityKey as keyof typeof landingPageModuleVariantCatalogRegistry[1]["capabilities"]
+        ];
+      if (
+        capability.capabilityKey !== capabilityKey ||
+        !canonicalCapability ||
+        !isDeepEqual(capability, canonicalCapability)
+      ) {
+        context.addIssue({
+          code: "custom",
+          path: ["capabilities", capabilityKey],
+          message: "capability must match the approved v1 contract",
+        });
+      }
+    }
+
+    for (const [moduleKey, moduleEntry] of Object.entries(catalog.modules)) {
+      const canonicalModule =
+        landingPageModuleVariantCatalogRegistry[1].modules[
+          moduleKey as LandingPageModuleKey
+        ];
+      if (
+        moduleEntry.moduleKey !== moduleKey ||
+        moduleEntry.moduleVersion !== canonicalModule?.moduleVersion
+      ) {
+        context.addIssue({
+          code: "custom",
+          path: ["modules", moduleKey],
+          message: "variant module identity must match the approved v1 contract",
+        });
+      }
+      if (!canonicalModule) continue;
+
+      validateExactValues({
+        context,
+        path: ["modules", moduleKey, "variants"],
+        actual: Object.keys(moduleEntry.variants),
+        expected: Object.keys(canonicalModule.variants),
+      });
+
+      for (const [variantKey, variant] of Object.entries(
+        moduleEntry.variants,
+      )) {
+        const canonicalVariant = canonicalModule.variants[variantKey];
+        if (
+          variant.variantKey !== variantKey ||
+          variant.compatibleModuleVersion !== moduleEntry.moduleVersion ||
+          !canonicalVariant ||
+          !isDeepEqual(variant, canonicalVariant)
+        ) {
+          context.addIssue({
+            code: "custom",
+            path: ["modules", moduleKey, "variants", variantKey],
+            message: "variant must match the approved v1 contract",
+          });
+        }
+        validateCapabilityBindings({
+          moduleKey,
+          variantKey,
+          variant,
+          context,
         });
       }
     }
@@ -302,11 +469,9 @@ function validateExactModuleV1Structure(input: {
 }
 
 function validateFieldPaths(
-  moduleDefinition: LandingPageModuleFieldDefinition,
+  fields: Readonly<Record<string, LandingPageFieldDefinition>>,
   context: z.RefinementCtx,
 ) {
-  const fields = moduleDefinition.fields;
-
   for (const [fieldPath, fieldDefinition] of Object.entries(fields)) {
     if (fieldDefinition.path !== fieldPath) {
       context.addIssue({
@@ -378,6 +543,65 @@ function validateFieldPaths(
         message: "action requires a closed child contract",
       });
     }
+  }
+}
+
+function validateCapabilityBindings(input: {
+  moduleKey: string;
+  variantKey: string;
+  variant: {
+    fields: Readonly<Record<string, LandingPageFieldDefinition>>;
+    capabilities: readonly string[];
+  };
+  context: z.RefinementCtx;
+}) {
+  if (
+    input.variant.capabilities.includes("primary_action") &&
+    input.variant.fields.primaryCta?.fieldKind !== "action"
+  ) {
+    input.context.addIssue({
+      code: "custom",
+      path: [
+        "modules",
+        input.moduleKey,
+        "variants",
+        input.variantKey,
+        "capabilities",
+      ],
+      message: "primary action capability requires the approved action field",
+    });
+  }
+  if (
+    input.variant.capabilities.includes("image_asset") &&
+    input.variant.fields.media?.fieldKind !== "image"
+  ) {
+    input.context.addIssue({
+      code: "custom",
+      path: [
+        "modules",
+        input.moduleKey,
+        "variants",
+        input.variantKey,
+        "capabilities",
+      ],
+      message: "image asset capability requires the approved image field",
+    });
+  }
+  if (
+    input.variant.capabilities.includes("accordion_interaction") &&
+    (input.moduleKey !== "faq" || input.variantKey !== "accordion")
+  ) {
+    input.context.addIssue({
+      code: "custom",
+      path: [
+        "modules",
+        input.moduleKey,
+        "variants",
+        input.variantKey,
+        "capabilities",
+      ],
+      message: "accordion interaction belongs only to faq accordion",
+    });
   }
 }
 

--- a/lib/conversion-content/landing-page/module-catalog/schema.ts
+++ b/lib/conversion-content/landing-page/module-catalog/schema.ts
@@ -2,12 +2,14 @@ import { z } from "zod";
 
 import {
   landingPageCapabilityKeys,
+  landingPageCopySourceItemKeys,
   landingPageFieldKinds,
   landingPageFieldPolicies,
   landingPageFieldSupports,
   landingPageModuleKeys,
   landingPageModuleLifecycleStatuses,
   landingPageVariantKeys,
+  type LandingPageCopySourceMap,
   type LandingPageFieldDefinition,
   type LandingPageModuleDefinition,
   type LandingPageModuleKey,
@@ -233,6 +235,41 @@ const capabilityDefinitionSchema = z.discriminatedUnion("capabilityKey", [
   accordionInteractionCapabilitySchema,
 ]);
 
+const researchCopySourceSchema = z
+  .object({
+    sourceMode: z.literal("research"),
+    primaryItemKeys: z
+      .array(z.enum(landingPageCopySourceItemKeys))
+      .min(1)
+      .max(2),
+    auxiliaryItemKey: z.enum(landingPageCopySourceItemKeys).optional(),
+  })
+  .strict()
+  .superRefine((source, context) => {
+    if (new Set(source.primaryItemKeys).size !== source.primaryItemKeys.length) {
+      context.addIssue({
+        code: "custom",
+        path: ["primaryItemKeys"],
+        message: "primary item keys must be unique",
+      });
+    }
+    if (
+      source.auxiliaryItemKey !== undefined &&
+      source.primaryItemKeys.includes(source.auxiliaryItemKey)
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["auxiliaryItemKey"],
+        message: "auxiliary item key must differ from primary item keys",
+      });
+    }
+  });
+
+const copySourceSchema = z.discriminatedUnion("sourceMode", [
+  researchCopySourceSchema,
+  z.object({ sourceMode: z.literal("operational_evidence") }).strict(),
+]);
+
 const moduleVariantDefinitionSchema = z
   .object({
     variantKey: z.enum(landingPageVariantKeys),
@@ -241,12 +278,14 @@ const moduleVariantDefinitionSchema = z
     purpose: z.literal("controlled_test"),
     compatibleModuleVersion: z.literal(1),
     fields: z.record(z.string(), fieldDefinitionSchema),
+    copySourceMap: z.record(z.string(), copySourceSchema),
     capabilities: z.array(z.enum(landingPageCapabilityKeys)),
     rootDelta: rootDeltaSchema,
   })
   .strict()
   .superRefine((variant, context) => {
     validateFieldPaths(variant.fields, context);
+    validateCopySourceMap(variant, context);
     if (new Set(variant.capabilities).size !== variant.capabilities.length) {
       context.addIssue({
         code: "custom",
@@ -545,6 +584,35 @@ function validateFieldPaths(
         code: "custom",
         path: ["fields", fieldPath],
         message: "action requires a closed child contract",
+      });
+    }
+  }
+}
+
+function validateCopySourceMap(
+  variant: Readonly<{
+    fields: Readonly<Record<string, LandingPageFieldDefinition>>;
+    copySourceMap: LandingPageCopySourceMap;
+  }>,
+  context: z.RefinementCtx,
+) {
+  const textFieldPaths = Object.entries(variant.fields)
+    .filter(([, field]) => field.fieldKind === "text")
+    .map(([path]) => path);
+
+  validateExactValues({
+    context,
+    path: ["copySourceMap"],
+    actual: Object.keys(variant.copySourceMap),
+    expected: textFieldPaths,
+  });
+
+  for (const sourcePath of Object.keys(variant.copySourceMap)) {
+    if (variant.fields[sourcePath]?.fieldKind !== "text") {
+      context.addIssue({
+        code: "custom",
+        path: ["copySourceMap", sourcePath],
+        message: "copy source path must reference an approved text field",
       });
     }
   }

--- a/lib/conversion-content/landing-page/module-catalog/schema.ts
+++ b/lib/conversion-content/landing-page/module-catalog/schema.ts
@@ -540,6 +540,18 @@ export const landingPageModuleDefinitionSchema = z
   })
   .strict();
 
+export const landingPageModuleVariantReferenceSchema = z
+  .object({
+    family: z.literal("landing_page"),
+    moduleCatalogVersion: z.number().int().min(1),
+    rootVersion: z.number().int().min(1),
+    moduleKey: identifierSchema,
+    moduleVersion: z.number().int().min(1),
+    variantKey: identifierSchema,
+    variantVersion: z.number().int().min(1),
+  })
+  .strict();
+
 export const landingPageModuleCatalogEntrySchema = z
   .object({
     family: z.literal("landing_page"),

--- a/lib/conversion-content/landing-page/module-catalog/schema.ts
+++ b/lib/conversion-content/landing-page/module-catalog/schema.ts
@@ -349,7 +349,7 @@ const moduleVariantDefinitionSchema = z
   .object({
     variantKey: z.enum(landingPageVariantKeys),
     variantVersion: z.literal(1),
-    lifecycleStatus: z.literal("hypothesis"),
+    lifecycleStatus: z.enum(landingPageModuleLifecycleStatuses),
     purpose: z.literal("controlled_test"),
     compatibleModuleVersion: z.literal(1),
     fields: z.record(z.string(), fieldDefinitionSchema),
@@ -500,7 +500,7 @@ export const landingPageModuleVariantCatalogEntrySchema = z
           variant.variantKey !== variantKey ||
           variant.compatibleModuleVersion !== moduleEntry.moduleVersion ||
           !canonicalVariant ||
-          !isDeepEqual(variant, canonicalVariant)
+          !isDeepEqualExceptLifecycle(variant, canonicalVariant)
         ) {
           context.addIssue({
             code: "custom",
@@ -603,14 +603,6 @@ export const landingPageModuleCatalogEntrySchema = z
             message: "module catalog v1 requires module version 1",
           });
         }
-        if (moduleDefinition.lifecycleStatus !== "hypothesis") {
-          context.addIssue({
-            code: "custom",
-            path: ["modules", moduleKey, "lifecycleStatus"],
-            message: "module catalog v1 starts as hypothesis",
-          });
-        }
-
         const canonicalModule =
           landingPageModuleCatalogRegistry[1].modules[
             moduleKey as LandingPageModuleKey
@@ -633,6 +625,13 @@ function validateExactModuleV1Structure(input: {
   actual: LandingPageModuleDefinition;
   expected: LandingPageModuleDefinition;
 }) {
+  if (!isDeepEqualExceptLifecycle(input.actual, input.expected)) {
+    input.context.addIssue({
+      code: "custom",
+      path: ["modules", input.moduleKey],
+      message: "module must match the approved v1 contract except lifecycle",
+    });
+  }
   if (input.actual.function !== input.expected.function) {
     input.context.addIssue({
       code: "custom",
@@ -996,6 +995,15 @@ function isDeepEqual(left: unknown, right: unknown): boolean {
     );
   }
   return false;
+}
+
+function isDeepEqualExceptLifecycle(
+  left: Readonly<{ lifecycleStatus: unknown; [key: string]: unknown }>,
+  right: Readonly<{ lifecycleStatus: unknown; [key: string]: unknown }>,
+): boolean {
+  const { lifecycleStatus: _leftLifecycle, ...leftContract } = left;
+  const { lifecycleStatus: _rightLifecycle, ...rightContract } = right;
+  return isDeepEqual(leftContract, rightContract);
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/lib/conversion-content/landing-page/module-catalog/schema.ts
+++ b/lib/conversion-content/landing-page/module-catalog/schema.ts
@@ -3,7 +3,10 @@ import { z } from "zod";
 import {
   landingPageModuleKeys,
   landingPageModuleLifecycleStatuses,
+  type LandingPageModuleDefinition,
+  type LandingPageModuleKey,
 } from "./contracts";
+import { landingPageModuleCatalogRegistry } from "./registry";
 
 const identifierSchema = z.string().regex(/^[a-z][a-z0-9_]*$/);
 const uniqueIdentifiersSchema = z
@@ -88,9 +91,68 @@ export const landingPageModuleCatalogEntrySchema = z
             message: "module catalog v1 starts as hypothesis",
           });
         }
+
+        const canonicalModule =
+          landingPageModuleCatalogRegistry[1].modules[
+            moduleKey as LandingPageModuleKey
+          ];
+        if (moduleDefinition.moduleVersion === 1 && canonicalModule) {
+          validateExactModuleV1Structure({
+            context,
+            moduleKey,
+            actual: moduleDefinition,
+            expected: canonicalModule,
+          });
+        }
       }
     }
   });
+
+function validateExactModuleV1Structure(input: {
+  context: z.RefinementCtx;
+  moduleKey: string;
+  actual: LandingPageModuleDefinition;
+  expected: LandingPageModuleDefinition;
+}) {
+  if (input.actual.function !== input.expected.function) {
+    input.context.addIssue({
+      code: "custom",
+      path: ["modules", input.moduleKey, "function"],
+      message: "module function must match the approved v1 contract",
+    });
+  }
+
+  validateExactOrderedIdentifiers({
+    context: input.context,
+    path: ["modules", input.moduleKey, "boundaries"],
+    actual: input.actual.boundaries,
+    expected: input.expected.boundaries,
+  });
+  validateExactOrderedIdentifiers({
+    context: input.context,
+    path: ["modules", input.moduleKey, "invariants"],
+    actual: input.actual.invariants,
+    expected: input.expected.invariants,
+  });
+}
+
+function validateExactOrderedIdentifiers(input: {
+  context: z.RefinementCtx;
+  path: (string | number)[];
+  actual: readonly string[];
+  expected: readonly string[];
+}) {
+  if (
+    input.actual.length !== input.expected.length ||
+    input.actual.some((value, index) => value !== input.expected[index])
+  ) {
+    input.context.addIssue({
+      code: "custom",
+      path: input.path,
+      message: "structural identifiers must match the approved v1 contract",
+    });
+  }
+}
 
 function validateExactValues(input: {
   context: z.RefinementCtx;

--- a/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
+++ b/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
@@ -221,6 +221,20 @@ const cases: readonly Case[] = [
     },
   },
   {
+    name: "unknown runtime module key returns invalid without throwing",
+    run: () => {
+      let result: ReturnType<typeof validateLandingPageModuleFieldPayload>;
+
+      assert.doesNotThrow(() => {
+        result = validateLandingPageModuleFieldPayload(
+          "unknown_module" as LandingPageModuleDefinition["moduleKey"],
+          {},
+        );
+      });
+      assert.deepEqual(result!, { ok: false });
+    },
+  },
+  {
     name: "collection minimum and maximum cardinalities are enforced",
     run: () => {
       assert.equal(

--- a/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
+++ b/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
@@ -4,9 +4,17 @@ import {
   landingPageModuleKeys,
   type LandingPageModuleCatalogEntry,
   type LandingPageModuleDefinition,
+  type LandingPageModuleFieldCatalogEntry,
 } from "./contracts";
-import { landingPageModuleCatalogRegistry } from "./registry";
-import { landingPageModuleCatalogEntrySchema } from "./schema";
+import { validateLandingPageModuleFieldPayload } from "./payload-validator";
+import {
+  landingPageModuleCatalogRegistry,
+  landingPageModuleFieldCatalogRegistry,
+} from "./registry";
+import {
+  landingPageModuleCatalogEntrySchema,
+  landingPageModuleFieldCatalogEntrySchema,
+} from "./schema";
 
 type Case = Readonly<{
   name: string;
@@ -176,25 +184,261 @@ const cases: readonly Case[] = [
     },
   },
   {
+    name: "field catalog v1 is valid and contains all five field kinds",
+    run: () => {
+      const fieldCatalog = landingPageModuleFieldCatalogRegistry[1];
+      assert.equal(
+        landingPageModuleFieldCatalogEntrySchema.safeParse(fieldCatalog).success,
+        true,
+      );
+
+      const fieldKinds = new Set(
+        Object.values(fieldCatalog.modules).flatMap((moduleDefinition) =>
+          Object.values(moduleDefinition.fields).map((field) => field.fieldKind),
+        ),
+      );
+      assert.deepEqual([...fieldKinds].sort(), [
+        "action",
+        "collection",
+        "image",
+        "reference",
+        "text",
+      ]);
+    },
+  },
+  {
+    name: "approved payloads for all nine modules are valid",
+    run: () => {
+      for (const moduleKey of landingPageModuleKeys) {
+        assert.equal(
+          validateLandingPageModuleFieldPayload(
+            moduleKey,
+            validPayloads[moduleKey],
+          ).ok,
+          true,
+        );
+      }
+    },
+  },
+  {
+    name: "collection minimum and maximum cardinalities are enforced",
+    run: () => {
+      assert.equal(
+        validateLandingPageModuleFieldPayload("trust_bar", trustBarPayload(2)).ok,
+        true,
+      );
+      assert.equal(
+        validateLandingPageModuleFieldPayload("trust_bar", trustBarPayload(4)).ok,
+        true,
+      );
+      assert.equal(
+        validateLandingPageModuleFieldPayload("trust_bar", trustBarPayload(1)).ok,
+        false,
+      );
+      assert.equal(
+        validateLandingPageModuleFieldPayload("trust_bar", trustBarPayload(5)).ok,
+        false,
+      );
+    },
+  },
+  {
+    name: "invalid field cardinality fails closed",
+    run: () => {
+      assertFieldCatalogMutationInvalid((catalog) => {
+        mutableField(catalog, "trust_bar", "items").cardinality = {
+          min: 4,
+          max: 2,
+        };
+      });
+    },
+  },
+  {
+    name: "nested collection contract fails closed",
+    run: () => {
+      assertFieldCatalogMutationInvalid((catalog) => {
+        mutableFields(catalog, "trust_bar")["items[].text"] = {
+          path: "items[].text",
+          fieldKind: "collection",
+          cardinality: { min: 1, max: 2 },
+          policy: "not_copy",
+        };
+      });
+    },
+  },
+  {
+    name: "additional payload field and additional contract field fail closed",
+    run: () => {
+      const heroPayload = validPayloads.hero as Record<string, unknown>;
+      assert.equal(
+        validateLandingPageModuleFieldPayload("hero", {
+          ...heroPayload,
+          extra: "not allowed",
+        }).ok,
+        false,
+      );
+      assertFieldCatalogMutationInvalid((catalog) => {
+        mutableFields(catalog, "hero").extra = {
+          path: "extra",
+          fieldKind: "text",
+          semanticRole: "paragraph",
+          cardinality: { min: 0, max: 1 },
+          policy: "hybrid",
+          support: "when_factual",
+        };
+      });
+    },
+  },
+  {
+    name: "unknown field path fails closed",
+    run: () => {
+      assertFieldCatalogMutationInvalid((catalog) => {
+        const fields = mutableFields(catalog, "hero");
+        const title = fields.title;
+        delete fields.title;
+        fields.unknownPath = { ...title, path: "unknownPath" };
+      });
+    },
+  },
+  {
+    name: "incompatible field policy fails closed",
+    run: () => {
+      assertFieldCatalogMutationInvalid((catalog) => {
+        mutableField(catalog, "hero", "title").policy =
+          "technical_reference";
+      });
+    },
+  },
+  {
+    name: "incompatible field support fails closed",
+    run: () => {
+      assertFieldCatalogMutationInvalid((catalog) => {
+        mutableField(catalog, "social_proof", "items[].quote").support =
+          "when_factual";
+      });
+    },
+  },
+  {
+    name: "visible text without a semantic role fails closed",
+    run: () => {
+      assertFieldCatalogMutationInvalid((catalog) => {
+        delete mutableField(catalog, "hero", "title").semanticRole;
+      });
+    },
+  },
+  {
+    name: "unknown field kind and invalid structural combination fail closed",
+    run: () => {
+      assertFieldCatalogMutationInvalid((catalog) => {
+        mutableField(catalog, "hero", "title").fieldKind = "video";
+      });
+      assertFieldCatalogMutationInvalid((catalog) => {
+        mutableField(catalog, "hero", "media").support = "when_present";
+      });
+    },
+  },
+  {
+    name: "action payload rejects concrete destination and channel",
+    run: () => {
+      const heroPayload = validPayloads.hero as Record<string, unknown>;
+      assert.equal(
+        validateLandingPageModuleFieldPayload("hero", {
+          ...heroPayload,
+          primaryCta: {
+            label: "Comecar",
+            destination: "https://example.com",
+          },
+        }).ok,
+        false,
+      );
+      assert.equal(
+        validateLandingPageModuleFieldPayload("hero", {
+          ...heroPayload,
+          primaryCta: { label: "Comecar", channel: "whatsapp" },
+        }).ok,
+        false,
+      );
+    },
+  },
+  {
+    name: "image payload enforces mode, alt text, and visibility",
+    run: () => {
+      const heroPayload = validPayloads.hero as Record<string, unknown>;
+      assert.equal(
+        validateLandingPageModuleFieldPayload("hero", {
+          ...heroPayload,
+          media: imagePayload("informative", ""),
+        }).ok,
+        false,
+      );
+      assert.equal(
+        validateLandingPageModuleFieldPayload("hero", {
+          ...heroPayload,
+          media: imagePayload("decorative", "Visible alternative"),
+        }).ok,
+        false,
+      );
+      assert.equal(
+        validateLandingPageModuleFieldPayload("hero", {
+          ...heroPayload,
+          media: {
+            ...imagePayload("informative", "Product overview"),
+            visibility: "desktop_only",
+          },
+        }).ok,
+        false,
+      );
+    },
+  },
+  {
+    name: "reference payload rejects unknown reference kind",
+    run: () => {
+      assert.equal(
+        validateLandingPageModuleFieldPayload("social_proof", {
+          title: "Resultados",
+          items: [
+            {
+              quote: "Resultado comprovado",
+              attribution: "Cliente verificado",
+              evidenceRef: {
+                referenceKind: "external_url",
+                evidenceRef: "evidence/customer-1",
+              },
+            },
+          ],
+        }).ok,
+        false,
+      );
+    },
+  },
+  {
     name: "catalog and nested structural definitions are deeply immutable",
     run: () => {
       const catalog = landingPageModuleCatalogRegistry[1];
+      const fieldCatalog = landingPageModuleFieldCatalogRegistry[1];
 
       assert.equal(Object.isFrozen(landingPageModuleCatalogRegistry), true);
       assert.equal(Object.isFrozen(catalog), true);
       assert.equal(Object.isFrozen(catalog.modules.hero), true);
       assert.equal(Object.isFrozen(catalog.modules.hero.boundaries), true);
+      assert.equal(Object.isFrozen(landingPageModuleFieldCatalogRegistry), true);
+      assert.equal(Object.isFrozen(fieldCatalog.modules.hero.fields), true);
+      assert.equal(
+        Object.isFrozen(fieldCatalog.modules.hero.fields.title.cardinality),
+        true,
+      );
       assert.throws(() => {
         (catalog.modules.hero.boundaries as string[]).push("forbidden");
+      }, TypeError);
+      assert.throws(() => {
+        (
+          fieldCatalog.modules.hero.fields.title.cardinality as {
+            min: number;
+          }
+        ).min = 0;
       }, TypeError);
     },
   },
 ];
-
-for (const validationCase of cases) {
-  validationCase.run();
-  console.log(`ok - ${validationCase.name}`);
-}
 
 function assertInvalid(catalog: LandingPageModuleCatalogEntry) {
   assert.equal(landingPageModuleCatalogEntrySchema.safeParse(catalog).success, false);
@@ -214,6 +458,131 @@ function cloneCatalog(): LandingPageModuleCatalogEntry {
   ) as LandingPageModuleCatalogEntry;
 }
 
+function assertFieldCatalogInvalid(catalog: LandingPageModuleFieldCatalogEntry) {
+  assert.equal(
+    landingPageModuleFieldCatalogEntrySchema.safeParse(catalog).success,
+    false,
+  );
+}
+
+function assertFieldCatalogMutationInvalid(
+  mutate: (catalog: LandingPageModuleFieldCatalogEntry) => void,
+) {
+  const catalog = cloneFieldCatalog();
+  mutate(catalog);
+  assertFieldCatalogInvalid(catalog);
+}
+
+function cloneFieldCatalog(): LandingPageModuleFieldCatalogEntry {
+  return JSON.parse(
+    JSON.stringify(landingPageModuleFieldCatalogRegistry[1]),
+  ) as LandingPageModuleFieldCatalogEntry;
+}
+
+function mutableFields(
+  catalog: LandingPageModuleFieldCatalogEntry,
+  moduleKey: LandingPageModuleDefinition["moduleKey"],
+): Record<string, Record<string, unknown>> {
+  return catalog.modules[moduleKey].fields as unknown as Record<
+    string,
+    Record<string, unknown>
+  >;
+}
+
+function mutableField(
+  catalog: LandingPageModuleFieldCatalogEntry,
+  moduleKey: LandingPageModuleDefinition["moduleKey"],
+  path: string,
+): Record<string, unknown> {
+  const field = mutableFields(catalog, moduleKey)[path];
+  assert.notEqual(field, undefined);
+  return field;
+}
+
+function trustBarPayload(itemCount: number) {
+  return {
+    items: Array.from({ length: itemCount }, (_, index) => ({
+      text: `Trust signal ${index + 1}`,
+    })),
+  };
+}
+
+function imagePayload(mode: "informative" | "decorative", altText: string) {
+  return {
+    assetRef: "assets/hero-primary",
+    mode,
+    altText,
+    visibility: "all_viewports",
+  };
+}
+
+const validPayloads: Readonly<Record<
+  LandingPageModuleDefinition["moduleKey"],
+  unknown
+>> = {
+  hero: {
+    eyebrow: "Novidade",
+    title: "Uma proposta principal",
+    subtitle: "Contexto suficiente para orientar a decisao.",
+    primaryCta: { label: "Comecar" },
+    proofShort: "Evidencia disponivel",
+    media: imagePayload("informative", "Visao geral da proposta"),
+  },
+  trust_bar: trustBarPayload(2),
+  problem_solution: {
+    title: "Do problema a solucao",
+    items: [
+      { problem: "Problema um", solution: "Solucao um" },
+      { problem: "Problema dois", solution: "Solucao dois" },
+    ],
+  },
+  offer: {
+    title: "O que esta incluido",
+    items: [{ itemTitle: "Entrega", description: "Descricao da entrega" }],
+  },
+  process: {
+    title: "Como funciona",
+    steps: [
+      { stepTitle: "Primeiro passo", stepBody: "Descricao do primeiro passo" },
+      { stepTitle: "Segundo passo", stepBody: "Descricao do segundo passo" },
+    ],
+  },
+  technical_assurance: {
+    title: "Garantias tecnicas",
+    items: [
+      {
+        assuranceTitle: "Criterio verificavel",
+        assuranceBody: "Descricao suportada do criterio",
+      },
+    ],
+  },
+  social_proof: {
+    title: "Resultados",
+    items: [
+      {
+        quote: "Resultado comprovado",
+        attribution: "Cliente verificado",
+        evidenceRef: {
+          referenceKind: "operational_evidence",
+          evidenceRef: "evidence/customer-1",
+        },
+      },
+    ],
+  },
+  faq: {
+    title: "Perguntas frequentes",
+    items: [
+      { question: "Pergunta um?", answer: "Resposta um." },
+      { question: "Pergunta dois?", answer: "Resposta dois." },
+    ],
+  },
+  final_cta: {
+    title: "Proximo passo",
+    body: "Encerramento coerente com a proposta.",
+    primaryCta: { label: "Comecar" },
+  },
+};
+
 function fixtureModule(
   moduleKey: LandingPageModuleDefinition["moduleKey"],
 ): LandingPageModuleDefinition {
@@ -231,3 +600,8 @@ function fixtureModule(
 type MutableModule = {
   -readonly [Key in keyof LandingPageModuleDefinition]: LandingPageModuleDefinition[Key];
 };
+
+for (const validationCase of cases) {
+  validationCase.run();
+  console.log(`ok - ${validationCase.name}`);
+}

--- a/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
+++ b/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
@@ -10,7 +10,13 @@ import {
 import {
   landingPageCopySourceItemKeyCatalog,
   landingPageCopySourceItemKeys,
+  landingPageCopyTreatments,
+  landingPageCtaModeTreatmentMap,
+  landingPageFunnelStages,
   landingPageModuleKeys,
+  type LandingPageCopyTreatment,
+  type LandingPageFunnelCopyProfile,
+  type LandingPageFunnelProfileStageDelta,
   type LandingPageCopySourceMap,
   type LandingPageModuleCatalogEntry,
   type LandingPageModuleDefinition,
@@ -23,6 +29,7 @@ import {
   landingPageModuleCatalogRegistry,
   landingPageModuleFieldCatalogRegistry,
   landingPageModuleVariantCatalogRegistry,
+  applyLandingPageFunnelProfileDeltaInternal,
   resolveLandingPageModuleVariantDefinitionInternal,
 } from "./registry";
 import {
@@ -863,6 +870,295 @@ const cases: readonly Case[] = [
     },
   },
   {
+    name: "bofu mofu and tofu profiles classify every approved treatment exactly once",
+    run: () => {
+      const profiles =
+        landingPageModuleVariantCatalogRegistry[1].funnelCopyProfiles;
+      assert.deepEqual(profiles, {
+        bofu: {
+          allowed: [
+            "direct_action",
+            "qualified_action",
+            "low_friction_action",
+            "educational_context",
+            "problem_emphasis",
+            "offer_specificity",
+          ],
+          restricted: [
+            "proof",
+            "comparison",
+            "price",
+            "promise",
+            "credential",
+            "authority",
+            "urgency",
+            "scarcity",
+            "guarantee",
+          ],
+          prohibited: [],
+          ctaMode: "direct",
+        },
+        mofu: {
+          allowed: [
+            "qualified_action",
+            "low_friction_action",
+            "educational_context",
+            "problem_emphasis",
+            "offer_specificity",
+          ],
+          restricted: [
+            "direct_action",
+            "proof",
+            "comparison",
+            "price",
+            "promise",
+            "credential",
+            "authority",
+            "urgency",
+            "scarcity",
+            "guarantee",
+          ],
+          prohibited: [],
+          ctaMode: "qualified",
+        },
+        tofu: {
+          allowed: [
+            "low_friction_action",
+            "educational_context",
+            "problem_emphasis",
+          ],
+          restricted: [
+            "qualified_action",
+            "offer_specificity",
+            "proof",
+            "credential",
+            "authority",
+          ],
+          prohibited: [
+            "direct_action",
+            "comparison",
+            "price",
+            "promise",
+            "urgency",
+            "scarcity",
+            "guarantee",
+          ],
+          ctaMode: "low_friction",
+        },
+      });
+
+      for (const stage of landingPageFunnelStages) {
+        const profile = profiles[stage];
+        const classified = [
+          ...profile.allowed,
+          ...profile.restricted,
+          ...profile.prohibited,
+        ];
+        assert.equal(classified.length, landingPageCopyTreatments.length);
+        assert.equal(new Set(classified).size, landingPageCopyTreatments.length);
+        assert.deepEqual(new Set(classified), new Set(landingPageCopyTreatments));
+      }
+    },
+  },
+  {
+    name: "profiles reject missing duplicate unknown aliased or internal-category treatments",
+    run: () => {
+      assertVariantCatalogMutationInvalid((catalog) => {
+        mutableFunnelProfile(catalog, "bofu").allowed.pop();
+      });
+      assertVariantCatalogMutationInvalid((catalog) => {
+        mutableFunnelProfile(catalog, "bofu").allowed.push("direct_action");
+      });
+      for (const invalidTreatment of [
+        "unknown_treatment",
+        "action",
+        "action_treatment",
+      ]) {
+        assertVariantCatalogMutationInvalid((catalog) => {
+          mutableFunnelProfile(catalog, "bofu").allowed[0] = invalidTreatment;
+        });
+      }
+      assertVariantCatalogMutationInvalid((catalog) => {
+        mutableFunnelProfile(catalog, "bofu").restricted.push("direct_action");
+      });
+      assertVariantCatalogMutationInvalid((catalog) => {
+        (catalog.funnelCopyProfiles as Record<string, unknown>).unknown = {};
+      });
+    },
+  },
+  {
+    name: "cta modes map to their allowed action treatments and incompatible modes fail closed",
+    run: () => {
+      const profiles =
+        landingPageModuleVariantCatalogRegistry[1].funnelCopyProfiles;
+      assert.deepEqual(landingPageCtaModeTreatmentMap, {
+        direct: "direct_action",
+        qualified: "qualified_action",
+        low_friction: "low_friction_action",
+      });
+      for (const profile of Object.values(profiles)) {
+        assert.equal(
+          (profile.allowed as readonly LandingPageCopyTreatment[]).includes(
+            landingPageCtaModeTreatmentMap[profile.ctaMode],
+          ),
+          true,
+        );
+      }
+      assertVariantCatalogMutationInvalid((catalog) => {
+        mutableFunnelProfile(catalog, "bofu").ctaMode = "qualified";
+      });
+      assertVariantCatalogMutationInvalid((catalog) => {
+        mutableFunnelProfile(catalog, "bofu").ctaMode = "unknown";
+      });
+    },
+  },
+  {
+    name: "delta precedence is prohibited over restricted over allowed",
+    run: () => {
+      const profile =
+        landingPageModuleVariantCatalogRegistry[1].funnelCopyProfiles.bofu;
+      const restricted = applyLandingPageFunnelProfileDeltaInternal(
+        profile,
+        syntheticStageDelta({ restricted: ["educational_context"] }),
+      );
+      assert.equal(restricted?.restricted.includes("educational_context"), true);
+      assert.equal(restricted?.allowed.includes("educational_context"), false);
+
+      const prohibited = applyLandingPageFunnelProfileDeltaInternal(
+        profile,
+        syntheticStageDelta({
+          restricted: ["educational_context"],
+          prohibited: ["educational_context", "proof"],
+        }),
+      );
+      assert.equal(prohibited?.prohibited.includes("educational_context"), true);
+      assert.equal(prohibited?.restricted.includes("educational_context"), false);
+      assert.equal(prohibited?.prohibited.includes("proof"), true);
+    },
+  },
+  {
+    name: "nine module and ten variant deltas produce only the approved effective treatments",
+    run: () => {
+      const catalog = landingPageModuleVariantCatalogRegistry[1];
+      assert.equal(Object.keys(catalog.modules).length, 9);
+      assert.equal(
+        Object.values(catalog.modules).reduce(
+          (count, moduleEntry) => count + Object.keys(moduleEntry.variants).length,
+          0,
+        ),
+        10,
+      );
+
+      for (const [moduleKey, moduleEntry] of Object.entries(catalog.modules)) {
+        for (const stage of landingPageFunnelStages) {
+          const result = applyLandingPageFunnelProfileDeltaInternal(
+            catalog.funnelCopyProfiles[stage],
+            moduleEntry.funnelProfileDelta[stage],
+          );
+          assert.ok(result);
+          assertModuleTreatmentContract(moduleKey, result);
+        }
+        for (const variant of Object.values(moduleEntry.variants)) {
+          assert.deepEqual(variant.funnelProfileDelta, moduleEntry.funnelProfileDelta);
+          assert.notStrictEqual(variant.funnelProfileDelta, moduleEntry.funnelProfileDelta);
+        }
+      }
+    },
+  },
+  {
+    name: "faq deltas are equivalent independent contracts",
+    run: () => {
+      const faq = landingPageModuleVariantCatalogRegistry[1].modules.faq;
+      const standard = faq.variants.standard.funnelProfileDelta;
+      const accordion = faq.variants.accordion.funnelProfileDelta;
+      assert.deepEqual(standard, accordion);
+      assert.notStrictEqual(standard, accordion);
+      assert.notStrictEqual(standard.bofu, accordion.bofu);
+      assert.notStrictEqual(standard.bofu.prohibited, accordion.bofu.prohibited);
+      assert.notStrictEqual(
+        standard.bofu.supportRequirements,
+        accordion.bofu.supportRequirements,
+      );
+    },
+  },
+  {
+    name: "restricted treatments bind compatible support and social proof stays operational",
+    run: () => {
+      const catalog = landingPageModuleVariantCatalogRegistry[1];
+      for (const moduleEntry of Object.values(catalog.modules)) {
+        const variant = Object.values(moduleEntry.variants)[0];
+        for (const stage of landingPageFunnelStages) {
+          const delta = moduleEntry.funnelProfileDelta[stage];
+          const result = applyLandingPageFunnelProfileDeltaInternal(
+            catalog.funnelCopyProfiles[stage],
+            delta,
+          );
+          assert.ok(result);
+          assert.deepEqual(
+            new Set(Object.keys(delta.supportRequirements)),
+            new Set(result.restricted),
+          );
+          for (const requirement of Object.values(delta.supportRequirements)) {
+            assert.ok(requirement);
+            for (const fieldPath of requirement.fieldPaths) {
+              const field = variant.fields[fieldPath];
+              const source = variant.copySourceMap[fieldPath];
+              assert.equal(field?.fieldKind, "text");
+              if (!field || field.fieldKind !== "text" || !source) assert.fail();
+              assert.equal(requirement.policies.includes(field.policy as never), true);
+              assert.equal(requirement.supports.includes(field.support as never), true);
+              assert.equal(requirement.sourceModes.includes(source.sourceMode), true);
+            }
+          }
+        }
+      }
+
+      const social = catalog.modules.social_proof.funnelProfileDelta;
+      for (const stage of landingPageFunnelStages) {
+        const result = applyLandingPageFunnelProfileDeltaInternal(
+          catalog.funnelCopyProfiles[stage],
+          social[stage],
+        );
+        assert.deepEqual(result?.restricted, ["proof"]);
+        assert.deepEqual(social[stage].supportRequirements.proof, {
+          fieldPaths: ["items[].quote", "items[].attribution"],
+          policies: ["operational_required"],
+          supports: ["when_present"],
+          sourceModes: ["operational_evidence"],
+        });
+      }
+    },
+  },
+  {
+    name: "unknown or permission-expanding deltas and missing support fail closed",
+    run: () => {
+      assertVariantCatalogMutationInvalid((catalog) => {
+        mutableFunnelStageDelta(catalog, "hero", "bofu").prohibited.push(
+          "unknown_treatment",
+        );
+      });
+      assertVariantCatalogMutationInvalid((catalog) => {
+        mutableFunnelStageDelta(catalog, "trust_bar", "bofu").prohibited = [];
+      });
+      assertVariantCatalogMutationInvalid((catalog) => {
+        delete mutableFunnelStageDelta(catalog, "hero", "bofu")
+          .supportRequirements.proof;
+      });
+      assertVariantCatalogMutationInvalid((catalog) => {
+        mutableFunnelStageDelta(
+          catalog,
+          "hero",
+          "bofu",
+        ).supportRequirements.proof = {
+          fieldPaths: ["title"],
+          policies: ["operational_required"],
+          supports: ["when_present"],
+          sourceModes: ["operational_evidence"],
+        };
+      });
+    },
+  },
+  {
     name: "root text normalization and absolute maximum use the public root boundary",
     run: () => {
       const rootParameters = resolveApprovedRootParameters();
@@ -1013,7 +1309,24 @@ const cases: readonly Case[] = [
         true,
       );
       assert.equal(Object.isFrozen(landingPageModuleVariantCatalogRegistry), true);
+      assert.equal(Object.isFrozen(variantCatalog.funnelCopyProfiles), true);
+      assert.equal(Object.isFrozen(variantCatalog.funnelCopyProfiles.bofu), true);
+      assert.equal(
+        Object.isFrozen(variantCatalog.funnelCopyProfiles.bofu.allowed),
+        true,
+      );
       assert.equal(Object.isFrozen(variantCatalog.modules.faq.variants), true);
+      assert.equal(
+        Object.isFrozen(variantCatalog.modules.faq.funnelProfileDelta),
+        true,
+      );
+      assert.equal(
+        Object.isFrozen(
+          variantCatalog.modules.faq.variants.accordion.funnelProfileDelta
+            .bofu.prohibited,
+        ),
+        true,
+      );
       assert.equal(Object.isFrozen(variantCatalog.modules.faq.rootDelta), true);
       assert.equal(
         Object.isFrozen(variantCatalog.modules.faq.variants.accordion.fields),
@@ -1061,6 +1374,17 @@ const cases: readonly Case[] = [
         ).min = 0;
       }, TypeError);
       assert.throws(() => {
+        (variantCatalog.funnelCopyProfiles.bofu.allowed as string[]).push(
+          "forbidden",
+        );
+      }, TypeError);
+      assert.throws(() => {
+        (
+          variantCatalog.modules.faq.variants.accordion.funnelProfileDelta.bofu
+            .prohibited as string[]
+        ).push("forbidden");
+      }, TypeError);
+      assert.throws(() => {
         (
           variantCatalog.modules.faq.variants.accordion
             .capabilities as string[]
@@ -1077,6 +1401,131 @@ const cases: readonly Case[] = [
     },
   },
 ];
+
+function syntheticStageDelta(input: {
+  restricted?: readonly LandingPageCopyTreatment[];
+  prohibited?: readonly LandingPageCopyTreatment[];
+}): LandingPageFunnelProfileStageDelta {
+  return {
+    restricted: input.restricted ?? [],
+    prohibited: input.prohibited ?? [],
+    emphasized: [],
+    supportRequirements: {},
+  };
+}
+
+function assertModuleTreatmentContract(
+  moduleKey: string,
+  result: LandingPageFunnelCopyProfile,
+) {
+  const effectiveAction = landingPageCtaModeTreatmentMap[result.ctaMode];
+  const expected = (() => {
+    switch (moduleKey) {
+      case "hero":
+        return {
+          allowed: result.allowed,
+          restricted: result.restricted,
+          prohibited: result.prohibited,
+        };
+      case "trust_bar":
+        return {
+          allowed: [],
+          restricted: ["proof", "credential", "authority"],
+          prohibited: landingPageCopyTreatments.filter(
+            (treatment) =>
+              !["proof", "credential", "authority"].includes(treatment),
+          ),
+        };
+      case "problem_solution":
+      case "faq":
+        return onlyTreatments(["educational_context", "problem_emphasis"]);
+      case "offer":
+        return {
+          allowed: ["educational_context", "problem_emphasis"],
+          restricted: ["offer_specificity"],
+          prohibited: landingPageCopyTreatments.filter(
+            (treatment) =>
+              ![
+                "educational_context",
+                "problem_emphasis",
+                "offer_specificity",
+              ].includes(treatment),
+          ),
+        };
+      case "process":
+        return onlyTreatments(["educational_context"]);
+      case "technical_assurance":
+        return {
+          allowed: ["educational_context"],
+          restricted: ["proof", "credential", "authority"],
+          prohibited: landingPageCopyTreatments.filter(
+            (treatment) =>
+              ![
+                "educational_context",
+                "proof",
+                "credential",
+                "authority",
+              ].includes(treatment),
+          ),
+        };
+      case "social_proof":
+        return {
+          allowed: [],
+          restricted: ["proof"],
+          prohibited: landingPageCopyTreatments.filter(
+            (treatment) => treatment !== "proof",
+          ),
+        };
+      case "final_cta":
+        return onlyTreatments([effectiveAction]);
+      default:
+        assert.fail(`unknown module treatment contract: ${moduleKey}`);
+    }
+  })();
+
+  if (moduleKey === "hero") {
+    assert.equal(result.allowed.includes(effectiveAction), true);
+    for (const treatment of [
+      "direct_action",
+      "qualified_action",
+      "low_friction_action",
+    ] as const) {
+      assert.equal(
+        treatment === effectiveAction
+          ? result.allowed.includes(treatment)
+          : result.prohibited.includes(treatment),
+        true,
+      );
+    }
+    assert.equal(result.restricted.includes("proof"), true);
+    for (const treatment of [
+      "comparison",
+      "price",
+      "guarantee",
+      "urgency",
+      "scarcity",
+    ] as const) {
+      assert.equal(result.prohibited.includes(treatment), true);
+    }
+    return;
+  }
+
+  assert.deepEqual(result.allowed, expected.allowed);
+  assert.deepEqual(result.restricted, expected.restricted);
+  assert.deepEqual(result.prohibited, expected.prohibited);
+}
+
+function onlyTreatments(
+  allowed: readonly LandingPageCopyTreatment[],
+): Pick<LandingPageFunnelCopyProfile, "allowed" | "restricted" | "prohibited"> {
+  return {
+    allowed,
+    restricted: [],
+    prohibited: landingPageCopyTreatments.filter(
+      (treatment) => !allowed.includes(treatment),
+    ),
+  };
+}
 
 function assertInvalid(catalog: LandingPageModuleCatalogEntry) {
   assert.equal(landingPageModuleCatalogEntrySchema.safeParse(catalog).success, false);
@@ -1132,6 +1581,41 @@ function cloneVariantCatalog(): LandingPageModuleVariantCatalogEntry {
   return JSON.parse(
     JSON.stringify(landingPageModuleVariantCatalogRegistry[1]),
   ) as LandingPageModuleVariantCatalogEntry;
+}
+
+function mutableFunnelProfile(
+  catalog: LandingPageModuleVariantCatalogEntry,
+  stage: (typeof landingPageFunnelStages)[number],
+): {
+  allowed: string[];
+  restricted: string[];
+  prohibited: string[];
+  ctaMode: string;
+} {
+  return catalog.funnelCopyProfiles[stage] as unknown as {
+    allowed: string[];
+    restricted: string[];
+    prohibited: string[];
+    ctaMode: string;
+  };
+}
+
+function mutableFunnelStageDelta(
+  catalog: LandingPageModuleVariantCatalogEntry,
+  moduleKey: LandingPageModuleDefinition["moduleKey"],
+  stage: (typeof landingPageFunnelStages)[number],
+): {
+  restricted: string[];
+  prohibited: string[];
+  emphasized: string[];
+  supportRequirements: Record<string, unknown>;
+} {
+  return catalog.modules[moduleKey].funnelProfileDelta[stage] as unknown as {
+    restricted: string[];
+    prohibited: string[];
+    emphasized: string[];
+    supportRequirements: Record<string, unknown>;
+  };
 }
 
 function mutableVariants(

--- a/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
+++ b/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
@@ -40,18 +40,13 @@ const cases: readonly Case[] = [
     },
   },
   {
-    name: "landing page identities remain scoped away from commercial activation",
+    name: "commercial activation cannot replace the landing page family",
     run: () => {
-      const landingPageIdentities = landingPageModuleKeys.map(
-        (moduleKey) => `landing_page:${moduleKey}@1`,
-      );
-      const commercialActivationIdentities = landingPageModuleKeys.map(
-        (moduleKey) => `commercial_activation:${moduleKey}@1`,
-      );
+      const catalog = cloneCatalog();
+      (catalog as unknown as { family: string }).family =
+        "commercial_activation";
 
-      for (const identity of landingPageIdentities) {
-        assert.equal(commercialActivationIdentities.includes(identity), false);
-      }
+      assertInvalid(catalog);
     },
   },
   {
@@ -114,6 +109,40 @@ const cases: readonly Case[] = [
       });
       assertMutationInvalid((catalog) => {
         (catalog.modules.hero as MutableModule).invariants = [];
+      });
+    },
+  },
+  {
+    name: "a valid but unapproved v1 module function fails closed",
+    run: () => {
+      assertMutationInvalid((catalog) => {
+        assert.equal(catalog.modules.hero.moduleVersion, 1);
+        (catalog.modules.hero as MutableModule).function =
+          "unapproved_but_valid_function";
+      });
+    },
+  },
+  {
+    name: "a valid but unapproved v1 module boundary fails closed",
+    run: () => {
+      assertMutationInvalid((catalog) => {
+        assert.equal(catalog.modules.hero.moduleVersion, 1);
+        (catalog.modules.hero as MutableModule).boundaries = [
+          "unapproved_but_valid_boundary",
+          ...catalog.modules.hero.boundaries.slice(1),
+        ];
+      });
+    },
+  },
+  {
+    name: "a valid but unapproved v1 module invariant fails closed",
+    run: () => {
+      assertMutationInvalid((catalog) => {
+        assert.equal(catalog.modules.hero.moduleVersion, 1);
+        (catalog.modules.hero as MutableModule).invariants = [
+          "unapproved_but_valid_invariant",
+          ...catalog.modules.hero.invariants.slice(1),
+        ];
       });
     },
   },

--- a/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
+++ b/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
@@ -1,0 +1,204 @@
+import assert from "node:assert/strict";
+
+import {
+  landingPageModuleKeys,
+  type LandingPageModuleCatalogEntry,
+  type LandingPageModuleDefinition,
+} from "./contracts";
+import { landingPageModuleCatalogRegistry } from "./registry";
+import { landingPageModuleCatalogEntrySchema } from "./schema";
+
+type Case = Readonly<{
+  name: string;
+  run: () => void;
+}>;
+
+const cases: readonly Case[] = [
+  {
+    name: "module catalog v1 is valid and has the approved metadata",
+    run: () => {
+      const catalog = landingPageModuleCatalogRegistry[1];
+
+      assert.equal(landingPageModuleCatalogEntrySchema.safeParse(catalog).success, true);
+      assert.equal(catalog.family, "landing_page");
+      assert.equal(catalog.moduleCatalogVersion, 1);
+      assert.deepEqual(catalog.compatibleRootVersions, [1]);
+    },
+  },
+  {
+    name: "module catalog v1 contains exactly the nine approved identities",
+    run: () => {
+      const modules = landingPageModuleCatalogRegistry[1].modules;
+
+      assert.deepEqual(Object.keys(modules), landingPageModuleKeys);
+      for (const moduleKey of landingPageModuleKeys) {
+        assert.equal(modules[moduleKey].moduleKey, moduleKey);
+        assert.equal(modules[moduleKey].moduleVersion, 1);
+        assert.equal(modules[moduleKey].lifecycleStatus, "hypothesis");
+        assert.equal(modules[moduleKey].purpose, "controlled_test");
+      }
+    },
+  },
+  {
+    name: "landing page identities remain scoped away from commercial activation",
+    run: () => {
+      const landingPageIdentities = landingPageModuleKeys.map(
+        (moduleKey) => `landing_page:${moduleKey}@1`,
+      );
+      const commercialActivationIdentities = landingPageModuleKeys.map(
+        (moduleKey) => `commercial_activation:${moduleKey}@1`,
+      );
+
+      for (const identity of landingPageIdentities) {
+        assert.equal(commercialActivationIdentities.includes(identity), false);
+      }
+    },
+  },
+  {
+    name: "module functions boundaries and invariants are closed structural identifiers",
+    run: () => {
+      const modules = landingPageModuleCatalogRegistry[1].modules;
+
+      for (const moduleDefinition of Object.values(modules)) {
+        assert.match(moduleDefinition.function, /^[a-z][a-z0-9_]*$/);
+        assert.ok(moduleDefinition.boundaries.length > 0);
+        assert.ok(moduleDefinition.invariants.length > 0);
+        assert.equal(
+          new Set(moduleDefinition.boundaries).size,
+          moduleDefinition.boundaries.length,
+        );
+        assert.equal(
+          new Set(moduleDefinition.invariants).size,
+          moduleDefinition.invariants.length,
+        );
+      }
+    },
+  },
+  {
+    name: "unknown missing or mismatched module identities fail closed",
+    run: () => {
+      const unknown = cloneCatalog();
+      (unknown.modules as Record<string, LandingPageModuleDefinition>).unknown =
+        fixtureModule("hero");
+      assertInvalid(unknown);
+
+      const missing = cloneCatalog();
+      delete (missing.modules as Partial<Record<string, unknown>>).hero;
+      assertInvalid(missing);
+
+      const mismatched = cloneCatalog();
+      (mismatched.modules.hero as MutableModule).moduleKey = "faq";
+      assertInvalid(mismatched);
+    },
+  },
+  {
+    name: "invalid lifecycle purpose version and structural definitions fail closed",
+    run: () => {
+      assertMutationInvalid((catalog) => {
+        (catalog.modules.hero as MutableModule).lifecycleStatus = "draft" as never;
+      });
+      assertMutationInvalid((catalog) => {
+        (catalog.modules.hero as MutableModule).purpose = "production" as never;
+      });
+      assertMutationInvalid((catalog) => {
+        (catalog.modules.hero as MutableModule).moduleVersion = 2;
+      });
+      assertMutationInvalid((catalog) => {
+        (catalog.modules.hero as MutableModule).function = "";
+      });
+      assertMutationInvalid((catalog) => {
+        (catalog.modules.hero as MutableModule).boundaries = [
+          "opening_section_only",
+          "opening_section_only",
+        ];
+      });
+      assertMutationInvalid((catalog) => {
+        (catalog.modules.hero as MutableModule).invariants = [];
+      });
+    },
+  },
+  {
+    name: "concrete context and future phase contracts are rejected",
+    run: () => {
+      const forbiddenKeys = [
+        "taxon",
+        "campaign",
+        "plan",
+        "copy",
+        "asset",
+        "order",
+        "quantity",
+        "content",
+        "variants",
+        "fields",
+        "copySourceMap",
+        "funnelCopyProfile",
+        "capabilities",
+        "rootDelta",
+      ] as const;
+
+      for (const forbiddenKey of forbiddenKeys) {
+        assertMutationInvalid((catalog) => {
+          (catalog.modules.hero as unknown as Record<string, unknown>)[
+            forbiddenKey
+          ] = {};
+        });
+      }
+    },
+  },
+  {
+    name: "catalog and nested structural definitions are deeply immutable",
+    run: () => {
+      const catalog = landingPageModuleCatalogRegistry[1];
+
+      assert.equal(Object.isFrozen(landingPageModuleCatalogRegistry), true);
+      assert.equal(Object.isFrozen(catalog), true);
+      assert.equal(Object.isFrozen(catalog.modules.hero), true);
+      assert.equal(Object.isFrozen(catalog.modules.hero.boundaries), true);
+      assert.throws(() => {
+        (catalog.modules.hero.boundaries as string[]).push("forbidden");
+      }, TypeError);
+    },
+  },
+];
+
+for (const validationCase of cases) {
+  validationCase.run();
+  console.log(`ok - ${validationCase.name}`);
+}
+
+function assertInvalid(catalog: LandingPageModuleCatalogEntry) {
+  assert.equal(landingPageModuleCatalogEntrySchema.safeParse(catalog).success, false);
+}
+
+function assertMutationInvalid(
+  mutate: (catalog: LandingPageModuleCatalogEntry) => void,
+) {
+  const catalog = cloneCatalog();
+  mutate(catalog);
+  assertInvalid(catalog);
+}
+
+function cloneCatalog(): LandingPageModuleCatalogEntry {
+  return JSON.parse(
+    JSON.stringify(landingPageModuleCatalogRegistry[1]),
+  ) as LandingPageModuleCatalogEntry;
+}
+
+function fixtureModule(
+  moduleKey: LandingPageModuleDefinition["moduleKey"],
+): LandingPageModuleDefinition {
+  return {
+    moduleKey,
+    moduleVersion: 1,
+    lifecycleStatus: "hypothesis",
+    purpose: "controlled_test",
+    function: "fixture_function",
+    boundaries: ["fixture_boundary"],
+    invariants: ["fixture_invariant"],
+  };
+}
+
+type MutableModule = {
+  -readonly [Key in keyof LandingPageModuleDefinition]: LandingPageModuleDefinition[Key];
+};

--- a/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
+++ b/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
@@ -8,11 +8,15 @@ import {
   resolveLandingPageRootParameters,
 } from "..";
 import {
+  landingPageCopySourceItemKeyCatalog,
+  landingPageCopySourceItemKeys,
   landingPageModuleKeys,
+  type LandingPageCopySourceMap,
   type LandingPageModuleCatalogEntry,
   type LandingPageModuleDefinition,
   type LandingPageModuleFieldCatalogEntry,
   type LandingPageModuleVariantCatalogEntry,
+  type LandingPageResearchCopySource,
 } from "./contracts";
 import { validateLandingPageModuleFieldPayload } from "./payload-validator";
 import {
@@ -513,6 +517,187 @@ const cases: readonly Case[] = [
     },
   },
   {
+    name: "all approved literal copy source maps are registered per variant",
+    run: () => {
+      const catalog = landingPageModuleVariantCatalogRegistry[1];
+
+      for (const [moduleKey, moduleEntry] of Object.entries(catalog.modules)) {
+        for (const variant of Object.values(moduleEntry.variants)) {
+          assert.deepEqual(
+            variant.copySourceMap,
+            expectedCopySourceMaps[
+              moduleKey as LandingPageModuleDefinition["moduleKey"]
+            ],
+          );
+        }
+      }
+    },
+  },
+  {
+    name: "copy source paths exactly cover approved text fields",
+    run: () => {
+      const catalog = landingPageModuleVariantCatalogRegistry[1];
+
+      for (const moduleEntry of Object.values(catalog.modules)) {
+        for (const variant of Object.values(moduleEntry.variants)) {
+          const textFieldPaths = Object.entries(variant.fields)
+            .filter(([, field]) => field.fieldKind === "text")
+            .map(([path]) => path);
+          assert.deepEqual(Object.keys(variant.copySourceMap), textFieldPaths);
+
+          for (const source of Object.values(variant.copySourceMap)) {
+            if (source.sourceMode !== "research") continue;
+            for (const itemKey of [
+              ...source.primaryItemKeys,
+              ...(source.auxiliaryItemKey === undefined
+                ? []
+                : [source.auxiliaryItemKey]),
+            ]) {
+              assert.equal(landingPageCopySourceItemKeys.includes(itemKey), true);
+            }
+          }
+        }
+      }
+
+      assert.deepEqual(landingPageCopySourceItemKeys, [
+        ...landingPageCopySourceItemKeyCatalog.strategic_core,
+        ...landingPageCopySourceItemKeyCatalog.seo,
+      ]);
+      assert.equal(
+        new Set(landingPageCopySourceItemKeys).size,
+        landingPageCopySourceItemKeys.length,
+      );
+    },
+  },
+  {
+    name: "research copy sources enforce primary and auxiliary cardinalities",
+    run: () => {
+      const sources = allResearchCopySources();
+      assert.ok(sources.some((source) => source.primaryItemKeys.length === 1));
+      assert.ok(sources.some((source) => source.primaryItemKeys.length === 2));
+      assert.ok(sources.some((source) => source.auxiliaryItemKey === undefined));
+      assert.ok(sources.some((source) => source.auxiliaryItemKey !== undefined));
+
+      assertVariantCatalogMutationInvalid((catalog) => {
+        delete mutableCopySource(catalog, "hero", "standard", "title")
+          .primaryItemKeys;
+      });
+      assertVariantCatalogMutationInvalid((catalog) => {
+        (
+          mutableCopySource(
+            catalog,
+            "hero",
+            "standard",
+            "title",
+          ).primaryItemKeys as string[]
+        ).push("belief");
+      });
+      assertVariantCatalogMutationInvalid((catalog) => {
+        mutableCopySource(
+          catalog,
+          "offer",
+          "standard",
+          "items[].itemTitle",
+        ).auxiliaryItemKey = ["belief", "objection"];
+      });
+    },
+  },
+  {
+    name: "unknown item key path and source mode fail closed",
+    run: () => {
+      assertVariantCatalogMutationInvalid((catalog) => {
+        const source = mutableCopySource(
+          catalog,
+          "hero",
+          "standard",
+          "title",
+        );
+        source.primaryItemKeys = ["unknown_item_key"];
+      });
+      assertVariantCatalogMutationInvalid((catalog) => {
+        mutableCopySourceMap(catalog, "hero", "standard").unknownPath = {
+          sourceMode: "research",
+          primaryItemKeys: ["desire"],
+        };
+      });
+      assertVariantCatalogMutationInvalid((catalog) => {
+        mutableCopySource(
+          catalog,
+          "hero",
+          "standard",
+          "title",
+        ).sourceMode = "generated";
+      });
+    },
+  },
+  {
+    name: "research and operational evidence source shapes cannot be mixed",
+    run: () => {
+      assertVariantCatalogMutationInvalid((catalog) => {
+        mutableCopySource(
+          catalog,
+          "social_proof",
+          "standard",
+          "items[].quote",
+        ).primaryItemKeys = ["proof_type"];
+      });
+      assertVariantCatalogMutationInvalid((catalog) => {
+        delete mutableCopySource(catalog, "hero", "standard", "title")
+          .primaryItemKeys;
+      });
+      assertVariantCatalogMutationInvalid((catalog) => {
+        mutableCopySourceMap(catalog, "hero", "standard").media = {
+          sourceMode: "research",
+          primaryItemKeys: ["desire"],
+        };
+      });
+      assertVariantCatalogMutationInvalid((catalog) => {
+        mutableVariant(catalog, "hero", "standard").copySourceMap =
+          JSON.parse(
+            JSON.stringify(
+              catalog.modules.final_cta.variants.standard.copySourceMap,
+            ),
+          );
+      });
+    },
+  },
+  {
+    name: "social proof preserves operational evidence sources",
+    run: () => {
+      const copySourceMap =
+        landingPageModuleVariantCatalogRegistry[1].modules.social_proof
+          .variants.standard.copySourceMap;
+
+      assert.deepEqual(copySourceMap["items[].quote"], {
+        sourceMode: "operational_evidence",
+      });
+      assert.deepEqual(copySourceMap["items[].attribution"], {
+        sourceMode: "operational_evidence",
+      });
+      assert.equal(copySourceMap.title.sourceMode, "research");
+    },
+  },
+  {
+    name: "faq standard and accordion own independent copy source maps",
+    run: () => {
+      const faq = landingPageModuleVariantCatalogRegistry[1].modules.faq;
+      const standard = faq.variants.standard.copySourceMap;
+      const accordion = faq.variants.accordion.copySourceMap;
+
+      assert.deepEqual(standard, accordion);
+      assert.notStrictEqual(standard, accordion);
+      assert.notStrictEqual(standard.title, accordion.title);
+      assert.notStrictEqual(
+        "primaryItemKeys" in standard.title
+          ? standard.title.primaryItemKeys
+          : undefined,
+        "primaryItemKeys" in accordion.title
+          ? accordion.title.primaryItemKeys
+          : undefined,
+      );
+    },
+  },
+  {
     name: "faq variants own independent contracts and accordion declares wcag 2.2",
     run: () => {
       const catalog = landingPageModuleVariantCatalogRegistry[1];
@@ -836,6 +1021,27 @@ const cases: readonly Case[] = [
       );
       assert.equal(
         Object.isFrozen(
+          variantCatalog.modules.faq.variants.accordion.copySourceMap,
+        ),
+        true,
+      );
+      assert.equal(
+        Object.isFrozen(
+          variantCatalog.modules.faq.variants.accordion.copySourceMap.title,
+        ),
+        true,
+      );
+      assert.equal(
+        Object.isFrozen(
+          (
+            variantCatalog.modules.faq.variants.accordion.copySourceMap
+              .title as LandingPageResearchCopySource
+          ).primaryItemKeys,
+        ),
+        true,
+      );
+      assert.equal(
+        Object.isFrozen(
           variantCatalog.modules.faq.variants.accordion.rootDelta,
         ),
         true,
@@ -858,6 +1064,14 @@ const cases: readonly Case[] = [
         (
           variantCatalog.modules.faq.variants.accordion
             .capabilities as string[]
+        ).push("forbidden");
+      }, TypeError);
+      assert.throws(() => {
+        (
+          (
+            variantCatalog.modules.faq.variants.accordion.copySourceMap
+              .title as LandingPageResearchCopySource
+          ).primaryItemKeys as string[]
         ).push("forbidden");
       }, TypeError);
     },
@@ -958,6 +1172,39 @@ function mutableVariantFields(
     string,
     Record<string, unknown>
   >;
+}
+
+function mutableCopySourceMap(
+  catalog: LandingPageModuleVariantCatalogEntry,
+  moduleKey: LandingPageModuleDefinition["moduleKey"],
+  variantKey: string,
+): Record<string, Record<string, unknown>> {
+  return mutableVariant(catalog, moduleKey, variantKey)
+    .copySourceMap as Record<string, Record<string, unknown>>;
+}
+
+function mutableCopySource(
+  catalog: LandingPageModuleVariantCatalogEntry,
+  moduleKey: LandingPageModuleDefinition["moduleKey"],
+  variantKey: string,
+  path: string,
+): Record<string, unknown> {
+  const source = mutableCopySourceMap(catalog, moduleKey, variantKey)[path];
+  assert.notEqual(source, undefined);
+  return source;
+}
+
+function allResearchCopySources(): LandingPageResearchCopySource[] {
+  return Object.values(
+    landingPageModuleVariantCatalogRegistry[1].modules,
+  ).flatMap((moduleEntry) =>
+    Object.values(moduleEntry.variants).flatMap((variant) =>
+      Object.values(variant.copySourceMap).filter(
+        (source): source is LandingPageResearchCopySource =>
+          source.sourceMode === "research",
+      ),
+    ),
+  );
 }
 
 function mutableFields(
@@ -1079,6 +1326,155 @@ const validPayloads: Readonly<Record<
     primaryCta: { label: "Comecar" },
   },
 };
+
+const expectedCopySourceMaps = {
+  hero: {
+    eyebrow: {
+      sourceMode: "research",
+      primaryItemKeys: ["positioning_opportunity"],
+      auxiliaryItemKey: "search_intent",
+    },
+    title: {
+      sourceMode: "research",
+      primaryItemKeys: ["positioning_opportunity", "desire"],
+      auxiliaryItemKey: "commercial_keywords",
+    },
+    subtitle: {
+      sourceMode: "research",
+      primaryItemKeys: ["pain", "desire"],
+      auxiliaryItemKey: "belief",
+    },
+    "primaryCta.label": {
+      sourceMode: "research",
+      primaryItemKeys: ["trigger"],
+      auxiliaryItemKey: "search_intent",
+    },
+    proofShort: {
+      sourceMode: "research",
+      primaryItemKeys: ["proof_type"],
+      auxiliaryItemKey: "objection",
+    },
+  },
+  trust_bar: {
+    "items[].text": {
+      sourceMode: "research",
+      primaryItemKeys: ["proof_type", "belief"],
+      auxiliaryItemKey: "objection",
+    },
+  },
+  problem_solution: {
+    title: {
+      sourceMode: "research",
+      primaryItemKeys: ["pain", "desire"],
+      auxiliaryItemKey: "positioning_opportunity",
+    },
+    "items[].problem": {
+      sourceMode: "research",
+      primaryItemKeys: ["pain", "fear"],
+      auxiliaryItemKey: "objection",
+    },
+    "items[].solution": {
+      sourceMode: "research",
+      primaryItemKeys: ["positioning_opportunity", "desire"],
+      auxiliaryItemKey: "belief",
+    },
+  },
+  offer: {
+    title: {
+      sourceMode: "research",
+      primaryItemKeys: ["desire", "trigger"],
+      auxiliaryItemKey: "positioning_opportunity",
+    },
+    "items[].itemTitle": {
+      sourceMode: "research",
+      primaryItemKeys: ["trigger", "desire"],
+    },
+    "items[].description": {
+      sourceMode: "research",
+      primaryItemKeys: ["positioning_opportunity", "belief"],
+      auxiliaryItemKey: "objection",
+    },
+  },
+  process: {
+    title: {
+      sourceMode: "research",
+      primaryItemKeys: ["belief", "desire"],
+      auxiliaryItemKey: "positioning_opportunity",
+    },
+    "steps[].stepTitle": {
+      sourceMode: "research",
+      primaryItemKeys: ["trigger", "positioning_opportunity"],
+      auxiliaryItemKey: "desire",
+    },
+    "steps[].stepBody": {
+      sourceMode: "research",
+      primaryItemKeys: ["belief", "desire"],
+      auxiliaryItemKey: "objection",
+    },
+  },
+  technical_assurance: {
+    title: {
+      sourceMode: "research",
+      primaryItemKeys: ["proof_type", "belief"],
+      auxiliaryItemKey: "objection",
+    },
+    "items[].assuranceTitle": {
+      sourceMode: "research",
+      primaryItemKeys: ["proof_type"],
+      auxiliaryItemKey: "belief",
+    },
+    "items[].assuranceBody": {
+      sourceMode: "research",
+      primaryItemKeys: ["proof_type", "positioning_opportunity"],
+      auxiliaryItemKey: "objection",
+    },
+  },
+  social_proof: {
+    title: {
+      sourceMode: "research",
+      primaryItemKeys: ["proof_type", "belief"],
+      auxiliaryItemKey: "objection",
+    },
+    "items[].quote": { sourceMode: "operational_evidence" },
+    "items[].attribution": { sourceMode: "operational_evidence" },
+  },
+  faq: {
+    title: {
+      sourceMode: "research",
+      primaryItemKeys: ["objection", "awareness_level"],
+      auxiliaryItemKey: "search_intent",
+    },
+    "items[].question": {
+      sourceMode: "research",
+      primaryItemKeys: ["objection", "fear"],
+      auxiliaryItemKey: "faq_questions",
+    },
+    "items[].answer": {
+      sourceMode: "research",
+      primaryItemKeys: ["belief", "positioning_opportunity"],
+      auxiliaryItemKey: "desire",
+    },
+  },
+  final_cta: {
+    title: {
+      sourceMode: "research",
+      primaryItemKeys: ["trigger", "desire"],
+      auxiliaryItemKey: "positioning_opportunity",
+    },
+    body: {
+      sourceMode: "research",
+      primaryItemKeys: ["desire", "objection"],
+      auxiliaryItemKey: "belief",
+    },
+    "primaryCta.label": {
+      sourceMode: "research",
+      primaryItemKeys: ["trigger"],
+      auxiliaryItemKey: "search_intent",
+    },
+  },
+} satisfies Readonly<
+  Record<LandingPageModuleDefinition["moduleKey"], LandingPageCopySourceMap>
+>;
 
 function fixtureModule(
   moduleKey: LandingPageModuleDefinition["moduleKey"],

--- a/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
+++ b/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
@@ -22,9 +22,11 @@ import {
   type LandingPageModuleCatalogEntry,
   type LandingPageModuleDefinition,
   type LandingPageModuleFieldCatalogEntry,
+  type LandingPageModuleLifecycleStatus,
   type LandingPageModuleVariantCatalogEntry,
   type LandingPageModuleVariantReference,
   type LandingPageResearchCopySource,
+  type ResolvedLandingPageModuleVariant,
   type ResolveLandingPageModuleVariantResult,
 } from "./contracts";
 import {
@@ -39,7 +41,6 @@ import {
   resolveLandingPageModuleVariantDefinitionInternal,
 } from "./registry";
 import {
-  calculateLandingPageEffectiveLifecycleStatusInternal,
   resolveLandingPageModuleVariant,
   resolveLandingPageModuleVariantWithDependenciesInternal,
   type LandingPageModuleResolverDependenciesInternal,
@@ -79,6 +80,24 @@ const cases: readonly Case[] = [
         assert.equal(modules[moduleKey].moduleVersion, 1);
         assert.equal(modules[moduleKey].lifecycleStatus, "hypothesis");
         assert.equal(modules[moduleKey].purpose, "controlled_test");
+      }
+    },
+  },
+  {
+    name: "canonical v1 registry starts every module and variant as hypothesis",
+    run: () => {
+      for (const moduleKey of landingPageModuleKeys) {
+        assert.equal(
+          landingPageModuleCatalogRegistry[1].modules[moduleKey]
+            .lifecycleStatus,
+          "hypothesis",
+        );
+        for (const variant of Object.values(
+          landingPageModuleVariantCatalogRegistry[1].modules[moduleKey]
+            .variants,
+        )) {
+          assert.equal(variant.lifecycleStatus, "hypothesis");
+        }
       }
     },
   },
@@ -1643,78 +1662,88 @@ const cases: readonly Case[] = [
     },
   },
   {
-    name: "effective lifecycle follows deprecated hypothesis validated precedence",
+    name: "full resolver applies lifecycle promotions and effective precedence",
     run: () => {
-      assert.equal(
-        calculateLandingPageEffectiveLifecycleStatusInternal(
-          "deprecated",
-          "hypothesis",
-          "validated",
-        ),
-        "deprecated",
-      );
-      assert.equal(
-        calculateLandingPageEffectiveLifecycleStatusInternal(
-          "validated",
-          "hypothesis",
-          "validated",
-        ),
-        "hypothesis",
-      );
-      assert.equal(
-        calculateLandingPageEffectiveLifecycleStatusInternal(
-          "validated",
-          "validated",
-          "validated",
-        ),
+      const validated = assertIntegratedLifecycle(
+        "validated",
+        "validated",
+        "validated",
         "validated",
       );
-
-      const dependencies = cloneResolverDependencies();
-      dependencies.resolveRootParameters = () => {
-        const value = cloneJson(resolveApprovedRootParameters()) as {
-          lifecycleStatus: string;
-        };
-        value.lifecycleStatus = "deprecated";
-        return { ok: true, value: value as never };
-      };
-      const deprecated = resolveLandingPageModuleVariantWithDependenciesInternal(
-        approvedReference("hero"),
-        {},
-        dependencies,
+      assert.deepEqual(
+        contractWithoutLifecycle(validated.module),
+        contractWithoutLifecycle(
+          landingPageModuleCatalogRegistry[1].modules.hero,
+        ),
       );
-      assert.equal(deprecated.ok, true);
-      if (deprecated.ok) {
-        assert.equal(deprecated.value.effectiveLifecycleStatus, "deprecated");
-        assert.equal(deprecated.value.moduleLifecycleStatus, "hypothesis");
-      }
+      assert.deepEqual(
+        contractWithoutLifecycle(validated.variant),
+        contractWithoutLifecycle(
+          landingPageModuleVariantCatalogRegistry[1].modules.hero.variants
+            .standard,
+        ),
+      );
+
+      assertIntegratedLifecycle(
+        "deprecated",
+        "validated",
+        "validated",
+        "deprecated",
+      );
+      assertIntegratedLifecycle(
+        "validated",
+        "deprecated",
+        "validated",
+        "deprecated",
+      );
+      assertIntegratedLifecycle(
+        "validated",
+        "validated",
+        "deprecated",
+        "deprecated",
+      );
+      assertIntegratedLifecycle(
+        "hypothesis",
+        "validated",
+        "validated",
+        "hypothesis",
+      );
+      assertIntegratedLifecycle(
+        "validated",
+        "hypothesis",
+        "validated",
+        "hypothesis",
+      );
+      assertIntegratedLifecycle(
+        "validated",
+        "validated",
+        "hypothesis",
+        "hypothesis",
+      );
     },
   },
   {
-    name: "unknown lifecycle fails closed",
+    name: "full resolver rejects unknown root module and variant lifecycle",
     run: () => {
-      assert.equal(
-        calculateLandingPageEffectiveLifecycleStatusInternal(
-          "unknown",
-          "validated",
-          "validated",
-        ),
-        undefined,
-      );
-      const dependencies = cloneResolverDependencies();
-      (
-        dependencies.moduleCatalogRegistry[1].modules.hero as unknown as {
-          lifecycleStatus: string;
-        }
-      ).lifecycleStatus = "unknown";
-      assertPublicError(
-        resolveLandingPageModuleVariantWithDependenciesInternal(
-          approvedReference("hero"),
-          {},
-          dependencies,
-        ),
-        "INVALID_MODULE_CATALOG_CONTRACT",
-      );
+      for (const statuses of [
+        ["unknown", "validated", "validated"],
+        ["validated", "unknown", "validated"],
+        ["validated", "validated", "unknown"],
+      ] as const) {
+        const dependencies = lifecycleResolverDependencies(
+          statuses[0],
+          statuses[1],
+          statuses[2],
+        );
+        assertPublicError(
+          resolveLandingPageModuleVariantWithDependenciesInternal(
+            approvedReference("hero"),
+            {},
+            dependencies,
+          ),
+          "INVALID_MODULE_CATALOG_CONTRACT",
+        );
+      }
     },
   },
   {
@@ -1820,6 +1849,59 @@ function cloneResolverDependencies(): MutableResolverDependencies {
   };
 }
 
+function lifecycleResolverDependencies(
+  rootLifecycleStatus: string,
+  moduleLifecycleStatus: string,
+  variantLifecycleStatus: string,
+): MutableResolverDependencies {
+  const dependencies = cloneResolverDependencies();
+  (
+    dependencies.moduleCatalogRegistry[1].modules.hero as unknown as {
+      lifecycleStatus: string;
+    }
+  ).lifecycleStatus = moduleLifecycleStatus;
+  mutableVariant(
+    dependencies.variantCatalogRegistry[1],
+    "hero",
+    "standard",
+  ).lifecycleStatus = variantLifecycleStatus;
+  dependencies.resolveRootParameters = () => {
+    const value = cloneJson(resolveApprovedRootParameters()) as unknown as {
+      lifecycleStatus: string;
+    };
+    value.lifecycleStatus = rootLifecycleStatus;
+    return { ok: true, value: value as never };
+  };
+  return dependencies;
+}
+
+function assertIntegratedLifecycle(
+  rootLifecycleStatus: LandingPageModuleLifecycleStatus,
+  moduleLifecycleStatus: LandingPageModuleLifecycleStatus,
+  variantLifecycleStatus: LandingPageModuleLifecycleStatus,
+  expectedLifecycleStatus: LandingPageModuleLifecycleStatus,
+): ResolvedLandingPageModuleVariant {
+  const result = resolveLandingPageModuleVariantWithDependenciesInternal(
+    approvedReference("hero"),
+    {},
+    lifecycleResolverDependencies(
+      rootLifecycleStatus,
+      moduleLifecycleStatus,
+      variantLifecycleStatus,
+    ),
+  );
+  assert.equal(result.ok, true);
+  if (!result.ok) assert.fail("known lifecycle promotion must resolve");
+  assert.equal(result.value.rootLifecycleStatus, rootLifecycleStatus);
+  assert.equal(result.value.moduleLifecycleStatus, moduleLifecycleStatus);
+  assert.equal(result.value.variantLifecycleStatus, variantLifecycleStatus);
+  assert.equal(result.value.effectiveLifecycleStatus, expectedLifecycleStatus);
+  assert.equal(Object.isFrozen(result.value), true);
+  assert.equal(Object.isFrozen(result.value.module), true);
+  assert.equal(Object.isFrozen(result.value.variant), true);
+  return result.value;
+}
+
 function assertPublicError(
   result:
     | ResolveLandingPageModuleVariantResult
@@ -1837,6 +1919,12 @@ function assertPublicError(
 
 function cloneJson<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function contractWithoutLifecycle(value: object): Record<string, unknown> {
+  const contract = cloneJson(value) as Record<string, unknown>;
+  delete contract.lifecycleStatus;
+  return contract;
 }
 
 function syntheticStageDelta(input: {

--- a/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
+++ b/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
@@ -1066,6 +1066,34 @@ const cases: readonly Case[] = [
     },
   },
   {
+    name: "all v1 module and variant deltas keep emphasized treatments empty",
+    run: () => {
+      const catalog = landingPageModuleVariantCatalogRegistry[1];
+
+      for (const [moduleKey, moduleEntry] of Object.entries(catalog.modules)) {
+        for (const stage of landingPageFunnelStages) {
+          assert.deepEqual(
+            moduleEntry.funnelProfileDelta[stage].emphasized,
+            [],
+            `${moduleKey}.${stage} must not emphasize a treatment`,
+          );
+        }
+
+        for (const [variantKey, variant] of Object.entries(
+          moduleEntry.variants,
+        )) {
+          for (const stage of landingPageFunnelStages) {
+            assert.deepEqual(
+              variant.funnelProfileDelta[stage].emphasized,
+              [],
+              `${moduleKey}.${variantKey}.${stage} must not emphasize a treatment`,
+            );
+          }
+        }
+      }
+    },
+  },
+  {
     name: "faq deltas are equivalent independent contracts",
     run: () => {
       const faq = landingPageModuleVariantCatalogRegistry[1].modules.faq;
@@ -1075,6 +1103,9 @@ const cases: readonly Case[] = [
       assert.notStrictEqual(standard, accordion);
       assert.notStrictEqual(standard.bofu, accordion.bofu);
       assert.notStrictEqual(standard.bofu.prohibited, accordion.bofu.prohibited);
+      assert.deepEqual(standard.bofu.emphasized, []);
+      assert.deepEqual(accordion.bofu.emphasized, []);
+      assert.notStrictEqual(standard.bofu.emphasized, accordion.bofu.emphasized);
       assert.notStrictEqual(
         standard.bofu.supportRequirements,
         accordion.bofu.supportRequirements,
@@ -1135,6 +1166,11 @@ const cases: readonly Case[] = [
       assertVariantCatalogMutationInvalid((catalog) => {
         mutableFunnelStageDelta(catalog, "hero", "bofu").prohibited.push(
           "unknown_treatment",
+        );
+      });
+      assertVariantCatalogMutationInvalid((catalog) => {
+        mutableFunnelStageDelta(catalog, "hero", "bofu").emphasized.push(
+          "direct_action",
         );
       });
       assertVariantCatalogMutationInvalid((catalog) => {

--- a/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
+++ b/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 import { landingPageInputCatalogRegistry } from "../input-catalog";
+import * as publicModuleCatalog from "./index";
 import {
   countLandingPageRootTextCharacters,
   normalizeLandingPageRootText,
@@ -22,9 +23,14 @@ import {
   type LandingPageModuleDefinition,
   type LandingPageModuleFieldCatalogEntry,
   type LandingPageModuleVariantCatalogEntry,
+  type LandingPageModuleVariantReference,
   type LandingPageResearchCopySource,
+  type ResolveLandingPageModuleVariantResult,
 } from "./contracts";
-import { validateLandingPageModuleFieldPayload } from "./payload-validator";
+import {
+  validateLandingPageModuleFieldPayload,
+  validateLandingPageVariantPayload,
+} from "./payload-validator";
 import {
   landingPageModuleCatalogRegistry,
   landingPageModuleFieldCatalogRegistry,
@@ -33,9 +39,16 @@ import {
   resolveLandingPageModuleVariantDefinitionInternal,
 } from "./registry";
 import {
+  calculateLandingPageEffectiveLifecycleStatusInternal,
+  resolveLandingPageModuleVariant,
+  resolveLandingPageModuleVariantWithDependenciesInternal,
+  type LandingPageModuleResolverDependenciesInternal,
+} from "./resolver";
+import {
   landingPageModuleCatalogEntrySchema,
   landingPageModuleFieldCatalogEntrySchema,
   landingPageModuleVariantCatalogEntrySchema,
+  landingPageModuleVariantReferenceSchema,
 } from "./schema";
 
 type Case = Readonly<{
@@ -1305,6 +1318,7 @@ const cases: readonly Case[] = [
         "contracts.ts",
         "payload-validator.ts",
         "registry.ts",
+        "resolver.ts",
         "schema.ts",
       ].map((fileName) =>
         readFileSync(
@@ -1436,7 +1450,394 @@ const cases: readonly Case[] = [
       }, TypeError);
     },
   },
+  {
+    name: "public reference requires all seven exact fields",
+    run: () => {
+      const reference = approvedReference("hero");
+      assert.equal(
+        landingPageModuleVariantReferenceSchema.safeParse(reference).success,
+        true,
+      );
+      for (const key of Object.keys(reference)) {
+        const missing = cloneJson(reference) as Record<string, unknown>;
+        delete missing[key];
+        assertPublicError(
+          resolveLandingPageModuleVariant(
+            missing as LandingPageModuleVariantReference,
+          ),
+          "INCOMPATIBLE_REFERENCE",
+        );
+      }
+      assertPublicError(
+        resolveLandingPageModuleVariant({
+          ...reference,
+          additionalField: true,
+        } as unknown as LandingPageModuleVariantReference),
+        "INCOMPATIBLE_REFERENCE",
+      );
+    },
+  },
+  {
+    name: "public resolver resolves all ten approved variants without fallback",
+    run: () => {
+      for (const reference of approvedVariantReferences()) {
+        const result = resolveLandingPageModuleVariant(reference);
+        assert.equal(result.ok, true);
+        if (!result.ok) assert.fail("approved variant must resolve");
+        assert.deepEqual(result.value.reference, reference);
+        assert.equal(result.value.module.moduleKey, reference.moduleKey);
+        assert.equal(result.value.variant.variantKey, reference.variantKey);
+        assert.equal(result.value.rootParameters.rootVersion, reference.rootVersion);
+        assert.equal(result.value.effectiveLifecycleStatus, "hypothesis");
+        for (const stage of landingPageFunnelStages) {
+          assert.deepEqual(result.value.funnelCopyProfile[stage].emphasized, []);
+        }
+      }
+    },
+  },
+  {
+    name: "UNKNOWN_MODULE_CATALOG_VERSION is returned safely",
+    run: () => {
+      assertPublicError(
+        resolveLandingPageModuleVariant({
+          ...approvedReference("hero"),
+          moduleCatalogVersion: 2,
+        }),
+        "UNKNOWN_MODULE_CATALOG_VERSION",
+      );
+    },
+  },
+  {
+    name: "INVALID_MODULE_CATALOG_CONTRACT is returned safely",
+    run: () => {
+      const dependencies = cloneResolverDependencies();
+      const catalog = dependencies.moduleCatalogRegistry[1] as unknown as {
+        modules: Record<string, unknown>;
+      };
+      delete catalog.modules.hero;
+      assertPublicError(
+        resolveLandingPageModuleVariantWithDependenciesInternal(
+          approvedReference("hero"),
+          {},
+          dependencies,
+        ),
+        "INVALID_MODULE_CATALOG_CONTRACT",
+      );
+    },
+  },
+  {
+    name: "ROOT_RESOLUTION_FAILED is returned safely",
+    run: () => {
+      assertPublicError(
+        resolveLandingPageModuleVariant(approvedReference("hero"), {
+          presetKey: "unknown_preset",
+        }),
+        "ROOT_RESOLUTION_FAILED",
+      );
+    },
+  },
+  {
+    name: "INCOMPATIBLE_ROOT_VERSION is returned without selecting a fallback",
+    run: () => {
+      assertPublicError(
+        resolveLandingPageModuleVariant({
+          ...approvedReference("hero"),
+          rootVersion: 2,
+        }),
+        "INCOMPATIBLE_ROOT_VERSION",
+      );
+    },
+  },
+  {
+    name: "UNKNOWN_MODULE is returned safely",
+    run: () => {
+      assertPublicError(
+        resolveLandingPageModuleVariant({
+          ...approvedReference("hero"),
+          moduleKey: "unknown_module",
+        } as unknown as LandingPageModuleVariantReference),
+        "UNKNOWN_MODULE",
+      );
+    },
+  },
+  {
+    name: "UNKNOWN_MODULE_VERSION is returned without selecting a fallback",
+    run: () => {
+      assertPublicError(
+        resolveLandingPageModuleVariant({
+          ...approvedReference("hero"),
+          moduleVersion: 2,
+        }),
+        "UNKNOWN_MODULE_VERSION",
+      );
+    },
+  },
+  {
+    name: "UNKNOWN_VARIANT is returned safely",
+    run: () => {
+      assertPublicError(
+        resolveLandingPageModuleVariant({
+          ...approvedReference("hero"),
+          variantKey: "unknown_variant",
+        } as unknown as LandingPageModuleVariantReference),
+        "UNKNOWN_VARIANT",
+      );
+    },
+  },
+  {
+    name: "UNKNOWN_VARIANT_VERSION is returned without selecting a fallback",
+    run: () => {
+      assertPublicError(
+        resolveLandingPageModuleVariant({
+          ...approvedReference("hero"),
+          variantVersion: 2,
+        }),
+        "UNKNOWN_VARIANT_VERSION",
+      );
+    },
+  },
+  {
+    name: "INCOMPATIBLE_REFERENCE is returned for mismatched root resolution",
+    run: () => {
+      const dependencies = cloneResolverDependencies();
+      dependencies.resolveRootParameters = () => {
+        const rootParameters = cloneJson(resolveApprovedRootParameters()) as {
+          rootVersion: number;
+        };
+        rootParameters.rootVersion = 2;
+        return { ok: true, value: rootParameters as never };
+      };
+      assertPublicError(
+        resolveLandingPageModuleVariantWithDependenciesInternal(
+          approvedReference("hero"),
+          {},
+          dependencies,
+        ),
+        "INCOMPATIBLE_REFERENCE",
+      );
+    },
+  },
+  {
+    name: "INVALID_VARIANT_PAYLOAD is returned safely",
+    run: () => {
+      assertPublicError(
+        validateLandingPageVariantPayload(approvedReference("hero"), {
+          title: "incomplete",
+        }),
+        "INVALID_VARIANT_PAYLOAD",
+      );
+    },
+  },
+  {
+    name: "public payload validator accepts all nine modules and ten variants",
+    run: () => {
+      for (const reference of approvedVariantReferences()) {
+        assert.deepEqual(
+          validateLandingPageVariantPayload(
+            reference,
+            validPayloads[reference.moduleKey],
+          ),
+          { ok: true },
+        );
+      }
+    },
+  },
+  {
+    name: "effective lifecycle follows deprecated hypothesis validated precedence",
+    run: () => {
+      assert.equal(
+        calculateLandingPageEffectiveLifecycleStatusInternal(
+          "deprecated",
+          "hypothesis",
+          "validated",
+        ),
+        "deprecated",
+      );
+      assert.equal(
+        calculateLandingPageEffectiveLifecycleStatusInternal(
+          "validated",
+          "hypothesis",
+          "validated",
+        ),
+        "hypothesis",
+      );
+      assert.equal(
+        calculateLandingPageEffectiveLifecycleStatusInternal(
+          "validated",
+          "validated",
+          "validated",
+        ),
+        "validated",
+      );
+
+      const dependencies = cloneResolverDependencies();
+      dependencies.resolveRootParameters = () => {
+        const value = cloneJson(resolveApprovedRootParameters()) as {
+          lifecycleStatus: string;
+        };
+        value.lifecycleStatus = "deprecated";
+        return { ok: true, value: value as never };
+      };
+      const deprecated = resolveLandingPageModuleVariantWithDependenciesInternal(
+        approvedReference("hero"),
+        {},
+        dependencies,
+      );
+      assert.equal(deprecated.ok, true);
+      if (deprecated.ok) {
+        assert.equal(deprecated.value.effectiveLifecycleStatus, "deprecated");
+        assert.equal(deprecated.value.moduleLifecycleStatus, "hypothesis");
+      }
+    },
+  },
+  {
+    name: "unknown lifecycle fails closed",
+    run: () => {
+      assert.equal(
+        calculateLandingPageEffectiveLifecycleStatusInternal(
+          "unknown",
+          "validated",
+          "validated",
+        ),
+        undefined,
+      );
+      const dependencies = cloneResolverDependencies();
+      (
+        dependencies.moduleCatalogRegistry[1].modules.hero as unknown as {
+          lifecycleStatus: string;
+        }
+      ).lifecycleStatus = "unknown";
+      assertPublicError(
+        resolveLandingPageModuleVariantWithDependenciesInternal(
+          approvedReference("hero"),
+          {},
+          dependencies,
+        ),
+        "INVALID_MODULE_CATALOG_CONTRACT",
+      );
+    },
+  },
+  {
+    name: "public namespace exposes only the approved module catalog boundary",
+    run: () => {
+      const boundary = publicModuleCatalog as Record<string, unknown>;
+      for (const key of [
+        "landingPageModuleCatalogRegistry",
+        "landingPageModuleFieldCatalogRegistry",
+        "landingPageModuleVariantCatalogRegistry",
+        "landingPageModuleCatalogEntrySchema",
+        "landingPageModuleFieldCatalogEntrySchema",
+        "landingPageModuleVariantCatalogEntrySchema",
+        "landingPageModuleVariantReferenceSchema",
+        "resolveLandingPageModuleVariant",
+        "validateLandingPageVariantPayload",
+      ]) {
+        assert.equal(Object.hasOwn(boundary, key), true);
+      }
+      for (const internalKey of [
+        "resolveLandingPageModuleVariantDefinitionInternal",
+        "applyLandingPageFunnelProfileDeltaInternal",
+        "resolveLandingPageModuleVariantWithDependenciesInternal",
+        "calculateLandingPageEffectiveLifecycleStatusInternal",
+      ]) {
+        assert.equal(Object.hasOwn(boundary, internalKey), false);
+      }
+      assert.match(
+        readFileSync("lib/conversion-content/index.ts", "utf8"),
+        /export \* as landingPageModuleCatalog from "\.\/landing-page\/module-catalog";/,
+      );
+      assert.equal(resolveLandingPageModuleVariant.length, 1);
+    },
+  },
+  {
+    name: "public registry resolver and validator results are deeply immutable",
+    run: () => {
+      const first = resolveLandingPageModuleVariant(approvedReference("faq", "accordion"));
+      assert.equal(first.ok, true);
+      if (!first.ok) assert.fail("approved variant must resolve");
+      assert.equal(Object.isFrozen(first), true);
+      assert.equal(Object.isFrozen(first.value), true);
+      assert.equal(Object.isFrozen(first.value.reference), true);
+      assert.equal(Object.isFrozen(first.value.rootParameters), true);
+      assert.equal(Object.isFrozen(first.value.fields), true);
+      assert.equal(Object.isFrozen(first.value.capabilities), true);
+      assert.equal(Object.isFrozen(first.value.copySourceMap), true);
+      assert.equal(Object.isFrozen(first.value.funnelCopyProfile), true);
+      assert.equal(Object.isFrozen(first.value.funnelCopyProfile.bofu.emphasized), true);
+      assert.throws(() => {
+        (first.value.funnelCopyProfile.bofu.emphasized as string[]).push("proof");
+      }, TypeError);
+      const validation = validateLandingPageVariantPayload(
+        approvedReference("faq", "accordion"),
+        validPayloads.faq,
+      );
+      assert.equal(Object.isFrozen(validation), true);
+      const second = resolveLandingPageModuleVariant(approvedReference("faq", "accordion"));
+      assert.equal(second.ok, true);
+      if (second.ok) assert.deepEqual(second.value.funnelCopyProfile.bofu.emphasized, []);
+    },
+  },
 ];
+
+type MutableResolverDependencies = {
+  -readonly [Key in keyof LandingPageModuleResolverDependenciesInternal]: LandingPageModuleResolverDependenciesInternal[Key];
+};
+
+function approvedReference(
+  moduleKey: LandingPageModuleDefinition["moduleKey"],
+  variantKey: LandingPageModuleVariantReference["variantKey"] = "standard",
+): LandingPageModuleVariantReference {
+  return {
+    family: "landing_page",
+    moduleCatalogVersion: 1,
+    rootVersion: 1,
+    moduleKey,
+    moduleVersion: 1,
+    variantKey,
+    variantVersion: 1,
+  };
+}
+
+function approvedVariantReferences(): readonly LandingPageModuleVariantReference[] {
+  return [
+    ...landingPageModuleKeys.map((moduleKey) => approvedReference(moduleKey)),
+    approvedReference("faq", "accordion"),
+  ];
+}
+
+function cloneResolverDependencies(): MutableResolverDependencies {
+  return {
+    moduleCatalogRegistry: {
+      1: cloneJson(landingPageModuleCatalogRegistry[1]),
+    },
+    fieldCatalogRegistry: {
+      1: cloneJson(landingPageModuleFieldCatalogRegistry[1]),
+    },
+    variantCatalogRegistry: {
+      1: cloneJson(landingPageModuleVariantCatalogRegistry[1]),
+    },
+    resolveRootParameters: resolveLandingPageRootParameters,
+  };
+}
+
+function assertPublicError(
+  result:
+    | ResolveLandingPageModuleVariantResult
+    | ReturnType<typeof validateLandingPageVariantPayload>,
+  code: string,
+) {
+  assert.equal(result.ok, false);
+  if (result.ok) assert.fail(`expected public error ${code}`);
+  assert.deepEqual(Object.keys(result.error).sort(), ["code", "message"]);
+  assert.equal(result.error.code, code);
+  assert.equal(typeof result.error.message, "string");
+  assert.equal(Object.isFrozen(result), true);
+  assert.equal(Object.isFrozen(result.error), true);
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
 
 function syntheticStageDelta(input: {
   restricted?: readonly LandingPageCopyTreatment[];

--- a/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
+++ b/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 
 import { landingPageInputCatalogRegistry } from "../input-catalog";
+import {
+  countLandingPageRootTextCharacters,
+  normalizeLandingPageRootText,
+  resolveLandingPageRootParameters,
+} from "..";
 import {
   landingPageModuleKeys,
   type LandingPageModuleCatalogEntry,
@@ -176,7 +182,6 @@ const cases: readonly Case[] = [
         "copySourceMap",
         "funnelCopyProfile",
         "capabilities",
-        "rootDelta",
       ] as const;
 
       for (const forbiddenKey of forbiddenKeys) {
@@ -673,6 +678,138 @@ const cases: readonly Case[] = [
     },
   },
   {
+    name: "root text normalization and absolute maximum use the public root boundary",
+    run: () => {
+      const rootParameters = resolveApprovedRootParameters();
+      const h1Range = rootParameters.semanticRoles.h1.textRange;
+      const exactMaximum = "a".repeat(h1Range.absoluteMax);
+      const aboveMaximum = `${exactMaximum}a`;
+      const outsideRecommended = "a".repeat(h1Range.recommended.max + 1);
+
+      assert.equal(
+        validateLandingPageModuleFieldPayload(
+          "hero",
+          heroPayloadWithTitle(exactMaximum),
+        ).ok,
+        true,
+      );
+      assert.equal(
+        validateLandingPageModuleFieldPayload(
+          "hero",
+          heroPayloadWithTitle(aboveMaximum),
+        ).ok,
+        false,
+      );
+      assert.equal(
+        validateLandingPageModuleFieldPayload(
+          "hero",
+          heroPayloadWithTitle(" \t\r\n "),
+        ).ok,
+        false,
+      );
+
+      const rawText = "  Alpha \t Beta\r\nGamma  ";
+      assert.equal(
+        normalizeLandingPageRootText(rawText),
+        "Alpha Beta\nGamma",
+      );
+      assert.equal(
+        countLandingPageRootTextCharacters(rawText),
+        Array.from("Alpha Beta\nGamma").length,
+      );
+      assert.equal(
+        validateLandingPageModuleFieldPayload(
+          "hero",
+          heroPayloadWithTitle(`  ${exactMaximum}  `),
+        ).ok,
+        true,
+      );
+
+      assert.ok(h1Range.recommended.max < h1Range.absoluteMax);
+      assert.equal(
+        validateLandingPageModuleFieldPayload(
+          "hero",
+          heroPayloadWithTitle(outsideRecommended),
+        ).ok,
+        true,
+      );
+    },
+  },
+  {
+    name: "root resolution errors are converted to ROOT_RESOLUTION_FAILED",
+    run: () => {
+      assert.deepEqual(
+        validateLandingPageModuleFieldPayload("hero", validPayloads.hero, {
+          rootVersion: Number.MAX_SAFE_INTEGER,
+        }),
+        { ok: false, error: { code: "ROOT_RESOLUTION_FAILED" } },
+      );
+    },
+  },
+  {
+    name: "v1 modules and variants accept only an empty root delta",
+    run: () => {
+      for (const moduleDefinition of Object.values(
+        landingPageModuleCatalogRegistry[1].modules,
+      )) {
+        assert.deepEqual(moduleDefinition.rootDelta, {});
+      }
+
+      for (const moduleEntry of Object.values(
+        landingPageModuleVariantCatalogRegistry[1].modules,
+      )) {
+        assert.deepEqual(moduleEntry.rootDelta, {});
+        for (const variant of Object.values(moduleEntry.variants)) {
+          assert.deepEqual(variant.rootDelta, {});
+        }
+      }
+
+      assertMutationInvalid((catalog) => {
+        (catalog.modules.hero.rootDelta as Record<string, unknown>).spacing =
+          "compact";
+      });
+      assertVariantCatalogMutationInvalid((catalog) => {
+        (
+          catalog.modules.hero.rootDelta as Record<string, unknown>
+        ).presetKey = "compact";
+      });
+      assertVariantCatalogMutationInvalid((catalog) => {
+        (mutableVariant(catalog, "hero", "standard").rootDelta as Record<
+          string,
+          unknown
+        >).spacing = "compact";
+      });
+    },
+  },
+  {
+    name: "module catalog does not import or duplicate the root implementation",
+    run: () => {
+      const sources = [
+        "contracts.ts",
+        "payload-validator.ts",
+        "registry.ts",
+        "schema.ts",
+      ].map((fileName) =>
+        readFileSync(
+          `lib/conversion-content/landing-page/module-catalog/${fileName}`,
+          "utf8",
+        ),
+      );
+      const combinedSource = sources.join("\n");
+
+      assert.doesNotMatch(combinedSource, /root-registry/);
+      assert.doesNotMatch(
+        combinedSource,
+        /function\s+(?:normalizeLandingPageRootText|countLandingPageRootTextCharacters)/,
+      );
+      assert.doesNotMatch(
+        combinedSource,
+        /(?:const|let|var)\s+landingPageRootSemanticRoleKeys\s*=/,
+      );
+      assert.match(sources[1], /from "\.\.\/index"/);
+    },
+  },
+  {
     name: "catalog and nested structural definitions are deeply immutable",
     run: () => {
       const catalog = landingPageModuleCatalogRegistry[1];
@@ -682,6 +819,7 @@ const cases: readonly Case[] = [
       assert.equal(Object.isFrozen(landingPageModuleCatalogRegistry), true);
       assert.equal(Object.isFrozen(catalog), true);
       assert.equal(Object.isFrozen(catalog.modules.hero), true);
+      assert.equal(Object.isFrozen(catalog.modules.hero.rootDelta), true);
       assert.equal(Object.isFrozen(catalog.modules.hero.boundaries), true);
       assert.equal(Object.isFrozen(landingPageModuleFieldCatalogRegistry), true);
       assert.equal(Object.isFrozen(fieldCatalog.modules.hero.fields), true);
@@ -691,8 +829,15 @@ const cases: readonly Case[] = [
       );
       assert.equal(Object.isFrozen(landingPageModuleVariantCatalogRegistry), true);
       assert.equal(Object.isFrozen(variantCatalog.modules.faq.variants), true);
+      assert.equal(Object.isFrozen(variantCatalog.modules.faq.rootDelta), true);
       assert.equal(
         Object.isFrozen(variantCatalog.modules.faq.variants.accordion.fields),
+        true,
+      );
+      assert.equal(
+        Object.isFrozen(
+          variantCatalog.modules.faq.variants.accordion.rootDelta,
+        ),
         true,
       );
       assert.equal(
@@ -852,6 +997,22 @@ function imagePayload(mode: "informative" | "decorative", altText: string) {
   };
 }
 
+function heroPayloadWithTitle(title: string) {
+  return {
+    ...(validPayloads.hero as Record<string, unknown>),
+    title,
+  };
+}
+
+function resolveApprovedRootParameters() {
+  const result = resolveLandingPageRootParameters({
+    rootVersion: landingPageModuleCatalogRegistry[1].compatibleRootVersions[0],
+  });
+  assert.equal(result.ok, true);
+  if (!result.ok) assert.fail("approved root parameters must resolve");
+  return result.value;
+}
+
 const validPayloads: Readonly<Record<
   LandingPageModuleDefinition["moduleKey"],
   unknown
@@ -930,6 +1091,7 @@ function fixtureModule(
     function: "fixture_function",
     boundaries: ["fixture_boundary"],
     invariants: ["fixture_invariant"],
+    rootDelta: {},
   };
 }
 

--- a/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
+++ b/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
@@ -1,19 +1,24 @@
 import assert from "node:assert/strict";
 
+import { landingPageInputCatalogRegistry } from "../input-catalog";
 import {
   landingPageModuleKeys,
   type LandingPageModuleCatalogEntry,
   type LandingPageModuleDefinition,
   type LandingPageModuleFieldCatalogEntry,
+  type LandingPageModuleVariantCatalogEntry,
 } from "./contracts";
 import { validateLandingPageModuleFieldPayload } from "./payload-validator";
 import {
   landingPageModuleCatalogRegistry,
   landingPageModuleFieldCatalogRegistry,
+  landingPageModuleVariantCatalogRegistry,
+  resolveLandingPageModuleVariantDefinitionInternal,
 } from "./registry";
 import {
   landingPageModuleCatalogEntrySchema,
   landingPageModuleFieldCatalogEntrySchema,
+  landingPageModuleVariantCatalogEntrySchema,
 } from "./schema";
 
 type Case = Readonly<{
@@ -425,10 +430,254 @@ const cases: readonly Case[] = [
     },
   },
   {
+    name: "ten approved variant identities resolve internally",
+    run: () => {
+      const catalog = landingPageModuleVariantCatalogRegistry[1];
+      assert.equal(
+        landingPageModuleVariantCatalogEntrySchema.safeParse(catalog).success,
+        true,
+      );
+
+      const identities: string[] = [];
+      for (const [moduleKey, moduleEntry] of Object.entries(catalog.modules)) {
+        for (const [variantKey, variant] of Object.entries(
+          moduleEntry.variants,
+        )) {
+          identities.push(
+            `${moduleKey}.${variantKey}@v${variant.variantVersion}`,
+          );
+          assert.strictEqual(
+            resolveLandingPageModuleVariantDefinitionInternal({
+              moduleKey,
+              moduleVersion: moduleEntry.moduleVersion,
+              variantKey,
+              variantVersion: variant.variantVersion,
+            }),
+            variant,
+          );
+        }
+      }
+
+      assert.deepEqual(identities, [
+        "hero.standard@v1",
+        "trust_bar.standard@v1",
+        "problem_solution.standard@v1",
+        "offer.standard@v1",
+        "process.standard@v1",
+        "technical_assurance.standard@v1",
+        "social_proof.standard@v1",
+        "faq.standard@v1",
+        "faq.accordion@v1",
+        "final_cta.standard@v1",
+      ]);
+    },
+  },
+  {
+    name: "variants bind to one module version and approved fields only",
+    run: () => {
+      const catalog = landingPageModuleVariantCatalogRegistry[1];
+      for (const [moduleKey, moduleEntry] of Object.entries(catalog.modules)) {
+        for (const variant of Object.values(moduleEntry.variants)) {
+          assert.equal(
+            variant.compatibleModuleVersion,
+            moduleEntry.moduleVersion,
+          );
+          assert.deepEqual(
+            variant.fields,
+            landingPageModuleFieldCatalogRegistry[1].modules[
+              moduleKey as LandingPageModuleDefinition["moduleKey"]
+            ].fields,
+          );
+          assert.notStrictEqual(
+            variant.fields,
+            landingPageModuleFieldCatalogRegistry[1].modules[
+              moduleKey as LandingPageModuleDefinition["moduleKey"]
+            ].fields,
+          );
+        }
+      }
+
+      assert.deepEqual(catalog.modules.hero.variants.standard.capabilities, [
+        "primary_action",
+        "image_asset",
+      ]);
+      assert.deepEqual(
+        catalog.modules.final_cta.variants.standard.capabilities,
+        ["primary_action"],
+      );
+    },
+  },
+  {
+    name: "faq variants own independent contracts and accordion declares wcag 2.2",
+    run: () => {
+      const catalog = landingPageModuleVariantCatalogRegistry[1];
+      const standard = catalog.modules.faq.variants.standard;
+      const accordion = catalog.modules.faq.variants.accordion;
+      const interaction = catalog.capabilities.accordion_interaction;
+
+      assert.notStrictEqual(standard, accordion);
+      assert.notStrictEqual(standard.fields, accordion.fields);
+      assert.notStrictEqual(
+        standard.fields.title,
+        accordion.fields.title,
+      );
+      assert.deepEqual(standard.fields, accordion.fields);
+      assert.deepEqual(standard.capabilities, []);
+      assert.deepEqual(accordion.capabilities, ["accordion_interaction"]);
+      assert.deepEqual(interaction, {
+        capabilityKey: "accordion_interaction",
+        initialState: "all_closed",
+        expansionMode: "single",
+        toggleMode: "own_control",
+        keyboardRequired: true,
+        stateExposed: true,
+        controlContentAssociationRequired: true,
+        focusPreserved: true,
+        focusVisible: "inherited_from_root",
+        wcagBaseline: "2.2",
+      });
+    },
+  },
+  {
+    name: "unknown capability fails closed",
+    run: () => {
+      assertVariantCatalogMutationInvalid((catalog) => {
+        mutableVariantCapabilities(catalog, "hero", "standard").push(
+          "unknown_capability",
+        );
+      });
+    },
+  },
+  {
+    name: "primary action is a strict subset of public conversion channels",
+    run: () => {
+      const inputField = landingPageInputCatalogRegistry[1].universal.entries.find(
+        (entry) =>
+          entry.kind === "field" &&
+          entry.fieldKey === "primary_conversion_channel",
+      );
+      assert.equal(inputField?.kind, "field");
+      assert.equal(inputField?.validation.kind, "enum");
+      if (!inputField || inputField.validation.kind !== "enum") {
+        assert.fail("primary conversion channel enum must exist");
+      }
+
+      const capability =
+        landingPageModuleVariantCatalogRegistry[1].capabilities.primary_action;
+      for (const value of capability.allowedValues) {
+        assert.equal(inputField.validation.allowedValues.includes(value), true);
+      }
+      assert.equal(inputField.validation.allowedValues.includes("form"), true);
+      assert.equal(
+        (capability.allowedValues as readonly string[]).includes("form"),
+        false,
+      );
+      assert.equal(
+        landingPageModuleVariantCatalogRegistry[1].modules.hero.variants.standard.capabilities.includes(
+          "primary_action",
+        ),
+        true,
+      );
+      assert.equal(
+        landingPageModuleVariantCatalogRegistry[1].modules.final_cta.variants.standard.capabilities.includes(
+          "primary_action",
+        ),
+        true,
+      );
+    },
+  },
+  {
+    name: "unknown identity module and incompatible versions fail closed",
+    run: () => {
+      assert.equal(
+        resolveLandingPageModuleVariantDefinitionInternal({
+          moduleKey: "unknown_module",
+          moduleVersion: 1,
+          variantKey: "standard",
+          variantVersion: 1,
+        }),
+        undefined,
+      );
+      assert.equal(
+        resolveLandingPageModuleVariantDefinitionInternal({
+          moduleKey: "hero",
+          moduleVersion: 2,
+          variantKey: "standard",
+          variantVersion: 1,
+        }),
+        undefined,
+      );
+      assert.equal(
+        resolveLandingPageModuleVariantDefinitionInternal({
+          moduleKey: "hero",
+          moduleVersion: 1,
+          variantKey: "unknown_variant",
+          variantVersion: 1,
+        }),
+        undefined,
+      );
+      assert.equal(
+        resolveLandingPageModuleVariantDefinitionInternal({
+          moduleKey: "hero",
+          moduleVersion: 1,
+          variantKey: "standard",
+          variantVersion: 2,
+        }),
+        undefined,
+      );
+      assertVariantCatalogMutationInvalid((catalog) => {
+        mutableVariant(catalog, "hero", "standard").compatibleModuleVersion =
+          2;
+      });
+    },
+  },
+  {
+    name: "variant field outside the approved contract fails closed",
+    run: () => {
+      assertVariantCatalogMutationInvalid((catalog) => {
+        const fields = mutableVariantFields(catalog, "faq", "accordion");
+        delete fields["items[].answer"];
+      });
+      assertVariantCatalogMutationInvalid((catalog) => {
+        mutableVariantFields(catalog, "faq", "standard").unknownField = {
+          path: "unknownField",
+          fieldKind: "text",
+          semanticRole: "paragraph",
+          cardinality: { min: 0, max: 1 },
+          policy: "hybrid",
+          support: "when_factual",
+        };
+      });
+    },
+  },
+  {
+    name: "commercial context alone cannot create a variant",
+    run: () => {
+      for (const variantKey of [
+        "taxon_specific",
+        "copy_specific",
+        "plan_specific",
+        "campaign_specific",
+        "asset_specific",
+        "order_specific",
+        "quantity_specific",
+      ]) {
+        assertVariantCatalogMutationInvalid((catalog) => {
+          const variants = mutableVariants(catalog, "hero");
+          variants[variantKey] = {
+            ...JSON.parse(JSON.stringify(variants.standard)),
+            variantKey,
+          };
+        });
+      }
+    },
+  },
+  {
     name: "catalog and nested structural definitions are deeply immutable",
     run: () => {
       const catalog = landingPageModuleCatalogRegistry[1];
       const fieldCatalog = landingPageModuleFieldCatalogRegistry[1];
+      const variantCatalog = landingPageModuleVariantCatalogRegistry[1];
 
       assert.equal(Object.isFrozen(landingPageModuleCatalogRegistry), true);
       assert.equal(Object.isFrozen(catalog), true);
@@ -440,6 +689,16 @@ const cases: readonly Case[] = [
         Object.isFrozen(fieldCatalog.modules.hero.fields.title.cardinality),
         true,
       );
+      assert.equal(Object.isFrozen(landingPageModuleVariantCatalogRegistry), true);
+      assert.equal(Object.isFrozen(variantCatalog.modules.faq.variants), true);
+      assert.equal(
+        Object.isFrozen(variantCatalog.modules.faq.variants.accordion.fields),
+        true,
+      );
+      assert.equal(
+        Object.isFrozen(variantCatalog.capabilities.accordion_interaction),
+        true,
+      );
       assert.throws(() => {
         (catalog.modules.hero.boundaries as string[]).push("forbidden");
       }, TypeError);
@@ -449,6 +708,12 @@ const cases: readonly Case[] = [
             min: number;
           }
         ).min = 0;
+      }, TypeError);
+      assert.throws(() => {
+        (
+          variantCatalog.modules.faq.variants.accordion
+            .capabilities as string[]
+        ).push("forbidden");
       }, TypeError);
     },
   },
@@ -491,6 +756,63 @@ function cloneFieldCatalog(): LandingPageModuleFieldCatalogEntry {
   return JSON.parse(
     JSON.stringify(landingPageModuleFieldCatalogRegistry[1]),
   ) as LandingPageModuleFieldCatalogEntry;
+}
+
+function assertVariantCatalogMutationInvalid(
+  mutate: (catalog: LandingPageModuleVariantCatalogEntry) => void,
+) {
+  const catalog = cloneVariantCatalog();
+  mutate(catalog);
+  assert.equal(
+    landingPageModuleVariantCatalogEntrySchema.safeParse(catalog).success,
+    false,
+  );
+}
+
+function cloneVariantCatalog(): LandingPageModuleVariantCatalogEntry {
+  return JSON.parse(
+    JSON.stringify(landingPageModuleVariantCatalogRegistry[1]),
+  ) as LandingPageModuleVariantCatalogEntry;
+}
+
+function mutableVariants(
+  catalog: LandingPageModuleVariantCatalogEntry,
+  moduleKey: LandingPageModuleDefinition["moduleKey"],
+): Record<string, Record<string, unknown>> {
+  return catalog.modules[moduleKey].variants as unknown as Record<
+    string,
+    Record<string, unknown>
+  >;
+}
+
+function mutableVariant(
+  catalog: LandingPageModuleVariantCatalogEntry,
+  moduleKey: LandingPageModuleDefinition["moduleKey"],
+  variantKey: string,
+): Record<string, unknown> {
+  const variant = mutableVariants(catalog, moduleKey)[variantKey];
+  assert.notEqual(variant, undefined);
+  return variant;
+}
+
+function mutableVariantCapabilities(
+  catalog: LandingPageModuleVariantCatalogEntry,
+  moduleKey: LandingPageModuleDefinition["moduleKey"],
+  variantKey: string,
+): string[] {
+  return mutableVariant(catalog, moduleKey, variantKey)
+    .capabilities as string[];
+}
+
+function mutableVariantFields(
+  catalog: LandingPageModuleVariantCatalogEntry,
+  moduleKey: LandingPageModuleDefinition["moduleKey"],
+  variantKey: string,
+): Record<string, Record<string, unknown>> {
+  return mutableVariant(catalog, moduleKey, variantKey).fields as Record<
+    string,
+    Record<string, unknown>
+  >;
 }
 
 function mutableFields(

--- a/lib/conversion-content/landing-page/root-schema.ts
+++ b/lib/conversion-content/landing-page/root-schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-const semanticRoleKeys = [
+export const landingPageRootSemanticRoleKeys = [
   "eyebrow",
   "h1",
   "h2",
@@ -35,7 +35,7 @@ const requiredVersionOneSpacingOptions = [
 
 const lifecycleStatuses = ["hypothesis", "validated", "deprecated"] as const;
 
-const semanticRoleKeySet = new Set<string>(semanticRoleKeys);
+const semanticRoleKeySet = new Set<string>(landingPageRootSemanticRoleKeys);
 const visualRoleKeySet = new Set<string>(visualRoleKeys);
 const lifecycleStatusSet = new Set<string>(lifecycleStatuses);
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "validate:commercial-activation": "tsx lib/conversion-content/commercial-activation/validation-cases.ts",
     "validate:landing-page-root": "tsx lib/conversion-content/landing-page/root-validation-cases.ts",
     "validate:landing-page-research": "tsx lib/conversion-content/landing-page/research-resolution/validation-cases.ts",
-    "validate:landing-page-input-catalog": "tsx lib/conversion-content/landing-page/input-catalog/validation-cases.ts"
+    "validate:landing-page-input-catalog": "tsx lib/conversion-content/landing-page/input-catalog/validation-cases.ts",
+    "validate:landing-page-module-catalog": "tsx lib/conversion-content/landing-page/module-catalog/validation-cases.ts"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "1.1.7",


### PR DESCRIPTION
## Escopo

Implementação manual comparativa das fases autorizadas da E18.5:

- `18.5.3 — Módulos e funções estruturais`: concluída e aprovada;
- `18.5.4 — Campos, estruturas e cardinalidades`: concluída e aprovada;
- `18.5.5 — Variantes e critérios de criação`: concluída e aprovada;
- `18.5.6 — Especializações sobre a parametrização raiz`: concluída e aprovada;
- `18.5.7 — Mapa de fontes de copy`: concluída e aprovada;
- `18.5.8 — Perfis de copy por intenção e funil`: concluída e aprovada;
- `18.5.9 — Ciclo de vida, compatibilidade e validação`: ajuste funcional implementado e aguardando nova avaliação.

## Fase 18.5.9

- adiciona a referência pública completa e estrita: `family`, `moduleCatalogVersion`, `rootVersion`, `moduleKey`, `moduleVersion`, `variantKey` e `variantVersion`;
- implementa `resolveLandingPageModuleVariant(reference, options?)` sem injeção pública, fallback ou acesso direto ao registry da raiz;
- resolve a raiz pelo boundary público e compõe os profiles BOFU, MOFU e TOFU com os deltas canônicos, preservando `emphasized=[]`;
- retorna referência, parâmetros da raiz, módulo, variante, fields, capabilities, `copySourceMap`, `funnelCopyProfile`, lifecycle e purposes em resultado profundamente imutável;
- implementa lifecycle efetivo com precedência `deprecated > hypothesis > validated`;
- implementa `validateLandingPageVariantPayload(reference, payload, options?)`, reutilizando o resolver e o contrato da variante;
- expõe o namespace TypeScript `landingPageModuleCatalog` com registries, schemas, resolver, validator e types aprovados, sem helpers internos ou mecanismos de injeção;
- fecha compatibilidade entre família, catálogo, raiz, módulo e variante, sem fallback de versão;
- preserva os contracts aprovados das fases 18.5.3 a 18.5.8 e não antecipa E19 ou E20.

## Matriz pública de erros

A API retorna somente código e mensagem segura para:

- `UNKNOWN_MODULE_CATALOG_VERSION`;
- `INVALID_MODULE_CATALOG_CONTRACT`;
- `ROOT_RESOLUTION_FAILED`;
- `INCOMPATIBLE_ROOT_VERSION`;
- `UNKNOWN_MODULE`;
- `UNKNOWN_MODULE_VERSION`;
- `UNKNOWN_VARIANT`;
- `UNKNOWN_VARIANT_VERSION`;
- `INCOMPATIBLE_REFERENCE`;
- `INVALID_VARIANT_PAYLOAD`.

## Casos executáveis

A suíte integrada do catálogo possui **72 casos** e cobre:

- resolução pública das dez variantes;
- referência completa, campos ausentes e campo adicional;
- os dez erros públicos separadamente;
- payload válido para os nove módulos e dez variantes;
- lifecycle `deprecated`, `hypothesis`, `validated` e lifecycle desconhecido;
- ausência de fallback e de injeção pública;
- imutabilidade profunda do registry e dos resultados;
- namespace público seletivo;
- subconjunto de canais de `primary_action` pelo boundary público do catálogo de entradas;
- regressão integral das fases 18.5.3 a 18.5.8.

## Gate do Analista

- ajuste funcional de lifecycle: `aprovado para avançar` no gate técnico read-only;
- schemas aceitam `hypothesis`, `validated` e `deprecated` sem descongelar o restante do contrato canônico;
- registry inicial permanece integralmente em `hypothesis`;
- fase `18.5.9`: aguardando nova avaliação;
- merge ainda não autorizado.

## Validação

- `npm ci`: aprovado; 430 pacotes instalados e 13 achados de audit preexistentes;
- `npm run validate:landing-page-module-catalog`: aprovado, 72/72 casos;
- `npm run validate:landing-page-root`: aprovado, 27/27 casos;
- `npm run validate:landing-page-research`: aprovado, 17/17 casos;
- `npm run validate:landing-page-input-catalog`: aprovado, 32/32 casos;
- `npm run validate:commercial-activation`: aprovado, 20/20 casos;
- `npm run check`: aprovado, com 0 erros e 24 warnings preexistentes;
- `git diff --check`: aprovado;
- Vercel do ajuste de lifecycle: dois checks aprovados (`lpf-10-services` e `lp-factory-10`).

## Fluxo experimental

- base: `codex-app/e18-5-v2-processo-atual`;
- branch: `codex-app/e18-5-implementacao-manual`;
- commit da 18.5.9: `5a6c1f0`;
- commit do ajuste de lifecycle: `e0694fd`;
- este PR permanece draft e não deve ser mergeado durante a comparação;
- não marcar como pronto para revisão;
- merge e encerramento da E18.5 dependem da avaliação final e da decisão do Estrategista.