### PR TITLE
feat: implementa E18.5.3 a E18.5.5 do catálogo (automação)

### DIFF
--- a/lib/conversion-content/index.ts
+++ b/lib/conversion-content/index.ts
@@ -4,6 +4,7 @@ export * from "./commercial-activation";
 export * as landingPageRoot from "./landing-page";
 export * as landingPageResearch from "./landing-page/research-resolution";
 export * as landingPageInputCatalog from "./landing-page/input-catalog";
+export * as landingPageModuleCatalog from "./landing-page/module-catalog";
 export {
   getCommercialActivationBundle,
   getCommercialActivationHierarchicalBundle,

--- a/lib/conversion-content/landing-page/module-catalog/contracts.ts
+++ b/lib/conversion-content/landing-page/module-catalog/contracts.ts
@@ -49,6 +49,14 @@ export const landingPageFieldSupports = [
   "when_present",
 ] as const;
 
+export const landingPageVariantKeys = landingPageVariantFieldContractKeys;
+
+export const landingPageVariantCapabilities = [
+  "primary_action",
+  "image_asset",
+  "accordion_interaction",
+] as const;
+
 export type LandingPageModuleFamily = "landing_page";
 export type LandingPageModuleCatalogVersion = 1;
 export type LandingPageCompatibleRootVersion = 1;
@@ -63,6 +71,26 @@ export type LandingPageFieldPolicy =
   (typeof landingPageFieldPolicies)[number];
 export type LandingPageFieldSupport =
   (typeof landingPageFieldSupports)[number];
+export type LandingPageVariantKey = (typeof landingPageVariantKeys)[number];
+export type LandingPageVariantName = "standard" | "accordion";
+export type LandingPageVariantVersion = 1;
+export type LandingPageVariantCapability =
+  (typeof landingPageVariantCapabilities)[number];
+export type LandingPageVariantLifecycleStatus = LandingPageRootLifecycleStatus;
+
+export type LandingPageActionCompatibility = Readonly<{
+  supportsPrimaryConversionForm: false;
+}>;
+
+export type LandingPageAccordionAccessibilityContract = Readonly<{
+  baseline: "WCAG 2.2";
+  keyboardOperable: true;
+  exposesExpandedState: true;
+  associatesControlAndRegion: true;
+  preservesFocus: true;
+  initiallyCollapsed: true;
+  singleExpandedItem: true;
+}>;
 
 export type LandingPageFieldCardinality = Readonly<{
   min: number;
@@ -128,6 +156,20 @@ export type LandingPageVariantFieldContract = Readonly<{
   fields: readonly LandingPageFieldDefinition[];
 }>;
 
+export type LandingPageVariantDefinition = Readonly<{
+  variantKey: LandingPageVariantKey;
+  variantName: LandingPageVariantName;
+  variantVersion: LandingPageVariantVersion;
+  moduleKey: LandingPageModuleKey;
+  moduleVersion: LandingPageModuleVersion;
+  fieldContractKey: LandingPageVariantFieldContractKey;
+  lifecycleStatus: LandingPageVariantLifecycleStatus;
+  purpose: LandingPageModulePurpose;
+  capabilities: readonly LandingPageVariantCapability[];
+  actionCompatibility?: LandingPageActionCompatibility;
+  accordionAccessibility?: LandingPageAccordionAccessibilityContract;
+}>;
+
 export type LandingPageModuleDefinition = Readonly<{
   family: LandingPageModuleFamily;
   moduleKey: LandingPageModuleKey;
@@ -149,4 +191,5 @@ export type LandingPageModuleCatalogRegistry = Readonly<{
   variantFieldContracts: Readonly<
     Record<LandingPageVariantFieldContractKey, LandingPageVariantFieldContract>
   >;
+  variants: Readonly<Record<LandingPageVariantKey, LandingPageVariantDefinition>>;
 }>;

--- a/lib/conversion-content/landing-page/module-catalog/contracts.ts
+++ b/lib/conversion-content/landing-page/module-catalog/contracts.ts
@@ -1,4 +1,7 @@
-import type { LandingPageRootLifecycleStatus } from "../contracts";
+import type {
+  LandingPageRootLifecycleStatus,
+  LandingPageRootSemanticRoleKey,
+} from "../contracts";
 
 export const landingPageModuleKeys = [
   "hero",
@@ -12,6 +15,40 @@ export const landingPageModuleKeys = [
   "final_cta",
 ] as const;
 
+export const landingPageVariantFieldContractKeys = [
+  "hero.standard@v1",
+  "trust_bar.standard@v1",
+  "problem_solution.standard@v1",
+  "offer.standard@v1",
+  "process.standard@v1",
+  "technical_assurance.standard@v1",
+  "social_proof.standard@v1",
+  "faq.standard@v1",
+  "faq.accordion@v1",
+  "final_cta.standard@v1",
+] as const;
+
+export const landingPageFieldKinds = [
+  "text",
+  "collection",
+  "action",
+  "image",
+  "technical_reference",
+] as const;
+
+export const landingPageFieldPolicies = [
+  "research_guided",
+  "hybrid",
+  "operational_required",
+  "technical_reference",
+  "not_copy",
+] as const;
+
+export const landingPageFieldSupports = [
+  "when_factual",
+  "when_present",
+] as const;
+
 export type LandingPageModuleFamily = "landing_page";
 export type LandingPageModuleCatalogVersion = 1;
 export type LandingPageCompatibleRootVersion = 1;
@@ -19,6 +56,77 @@ export type LandingPageModuleKey = (typeof landingPageModuleKeys)[number];
 export type LandingPageModuleVersion = 1;
 export type LandingPageModuleLifecycleStatus = LandingPageRootLifecycleStatus;
 export type LandingPageModulePurpose = "controlled_test";
+export type LandingPageVariantFieldContractKey =
+  (typeof landingPageVariantFieldContractKeys)[number];
+export type LandingPageFieldKind = (typeof landingPageFieldKinds)[number];
+export type LandingPageFieldPolicy =
+  (typeof landingPageFieldPolicies)[number];
+export type LandingPageFieldSupport =
+  (typeof landingPageFieldSupports)[number];
+
+export type LandingPageFieldCardinality = Readonly<{
+  min: number;
+  max: number;
+}>;
+
+type LandingPageFieldBase = Readonly<{
+  fieldKey: string;
+  path: string;
+  cardinality: LandingPageFieldCardinality;
+  policy: LandingPageFieldPolicy;
+}>;
+
+export type LandingPageTextFieldDefinition = LandingPageFieldBase &
+  Readonly<{
+    fieldKind: "text";
+    semanticRole: LandingPageRootSemanticRoleKey;
+    support?: LandingPageFieldSupport;
+  }>;
+
+export type LandingPageTechnicalReferenceFieldDefinition =
+  LandingPageFieldBase &
+    Readonly<{
+      fieldKind: "technical_reference";
+      policy: "technical_reference";
+    }>;
+
+export type LandingPageCollectionItemFieldDefinition =
+  | LandingPageTextFieldDefinition
+  | LandingPageTechnicalReferenceFieldDefinition;
+
+export type LandingPageCollectionFieldDefinition = LandingPageFieldBase &
+  Readonly<{
+    fieldKind: "collection";
+    policy: "not_copy";
+    itemFields: readonly LandingPageCollectionItemFieldDefinition[];
+  }>;
+
+export type LandingPageActionFieldDefinition = LandingPageFieldBase &
+  Readonly<{
+    fieldKind: "action";
+    policy: "not_copy";
+    label: LandingPageTextFieldDefinition;
+    operationalBinding: "primary_conversion_channel";
+  }>;
+
+export type LandingPageImageFieldDefinition = LandingPageFieldBase &
+  Readonly<{
+    fieldKind: "image";
+    policy: "technical_reference";
+    alternativeTextRequiredWhenInformative: true;
+  }>;
+
+export type LandingPageFieldDefinition =
+  | LandingPageTextFieldDefinition
+  | LandingPageCollectionFieldDefinition
+  | LandingPageActionFieldDefinition
+  | LandingPageImageFieldDefinition
+  | LandingPageTechnicalReferenceFieldDefinition;
+
+export type LandingPageVariantFieldContract = Readonly<{
+  fieldContractKey: LandingPageVariantFieldContractKey;
+  fields: readonly LandingPageFieldDefinition[];
+}>;
 
 export type LandingPageModuleDefinition = Readonly<{
   family: LandingPageModuleFamily;
@@ -37,5 +145,8 @@ export type LandingPageModuleCatalogRegistry = Readonly<{
   compatibleRootVersions: readonly [LandingPageCompatibleRootVersion];
   modules: Readonly<
     Record<LandingPageModuleKey, LandingPageModuleDefinition>
+  >;
+  variantFieldContracts: Readonly<
+    Record<LandingPageVariantFieldContractKey, LandingPageVariantFieldContract>
   >;
 }>;

--- a/lib/conversion-content/landing-page/module-catalog/contracts.ts
+++ b/lib/conversion-content/landing-page/module-catalog/contracts.ts
@@ -57,6 +57,25 @@ export const landingPageVariantCapabilities = [
   "accordion_interaction",
 ] as const;
 
+export const landingPageResearchItemKeys = [
+  "positioning_opportunity", "trigger", "desire", "pain", "objection",
+  "proof_type", "belief", "fear", "narrative_arc", "awareness_level",
+  "search_intent",
+] as const;
+
+export const landingPageTextFieldPaths = [
+  "hero.standard.eyebrow", "hero.standard.title", "hero.standard.subtitle", "hero.standard.primaryCta.label", "hero.standard.proofShort",
+  "trust_bar.standard.items[].text",
+  "problem_solution.standard.title", "problem_solution.standard.items[].problem", "problem_solution.standard.items[].solution",
+  "offer.standard.title", "offer.standard.items[].itemTitle", "offer.standard.items[].description",
+  "process.standard.title", "process.standard.steps[].stepTitle", "process.standard.steps[].stepBody",
+  "technical_assurance.standard.title", "technical_assurance.standard.items[].assuranceTitle", "technical_assurance.standard.items[].assuranceBody",
+  "social_proof.standard.title", "social_proof.standard.items[].quote", "social_proof.standard.items[].attribution",
+  "faq.standard.title", "faq.standard.items[].question", "faq.standard.items[].answer",
+  "faq.accordion.title", "faq.accordion.items[].question", "faq.accordion.items[].answer",
+  "final_cta.standard.title", "final_cta.standard.body", "final_cta.standard.primaryCta.label",
+] as const;
+
 export type LandingPageModuleFamily = "landing_page";
 export type LandingPageModuleCatalogVersion = 1;
 export type LandingPageCompatibleRootVersion = 1;
@@ -77,6 +96,20 @@ export type LandingPageVariantVersion = 1;
 export type LandingPageVariantCapability =
   (typeof landingPageVariantCapabilities)[number];
 export type LandingPageVariantLifecycleStatus = LandingPageRootLifecycleStatus;
+export type LandingPageResearchItemKey = (typeof landingPageResearchItemKeys)[number];
+export type LandingPageTextFieldPath = (typeof landingPageTextFieldPaths)[number];
+
+export type LandingPageCopySourceMap =
+  | Readonly<{
+      sourceMode: "research";
+      researchPath: "endCustomer.researches[].items[]";
+      primaryItemKeys: readonly [LandingPageResearchItemKey, LandingPageResearchItemKey?];
+      auxiliaryItemKey?: LandingPageResearchItemKey;
+    }>
+  | Readonly<{
+      sourceMode: "operational_evidence";
+      evidencePath: string;
+    }>;
 
 export type LandingPageTextRangeRestriction = Readonly<{
   semanticRole: LandingPageRootSemanticRoleKey;
@@ -119,6 +152,7 @@ export type LandingPageTextFieldDefinition = LandingPageFieldBase &
     fieldKind: "text";
     semanticRole: LandingPageRootSemanticRoleKey;
     support?: LandingPageFieldSupport;
+    copySourceMap: LandingPageCopySourceMap;
   }>;
 
 export type LandingPageTechnicalReferenceFieldDefinition =
@@ -199,6 +233,7 @@ export type LandingPageModuleCatalogRegistry = Readonly<{
   family: LandingPageModuleFamily;
   moduleCatalogVersion: LandingPageModuleCatalogVersion;
   compatibleRootVersions: readonly [LandingPageCompatibleRootVersion];
+  copySourceMaps: Readonly<Record<LandingPageTextFieldPath, LandingPageCopySourceMap>>;
   modules: Readonly<
     Record<LandingPageModuleKey, LandingPageModuleDefinition>
   >;

--- a/lib/conversion-content/landing-page/module-catalog/contracts.ts
+++ b/lib/conversion-content/landing-page/module-catalog/contracts.ts
@@ -1,0 +1,41 @@
+import type { LandingPageRootLifecycleStatus } from "../contracts";
+
+export const landingPageModuleKeys = [
+  "hero",
+  "trust_bar",
+  "problem_solution",
+  "offer",
+  "process",
+  "technical_assurance",
+  "social_proof",
+  "faq",
+  "final_cta",
+] as const;
+
+export type LandingPageModuleFamily = "landing_page";
+export type LandingPageModuleCatalogVersion = 1;
+export type LandingPageCompatibleRootVersion = 1;
+export type LandingPageModuleKey = (typeof landingPageModuleKeys)[number];
+export type LandingPageModuleVersion = 1;
+export type LandingPageModuleLifecycleStatus = LandingPageRootLifecycleStatus;
+export type LandingPageModulePurpose = "controlled_test";
+
+export type LandingPageModuleDefinition = Readonly<{
+  family: LandingPageModuleFamily;
+  moduleKey: LandingPageModuleKey;
+  moduleVersion: LandingPageModuleVersion;
+  lifecycleStatus: LandingPageModuleLifecycleStatus;
+  purpose: LandingPageModulePurpose;
+  structuralFunction: string;
+  invariants: readonly string[];
+  boundaries: readonly string[];
+}>;
+
+export type LandingPageModuleCatalogRegistry = Readonly<{
+  family: LandingPageModuleFamily;
+  moduleCatalogVersion: LandingPageModuleCatalogVersion;
+  compatibleRootVersions: readonly [LandingPageCompatibleRootVersion];
+  modules: Readonly<
+    Record<LandingPageModuleKey, LandingPageModuleDefinition>
+  >;
+}>;

--- a/lib/conversion-content/landing-page/module-catalog/contracts.ts
+++ b/lib/conversion-content/landing-page/module-catalog/contracts.ts
@@ -1,7 +1,7 @@
 import type {
   LandingPageRootLifecycleStatus,
   LandingPageRootSemanticRoleKey,
-} from "../contracts";
+} from "../index";
 
 export const landingPageModuleKeys = [
   "hero",
@@ -77,6 +77,16 @@ export type LandingPageVariantVersion = 1;
 export type LandingPageVariantCapability =
   (typeof landingPageVariantCapabilities)[number];
 export type LandingPageVariantLifecycleStatus = LandingPageRootLifecycleStatus;
+
+export type LandingPageTextRangeRestriction = Readonly<{
+  semanticRole: LandingPageRootSemanticRoleKey;
+  recommended?: Readonly<{ min: number; max: number }>;
+  absoluteMax?: number;
+}>;
+
+export type LandingPageRootSpecializationDelta = Readonly<{
+  textRanges: readonly LandingPageTextRangeRestriction[];
+}>;
 
 export type LandingPageActionCompatibility = Readonly<{
   supportsPrimaryConversionForm: false;
@@ -165,6 +175,8 @@ export type LandingPageVariantDefinition = Readonly<{
   fieldContractKey: LandingPageVariantFieldContractKey;
   lifecycleStatus: LandingPageVariantLifecycleStatus;
   purpose: LandingPageModulePurpose;
+  compatibleRootVersion: LandingPageCompatibleRootVersion;
+  rootDelta: LandingPageRootSpecializationDelta;
   capabilities: readonly LandingPageVariantCapability[];
   actionCompatibility?: LandingPageActionCompatibility;
   accordionAccessibility?: LandingPageAccordionAccessibilityContract;
@@ -176,6 +188,8 @@ export type LandingPageModuleDefinition = Readonly<{
   moduleVersion: LandingPageModuleVersion;
   lifecycleStatus: LandingPageModuleLifecycleStatus;
   purpose: LandingPageModulePurpose;
+  compatibleRootVersion: LandingPageCompatibleRootVersion;
+  rootDelta: LandingPageRootSpecializationDelta;
   structuralFunction: string;
   invariants: readonly string[];
   boundaries: readonly string[];

--- a/lib/conversion-content/landing-page/module-catalog/contracts.ts
+++ b/lib/conversion-content/landing-page/module-catalog/contracts.ts
@@ -76,6 +76,18 @@ export const landingPageTextFieldPaths = [
   "final_cta.standard.title", "final_cta.standard.body", "final_cta.standard.primaryCta.label",
 ] as const;
 
+export const landingPageFunnelProfileKeys = ["bofu", "mofu", "tofu"] as const;
+export const landingPageCtaModes = ["direct_next_step", "non_coercive_direct", "low_pressure"] as const;
+export const landingPageFunnelTreatmentKeys = [
+  "direct_next_step", "objection_response", "supported_proof", "supported_urgency", "supported_commercial_condition",
+  "supported_price", "supported_deadline", "supported_guarantee", "supported_availability", "coercion", "unsupported_scarcity",
+  "unsupported_promise", "unsupported_credential", "unsupported_result", "education", "problem_solution_relation", "process",
+  "technical_assurance", "faq", "direct_cta", "supported_offer", "invented_price", "invented_urgency", "invented_guarantee",
+  "invented_comparison", "invented_result", "context", "problem_recognition", "desire", "introductory_education",
+  "low_pressure_offer", "low_pressure_cta", "supported_factual_proof", "scarcity", "urgency", "guarantee",
+  "commercial_condition", "result_promise",
+] as const;
+
 export type LandingPageModuleFamily = "landing_page";
 export type LandingPageModuleCatalogVersion = 1;
 export type LandingPageCompatibleRootVersion = 1;
@@ -98,6 +110,24 @@ export type LandingPageVariantCapability =
 export type LandingPageVariantLifecycleStatus = LandingPageRootLifecycleStatus;
 export type LandingPageResearchItemKey = (typeof landingPageResearchItemKeys)[number];
 export type LandingPageTextFieldPath = (typeof landingPageTextFieldPaths)[number];
+export type LandingPageFunnelProfileKey = (typeof landingPageFunnelProfileKeys)[number];
+export type LandingPageCtaMode = (typeof landingPageCtaModes)[number];
+export type LandingPageFunnelTreatmentKey = (typeof landingPageFunnelTreatmentKeys)[number];
+
+export type LandingPageFunnelCopyProfile = Readonly<{
+  profileKey: LandingPageFunnelProfileKey;
+  prioritizedSources: readonly LandingPageResearchItemKey[];
+  permittedTreatments: readonly LandingPageFunnelTreatmentKey[];
+  restrictedTreatments: readonly LandingPageFunnelTreatmentKey[];
+  prohibitedTreatments: readonly LandingPageFunnelTreatmentKey[];
+  ctaMode: LandingPageCtaMode;
+}>;
+
+export type LandingPageFunnelProfileDelta = Readonly<{
+  emphasizeTreatments: readonly LandingPageFunnelTreatmentKey[];
+  restrictTreatments: readonly LandingPageFunnelTreatmentKey[];
+  prohibitTreatments: readonly LandingPageFunnelTreatmentKey[];
+}>;
 
 export type LandingPageCopySourceMap =
   | Readonly<{
@@ -224,6 +254,7 @@ export type LandingPageModuleDefinition = Readonly<{
   purpose: LandingPageModulePurpose;
   compatibleRootVersion: LandingPageCompatibleRootVersion;
   rootDelta: LandingPageRootSpecializationDelta;
+  funnelProfileDeltas: Readonly<Record<LandingPageFunnelProfileKey, LandingPageFunnelProfileDelta>>;
   structuralFunction: string;
   invariants: readonly string[];
   boundaries: readonly string[];
@@ -234,6 +265,7 @@ export type LandingPageModuleCatalogRegistry = Readonly<{
   moduleCatalogVersion: LandingPageModuleCatalogVersion;
   compatibleRootVersions: readonly [LandingPageCompatibleRootVersion];
   copySourceMaps: Readonly<Record<LandingPageTextFieldPath, LandingPageCopySourceMap>>;
+  funnelCopyProfiles: Readonly<Record<LandingPageFunnelProfileKey, LandingPageFunnelCopyProfile>>;
   modules: Readonly<
     Record<LandingPageModuleKey, LandingPageModuleDefinition>
   >;

--- a/lib/conversion-content/landing-page/module-catalog/contracts.ts
+++ b/lib/conversion-content/landing-page/module-catalog/contracts.ts
@@ -274,3 +274,43 @@ export type LandingPageModuleCatalogRegistry = Readonly<{
   >;
   variants: Readonly<Record<LandingPageVariantKey, LandingPageVariantDefinition>>;
 }>;
+
+export type LandingPageModuleCatalogErrorCode =
+  | "UNKNOWN_MODULE_CATALOG_VERSION"
+  | "INCOMPATIBLE_ROOT_VERSION"
+  | "UNKNOWN_MODULE"
+  | "UNKNOWN_MODULE_VERSION"
+  | "UNKNOWN_VARIANT"
+  | "UNKNOWN_FUNNEL_PROFILE"
+  | "INVALID_MODULE_CATALOG_CONTRACT";
+
+export type LandingPageModuleCatalogError = Readonly<{
+  code: LandingPageModuleCatalogErrorCode;
+  message: string;
+}>;
+
+export type ResolveLandingPageModuleCatalogInput = Readonly<{
+  moduleCatalogVersion: number;
+  rootVersion: number;
+  moduleKey: string;
+  moduleVersion: number;
+  variantName: string;
+  variantVersion: number;
+  funnelProfileKey: string;
+}>;
+
+export type ResolvedLandingPageModuleCatalog = Readonly<{
+  family: LandingPageModuleFamily;
+  moduleCatalogVersion: LandingPageModuleCatalogVersion;
+  root: import("../index").LandingPageRootParameters;
+  module: LandingPageModuleDefinition;
+  variant: LandingPageVariantDefinition;
+  fieldContract: LandingPageVariantFieldContract;
+  copySourceMaps: Readonly<Record<LandingPageTextFieldPath, LandingPageCopySourceMap>>;
+  funnelCopyProfile: LandingPageFunnelCopyProfile;
+  funnelProfileDelta: LandingPageFunnelProfileDelta;
+}>;
+
+export type ResolveLandingPageModuleCatalogResult =
+  | Readonly<{ ok: true; value: ResolvedLandingPageModuleCatalog }>
+  | Readonly<{ ok: false; error: LandingPageModuleCatalogError }>;

--- a/lib/conversion-content/landing-page/module-catalog/index.ts
+++ b/lib/conversion-content/landing-page/module-catalog/index.ts
@@ -1,0 +1,23 @@
+export type {
+  LandingPageCopySourceMap,
+  LandingPageCtaMode,
+  LandingPageFunnelCopyProfile,
+  LandingPageFunnelProfileDelta,
+  LandingPageFunnelProfileKey,
+  LandingPageFunnelTreatmentKey,
+  LandingPageModuleCatalogError,
+  LandingPageModuleCatalogErrorCode,
+  LandingPageModuleDefinition,
+  LandingPageModuleKey,
+  LandingPageModuleLifecycleStatus,
+  LandingPageResearchItemKey,
+  LandingPageTextFieldPath,
+  LandingPageVariantDefinition,
+  LandingPageVariantFieldContract,
+  LandingPageVariantKey,
+  LandingPageVariantLifecycleStatus,
+  ResolveLandingPageModuleCatalogInput,
+  ResolveLandingPageModuleCatalogResult,
+  ResolvedLandingPageModuleCatalog,
+} from "./contracts";
+export { resolveLandingPageModuleCatalog } from "./resolver";

--- a/lib/conversion-content/landing-page/module-catalog/registry.ts
+++ b/lib/conversion-content/landing-page/module-catalog/registry.ts
@@ -6,6 +6,8 @@ import type {
   LandingPageCollectionFieldDefinition,
   LandingPageCollectionItemFieldDefinition,
   LandingPageCopySourceMap,
+  LandingPageFunnelProfileDelta,
+  LandingPageFunnelProfileKey,
   LandingPageFieldCardinality,
   LandingPageFieldPolicy,
   LandingPageFieldSupport,
@@ -55,6 +57,32 @@ const copySourceMaps: Readonly<Record<LandingPageTextFieldPath, LandingPageCopyS
   "final_cta.standard.body": research(["desire", "objection"], "belief"),
   "final_cta.standard.primaryCta.label": research(["trigger", "desire"], "objection"),
 };
+const funnelCopyProfiles = {
+  bofu: {
+    profileKey: "bofu",
+    prioritizedSources: ["trigger", "desire", "objection", "proof_type", "positioning_opportunity"],
+    permittedTreatments: ["direct_next_step", "objection_response", "supported_proof"],
+    restrictedTreatments: ["supported_urgency", "supported_commercial_condition", "supported_price", "supported_deadline", "supported_guarantee", "supported_availability"],
+    prohibitedTreatments: ["coercion", "unsupported_scarcity", "unsupported_promise", "unsupported_credential", "unsupported_result"],
+    ctaMode: "direct_next_step",
+  },
+  mofu: {
+    profileKey: "mofu",
+    prioritizedSources: ["pain", "belief", "positioning_opportunity", "objection", "proof_type", "narrative_arc"],
+    permittedTreatments: ["education", "problem_solution_relation", "process", "technical_assurance", "faq"],
+    restrictedTreatments: ["direct_cta", "supported_offer", "supported_proof"],
+    prohibitedTreatments: ["invented_price", "invented_urgency", "invented_guarantee", "invented_comparison", "invented_result"],
+    ctaMode: "non_coercive_direct",
+  },
+  tofu: {
+    profileKey: "tofu",
+    prioritizedSources: ["awareness_level", "search_intent", "pain", "desire", "belief", "positioning_opportunity"],
+    permittedTreatments: ["context", "problem_recognition", "desire", "introductory_education"],
+    restrictedTreatments: ["low_pressure_offer", "low_pressure_cta", "supported_factual_proof"],
+    prohibitedTreatments: ["scarcity", "urgency", "guarantee", "commercial_condition", "result_promise"],
+    ctaMode: "low_pressure",
+  },
+} as const;
 
 function research(
   primaryItemKeys: readonly [import("./contracts").LandingPageResearchItemKey, import("./contracts").LandingPageResearchItemKey?],
@@ -68,6 +96,7 @@ export const landingPageModuleCatalogRegistry = deepFreeze({
   moduleCatalogVersion: 1,
   compatibleRootVersions: [1],
   copySourceMaps,
+  funnelCopyProfiles,
   modules: {
     hero: moduleDefinition(
       "hero",
@@ -353,6 +382,34 @@ function variant(
   };
 }
 
+function emptyFunnelDelta(): LandingPageFunnelProfileDelta {
+  return { emphasizeTreatments: [], restrictTreatments: [], prohibitTreatments: [] };
+}
+
+function moduleFunnelDeltas(moduleKey: LandingPageModuleKey): Readonly<Record<LandingPageFunnelProfileKey, LandingPageFunnelProfileDelta>> {
+  const deltas: Record<LandingPageFunnelProfileKey, LandingPageFunnelProfileDelta> = {
+    bofu: emptyFunnelDelta(), mofu: emptyFunnelDelta(), tofu: emptyFunnelDelta(),
+  };
+  if (moduleKey === "hero" || moduleKey === "final_cta") {
+    deltas.bofu = { ...emptyFunnelDelta(), emphasizeTreatments: ["direct_next_step"] };
+    deltas.mofu = { ...emptyFunnelDelta(), restrictTreatments: ["direct_cta"] };
+    deltas.tofu = { ...emptyFunnelDelta(), restrictTreatments: ["low_pressure_cta"] };
+  } else if (moduleKey === "problem_solution" || moduleKey === "faq") {
+    deltas.bofu = { ...emptyFunnelDelta(), emphasizeTreatments: ["objection_response"] };
+    deltas.mofu = { ...emptyFunnelDelta(), emphasizeTreatments: [moduleKey === "faq" ? "faq" : "problem_solution_relation"] };
+    deltas.tofu = { ...emptyFunnelDelta(), emphasizeTreatments: ["problem_recognition"] };
+  } else if (moduleKey === "offer" || moduleKey === "process") {
+    deltas.bofu = { ...emptyFunnelDelta(), emphasizeTreatments: [moduleKey === "offer" ? "direct_next_step" : "objection_response"] };
+    deltas.mofu = { ...emptyFunnelDelta(), emphasizeTreatments: [moduleKey === "offer" ? "supported_offer" : "process"] };
+    deltas.tofu = { ...emptyFunnelDelta(), restrictTreatments: [moduleKey === "offer" ? "low_pressure_offer" : "introductory_education"] };
+  } else if (["trust_bar", "technical_assurance", "social_proof"].includes(moduleKey)) {
+    deltas.bofu = { ...emptyFunnelDelta(), emphasizeTreatments: ["supported_proof"] };
+    deltas.mofu = { ...emptyFunnelDelta(), emphasizeTreatments: [moduleKey === "technical_assurance" ? "technical_assurance" : "supported_proof"] };
+    deltas.tofu = { ...emptyFunnelDelta(), emphasizeTreatments: ["supported_factual_proof"] };
+  }
+  return deltas;
+}
+
 function text(
   path: string,
   fieldKey: string,
@@ -463,6 +520,7 @@ function moduleDefinition(
     purpose: "controlled_test",
     compatibleRootVersion: 1,
     rootDelta: noRootRestrictions,
+    funnelProfileDeltas: moduleFunnelDeltas(moduleKey),
     structuralFunction,
     invariants,
     boundaries,

--- a/lib/conversion-content/landing-page/module-catalog/registry.ts
+++ b/lib/conversion-content/landing-page/module-catalog/registry.ts
@@ -1,8 +1,18 @@
 import type {
+  LandingPageActionFieldDefinition,
   LandingPageModuleCatalogRegistry,
   LandingPageModuleDefinition,
   LandingPageModuleKey,
+  LandingPageCollectionFieldDefinition,
+  LandingPageCollectionItemFieldDefinition,
+  LandingPageFieldCardinality,
+  LandingPageFieldPolicy,
+  LandingPageFieldSupport,
+  LandingPageImageFieldDefinition,
+  LandingPageTechnicalReferenceFieldDefinition,
+  LandingPageTextFieldDefinition,
 } from "./contracts";
+import type { LandingPageRootSemanticRoleKey } from "../contracts";
 
 export const landingPageModuleCatalogRegistry = deepFreeze({
   family: "landing_page",
@@ -109,7 +119,190 @@ export const landingPageModuleCatalogRegistry = deepFreeze({
       ],
     ),
   },
+  variantFieldContracts: {
+    "hero.standard@v1": {
+      fieldContractKey: "hero.standard@v1",
+      fields: [
+        text("hero.standard.eyebrow", "eyebrow", "eyebrow", 0, 1, "research_guided"),
+        text("hero.standard.title", "title", "h1", 1, 1, "hybrid", "when_factual"),
+        text("hero.standard.subtitle", "subtitle", "paragraph", 1, 1, "hybrid", "when_factual"),
+        action("hero.standard.primaryCta", "primaryCta"),
+        text("hero.standard.proofShort", "proofShort", "paragraph", 0, 1, "hybrid", "when_present"),
+        image("hero.standard.media", "media", 0, 1),
+      ],
+    },
+    "trust_bar.standard@v1": {
+      fieldContractKey: "trust_bar.standard@v1",
+      fields: [
+        collection("trust_bar.standard.items", "items", 2, 4, [
+          text("trust_bar.standard.items[].text", "text", "benefit_item", 1, 1, "hybrid", "when_present"),
+        ]),
+      ],
+    },
+    "problem_solution.standard@v1": {
+      fieldContractKey: "problem_solution.standard@v1",
+      fields: [
+        text("problem_solution.standard.title", "title", "h2", 1, 1, "research_guided"),
+        collection("problem_solution.standard.items", "items", 2, 4, [
+          text("problem_solution.standard.items[].problem", "problem", "card_title", 1, 1, "research_guided"),
+          text("problem_solution.standard.items[].solution", "solution", "card_body", 1, 1, "hybrid", "when_present"),
+        ]),
+      ],
+    },
+    "offer.standard@v1": {
+      fieldContractKey: "offer.standard@v1",
+      fields: [
+        text("offer.standard.title", "title", "h2", 1, 1, "research_guided"),
+        collection("offer.standard.items", "items", 1, 4, [
+          text("offer.standard.items[].itemTitle", "itemTitle", "card_title", 1, 1, "hybrid", "when_present"),
+          text("offer.standard.items[].description", "description", "card_body", 1, 1, "hybrid", "when_present"),
+        ]),
+      ],
+    },
+    "process.standard@v1": {
+      fieldContractKey: "process.standard@v1",
+      fields: [
+        text("process.standard.title", "title", "h2", 1, 1, "research_guided"),
+        collection("process.standard.steps", "steps", 2, 6, [
+          text("process.standard.steps[].stepTitle", "stepTitle", "step_title", 1, 1, "hybrid", "when_present"),
+          text("process.standard.steps[].stepBody", "stepBody", "step_body", 1, 1, "hybrid", "when_present"),
+        ]),
+      ],
+    },
+    "technical_assurance.standard@v1": {
+      fieldContractKey: "technical_assurance.standard@v1",
+      fields: [
+        text("technical_assurance.standard.title", "title", "h2", 1, 1, "research_guided"),
+        collection("technical_assurance.standard.items", "items", 1, 4, [
+          text("technical_assurance.standard.items[].assuranceTitle", "assuranceTitle", "card_title", 1, 1, "hybrid", "when_present"),
+          text("technical_assurance.standard.items[].assuranceBody", "assuranceBody", "card_body", 1, 1, "hybrid", "when_present"),
+        ]),
+      ],
+    },
+    "social_proof.standard@v1": {
+      fieldContractKey: "social_proof.standard@v1",
+      fields: [
+        text("social_proof.standard.title", "title", "h2", 1, 1, "research_guided"),
+        collection("social_proof.standard.items", "items", 1, 3, [
+          text("social_proof.standard.items[].quote", "quote", "card_body", 1, 1, "operational_required"),
+          text("social_proof.standard.items[].attribution", "attribution", "card_title", 1, 1, "operational_required"),
+          technicalReference("social_proof.standard.items[].evidenceRef", "evidenceRef"),
+        ]),
+      ],
+    },
+    "faq.standard@v1": {
+      fieldContractKey: "faq.standard@v1",
+      fields: faqFields("faq.standard"),
+    },
+    "faq.accordion@v1": {
+      fieldContractKey: "faq.accordion@v1",
+      fields: faqFields("faq.accordion"),
+    },
+    "final_cta.standard@v1": {
+      fieldContractKey: "final_cta.standard@v1",
+      fields: [
+        text("final_cta.standard.title", "title", "h2", 1, 1, "hybrid", "when_factual"),
+        text("final_cta.standard.body", "body", "paragraph", 1, 1, "hybrid", "when_factual"),
+        action("final_cta.standard.primaryCta", "primaryCta"),
+      ],
+    },
+  },
 } satisfies LandingPageModuleCatalogRegistry);
+
+function text(
+  path: string,
+  fieldKey: string,
+  semanticRole: LandingPageRootSemanticRoleKey,
+  min: number,
+  max: number,
+  policy: LandingPageFieldPolicy,
+  support?: LandingPageFieldSupport,
+): LandingPageTextFieldDefinition {
+  return {
+    fieldKind: "text",
+    fieldKey,
+    path,
+    cardinality: cardinality(min, max),
+    policy,
+    semanticRole,
+    ...(support ? { support } : {}),
+  };
+}
+
+function collection(
+  path: string,
+  fieldKey: string,
+  min: number,
+  max: number,
+  itemFields: readonly LandingPageCollectionItemFieldDefinition[],
+): LandingPageCollectionFieldDefinition {
+  return {
+    fieldKind: "collection",
+    fieldKey,
+    path,
+    cardinality: cardinality(min, max),
+    policy: "not_copy",
+    itemFields,
+  };
+}
+
+function action(
+  path: string,
+  fieldKey: string,
+): LandingPageActionFieldDefinition {
+  return {
+    fieldKind: "action",
+    fieldKey,
+    path,
+    cardinality: cardinality(1, 1),
+    policy: "not_copy",
+    label: text(`${path}.label`, "label", "cta_label", 1, 1, "hybrid", "when_present"),
+    operationalBinding: "primary_conversion_channel",
+  };
+}
+
+function image(
+  path: string,
+  fieldKey: string,
+  min: number,
+  max: number,
+): LandingPageImageFieldDefinition {
+  return {
+    fieldKind: "image",
+    fieldKey,
+    path,
+    cardinality: cardinality(min, max),
+    policy: "technical_reference",
+    alternativeTextRequiredWhenInformative: true,
+  };
+}
+
+function technicalReference(
+  path: string,
+  fieldKey: string,
+): LandingPageTechnicalReferenceFieldDefinition {
+  return {
+    fieldKind: "technical_reference",
+    fieldKey,
+    path,
+    cardinality: cardinality(1, 1),
+    policy: "technical_reference",
+  };
+}
+
+function faqFields(prefix: "faq.standard" | "faq.accordion") {
+  return [
+    text(`${prefix}.title`, "title", "h2", 1, 1, "research_guided"),
+    collection(`${prefix}.items`, "items", 2, 6, [
+      text(`${prefix}.items[].question`, "question", "faq_question", 1, 1, "research_guided"),
+      text(`${prefix}.items[].answer`, "answer", "faq_answer", 1, 1, "hybrid", "when_factual"),
+    ]),
+  ] as const;
+}
+
+function cardinality(min: number, max: number): LandingPageFieldCardinality {
+  return { min, max };
+}
 
 function moduleDefinition(
   moduleKey: LandingPageModuleKey,

--- a/lib/conversion-content/landing-page/module-catalog/registry.ts
+++ b/lib/conversion-content/landing-page/module-catalog/registry.ts
@@ -11,6 +11,11 @@ import type {
   LandingPageImageFieldDefinition,
   LandingPageTechnicalReferenceFieldDefinition,
   LandingPageTextFieldDefinition,
+  LandingPageVariantCapability,
+  LandingPageVariantDefinition,
+  LandingPageVariantFieldContractKey,
+  LandingPageVariantKey,
+  LandingPageVariantName,
 } from "./contracts";
 import type { LandingPageRootSemanticRoleKey } from "../contracts";
 
@@ -207,7 +212,99 @@ export const landingPageModuleCatalogRegistry = deepFreeze({
       ],
     },
   },
+  variants: {
+    "hero.standard@v1": variant(
+      "hero.standard@v1",
+      "standard",
+      "hero",
+      ["primary_action", "image_asset"],
+      { actionCompatibility: { supportsPrimaryConversionForm: false } },
+    ),
+    "trust_bar.standard@v1": variant(
+      "trust_bar.standard@v1",
+      "standard",
+      "trust_bar",
+    ),
+    "problem_solution.standard@v1": variant(
+      "problem_solution.standard@v1",
+      "standard",
+      "problem_solution",
+    ),
+    "offer.standard@v1": variant(
+      "offer.standard@v1",
+      "standard",
+      "offer",
+    ),
+    "process.standard@v1": variant(
+      "process.standard@v1",
+      "standard",
+      "process",
+    ),
+    "technical_assurance.standard@v1": variant(
+      "technical_assurance.standard@v1",
+      "standard",
+      "technical_assurance",
+    ),
+    "social_proof.standard@v1": variant(
+      "social_proof.standard@v1",
+      "standard",
+      "social_proof",
+    ),
+    "faq.standard@v1": variant(
+      "faq.standard@v1",
+      "standard",
+      "faq",
+    ),
+    "faq.accordion@v1": variant(
+      "faq.accordion@v1",
+      "accordion",
+      "faq",
+      ["accordion_interaction"],
+      {
+        accordionAccessibility: {
+          baseline: "WCAG 2.2",
+          keyboardOperable: true,
+          exposesExpandedState: true,
+          associatesControlAndRegion: true,
+          preservesFocus: true,
+          initiallyCollapsed: true,
+          singleExpandedItem: true,
+        },
+      },
+    ),
+    "final_cta.standard@v1": variant(
+      "final_cta.standard@v1",
+      "standard",
+      "final_cta",
+      ["primary_action"],
+      { actionCompatibility: { supportsPrimaryConversionForm: false } },
+    ),
+  },
 } satisfies LandingPageModuleCatalogRegistry);
+
+function variant(
+  variantKey: LandingPageVariantKey,
+  variantName: LandingPageVariantName,
+  moduleKey: LandingPageModuleKey,
+  capabilities: readonly LandingPageVariantCapability[] = [],
+  optional: Pick<
+    LandingPageVariantDefinition,
+    "actionCompatibility" | "accordionAccessibility"
+  > = {},
+): LandingPageVariantDefinition {
+  return {
+    variantKey,
+    variantName,
+    variantVersion: 1,
+    moduleKey,
+    moduleVersion: 1,
+    fieldContractKey: variantKey as LandingPageVariantFieldContractKey,
+    lifecycleStatus: "hypothesis",
+    purpose: "controlled_test",
+    capabilities,
+    ...optional,
+  };
+}
 
 function text(
   path: string,

--- a/lib/conversion-content/landing-page/module-catalog/registry.ts
+++ b/lib/conversion-content/landing-page/module-catalog/registry.ts
@@ -5,12 +5,14 @@ import type {
   LandingPageModuleKey,
   LandingPageCollectionFieldDefinition,
   LandingPageCollectionItemFieldDefinition,
+  LandingPageCopySourceMap,
   LandingPageFieldCardinality,
   LandingPageFieldPolicy,
   LandingPageFieldSupport,
   LandingPageImageFieldDefinition,
   LandingPageTechnicalReferenceFieldDefinition,
   LandingPageTextFieldDefinition,
+  LandingPageTextFieldPath,
   LandingPageVariantCapability,
   LandingPageVariantDefinition,
   LandingPageVariantFieldContractKey,
@@ -20,11 +22,52 @@ import type {
 import type { LandingPageRootSemanticRoleKey } from "../index";
 
 const noRootRestrictions = { textRanges: [] } as const;
+const researchPath = "endCustomer.researches[].items[]" as const;
+const copySourceMaps: Readonly<Record<LandingPageTextFieldPath, LandingPageCopySourceMap>> = {
+  "hero.standard.eyebrow": research(["positioning_opportunity", "trigger"], "desire"),
+  "hero.standard.title": research(["positioning_opportunity", "desire"], "trigger"),
+  "hero.standard.subtitle": research(["pain", "desire"], "objection"),
+  "hero.standard.primaryCta.label": research(["trigger", "desire"], "objection"),
+  "hero.standard.proofShort": research(["proof_type", "belief"], "objection"),
+  "trust_bar.standard.items[].text": research(["proof_type", "belief"], "objection"),
+  "problem_solution.standard.title": research(["pain", "desire"], "fear"),
+  "problem_solution.standard.items[].problem": research(["pain", "fear"], "objection"),
+  "problem_solution.standard.items[].solution": research(["positioning_opportunity", "desire"], "belief"),
+  "offer.standard.title": research(["desire", "trigger"], "positioning_opportunity"),
+  "offer.standard.items[].itemTitle": research(["trigger", "desire"], "positioning_opportunity"),
+  "offer.standard.items[].description": research(["positioning_opportunity", "belief"], "objection"),
+  "process.standard.title": research(["belief", "desire"], "objection"),
+  "process.standard.steps[].stepTitle": research(["narrative_arc", "trigger"], "belief"),
+  "process.standard.steps[].stepBody": research(["belief", "desire"], "positioning_opportunity"),
+  "technical_assurance.standard.title": research(["proof_type", "belief"], "fear"),
+  "technical_assurance.standard.items[].assuranceTitle": research(["proof_type", "positioning_opportunity"], "objection"),
+  "technical_assurance.standard.items[].assuranceBody": research(["proof_type", "belief"], "fear"),
+  "social_proof.standard.title": research(["proof_type", "belief"], "objection"),
+  "social_proof.standard.items[].quote": { sourceMode: "operational_evidence", evidencePath: "social_proof.standard.items[].evidenceRef" },
+  "social_proof.standard.items[].attribution": { sourceMode: "operational_evidence", evidencePath: "social_proof.standard.items[].evidenceRef" },
+  "faq.standard.title": research(["objection", "awareness_level"], "search_intent"),
+  "faq.standard.items[].question": research(["objection", "fear"], "search_intent"),
+  "faq.standard.items[].answer": research(["belief", "positioning_opportunity"], "proof_type"),
+  "faq.accordion.title": research(["objection", "awareness_level"], "search_intent"),
+  "faq.accordion.items[].question": research(["objection", "fear"], "search_intent"),
+  "faq.accordion.items[].answer": research(["belief", "positioning_opportunity"], "proof_type"),
+  "final_cta.standard.title": research(["trigger", "desire"], "positioning_opportunity"),
+  "final_cta.standard.body": research(["desire", "objection"], "belief"),
+  "final_cta.standard.primaryCta.label": research(["trigger", "desire"], "objection"),
+};
+
+function research(
+  primaryItemKeys: readonly [import("./contracts").LandingPageResearchItemKey, import("./contracts").LandingPageResearchItemKey?],
+  auxiliaryItemKey?: import("./contracts").LandingPageResearchItemKey,
+): LandingPageCopySourceMap {
+  return { sourceMode: "research", researchPath, primaryItemKeys, ...(auxiliaryItemKey ? { auxiliaryItemKey } : {}) };
+}
 
 export const landingPageModuleCatalogRegistry = deepFreeze({
   family: "landing_page",
   moduleCatalogVersion: 1,
   compatibleRootVersions: [1],
+  copySourceMaps,
   modules: {
     hero: moduleDefinition(
       "hero",
@@ -327,6 +370,7 @@ function text(
     policy,
     semanticRole,
     ...(support ? { support } : {}),
+    copySourceMap: copySourceMaps[path as LandingPageTextFieldPath],
   };
 }
 

--- a/lib/conversion-content/landing-page/module-catalog/registry.ts
+++ b/lib/conversion-content/landing-page/module-catalog/registry.ts
@@ -1,0 +1,143 @@
+import type {
+  LandingPageModuleCatalogRegistry,
+  LandingPageModuleDefinition,
+  LandingPageModuleKey,
+} from "./contracts";
+
+export const landingPageModuleCatalogRegistry = deepFreeze({
+  family: "landing_page",
+  moduleCatalogVersion: 1,
+  compatibleRootVersions: [1],
+  modules: {
+    hero: moduleDefinition(
+      "hero",
+      "Present the primary proposition and lead to the priority route.",
+      [
+        "The proposition is identifiable.",
+        "The hierarchy is coherent.",
+        "An action remains abstract when present.",
+      ],
+      [
+        "No complete form, gallery, carousel, tour or global navigation.",
+        "No detailed offer or extensive proof.",
+      ],
+    ),
+    trust_bar: moduleDefinition(
+      "trust_bar",
+      "Present short and verifiable trust signals.",
+      ["Signals are brief, relevant and supported by real evidence."],
+      ["No testimonial, extensive proof, action, form or media."],
+    ),
+    problem_solution: moduleDefinition(
+      "problem_solution",
+      "Relate a problem or risk to a practical response.",
+      [
+        "Each response corresponds directly to its problem.",
+        "Problems and responses remain clearly distinct.",
+        "The module does not use alarmism.",
+      ],
+      [
+        "No detailed offer, process, proof, FAQ, action, media or interaction.",
+      ],
+    ),
+    offer: moduleDefinition(
+      "offer",
+      "Present available offers or use cases.",
+      ["Every item is real, coherent and operationally supported."],
+      [
+        "No price, commercial condition, action, media, proof, process or FAQ.",
+      ],
+    ),
+    process: moduleDefinition(
+      "process",
+      "Explain a real progression through distinct steps.",
+      [
+        "Steps preserve a real progression.",
+        "Steps remain distinct.",
+        "No deadline or result is invented.",
+      ],
+      ["No offer, proof, FAQ, action, price, media or interaction."],
+    ),
+    technical_assurance: moduleDefinition(
+      "technical_assurance",
+      "Explain safeguards, criteria, documents, credentials or checks.",
+      [
+        "Every item is real and verifiable.",
+        "No item implies zero risk, approval or a result.",
+      ],
+      [
+        "No trust bar, testimonial, process, offer, FAQ, action or media.",
+        "No download or link.",
+      ],
+    ),
+    social_proof: moduleDefinition(
+      "social_proof",
+      "Present real experiences from third parties.",
+      [
+        "Proof is real, traceable and authorized.",
+        "Proof is not materially altered.",
+      ],
+      [
+        "No trust bar, technical proof, offer, process, FAQ or action.",
+        "No rating, metric, logo, detailed case or media.",
+      ],
+    ),
+    faq: moduleDefinition(
+      "faq",
+      "Answer relevant questions and objections in question-and-answer pairs.",
+      [
+        "Questions are relevant and answers are direct.",
+        "Factual statements require support.",
+        "No advice or misleading promise is introduced.",
+      ],
+      [
+        "No offer, process, technical proof, action, media or form.",
+        "Interaction belongs to a variant contract.",
+      ],
+    ),
+    final_cta: moduleDefinition(
+      "final_cta",
+      "Close the journey with a clear and qualified next step.",
+      [
+        "There is one primary action.",
+        "Language is not coercive.",
+        "The action link remains abstract and factual claims remain supported.",
+      ],
+      [
+        "No repeated offer, process, FAQ or proof.",
+        "No form, media, secondary action or concrete destination.",
+      ],
+    ),
+  },
+} satisfies LandingPageModuleCatalogRegistry);
+
+function moduleDefinition(
+  moduleKey: LandingPageModuleKey,
+  structuralFunction: string,
+  invariants: readonly string[],
+  boundaries: readonly string[],
+): LandingPageModuleDefinition {
+  return {
+    family: "landing_page",
+    moduleKey,
+    moduleVersion: 1,
+    lifecycleStatus: "hypothesis",
+    purpose: "controlled_test",
+    structuralFunction,
+    invariants,
+    boundaries,
+  };
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === "object") {
+    for (const property of Object.getOwnPropertyNames(value)) {
+      const nested = value[property as keyof T];
+      if (nested && typeof nested === "object" && !Object.isFrozen(nested)) {
+        deepFreeze(nested);
+      }
+    }
+    Object.freeze(value);
+  }
+  return value;
+}

--- a/lib/conversion-content/landing-page/module-catalog/registry.ts
+++ b/lib/conversion-content/landing-page/module-catalog/registry.ts
@@ -17,7 +17,9 @@ import type {
   LandingPageVariantKey,
   LandingPageVariantName,
 } from "./contracts";
-import type { LandingPageRootSemanticRoleKey } from "../contracts";
+import type { LandingPageRootSemanticRoleKey } from "../index";
+
+const noRootRestrictions = { textRanges: [] } as const;
 
 export const landingPageModuleCatalogRegistry = deepFreeze({
   family: "landing_page",
@@ -301,6 +303,8 @@ function variant(
     fieldContractKey: variantKey as LandingPageVariantFieldContractKey,
     lifecycleStatus: "hypothesis",
     purpose: "controlled_test",
+    compatibleRootVersion: 1,
+    rootDelta: noRootRestrictions,
     capabilities,
     ...optional,
   };
@@ -413,11 +417,14 @@ function moduleDefinition(
     moduleVersion: 1,
     lifecycleStatus: "hypothesis",
     purpose: "controlled_test",
+    compatibleRootVersion: 1,
+    rootDelta: noRootRestrictions,
     structuralFunction,
     invariants,
     boundaries,
   };
 }
+
 
 function deepFreeze<T>(value: T): T {
   if (value && typeof value === "object") {

--- a/lib/conversion-content/landing-page/module-catalog/resolver.ts
+++ b/lib/conversion-content/landing-page/module-catalog/resolver.ts
@@ -1,0 +1,73 @@
+import { resolveLandingPageRootParameters } from "../index";
+import type {
+  LandingPageFunnelProfileKey,
+  LandingPageModuleCatalogErrorCode,
+  LandingPageModuleKey,
+  LandingPageVariantKey,
+  ResolveLandingPageModuleCatalogInput,
+  ResolveLandingPageModuleCatalogResult,
+} from "./contracts";
+import { landingPageModuleCatalogRegistry } from "./registry";
+import { landingPageModuleCatalogSchema } from "./schema";
+
+export function resolveLandingPageModuleCatalog(
+  input: ResolveLandingPageModuleCatalogInput,
+): ResolveLandingPageModuleCatalogResult {
+  if (input.moduleCatalogVersion !== 1) return failure("UNKNOWN_MODULE_CATALOG_VERSION", "Unknown landing-page module catalog version.");
+  if (!landingPageModuleCatalogRegistry.compatibleRootVersions.includes(input.rootVersion as 1)) {
+    return failure("INCOMPATIBLE_ROOT_VERSION", "Root version is incompatible with this module catalog.");
+  }
+  const parsed = landingPageModuleCatalogSchema.safeParse(landingPageModuleCatalogRegistry);
+  if (!parsed.success) return failure("INVALID_MODULE_CATALOG_CONTRACT", "Landing-page module catalog contract is invalid.");
+
+  const root = resolveLandingPageRootParameters({ rootVersion: input.rootVersion });
+  if (!root.ok) return failure("INCOMPATIBLE_ROOT_VERSION", "Compatible root contract is unavailable or invalid.");
+
+  if (!Object.hasOwn(landingPageModuleCatalogRegistry.modules, input.moduleKey)) {
+    return failure("UNKNOWN_MODULE", "Unknown landing-page module.");
+  }
+  const moduleDefinition = landingPageModuleCatalogRegistry.modules[input.moduleKey as LandingPageModuleKey];
+  if (moduleDefinition.moduleVersion !== input.moduleVersion) return failure("UNKNOWN_MODULE_VERSION", "Unknown landing-page module version.");
+
+  const variantKey = `${input.moduleKey}.${input.variantName}@v${input.variantVersion}` as LandingPageVariantKey;
+  if (!Object.hasOwn(landingPageModuleCatalogRegistry.variants, variantKey)) {
+    return failure("UNKNOWN_VARIANT", "Unknown landing-page module variant.");
+  }
+  const variant = landingPageModuleCatalogRegistry.variants[variantKey];
+  if (variant.moduleKey !== moduleDefinition.moduleKey || variant.moduleVersion !== moduleDefinition.moduleVersion) {
+    return failure("INVALID_MODULE_CATALOG_CONTRACT", "Variant and module identities are incompatible.");
+  }
+  if (!Object.hasOwn(landingPageModuleCatalogRegistry.funnelCopyProfiles, input.funnelProfileKey)) {
+    return failure("UNKNOWN_FUNNEL_PROFILE", "Unknown landing-page funnel profile.");
+  }
+  const profileKey = input.funnelProfileKey as LandingPageFunnelProfileKey;
+  const fieldContract = landingPageModuleCatalogRegistry.variantFieldContracts[variant.fieldContractKey];
+  if (!fieldContract) return failure("INVALID_MODULE_CATALOG_CONTRACT", "Variant field contract is unavailable.");
+
+  return {
+    ok: true,
+    value: deepFreeze(structuredClone({
+      family: landingPageModuleCatalogRegistry.family,
+      moduleCatalogVersion: landingPageModuleCatalogRegistry.moduleCatalogVersion,
+      root: root.value,
+      module: moduleDefinition,
+      variant,
+      fieldContract,
+      copySourceMaps: landingPageModuleCatalogRegistry.copySourceMaps,
+      funnelCopyProfile: landingPageModuleCatalogRegistry.funnelCopyProfiles[profileKey],
+      funnelProfileDelta: moduleDefinition.funnelProfileDeltas[profileKey],
+    })),
+  };
+}
+
+function failure(code: LandingPageModuleCatalogErrorCode, message: string): ResolveLandingPageModuleCatalogResult {
+  return { ok: false, error: { code, message } };
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === "object") {
+    for (const nested of Object.values(value)) deepFreeze(nested);
+    Object.freeze(value);
+  }
+  return value;
+}

--- a/lib/conversion-content/landing-page/module-catalog/schema.ts
+++ b/lib/conversion-content/landing-page/module-catalog/schema.ts
@@ -275,7 +275,7 @@ const variantDefinitionSchema = z
     moduleKey: z.enum(landingPageModuleKeys),
     moduleVersion: z.literal(1),
     fieldContractKey: z.enum(landingPageVariantFieldContractKeys),
-    lifecycleStatus: z.literal("hypothesis"),
+    lifecycleStatus: z.enum(["hypothesis", "validated", "deprecated"]),
     purpose: z.literal("controlled_test"),
     compatibleRootVersion: z.literal(1),
     rootDelta: rootDeltaSchema,
@@ -381,7 +381,7 @@ const moduleDefinitionSchema = z
     family: z.literal("landing_page"),
     moduleKey: z.enum(landingPageModuleKeys),
     moduleVersion: z.literal(1),
-    lifecycleStatus: z.literal("hypothesis"),
+    lifecycleStatus: z.enum(["hypothesis", "validated", "deprecated"]),
     purpose: z.literal("controlled_test"),
     compatibleRootVersion: z.literal(1),
     rootDelta: rootDeltaSchema,
@@ -589,7 +589,7 @@ export const landingPageModuleCatalogSchema = z
       }
       const canonical =
         landingPageModuleCatalogRegistry.variants[key as LandingPageVariantKey];
-      if (JSON.stringify(variant) !== JSON.stringify(canonical)) {
+      if (JSON.stringify({ ...variant, lifecycleStatus: canonical.lifecycleStatus }) !== JSON.stringify(canonical)) {
         context.addIssue({
           code: "custom",
           path: ["variants", key],

--- a/lib/conversion-content/landing-page/module-catalog/schema.ts
+++ b/lib/conversion-content/landing-page/module-catalog/schema.ts
@@ -12,6 +12,62 @@ import {
   type LandingPageVariantKey,
 } from "./contracts";
 import { landingPageModuleCatalogRegistry } from "./registry";
+import {
+  resolveLandingPageRootParameters,
+  type LandingPageRootSemanticRoleKey,
+} from "../index";
+
+const resolvedRootV1 = resolveLandingPageRootParameters({ rootVersion: 1 });
+const rootSemanticRoleSchema = z.string().refine(
+  (key) => resolvedRootV1.ok && Object.hasOwn(resolvedRootV1.value.semanticRoles, key),
+  { message: "semantic role is absent from the compatible root contract" },
+);
+
+const textRangeRestrictionSchema = z.object({
+  semanticRole: rootSemanticRoleSchema,
+  recommended: z.object({ min: z.number().int().min(0), max: z.number().int().min(1) }).strict().optional(),
+  absoluteMax: z.number().int().min(1).optional(),
+}).strict().superRefine((restriction, context) => {
+  if (restriction.recommended && restriction.recommended.min > restriction.recommended.max) {
+    context.addIssue({ code: "custom", message: "recommended range is inverted" });
+  }
+  if (!restriction.recommended && restriction.absoluteMax === undefined) {
+    context.addIssue({ code: "custom", message: "empty root restriction" });
+  }
+});
+
+const rootDeltaSchema = z.object({
+  textRanges: z.array(textRangeRestrictionSchema),
+}).strict().superRefine((delta, context) => {
+  const root = resolveLandingPageRootParameters({ rootVersion: 1 });
+  if (!root.ok) {
+    context.addIssue({ code: "custom", message: "compatible root contract is unavailable" });
+    return;
+  }
+  const seen = new Set<string>();
+  for (const [index, restriction] of delta.textRanges.entries()) {
+    if (seen.has(restriction.semanticRole)) {
+      context.addIssue({ code: "custom", path: ["textRanges", index], message: "duplicate semantic role restriction" });
+    }
+    seen.add(restriction.semanticRole);
+    if (!Object.hasOwn(root.value.semanticRoles, restriction.semanticRole)) {
+      continue;
+    }
+    const rootRange = root.value.semanticRoles[restriction.semanticRole as LandingPageRootSemanticRoleKey].textRange;
+    if (restriction.recommended && (
+      restriction.recommended.min < rootRange.recommended.min ||
+      restriction.recommended.max > rootRange.recommended.max
+    )) {
+      context.addIssue({ code: "custom", path: ["textRanges", index], message: "recommended range widens the root contract" });
+    }
+    if (restriction.absoluteMax !== undefined && restriction.absoluteMax > rootRange.absoluteMax) {
+      context.addIssue({ code: "custom", path: ["textRanges", index], message: "absolute limit widens the root contract" });
+    }
+    if (restriction.recommended && restriction.absoluteMax !== undefined && restriction.recommended.max > restriction.absoluteMax) {
+      context.addIssue({ code: "custom", path: ["textRanges", index], message: "recommended maximum exceeds absolute maximum" });
+    }
+  }
+});
 
 const nonEmptyPlainText = z
   .string()
@@ -168,6 +224,8 @@ const variantDefinitionSchema = z
     fieldContractKey: z.enum(landingPageVariantFieldContractKeys),
     lifecycleStatus: z.literal("hypothesis"),
     purpose: z.literal("controlled_test"),
+    compatibleRootVersion: z.literal(1),
+    rootDelta: rootDeltaSchema,
     capabilities: z.array(z.enum(landingPageVariantCapabilities)),
     actionCompatibility: z
       .object({
@@ -272,6 +330,8 @@ const moduleDefinitionSchema = z
     moduleVersion: z.literal(1),
     lifecycleStatus: z.literal("hypothesis"),
     purpose: z.literal("controlled_test"),
+    compatibleRootVersion: z.literal(1),
+    rootDelta: rootDeltaSchema,
     structuralFunction: nonEmptyPlainText,
     invariants: z.array(nonEmptyPlainText).min(1),
     boundaries: z.array(nonEmptyPlainText).min(1),
@@ -293,6 +353,11 @@ export const landingPageModuleCatalogSchema = z
   })
   .strict()
   .superRefine((catalog, context) => {
+    const root = resolveLandingPageRootParameters({ rootVersion: 1 });
+    if (!root.ok) {
+      context.addIssue({ code: "custom", message: "compatible root contract is unavailable" });
+      return;
+    }
     const expectedKeys = new Set<string>(landingPageModuleKeys);
     const actualKeys = Object.keys(catalog.modules);
 
@@ -326,6 +391,12 @@ export const landingPageModuleCatalogSchema = z
       }
 
       if (!expectedKeys.has(key)) continue;
+      validateComposedRootDelta({
+        parentRanges: root.value.semanticRoles,
+        delta: module.rootDelta,
+        context,
+        path: ["modules", key, "rootDelta"],
+      });
       const canonical =
         landingPageModuleCatalogRegistry.modules[key as LandingPageModuleKey];
 
@@ -422,6 +493,16 @@ export const landingPageModuleCatalogSchema = z
       }
 
       if (!expectedVariantKeys.has(key)) continue;
+      const moduleDefinition = catalog.modules[variant.moduleKey];
+      if (moduleDefinition) {
+        const moduleRanges = composeRootRanges(root.value.semanticRoles, moduleDefinition.rootDelta);
+        validateComposedRootDelta({
+          parentRanges: moduleRanges,
+          delta: variant.rootDelta,
+          context,
+          path: ["variants", key, "rootDelta"],
+        });
+      }
       const canonical =
         landingPageModuleCatalogRegistry.variants[key as LandingPageVariantKey];
       if (JSON.stringify(variant) !== JSON.stringify(canonical)) {
@@ -433,6 +514,52 @@ export const landingPageModuleCatalogSchema = z
       }
     }
   });
+
+type EffectiveTextRange = Readonly<{
+  recommended: Readonly<{ min: number; max: number }>;
+  absoluteMax: number;
+}>;
+
+function composeRootRanges(
+  parentRanges: Readonly<Record<string, { textRange?: EffectiveTextRange } | EffectiveTextRange>>,
+  delta: { textRanges: readonly { semanticRole: string; recommended?: { min: number; max: number }; absoluteMax?: number }[] },
+) {
+  const result: Record<string, EffectiveTextRange> = {};
+  for (const [key, parent] of Object.entries(parentRanges)) {
+    const range = "textRange" in parent && parent.textRange ? parent.textRange : parent as EffectiveTextRange;
+    const restriction = delta.textRanges.find((item) => item.semanticRole === key);
+    result[key] = {
+      recommended: restriction?.recommended ?? range.recommended,
+      absoluteMax: restriction?.absoluteMax ?? range.absoluteMax,
+    };
+  }
+  return result;
+}
+
+function validateComposedRootDelta(input: {
+  parentRanges: Readonly<Record<string, { textRange?: EffectiveTextRange } | EffectiveTextRange>>;
+  delta: { textRanges: readonly { semanticRole: string; recommended?: { min: number; max: number }; absoluteMax?: number }[] };
+  context: z.RefinementCtx;
+  path: (string | number)[];
+}) {
+  const effective = composeRootRanges(input.parentRanges, input.delta);
+  for (const [index, restriction] of input.delta.textRanges.entries()) {
+    if (!Object.hasOwn(input.parentRanges, restriction.semanticRole)) continue;
+    const parent = input.parentRanges[restriction.semanticRole];
+    const parentRange = "textRange" in parent && parent.textRange ? parent.textRange : parent as EffectiveTextRange;
+    const childRange = effective[restriction.semanticRole];
+    if (
+      childRange.recommended.min < parentRange.recommended.min ||
+      childRange.recommended.max > parentRange.recommended.max ||
+      childRange.absoluteMax > parentRange.absoluteMax
+    ) {
+      input.context.addIssue({ code: "custom", path: [...input.path, "textRanges", index], message: "specialization widens its parent contract" });
+    }
+    if (childRange.recommended.max > childRange.absoluteMax) {
+      input.context.addIssue({ code: "custom", path: [...input.path, "textRanges", index], message: "effective recommended maximum exceeds effective absolute maximum" });
+    }
+  }
+}
 
 function containsFreeMarkupOrRendererHint(value: string): boolean {
   return /<[^>]+>|<\/|script|style=|class=|className=|tailwind|component|props/i.test(

--- a/lib/conversion-content/landing-page/module-catalog/schema.ts
+++ b/lib/conversion-content/landing-page/module-catalog/schema.ts
@@ -1,0 +1,138 @@
+import { z } from "zod";
+
+import {
+  landingPageModuleKeys,
+  type LandingPageModuleKey,
+} from "./contracts";
+import { landingPageModuleCatalogRegistry } from "./registry";
+
+const nonEmptyPlainText = z
+  .string()
+  .trim()
+  .min(1)
+  .refine((value) => !containsFreeMarkupOrRendererHint(value), {
+    message: "text must not contain markup, scripts, styles or renderer hints",
+  });
+
+const moduleDefinitionSchema = z
+  .object({
+    family: z.literal("landing_page"),
+    moduleKey: z.enum(landingPageModuleKeys),
+    moduleVersion: z.literal(1),
+    lifecycleStatus: z.literal("hypothesis"),
+    purpose: z.literal("controlled_test"),
+    structuralFunction: nonEmptyPlainText,
+    invariants: z.array(nonEmptyPlainText).min(1),
+    boundaries: z.array(nonEmptyPlainText).min(1),
+  })
+  .strict()
+  .superRefine((module, context) => {
+    validateUniqueText(module.invariants, "invariants", context);
+    validateUniqueText(module.boundaries, "boundaries", context);
+  });
+
+export const landingPageModuleCatalogSchema = z
+  .object({
+    family: z.literal("landing_page"),
+    moduleCatalogVersion: z.literal(1),
+    compatibleRootVersions: z.tuple([z.literal(1)]),
+    modules: z.record(z.string(), moduleDefinitionSchema),
+  })
+  .strict()
+  .superRefine((catalog, context) => {
+    const expectedKeys = new Set<string>(landingPageModuleKeys);
+    const actualKeys = Object.keys(catalog.modules);
+
+    for (const key of actualKeys) {
+      if (!expectedKeys.has(key)) {
+        context.addIssue({
+          code: "custom",
+          path: ["modules", key],
+          message: "unknown module key",
+        });
+      }
+    }
+
+    for (const key of landingPageModuleKeys) {
+      if (!actualKeys.includes(key)) {
+        context.addIssue({
+          code: "custom",
+          path: ["modules", key],
+          message: "required module missing",
+        });
+      }
+    }
+
+    for (const [key, module] of Object.entries(catalog.modules)) {
+      if (module.moduleKey !== key) {
+        context.addIssue({
+          code: "custom",
+          path: ["modules", key, "moduleKey"],
+          message: "module key mismatch",
+        });
+      }
+
+      if (!expectedKeys.has(key)) continue;
+      const canonical =
+        landingPageModuleCatalogRegistry.modules[key as LandingPageModuleKey];
+
+      if (module.structuralFunction !== canonical.structuralFunction) {
+        context.addIssue({
+          code: "custom",
+          path: ["modules", key, "structuralFunction"],
+          message: "structural function differs from the canonical registry",
+        });
+      }
+      validateCanonicalTextList({
+        actual: module.invariants,
+        canonical: canonical.invariants,
+        context,
+        path: ["modules", key, "invariants"],
+      });
+      validateCanonicalTextList({
+        actual: module.boundaries,
+        canonical: canonical.boundaries,
+        context,
+        path: ["modules", key, "boundaries"],
+      });
+    }
+  });
+
+function containsFreeMarkupOrRendererHint(value: string): boolean {
+  return /<[^>]+>|<\/|script|style=|class=|className=|tailwind|component|props/i.test(
+    value,
+  );
+}
+
+function validateUniqueText(
+  values: readonly string[],
+  path: "invariants" | "boundaries",
+  context: z.RefinementCtx,
+) {
+  if (new Set(values).size !== values.length) {
+    context.addIssue({
+      code: "custom",
+      path: [path],
+      message: `${path} must be unique`,
+    });
+  }
+}
+
+function validateCanonicalTextList(input: {
+  actual: readonly string[];
+  canonical: readonly string[];
+  context: z.RefinementCtx;
+  path: (string | number)[];
+}) {
+  const matches =
+    input.actual.length === input.canonical.length &&
+    input.actual.every((value, index) => value === input.canonical[index]);
+
+  if (!matches) {
+    input.context.addIssue({
+      code: "custom",
+      path: input.path,
+      message: "structural values differ from the canonical registry",
+    });
+  }
+}

--- a/lib/conversion-content/landing-page/module-catalog/schema.ts
+++ b/lib/conversion-content/landing-page/module-catalog/schema.ts
@@ -1,8 +1,12 @@
 import { z } from "zod";
 
 import {
+  landingPageFieldPolicies,
+  landingPageFieldSupports,
   landingPageModuleKeys,
+  landingPageVariantFieldContractKeys,
   type LandingPageModuleKey,
+  type LandingPageVariantFieldContractKey,
 } from "./contracts";
 import { landingPageModuleCatalogRegistry } from "./registry";
 
@@ -12,6 +16,143 @@ const nonEmptyPlainText = z
   .min(1)
   .refine((value) => !containsFreeMarkupOrRendererHint(value), {
     message: "text must not contain markup, scripts, styles or renderer hints",
+  });
+
+const fieldKeySchema = z.string().regex(/^[a-z][A-Za-z0-9]*$/);
+const fieldPathSchema = z
+  .string()
+  .regex(/^[a-z][a-z0-9_]*(?:\.[A-Za-z][A-Za-z0-9]*|\.[A-Za-z][A-Za-z0-9]*\[\]\.[A-Za-z][A-Za-z0-9]*)+$/);
+const cardinalitySchema = z
+  .object({
+    min: z.number().int().min(0),
+    max: z.number().int().min(1),
+  })
+  .strict()
+  .superRefine((cardinality, context) => {
+    if (cardinality.min > cardinality.max) {
+      context.addIssue({
+        code: "custom",
+        message: "cardinality is inverted",
+      });
+    }
+  });
+
+const textFieldSchema = z
+  .object({
+    fieldKind: z.literal("text"),
+    fieldKey: fieldKeySchema,
+    path: fieldPathSchema,
+    cardinality: cardinalitySchema,
+    policy: z.enum(landingPageFieldPolicies),
+    semanticRole: nonEmptyPlainText,
+    support: z.enum(landingPageFieldSupports).optional(),
+  })
+  .strict();
+
+const technicalReferenceFieldSchema = z
+  .object({
+    fieldKind: z.literal("technical_reference"),
+    fieldKey: fieldKeySchema,
+    path: fieldPathSchema,
+    cardinality: cardinalitySchema,
+    policy: z.literal("technical_reference"),
+  })
+  .strict();
+
+const collectionItemFieldSchema = z.discriminatedUnion("fieldKind", [
+  textFieldSchema,
+  technicalReferenceFieldSchema,
+]);
+
+const collectionFieldSchema = z
+  .object({
+    fieldKind: z.literal("collection"),
+    fieldKey: fieldKeySchema,
+    path: fieldPathSchema,
+    cardinality: cardinalitySchema,
+    policy: z.literal("not_copy"),
+    itemFields: z.array(collectionItemFieldSchema).min(1),
+  })
+  .strict();
+
+const actionFieldSchema = z
+  .object({
+    fieldKind: z.literal("action"),
+    fieldKey: fieldKeySchema,
+    path: fieldPathSchema,
+    cardinality: cardinalitySchema,
+    policy: z.literal("not_copy"),
+    label: textFieldSchema,
+    operationalBinding: z.literal("primary_conversion_channel"),
+  })
+  .strict();
+
+const imageFieldSchema = z
+  .object({
+    fieldKind: z.literal("image"),
+    fieldKey: fieldKeySchema,
+    path: fieldPathSchema,
+    cardinality: cardinalitySchema,
+    policy: z.literal("technical_reference"),
+    alternativeTextRequiredWhenInformative: z.literal(true),
+  })
+  .strict();
+
+const fieldDefinitionSchema = z.discriminatedUnion("fieldKind", [
+  textFieldSchema,
+  collectionFieldSchema,
+  actionFieldSchema,
+  imageFieldSchema,
+  technicalReferenceFieldSchema,
+]);
+
+const variantFieldContractSchema = z
+  .object({
+    fieldContractKey: z.enum(landingPageVariantFieldContractKeys),
+    fields: z.array(fieldDefinitionSchema).min(1),
+  })
+  .strict()
+  .superRefine((contract, context) => {
+    const prefix = contract.fieldContractKey.replace("@v1", "");
+    validateUniqueFieldIdentities(contract.fields, context);
+
+    for (const [fieldIndex, field] of contract.fields.entries()) {
+      if (!field.path.startsWith(`${prefix}.`)) {
+        context.addIssue({
+          code: "custom",
+          path: ["fields", fieldIndex, "path"],
+          message: "field path does not belong to its contract",
+        });
+      }
+
+      if (field.fieldKind === "collection") {
+        validateUniqueFieldIdentities(field.itemFields, context, [
+          "fields",
+          fieldIndex,
+          "itemFields",
+        ]);
+        for (const [itemIndex, itemField] of field.itemFields.entries()) {
+          if (!itemField.path.startsWith(`${field.path}[].`)) {
+            context.addIssue({
+              code: "custom",
+              path: ["fields", fieldIndex, "itemFields", itemIndex, "path"],
+              message: "collection item path does not belong to its collection",
+            });
+          }
+        }
+      }
+
+      if (
+        field.fieldKind === "action" &&
+        !field.label.path.startsWith(`${field.path}.`)
+      ) {
+        context.addIssue({
+          code: "custom",
+          path: ["fields", fieldIndex, "label", "path"],
+          message: "action label path does not belong to its action",
+        });
+      }
+    }
   });
 
 const moduleDefinitionSchema = z
@@ -37,6 +178,7 @@ export const landingPageModuleCatalogSchema = z
     moduleCatalogVersion: z.literal(1),
     compatibleRootVersions: z.tuple([z.literal(1)]),
     modules: z.record(z.string(), moduleDefinitionSchema),
+    variantFieldContracts: z.record(z.string(), variantFieldContractSchema),
   })
   .strict()
   .superRefine((catalog, context) => {
@@ -96,6 +238,44 @@ export const landingPageModuleCatalogSchema = z
         path: ["modules", key, "boundaries"],
       });
     }
+
+    const expectedFieldContractKeys = new Set<string>(
+      landingPageVariantFieldContractKeys,
+    );
+    const actualFieldContractKeys = Object.keys(catalog.variantFieldContracts);
+
+    validateExactKeys({
+      actual: actualFieldContractKeys,
+      expected: expectedFieldContractKeys,
+      context,
+      path: ["variantFieldContracts"],
+      label: "field contract",
+    });
+
+    for (const [key, contract] of Object.entries(
+      catalog.variantFieldContracts,
+    )) {
+      if (contract.fieldContractKey !== key) {
+        context.addIssue({
+          code: "custom",
+          path: ["variantFieldContracts", key, "fieldContractKey"],
+          message: "field contract key mismatch",
+        });
+      }
+
+      if (!expectedFieldContractKeys.has(key)) continue;
+      const canonical =
+        landingPageModuleCatalogRegistry.variantFieldContracts[
+          key as LandingPageVariantFieldContractKey
+        ];
+      if (JSON.stringify(contract) !== JSON.stringify(canonical)) {
+        context.addIssue({
+          code: "custom",
+          path: ["variantFieldContracts", key],
+          message: "field contract differs from the canonical registry",
+        });
+      }
+    }
   });
 
 function containsFreeMarkupOrRendererHint(value: string): boolean {
@@ -134,5 +314,49 @@ function validateCanonicalTextList(input: {
       path: input.path,
       message: "structural values differ from the canonical registry",
     });
+  }
+}
+
+function validateUniqueFieldIdentities(
+  fields: readonly { fieldKey: string; path: string }[],
+  context: z.RefinementCtx,
+  path: (string | number)[] = ["fields"],
+) {
+  for (const property of ["fieldKey", "path"] as const) {
+    const values = fields.map((field) => field[property]);
+    if (new Set(values).size !== values.length) {
+      context.addIssue({
+        code: "custom",
+        path,
+        message: `${property} values must be unique`,
+      });
+    }
+  }
+}
+
+function validateExactKeys(input: {
+  actual: readonly string[];
+  expected: Set<string>;
+  context: z.RefinementCtx;
+  path: (string | number)[];
+  label: string;
+}) {
+  for (const key of input.actual) {
+    if (!input.expected.has(key)) {
+      input.context.addIssue({
+        code: "custom",
+        path: [...input.path, key],
+        message: `unknown ${input.label}`,
+      });
+    }
+  }
+  for (const key of input.expected) {
+    if (!input.actual.includes(key)) {
+      input.context.addIssue({
+        code: "custom",
+        path: [...input.path, key],
+        message: `required ${input.label} missing`,
+      });
+    }
   }
 }

--- a/lib/conversion-content/landing-page/module-catalog/schema.ts
+++ b/lib/conversion-content/landing-page/module-catalog/schema.ts
@@ -4,9 +4,12 @@ import {
   landingPageFieldPolicies,
   landingPageFieldSupports,
   landingPageModuleKeys,
+  landingPageVariantCapabilities,
   landingPageVariantFieldContractKeys,
+  landingPageVariantKeys,
   type LandingPageModuleKey,
   type LandingPageVariantFieldContractKey,
+  type LandingPageVariantKey,
 } from "./contracts";
 import { landingPageModuleCatalogRegistry } from "./registry";
 
@@ -155,6 +158,113 @@ const variantFieldContractSchema = z
     }
   });
 
+const variantDefinitionSchema = z
+  .object({
+    variantKey: z.enum(landingPageVariantKeys),
+    variantName: z.enum(["standard", "accordion"]),
+    variantVersion: z.literal(1),
+    moduleKey: z.enum(landingPageModuleKeys),
+    moduleVersion: z.literal(1),
+    fieldContractKey: z.enum(landingPageVariantFieldContractKeys),
+    lifecycleStatus: z.literal("hypothesis"),
+    purpose: z.literal("controlled_test"),
+    capabilities: z.array(z.enum(landingPageVariantCapabilities)),
+    actionCompatibility: z
+      .object({
+        supportsPrimaryConversionForm: z.literal(false),
+      })
+      .strict()
+      .optional(),
+    accordionAccessibility: z
+      .object({
+        baseline: z.literal("WCAG 2.2"),
+        keyboardOperable: z.literal(true),
+        exposesExpandedState: z.literal(true),
+        associatesControlAndRegion: z.literal(true),
+        preservesFocus: z.literal(true),
+        initiallyCollapsed: z.literal(true),
+        singleExpandedItem: z.literal(true),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict()
+  .superRefine((variant, context) => {
+    if (new Set(variant.capabilities).size !== variant.capabilities.length) {
+      context.addIssue({
+        code: "custom",
+        path: ["capabilities"],
+        message: "capabilities must be unique",
+      });
+    }
+
+    const [qualifiedModule, qualifiedVariant] = variant.variantKey.split(".");
+    const variantName = qualifiedVariant?.replace("@v1", "");
+    if (
+      variant.moduleKey !== qualifiedModule ||
+      variant.variantName !== variantName
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "variant identity does not match module and variant name",
+      });
+    }
+
+    if (variant.fieldContractKey !== variant.variantKey) {
+      context.addIssue({
+        code: "custom",
+        path: ["fieldContractKey"],
+        message: "variant must use its own field contract",
+      });
+    }
+
+    const hasPrimaryAction = variant.capabilities.includes("primary_action");
+    const hasImageAsset = variant.capabilities.includes("image_asset");
+    const hasAccordion = variant.capabilities.includes("accordion_interaction");
+    const isFormIncompatible =
+      variant.variantKey === "hero.standard@v1" ||
+      variant.variantKey === "final_cta.standard@v1";
+
+    if (hasPrimaryAction !== isFormIncompatible) {
+      context.addIssue({
+        code: "custom",
+        path: ["capabilities"],
+        message: "primary action capability is assigned to an invalid variant",
+      });
+    }
+    if (Boolean(variant.actionCompatibility) !== isFormIncompatible) {
+      context.addIssue({
+        code: "custom",
+        path: ["actionCompatibility"],
+        message: "form compatibility metadata is assigned to an invalid variant",
+      });
+    }
+    if (hasImageAsset !== (variant.variantKey === "hero.standard@v1")) {
+      context.addIssue({
+        code: "custom",
+        path: ["capabilities"],
+        message: "image asset capability is assigned to an invalid variant",
+      });
+    }
+    if (hasAccordion !== (variant.variantKey === "faq.accordion@v1")) {
+      context.addIssue({
+        code: "custom",
+        path: ["capabilities"],
+        message: "accordion capability is assigned to an invalid variant",
+      });
+    }
+    if (
+      Boolean(variant.accordionAccessibility) !==
+      (variant.variantKey === "faq.accordion@v1")
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["accordionAccessibility"],
+        message: "accordion accessibility belongs only to faq accordion",
+      });
+    }
+  });
+
 const moduleDefinitionSchema = z
   .object({
     family: z.literal("landing_page"),
@@ -179,6 +289,7 @@ export const landingPageModuleCatalogSchema = z
     compatibleRootVersions: z.tuple([z.literal(1)]),
     modules: z.record(z.string(), moduleDefinitionSchema),
     variantFieldContracts: z.record(z.string(), variantFieldContractSchema),
+    variants: z.record(z.string(), variantDefinitionSchema),
   })
   .strict()
   .superRefine((catalog, context) => {
@@ -273,6 +384,51 @@ export const landingPageModuleCatalogSchema = z
           code: "custom",
           path: ["variantFieldContracts", key],
           message: "field contract differs from the canonical registry",
+        });
+      }
+    }
+
+    const expectedVariantKeys = new Set<string>(landingPageVariantKeys);
+    const actualVariantKeys = Object.keys(catalog.variants);
+    validateExactKeys({
+      actual: actualVariantKeys,
+      expected: expectedVariantKeys,
+      context,
+      path: ["variants"],
+      label: "variant",
+    });
+
+    for (const [key, variant] of Object.entries(catalog.variants)) {
+      if (variant.variantKey !== key) {
+        context.addIssue({
+          code: "custom",
+          path: ["variants", key, "variantKey"],
+          message: "variant key mismatch",
+        });
+      }
+      if (!catalog.modules[variant.moduleKey]) {
+        context.addIssue({
+          code: "custom",
+          path: ["variants", key, "moduleKey"],
+          message: "variant module is not registered",
+        });
+      }
+      if (!catalog.variantFieldContracts[variant.fieldContractKey]) {
+        context.addIssue({
+          code: "custom",
+          path: ["variants", key, "fieldContractKey"],
+          message: "variant field contract is not registered",
+        });
+      }
+
+      if (!expectedVariantKeys.has(key)) continue;
+      const canonical =
+        landingPageModuleCatalogRegistry.variants[key as LandingPageVariantKey];
+      if (JSON.stringify(variant) !== JSON.stringify(canonical)) {
+        context.addIssue({
+          code: "custom",
+          path: ["variants", key],
+          message: "variant differs from the canonical registry",
         });
       }
     }

--- a/lib/conversion-content/landing-page/module-catalog/schema.ts
+++ b/lib/conversion-content/landing-page/module-catalog/schema.ts
@@ -5,6 +5,9 @@ import {
   landingPageFieldSupports,
   landingPageResearchItemKeys,
   landingPageTextFieldPaths,
+  landingPageCtaModes,
+  landingPageFunnelProfileKeys,
+  landingPageFunnelTreatmentKeys,
   landingPageModuleKeys,
   landingPageVariantCapabilities,
   landingPageVariantFieldContractKeys,
@@ -69,6 +72,30 @@ const rootDeltaSchema = z.object({
       context.addIssue({ code: "custom", path: ["textRanges", index], message: "recommended maximum exceeds absolute maximum" });
     }
   }
+});
+
+const funnelTreatmentSchema = z.enum(landingPageFunnelTreatmentKeys);
+const funnelProfileDeltaSchema = z.object({
+  emphasizeTreatments: z.array(funnelTreatmentSchema),
+  restrictTreatments: z.array(funnelTreatmentSchema),
+  prohibitTreatments: z.array(funnelTreatmentSchema),
+}).strict();
+const funnelProfileDeltasSchema = z.object({
+  bofu: funnelProfileDeltaSchema, mofu: funnelProfileDeltaSchema, tofu: funnelProfileDeltaSchema,
+}).strict();
+const funnelCopyProfileSchema = z.object({
+  profileKey: z.enum(landingPageFunnelProfileKeys),
+  prioritizedSources: z.array(z.enum(landingPageResearchItemKeys)).min(1),
+  permittedTreatments: z.array(funnelTreatmentSchema).min(1),
+  restrictedTreatments: z.array(funnelTreatmentSchema),
+  prohibitedTreatments: z.array(funnelTreatmentSchema).min(1),
+  ctaMode: z.enum(landingPageCtaModes),
+}).strict().superRefine((profile, context) => {
+  const all = [...profile.permittedTreatments, ...profile.restrictedTreatments, ...profile.prohibitedTreatments];
+  if (new Set(all).size !== all.length) context.addIssue({ code: "custom", message: "each treatment must appear exactly once in its profile" });
+  if (new Set(profile.prioritizedSources).size !== profile.prioritizedSources.length) context.addIssue({ code: "custom", message: "prioritized sources must be unique" });
+  const expectedCtaMode = { bofu: "direct_next_step", mofu: "non_coercive_direct", tofu: "low_pressure" } as const;
+  if (profile.ctaMode !== expectedCtaMode[profile.profileKey]) context.addIssue({ code: "custom", path: ["ctaMode"], message: "cta mode does not correspond to profile action" });
 });
 
 const nonEmptyPlainText = z
@@ -358,6 +385,7 @@ const moduleDefinitionSchema = z
     purpose: z.literal("controlled_test"),
     compatibleRootVersion: z.literal(1),
     rootDelta: rootDeltaSchema,
+    funnelProfileDeltas: funnelProfileDeltasSchema,
     structuralFunction: nonEmptyPlainText,
     invariants: z.array(nonEmptyPlainText).min(1),
     boundaries: z.array(nonEmptyPlainText).min(1),
@@ -374,6 +402,7 @@ export const landingPageModuleCatalogSchema = z
     moduleCatalogVersion: z.literal(1),
     compatibleRootVersions: z.tuple([z.literal(1)]),
     copySourceMaps: z.record(z.string(), copySourceMapSchema),
+    funnelCopyProfiles: z.record(z.string(), funnelCopyProfileSchema),
     modules: z.record(z.string(), moduleDefinitionSchema),
     variantFieldContracts: z.record(z.string(), variantFieldContractSchema),
     variants: z.record(z.string(), variantDefinitionSchema),
@@ -386,6 +415,18 @@ export const landingPageModuleCatalogSchema = z
       return;
     }
     const expectedKeys = new Set<string>(landingPageModuleKeys);
+    validateExactKeys({
+      actual: Object.keys(catalog.funnelCopyProfiles), expected: new Set(landingPageFunnelProfileKeys),
+      context, path: ["funnelCopyProfiles"], label: "funnel profile",
+    });
+    for (const profileKey of landingPageFunnelProfileKeys) {
+      const profile = catalog.funnelCopyProfiles[profileKey];
+      if (!profile) continue;
+      if (profile.profileKey !== profileKey) context.addIssue({ code: "custom", path: ["funnelCopyProfiles", profileKey, "profileKey"], message: "funnel profile key mismatch" });
+      if (JSON.stringify(profile) !== JSON.stringify(landingPageModuleCatalogRegistry.funnelCopyProfiles[profileKey])) {
+        context.addIssue({ code: "custom", path: ["funnelCopyProfiles", profileKey], message: "funnel profile differs from the canonical registry" });
+      }
+    }
     const expectedCopyPaths = new Set<string>(landingPageTextFieldPaths);
     validateExactKeys({
       actual: Object.keys(catalog.copySourceMaps), expected: expectedCopyPaths,
@@ -436,6 +477,7 @@ export const landingPageModuleCatalogSchema = z
         context,
         path: ["modules", key, "rootDelta"],
       });
+      validateModuleFunnelDeltas(module.funnelProfileDeltas, catalog.funnelCopyProfiles, context, ["modules", key, "funnelProfileDeltas"]);
       const canonical =
         landingPageModuleCatalogRegistry.modules[key as LandingPageModuleKey];
 
@@ -452,6 +494,9 @@ export const landingPageModuleCatalogSchema = z
         context,
         path: ["modules", key, "invariants"],
       });
+      if (JSON.stringify(module.funnelProfileDeltas) !== JSON.stringify(canonical.funnelProfileDeltas)) {
+        context.addIssue({ code: "custom", path: ["modules", key, "funnelProfileDeltas"], message: "funnel profile deltas differ from the canonical registry" });
+      }
       validateCanonicalTextList({
         actual: module.boundaries,
         canonical: canonical.boundaries,
@@ -596,6 +641,31 @@ function validateComposedRootDelta(input: {
     }
     if (childRange.recommended.max > childRange.absoluteMax) {
       input.context.addIssue({ code: "custom", path: [...input.path, "textRanges", index], message: "effective recommended maximum exceeds effective absolute maximum" });
+    }
+  }
+}
+
+function validateModuleFunnelDeltas(
+  deltas: Record<string, { emphasizeTreatments: string[]; restrictTreatments: string[]; prohibitTreatments: string[] }>,
+  profiles: Record<string, { permittedTreatments: string[]; restrictedTreatments: string[]; prohibitedTreatments: string[] }>,
+  context: z.RefinementCtx,
+  path: (string | number)[],
+) {
+  for (const profileKey of landingPageFunnelProfileKeys) {
+    const delta = deltas[profileKey];
+    const profile = profiles[profileKey];
+    if (!delta || !profile) continue;
+    const known = new Set([...profile.permittedTreatments, ...profile.restrictedTreatments, ...profile.prohibitedTreatments]);
+    const prohibited = new Set(profile.prohibitedTreatments);
+    const operations = [...delta.emphasizeTreatments, ...delta.restrictTreatments, ...delta.prohibitTreatments];
+    if (new Set(operations).size !== operations.length) {
+      context.addIssue({ code: "custom", path: [...path, profileKey], message: "funnel delta has conflicting treatment operations" });
+    }
+    for (const treatment of operations) {
+      if (!known.has(treatment)) context.addIssue({ code: "custom", path: [...path, profileKey], message: "funnel delta references treatment outside its profile" });
+    }
+    for (const treatment of [...delta.emphasizeTreatments, ...delta.restrictTreatments]) {
+      if (prohibited.has(treatment)) context.addIssue({ code: "custom", path: [...path, profileKey], message: "funnel delta cannot emphasize or merely restrict a prohibited treatment" });
     }
   }
 }

--- a/lib/conversion-content/landing-page/module-catalog/schema.ts
+++ b/lib/conversion-content/landing-page/module-catalog/schema.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import {
   landingPageFieldPolicies,
   landingPageFieldSupports,
+  landingPageResearchItemKeys,
+  landingPageTextFieldPaths,
   landingPageModuleKeys,
   landingPageVariantCapabilities,
   landingPageVariantFieldContractKeys,
@@ -96,6 +98,24 @@ const cardinalitySchema = z
     }
   });
 
+const copySourceMapSchema = z.discriminatedUnion("sourceMode", [
+  z.object({
+    sourceMode: z.literal("research"),
+    researchPath: z.literal("endCustomer.researches[].items[]"),
+    primaryItemKeys: z.tuple([z.enum(landingPageResearchItemKeys), z.enum(landingPageResearchItemKeys).optional()]),
+    auxiliaryItemKey: z.enum(landingPageResearchItemKeys).optional(),
+  }).strict().superRefine((map, context) => {
+    const keys = map.primaryItemKeys.filter((key): key is NonNullable<typeof key> => Boolean(key));
+    if (new Set(keys).size !== keys.length || (map.auxiliaryItemKey && keys.includes(map.auxiliaryItemKey))) {
+      context.addIssue({ code: "custom", message: "copy sources must be unique" });
+    }
+  }),
+  z.object({
+    sourceMode: z.literal("operational_evidence"),
+    evidencePath: fieldPathSchema,
+  }).strict(),
+]);
+
 const textFieldSchema = z
   .object({
     fieldKind: z.literal("text"),
@@ -105,6 +125,7 @@ const textFieldSchema = z
     policy: z.enum(landingPageFieldPolicies),
     semanticRole: nonEmptyPlainText,
     support: z.enum(landingPageFieldSupports).optional(),
+    copySourceMap: copySourceMapSchema,
   })
   .strict();
 
@@ -176,6 +197,7 @@ const variantFieldContractSchema = z
     validateUniqueFieldIdentities(contract.fields, context);
 
     for (const [fieldIndex, field] of contract.fields.entries()) {
+      validateCopySourceMode(field, context, ["fields", fieldIndex]);
       if (!field.path.startsWith(`${prefix}.`)) {
         context.addIssue({
           code: "custom",
@@ -191,6 +213,7 @@ const variantFieldContractSchema = z
           "itemFields",
         ]);
         for (const [itemIndex, itemField] of field.itemFields.entries()) {
+          validateCopySourceMode(itemField, context, ["fields", fieldIndex, "itemFields", itemIndex]);
           if (!itemField.path.startsWith(`${field.path}[].`)) {
             context.addIssue({
               code: "custom",
@@ -210,6 +233,9 @@ const variantFieldContractSchema = z
           path: ["fields", fieldIndex, "label", "path"],
           message: "action label path does not belong to its action",
         });
+      }
+      if (field.fieldKind === "action") {
+        validateCopySourceMode(field.label, context, ["fields", fieldIndex, "label"]);
       }
     }
   });
@@ -347,6 +373,7 @@ export const landingPageModuleCatalogSchema = z
     family: z.literal("landing_page"),
     moduleCatalogVersion: z.literal(1),
     compatibleRootVersions: z.tuple([z.literal(1)]),
+    copySourceMaps: z.record(z.string(), copySourceMapSchema),
     modules: z.record(z.string(), moduleDefinitionSchema),
     variantFieldContracts: z.record(z.string(), variantFieldContractSchema),
     variants: z.record(z.string(), variantDefinitionSchema),
@@ -359,6 +386,18 @@ export const landingPageModuleCatalogSchema = z
       return;
     }
     const expectedKeys = new Set<string>(landingPageModuleKeys);
+    const expectedCopyPaths = new Set<string>(landingPageTextFieldPaths);
+    validateExactKeys({
+      actual: Object.keys(catalog.copySourceMaps), expected: expectedCopyPaths,
+      context, path: ["copySourceMaps"], label: "copy source map",
+    });
+    for (const path of landingPageTextFieldPaths) {
+      const actual = catalog.copySourceMaps[path];
+      const canonical = landingPageModuleCatalogRegistry.copySourceMaps[path];
+      if (actual && JSON.stringify(actual) !== JSON.stringify(canonical)) {
+        context.addIssue({ code: "custom", path: ["copySourceMaps", path], message: "copy source map differs from the canonical registry" });
+      }
+    }
     const actualKeys = Object.keys(catalog.modules);
 
     for (const key of actualKeys) {
@@ -578,6 +617,24 @@ function validateUniqueText(
       path: [path],
       message: `${path} must be unique`,
     });
+  }
+}
+
+function validateCopySourceMode(
+  field: { fieldKind: string; policy: string; path: string; copySourceMap?: { sourceMode: string; evidencePath?: string } },
+  context: z.RefinementCtx,
+  path: (string | number)[],
+) {
+  if (field.fieldKind !== "text" || !field.copySourceMap) return;
+  const operational = field.policy === "operational_required";
+  if (operational !== (field.copySourceMap.sourceMode === "operational_evidence")) {
+    context.addIssue({ code: "custom", path: [...path, "copySourceMap"], message: "copy source mode is incompatible with field policy" });
+  }
+  if (operational) {
+    const collectionPrefix = field.path.replace(/\.(?:quote|attribution)$/, "");
+    if (field.copySourceMap.evidencePath !== `${collectionPrefix}.evidenceRef`) {
+      context.addIssue({ code: "custom", path: [...path, "copySourceMap", "evidencePath"], message: "operational evidence path does not belong to the field item" });
+    }
   }
 }
 

--- a/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
+++ b/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
@@ -492,6 +492,40 @@ const cases: readonly Case[] = [
       assert.doesNotThrow(() => assertInvalid(inheritedPropertyRole));
     },
   },
+  {
+    name: "copy source maps are closed and operational evidence stays separate",
+    run: () => {
+      const textualFields = Object.values(landingPageModuleCatalogRegistry.variantFieldContracts)
+        .flatMap((contract) => flattenFields(contract.fields))
+        .filter((field) => field.fieldKind === "text");
+      assert.equal(textualFields.length, 30);
+      assert.equal(textualFields.every((field) => Boolean(field.copySourceMap)), true);
+
+      const unknownSourceMode = cloneRegistry();
+      getMutableTextField(unknownSourceMode, "hero.standard@v1", "hero.standard.title").copySourceMap.sourceMode = "input_catalog";
+      assertInvalid(unknownSourceMode);
+
+      const unknownPath = cloneRegistry();
+      getMutableTextField(unknownPath, "hero.standard@v1", "hero.standard.title").copySourceMap.researchPath = "businessBuyer.items[]";
+      assertInvalid(unknownPath);
+
+      const unknownItemKey = cloneRegistry();
+      getMutableTextField(unknownItemKey, "hero.standard@v1", "hero.standard.title").copySourceMap.primaryItemKeys = ["unknown"];
+      assertInvalid(unknownItemKey);
+
+      const tooManySources = cloneRegistry();
+      getMutableTextField(tooManySources, "hero.standard@v1", "hero.standard.title").copySourceMap.primaryItemKeys = ["trigger", "desire", "belief"];
+      assertInvalid(tooManySources);
+
+      const orphanOperationalEvidence = cloneRegistry();
+      getMutableTextField(orphanOperationalEvidence, "social_proof.standard@v1", "social_proof.standard.items[].quote").copySourceMap.evidencePath = "social_proof.standard.orphan";
+      assertInvalid(orphanOperationalEvidence);
+
+      const orphanMap = cloneRegistry();
+      orphanMap.copySourceMaps["hero.standard.orphan"] = structuredClone(orphanMap.copySourceMaps["hero.standard.title"]);
+      assertInvalid(orphanMap);
+    },
+  },
 ];
 
 for (const testCase of cases) {
@@ -528,6 +562,20 @@ function collectFieldKinds(field: Record<string, unknown>, kinds: Set<string>) {
   if (field.label && typeof field.label === "object") {
     collectFieldKinds(field.label as Record<string, unknown>, kinds);
   }
+}
+
+function flattenFields(fields: readonly Record<string, unknown>[]): Record<string, unknown>[] {
+  return fields.flatMap((field) => [
+    field,
+    ...(Array.isArray(field.itemFields) ? flattenFields(field.itemFields) : []),
+    ...(field.label && typeof field.label === "object" ? flattenFields([field.label as Record<string, unknown>]) : []),
+  ]);
+}
+
+function getMutableTextField(catalog: MutableCatalog, contractKey: string, path: string): MutableField {
+  const field = flattenFields(catalog.variantFieldContracts[contractKey].fields).find((candidate) => candidate.path === path);
+  assert.ok(field);
+  return field as MutableField;
 }
 
 function cloneField(
@@ -575,6 +623,7 @@ type MutableCatalog = {
   family: string;
   moduleCatalogVersion: number;
   compatibleRootVersions: number[];
+  copySourceMaps: Record<string, MutableField["copySourceMap"]>;
   modules: Record<string, MutableModule>;
   variantFieldContracts: Record<
     string,
@@ -594,6 +643,13 @@ type MutableField = {
   policy: string;
   semanticRole?: string;
   support?: string;
+  copySourceMap: {
+    sourceMode: string;
+    researchPath?: string;
+    primaryItemKeys?: string[];
+    auxiliaryItemKey?: string;
+    evidencePath?: string;
+  };
   itemFields?: MutableField[];
   label?: MutableField;
   operationalBinding?: string;

--- a/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
+++ b/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
@@ -451,6 +451,47 @@ const cases: readonly Case[] = [
       assertInvalid(mismatchedFields);
     },
   },
+  {
+    name: "root compatibility and specialization deltas fail closed",
+    run: () => {
+      const incompatibleModule = cloneRegistry();
+      incompatibleModule.modules.hero.compatibleRootVersion = 2;
+      assertInvalid(incompatibleModule);
+
+      const incompatibleVariant = cloneRegistry();
+      incompatibleVariant.variants["hero.standard@v1"].compatibleRootVersion = 2;
+      assertInvalid(incompatibleVariant);
+
+      const widenedModuleLimit = cloneRegistry();
+      widenedModuleLimit.modules.hero.rootDelta.textRanges.push({ semanticRole: "h1", absoluteMax: 121 });
+      assertInvalid(widenedModuleLimit);
+
+      const widenedVariantLimit = cloneRegistry();
+      widenedVariantLimit.modules.hero.rootDelta.textRanges.push({ semanticRole: "h1", recommended: { min: 36, max: 64 }, absoluteMax: 100 });
+      widenedVariantLimit.variants["hero.standard@v1"].rootDelta.textRanges.push({ semanticRole: "h1", recommended: { min: 36, max: 70 }, absoluteMax: 110 });
+      assertInvalid(widenedVariantLimit);
+
+      const invalidInheritedRange = cloneRegistry();
+      invalidInheritedRange.modules.hero.rootDelta.textRanges.push({ semanticRole: "h1", recommended: { min: 36, max: 64 }, absoluteMax: 100 });
+      invalidInheritedRange.variants["hero.standard@v1"].rootDelta.textRanges.push({ semanticRole: "h1", absoluteMax: 50 });
+      assertInvalid(invalidInheritedRange);
+
+      const duplicateRestriction = cloneRegistry();
+      duplicateRestriction.variants["hero.standard@v1"].rootDelta.textRanges.push(
+        { semanticRole: "h1", absoluteMax: 100 },
+        { semanticRole: "h1", absoluteMax: 90 },
+      );
+      assertInvalid(duplicateRestriction);
+
+      const unknownRootContract = cloneRegistry();
+      unknownRootContract.compatibleRootVersions = [2];
+      assertInvalid(unknownRootContract);
+
+      const inheritedPropertyRole = cloneRegistry();
+      inheritedPropertyRole.modules.hero.rootDelta.textRanges.push({ semanticRole: "toString", absoluteMax: 1 });
+      assert.doesNotThrow(() => assertInvalid(inheritedPropertyRole));
+    },
+  },
 ];
 
 for (const testCase of cases) {
@@ -522,6 +563,8 @@ type MutableModule = {
   moduleVersion: number;
   lifecycleStatus: string;
   purpose: string;
+  compatibleRootVersion: number;
+  rootDelta: MutableRootDelta;
   structuralFunction: string;
   invariants: string[];
   boundaries: string[];
@@ -567,10 +610,20 @@ type MutableVariant = {
   fieldContractKey: string;
   lifecycleStatus: string;
   purpose: string;
+  compatibleRootVersion: number;
+  rootDelta: MutableRootDelta;
   capabilities: string[];
   actionCompatibility?: { supportsPrimaryConversionForm: boolean };
   accordionAccessibility?: Record<string, string | boolean>;
   fallbackChannel?: string;
   creationMotivation?: string;
   [key: string]: unknown;
+};
+
+type MutableRootDelta = {
+  textRanges: Array<{
+    semanticRole: string;
+    recommended?: { min: number; max: number };
+    absoluteMax?: number;
+  }>;
 };

--- a/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
+++ b/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
@@ -11,6 +11,9 @@ import {
 } from "./contracts";
 import { landingPageModuleCatalogRegistry } from "./registry";
 import { landingPageModuleCatalogSchema } from "./schema";
+import { resolveLandingPageModuleCatalog } from "./resolver";
+import * as publicModuleCatalog from "./index";
+import { resolveLandingPageRootParameters } from "../index";
 
 type Case = Readonly<{
   name: string;
@@ -567,6 +570,85 @@ const cases: readonly Case[] = [
       const emphasizedProhibition = cloneRegistry();
       emphasizedProhibition.modules.hero.funnelProfileDeltas.bofu.emphasizeTreatments = ["coercion"];
       assertInvalid(emphasizedProhibition);
+    },
+  },
+  {
+    name: "resolver returns ten complete isolated variants without fallback",
+    run: () => {
+      for (const variantKey of landingPageVariantKeys) {
+        const [moduleKey, qualifiedVariant] = variantKey.split(".");
+        const [variantName, version] = qualifiedVariant.split("@v");
+        const result = resolveLandingPageModuleCatalog({
+          moduleCatalogVersion: 1, rootVersion: 1, moduleKey, moduleVersion: 1,
+          variantName, variantVersion: Number(version), funnelProfileKey: "mofu",
+        });
+        assert.equal(result.ok, true);
+        if (!result.ok) continue;
+        assert.equal(result.value.variant.variantKey, variantKey);
+        assert.equal(result.value.module.moduleKey, moduleKey);
+        assert.equal(result.value.fieldContract.fieldContractKey, variantKey);
+        assert.equal(result.value.funnelCopyProfile.profileKey, "mofu");
+        assertDeeplyFrozen(result.value);
+      }
+
+      const first = resolveLandingPageModuleCatalog({ moduleCatalogVersion: 1, rootVersion: 1, moduleKey: "hero", moduleVersion: 1, variantName: "standard", variantVersion: 1, funnelProfileKey: "bofu" });
+      const second = resolveLandingPageModuleCatalog({ moduleCatalogVersion: 1, rootVersion: 1, moduleKey: "hero", moduleVersion: 1, variantName: "standard", variantVersion: 1, funnelProfileKey: "bofu" });
+      assert.equal(first.ok && second.ok, true);
+      if (first.ok && second.ok) {
+        assert.notEqual(first.value, second.value);
+        assert.notEqual(first.value.module, second.value.module);
+        assert.notEqual(first.value.root, second.value.root);
+        assert.notEqual(first.value.variant, second.value.variant);
+        assert.notEqual(first.value.fieldContract, second.value.fieldContract);
+        assert.notEqual(first.value.copySourceMaps, second.value.copySourceMaps);
+        assert.notEqual(first.value.funnelCopyProfile, second.value.funnelCopyProfile);
+        assert.notEqual(first.value.funnelProfileDelta, second.value.funnelProfileDelta);
+        assert.notEqual(first.value.module, landingPageModuleCatalogRegistry.modules.hero);
+        assert.notEqual(first.value.variant, landingPageModuleCatalogRegistry.variants["hero.standard@v1"]);
+        assert.notEqual(first.value.fieldContract, landingPageModuleCatalogRegistry.variantFieldContracts["hero.standard@v1"]);
+        assert.notEqual(first.value.copySourceMaps, landingPageModuleCatalogRegistry.copySourceMaps);
+        assert.notEqual(first.value.funnelCopyProfile, landingPageModuleCatalogRegistry.funnelCopyProfiles.bofu);
+        assert.notEqual(first.value.funnelProfileDelta, landingPageModuleCatalogRegistry.modules.hero.funnelProfileDeltas.bofu);
+        const canonicalRoot = resolveLandingPageRootParameters({ rootVersion: 1 });
+        assert.equal(canonicalRoot.ok, true);
+        if (canonicalRoot.ok) assert.notEqual(first.value.root, canonicalRoot.value);
+      }
+    },
+  },
+  {
+    name: "resolver identities versions and compatibility fail closed",
+    run: () => {
+      const base = { moduleCatalogVersion: 1, rootVersion: 1, moduleKey: "hero", moduleVersion: 1, variantName: "standard", variantVersion: 1, funnelProfileKey: "bofu" };
+      for (const [patch, code] of [
+        [{ moduleCatalogVersion: 2 }, "UNKNOWN_MODULE_CATALOG_VERSION"],
+        [{ rootVersion: 2 }, "INCOMPATIBLE_ROOT_VERSION"],
+        [{ moduleKey: "unknown" }, "UNKNOWN_MODULE"],
+        [{ moduleVersion: 2 }, "UNKNOWN_MODULE_VERSION"],
+        [{ variantName: "unknown" }, "UNKNOWN_VARIANT"],
+        [{ variantVersion: 2 }, "UNKNOWN_VARIANT"],
+        [{ funnelProfileKey: "bottom" }, "UNKNOWN_FUNNEL_PROFILE"],
+      ] as const) {
+        const result = resolveLandingPageModuleCatalog({ ...base, ...patch });
+        assert.equal(result.ok, false);
+        if (!result.ok) assert.equal(result.error.code, code);
+      }
+      assert.deepEqual(Object.keys(publicModuleCatalog).sort(), ["resolveLandingPageModuleCatalog"]);
+      assert.equal("landingPageModuleCatalogRegistry" in publicModuleCatalog, false);
+      assert.equal("landingPageModuleCatalogSchema" in publicModuleCatalog, false);
+    },
+  },
+  {
+    name: "canonical lifecycle vocabulary is accepted without composition enforcement",
+    run: () => {
+      for (const lifecycleStatus of ["validated", "deprecated"]) {
+        const historical = cloneRegistry();
+        historical.modules.hero.lifecycleStatus = lifecycleStatus;
+        historical.variants["hero.standard@v1"].lifecycleStatus = lifecycleStatus;
+        assert.equal(landingPageModuleCatalogSchema.safeParse(historical).success, true);
+      }
+      const unknown = cloneRegistry();
+      unknown.modules.hero.lifecycleStatus = "retired";
+      assertInvalid(unknown);
     },
   },
 ];

--- a/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
+++ b/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
 
 import {
+  landingPageFieldKinds,
   landingPageModuleKeys,
+  landingPageVariantFieldContractKeys,
   type LandingPageModuleKey,
 } from "./contracts";
 import { landingPageModuleCatalogRegistry } from "./registry";
@@ -165,6 +167,102 @@ const cases: readonly Case[] = [
       );
     },
   },
+  {
+    name: "all ten field contracts and five field kinds are valid",
+    run: () => {
+      assert.deepEqual(
+        Object.keys(
+          landingPageModuleCatalogRegistry.variantFieldContracts,
+        ).sort(),
+        [...landingPageVariantFieldContractKeys].sort(),
+      );
+
+      const kinds = new Set<string>();
+      for (const contract of Object.values(
+        landingPageModuleCatalogRegistry.variantFieldContracts,
+      )) {
+        for (const field of contract.fields) collectFieldKinds(field, kinds);
+      }
+      assert.deepEqual([...kinds].sort(), [...landingPageFieldKinds].sort());
+    },
+  },
+  {
+    name: "unknown field, path, shape, cardinality and policy fail closed",
+    run: () => {
+      const unknownField = cloneRegistry();
+      unknownField.variantFieldContracts["hero.standard@v1"].fields.push({
+        ...cloneField("hero.standard@v1", 0),
+        fieldKey: "unknown",
+        path: "hero.standard.unknown",
+      });
+      assertInvalid(unknownField);
+
+      const unknownPath = cloneRegistry();
+      unknownPath.variantFieldContracts["hero.standard@v1"].fields[0].path =
+        "hero.standard.unapproved";
+      assertInvalid(unknownPath);
+
+      const unknownShape = cloneRegistry();
+      unknownShape.variantFieldContracts["hero.standard@v1"].fields[0].fieldKind =
+        "video";
+      assertInvalid(unknownShape);
+
+      const invertedCardinality = cloneRegistry();
+      invertedCardinality.variantFieldContracts[
+        "hero.standard@v1"
+      ].fields[0].cardinality = { min: 2, max: 1 };
+      assertInvalid(invertedCardinality);
+
+      const unknownPolicy = cloneRegistry();
+      unknownPolicy.variantFieldContracts["hero.standard@v1"].fields[0].policy =
+        "generated";
+      assertInvalid(unknownPolicy);
+    },
+  },
+  {
+    name: "nested collections and concrete action destinations fail closed",
+    run: () => {
+      const nestedCollection = cloneRegistry();
+      const collection = nestedCollection.variantFieldContracts[
+        "trust_bar.standard@v1"
+      ].fields[0];
+      collection.itemFields = [structuredClone(collection)];
+      assertInvalid(nestedCollection);
+
+      const concreteDestination = cloneRegistry();
+      const action = concreteDestination.variantFieldContracts[
+        "hero.standard@v1"
+      ].fields.find((field) => field.fieldKind === "action");
+      assert.ok(action);
+      action.destination = "https://example.com";
+      assertInvalid(concreteDestination);
+    },
+  },
+  {
+    name: "field contract identity, semantic role and support fail closed",
+    run: () => {
+      const mismatchedContract = cloneRegistry();
+      mismatchedContract.variantFieldContracts[
+        "hero.standard@v1"
+      ].fieldContractKey = "faq.standard@v1";
+      assertInvalid(mismatchedContract);
+
+      const unknownSemanticRole = cloneRegistry();
+      unknownSemanticRole.variantFieldContracts[
+        "hero.standard@v1"
+      ].fields[0].semanticRole = "display";
+      assertInvalid(unknownSemanticRole);
+
+      const unknownSupport = cloneRegistry();
+      unknownSupport.variantFieldContracts["hero.standard@v1"].fields[1].support =
+        "always";
+      assertInvalid(unknownSupport);
+
+      const missingContract = cloneRegistry();
+      delete missingContract.variantFieldContracts["faq.accordion@v1"];
+      assertInvalid(missingContract);
+    },
+  },
 ];
 
 for (const testCase of cases) {
@@ -192,6 +290,32 @@ function assertDeeplyFrozen(value: unknown): void {
   for (const nested of Object.values(value)) assertDeeplyFrozen(nested);
 }
 
+function collectFieldKinds(field: Record<string, unknown>, kinds: Set<string>) {
+  assert.equal(typeof field.fieldKind, "string");
+  kinds.add(field.fieldKind as string);
+  if (Array.isArray(field.itemFields)) {
+    for (const itemField of field.itemFields) collectFieldKinds(itemField, kinds);
+  }
+  if (field.label && typeof field.label === "object") {
+    collectFieldKinds(field.label as Record<string, unknown>, kinds);
+  }
+}
+
+function cloneField(
+  contractKey: string,
+  fieldIndex: number,
+): MutableField {
+  return structuredClone(
+    landingPageModuleCatalogRegistry.variantFieldContracts[
+      contractKey as keyof typeof landingPageModuleCatalogRegistry.variantFieldContracts
+    ].fields[fieldIndex],
+  ) as unknown as MutableField;
+}
+
+function assertInvalid(catalog: MutableCatalog): void {
+  assert.equal(landingPageModuleCatalogSchema.safeParse(catalog).success, false);
+}
+
 type MutableModule = {
   family: string;
   moduleKey: string;
@@ -209,4 +333,26 @@ type MutableCatalog = {
   moduleCatalogVersion: number;
   compatibleRootVersions: number[];
   modules: Record<string, MutableModule>;
+  variantFieldContracts: Record<
+    string,
+    {
+      fieldContractKey: string;
+      fields: MutableField[];
+    }
+  >;
+};
+
+type MutableField = {
+  fieldKind: string;
+  fieldKey: string;
+  path: string;
+  cardinality: { min: number; max: number };
+  policy: string;
+  semanticRole?: string;
+  support?: string;
+  itemFields?: MutableField[];
+  label?: MutableField;
+  operationalBinding?: string;
+  destination?: string;
+  [key: string]: unknown;
 };

--- a/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
+++ b/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
@@ -526,6 +526,49 @@ const cases: readonly Case[] = [
       assertInvalid(orphanMap);
     },
   },
+  {
+    name: "funnel profiles and module deltas fail closed",
+    run: () => {
+      assert.deepEqual(Object.keys(landingPageModuleCatalogRegistry.funnelCopyProfiles), ["bofu", "mofu", "tofu"]);
+      const standardFaqModule = landingPageModuleCatalogRegistry.modules[
+        landingPageModuleCatalogRegistry.variants["faq.standard@v1"].moduleKey
+      ];
+      const accordionFaqModule = landingPageModuleCatalogRegistry.modules[
+        landingPageModuleCatalogRegistry.variants["faq.accordion@v1"].moduleKey
+      ];
+      assert.equal(standardFaqModule, accordionFaqModule);
+      assert.equal(standardFaqModule.moduleKey, "faq");
+      assert.deepEqual(standardFaqModule.funnelProfileDeltas, accordionFaqModule.funnelProfileDeltas);
+
+      const unknownProfile = cloneRegistry();
+      unknownProfile.funnelCopyProfiles.bottom = structuredClone(unknownProfile.funnelCopyProfiles.bofu);
+      assertInvalid(unknownProfile);
+
+      const mismatchedCtaMode = cloneRegistry();
+      mismatchedCtaMode.funnelCopyProfiles.bofu.ctaMode = "low_pressure";
+      assertInvalid(mismatchedCtaMode);
+
+      const duplicateTreatment = cloneRegistry();
+      duplicateTreatment.funnelCopyProfiles.bofu.prohibitedTreatments.push("direct_next_step");
+      assertInvalid(duplicateTreatment);
+
+      const unknownTreatment = cloneRegistry();
+      unknownTreatment.modules.hero.funnelProfileDeltas.bofu.emphasizeTreatments = ["viral_hook"];
+      assertInvalid(unknownTreatment);
+
+      const crossProfileTreatment = cloneRegistry();
+      crossProfileTreatment.modules.hero.funnelProfileDeltas.tofu.emphasizeTreatments = ["direct_next_step"];
+      assertInvalid(crossProfileTreatment);
+
+      const conflictingDelta = cloneRegistry();
+      conflictingDelta.modules.hero.funnelProfileDeltas.bofu.prohibitTreatments = ["direct_next_step"];
+      assertInvalid(conflictingDelta);
+
+      const emphasizedProhibition = cloneRegistry();
+      emphasizedProhibition.modules.hero.funnelProfileDeltas.bofu.emphasizeTreatments = ["coercion"];
+      assertInvalid(emphasizedProhibition);
+    },
+  },
 ];
 
 for (const testCase of cases) {
@@ -613,6 +656,7 @@ type MutableModule = {
   purpose: string;
   compatibleRootVersion: number;
   rootDelta: MutableRootDelta;
+  funnelProfileDeltas: Record<string, MutableFunnelDelta>;
   structuralFunction: string;
   invariants: string[];
   boundaries: string[];
@@ -624,6 +668,7 @@ type MutableCatalog = {
   moduleCatalogVersion: number;
   compatibleRootVersions: number[];
   copySourceMaps: Record<string, MutableField["copySourceMap"]>;
+  funnelCopyProfiles: Record<string, MutableFunnelProfile>;
   modules: Record<string, MutableModule>;
   variantFieldContracts: Record<
     string,
@@ -682,4 +727,19 @@ type MutableRootDelta = {
     recommended?: { min: number; max: number };
     absoluteMax?: number;
   }>;
+};
+
+type MutableFunnelDelta = {
+  emphasizeTreatments: string[];
+  restrictTreatments: string[];
+  prohibitTreatments: string[];
+};
+
+type MutableFunnelProfile = {
+  profileKey: string;
+  prioritizedSources: string[];
+  permittedTreatments: string[];
+  restrictedTreatments: string[];
+  prohibitedTreatments: string[];
+  ctaMode: string;
 };

--- a/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
+++ b/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
@@ -1,0 +1,212 @@
+import assert from "node:assert/strict";
+
+import {
+  landingPageModuleKeys,
+  type LandingPageModuleKey,
+} from "./contracts";
+import { landingPageModuleCatalogRegistry } from "./registry";
+import { landingPageModuleCatalogSchema } from "./schema";
+
+type Case = Readonly<{
+  name: string;
+  run: () => void;
+}>;
+
+const cases: readonly Case[] = [
+  {
+    name: "the versioned catalog and all nine modules are valid",
+    run: () => {
+      const result = landingPageModuleCatalogSchema.safeParse(
+        landingPageModuleCatalogRegistry,
+      );
+
+      assert.equal(result.success, true);
+      assert.equal(landingPageModuleCatalogRegistry.family, "landing_page");
+      assert.equal(landingPageModuleCatalogRegistry.moduleCatalogVersion, 1);
+      assert.deepEqual(
+        landingPageModuleCatalogRegistry.compatibleRootVersions,
+        [1],
+      );
+      assert.deepEqual(
+        Object.keys(landingPageModuleCatalogRegistry.modules).sort(),
+        [...landingPageModuleKeys].sort(),
+      );
+    },
+  },
+  {
+    name: "module identities are closed and scoped to landing_page",
+    run: () => {
+      const qualifiedIdentities = Object.values(
+        landingPageModuleCatalogRegistry.modules,
+      ).map((moduleDefinition) => {
+        assert.equal(moduleDefinition.family, "landing_page");
+        assert.equal(moduleDefinition.moduleVersion, 1);
+        assert.equal(moduleDefinition.lifecycleStatus, "hypothesis");
+        assert.equal(moduleDefinition.purpose, "controlled_test");
+        return `${moduleDefinition.family}:${moduleDefinition.moduleKey}@v${moduleDefinition.moduleVersion}`;
+      });
+
+      assert.equal(new Set(qualifiedIdentities).size, landingPageModuleKeys.length);
+      assert.equal(
+        qualifiedIdentities.some((identity) =>
+          identity.startsWith("commercial_activation:"),
+        ),
+        false,
+      );
+    },
+  },
+  {
+    name: "registry values are deeply immutable",
+    run: () => {
+      assertDeeplyFrozen(landingPageModuleCatalogRegistry);
+    },
+  },
+  {
+    name: "module contracts do not anticipate later catalog phases",
+    run: () => {
+      const forbiddenKeys = new Set([
+        "taxon",
+        "campaign",
+        "plan",
+        "copy",
+        "asset",
+        "order",
+        "channel",
+        "destination",
+        "variant",
+        "fields",
+        "sourceMap",
+        "profile",
+      ]);
+
+      for (const moduleDefinition of Object.values(
+        landingPageModuleCatalogRegistry.modules,
+      )) {
+        for (const key of Object.keys(moduleDefinition)) {
+          assert.equal(forbiddenKeys.has(key), false, `forbidden key: ${key}`);
+        }
+      }
+    },
+  },
+  {
+    name: "unknown modules and structural values fail closed",
+    run: () => {
+      const unknownModule = cloneRegistry();
+      unknownModule.modules.unknown = cloneModule("hero");
+      assert.equal(landingPageModuleCatalogSchema.safeParse(unknownModule).success, false);
+
+      const invalidLifecycle = cloneRegistry();
+      invalidLifecycle.modules.hero.lifecycleStatus = "active";
+      assert.equal(
+        landingPageModuleCatalogSchema.safeParse(invalidLifecycle).success,
+        false,
+      );
+
+      const invalidPurpose = cloneRegistry();
+      invalidPurpose.modules.hero.purpose = "production";
+      assert.equal(
+        landingPageModuleCatalogSchema.safeParse(invalidPurpose).success,
+        false,
+      );
+
+      const invalidStructuralFunction = cloneRegistry();
+      invalidStructuralFunction.modules.hero.structuralFunction =
+        "Arbitrary structural function.";
+      assert.equal(
+        landingPageModuleCatalogSchema.safeParse(invalidStructuralFunction)
+          .success,
+        false,
+      );
+
+      const invalidInvariant = cloneRegistry();
+      invalidInvariant.modules.hero.invariants[0] = "Arbitrary invariant.";
+      assert.equal(
+        landingPageModuleCatalogSchema.safeParse(invalidInvariant).success,
+        false,
+      );
+
+      const invalidBoundary = cloneRegistry();
+      invalidBoundary.modules.hero.boundaries[0] = "Arbitrary boundary.";
+      assert.equal(
+        landingPageModuleCatalogSchema.safeParse(invalidBoundary).success,
+        false,
+      );
+
+      const invalidFamily = cloneRegistry();
+      invalidFamily.family = "commercial_activation";
+      assert.equal(
+        landingPageModuleCatalogSchema.safeParse(invalidFamily).success,
+        false,
+      );
+    },
+  },
+  {
+    name: "missing modules, mismatched identities and extra fields fail closed",
+    run: () => {
+      const missingModule = cloneRegistry();
+      delete missingModule.modules.faq;
+      assert.equal(
+        landingPageModuleCatalogSchema.safeParse(missingModule).success,
+        false,
+      );
+
+      const mismatchedIdentity = cloneRegistry();
+      mismatchedIdentity.modules.hero.moduleKey = "faq";
+      assert.equal(
+        landingPageModuleCatalogSchema.safeParse(mismatchedIdentity).success,
+        false,
+      );
+
+      const extraField = cloneRegistry();
+      extraField.modules.hero.variant = "standard";
+      assert.equal(
+        landingPageModuleCatalogSchema.safeParse(extraField).success,
+        false,
+      );
+    },
+  },
+];
+
+for (const testCase of cases) {
+  testCase.run();
+  console.log(`PASS ${testCase.name}`);
+}
+
+console.log(`PASS ${cases.length} landing-page module catalog validation cases`);
+
+function cloneRegistry(): MutableCatalog {
+  return structuredClone(
+    landingPageModuleCatalogRegistry,
+  ) as unknown as MutableCatalog;
+}
+
+function cloneModule(moduleKey: LandingPageModuleKey): MutableModule {
+  return structuredClone(
+    landingPageModuleCatalogRegistry.modules[moduleKey],
+  ) as unknown as MutableModule;
+}
+
+function assertDeeplyFrozen(value: unknown): void {
+  if (!value || typeof value !== "object") return;
+  assert.equal(Object.isFrozen(value), true);
+  for (const nested of Object.values(value)) assertDeeplyFrozen(nested);
+}
+
+type MutableModule = {
+  family: string;
+  moduleKey: string;
+  moduleVersion: number;
+  lifecycleStatus: string;
+  purpose: string;
+  structuralFunction: string;
+  invariants: string[];
+  boundaries: string[];
+  [key: string]: unknown;
+};
+
+type MutableCatalog = {
+  family: string;
+  moduleCatalogVersion: number;
+  compatibleRootVersions: number[];
+  modules: Record<string, MutableModule>;
+};

--- a/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
+++ b/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
@@ -3,8 +3,11 @@ import assert from "node:assert/strict";
 import {
   landingPageFieldKinds,
   landingPageModuleKeys,
+  landingPageVariantCapabilities,
   landingPageVariantFieldContractKeys,
+  landingPageVariantKeys,
   type LandingPageModuleKey,
+  type LandingPageVariantKey,
 } from "./contracts";
 import { landingPageModuleCatalogRegistry } from "./registry";
 import { landingPageModuleCatalogSchema } from "./schema";
@@ -263,6 +266,191 @@ const cases: readonly Case[] = [
       assertInvalid(missingContract);
     },
   },
+  {
+    name: "all ten variants link one module and their own field contract",
+    run: () => {
+      assert.deepEqual(
+        Object.keys(landingPageModuleCatalogRegistry.variants).sort(),
+        [...landingPageVariantKeys].sort(),
+      );
+
+      for (const variantDefinition of Object.values(
+        landingPageModuleCatalogRegistry.variants,
+      )) {
+        assert.equal(variantDefinition.moduleVersion, 1);
+        assert.equal(variantDefinition.variantVersion, 1);
+        assert.equal(variantDefinition.lifecycleStatus, "hypothesis");
+        assert.equal(variantDefinition.purpose, "controlled_test");
+        assert.equal(
+          variantDefinition.fieldContractKey,
+          variantDefinition.variantKey,
+        );
+        assert.ok(
+          landingPageModuleCatalogRegistry.modules[variantDefinition.moduleKey],
+        );
+        assert.ok(
+          landingPageModuleCatalogRegistry.variantFieldContracts[
+            variantDefinition.fieldContractKey
+          ],
+        );
+      }
+    },
+  },
+  {
+    name: "only the three approved capabilities are assigned",
+    run: () => {
+      const assignedCapabilities = new Set(
+        Object.values(landingPageModuleCatalogRegistry.variants).flatMap(
+          (variantDefinition) => variantDefinition.capabilities,
+        ),
+      );
+      assert.deepEqual(
+        [...assignedCapabilities].sort(),
+        [...landingPageVariantCapabilities].sort(),
+      );
+      assert.deepEqual(
+        landingPageModuleCatalogRegistry.variants["hero.standard@v1"]
+          .capabilities,
+        ["primary_action", "image_asset"],
+      );
+      assert.deepEqual(
+        landingPageModuleCatalogRegistry.variants["final_cta.standard@v1"]
+          .capabilities,
+        ["primary_action"],
+      );
+      assert.deepEqual(
+        landingPageModuleCatalogRegistry.variants["faq.accordion@v1"]
+          .capabilities,
+        ["accordion_interaction"],
+      );
+    },
+  },
+  {
+    name: "faq variants are independent and accordion declares the WCAG contract",
+    run: () => {
+      const standardFields =
+        landingPageModuleCatalogRegistry.variantFieldContracts[
+          "faq.standard@v1"
+        ].fields;
+      const accordionFields =
+        landingPageModuleCatalogRegistry.variantFieldContracts[
+          "faq.accordion@v1"
+        ].fields;
+      assert.notEqual(standardFields, accordionFields);
+      assert.deepEqual(
+        normalizeFaqFieldPaths(standardFields),
+        normalizeFaqFieldPaths(accordionFields),
+      );
+
+      assert.equal(
+        landingPageModuleCatalogRegistry.variants["faq.standard@v1"]
+          .accordionAccessibility,
+        undefined,
+      );
+      assert.deepEqual(
+        landingPageModuleCatalogRegistry.variants["faq.accordion@v1"]
+          .accordionAccessibility,
+        {
+          baseline: "WCAG 2.2",
+          keyboardOperable: true,
+          exposesExpandedState: true,
+          associatesControlAndRegion: true,
+          preservesFocus: true,
+          initiallyCollapsed: true,
+          singleExpandedItem: true,
+        },
+      );
+    },
+  },
+  {
+    name: "form compatibility is explicit without channel fallback",
+    run: () => {
+      for (const variantKey of [
+        "hero.standard@v1",
+        "final_cta.standard@v1",
+      ] as const) {
+        assert.deepEqual(
+          landingPageModuleCatalogRegistry.variants[variantKey]
+            .actionCompatibility,
+          { supportsPrimaryConversionForm: false },
+        );
+      }
+
+      const formFallback = cloneRegistry();
+      formFallback.variants["hero.standard@v1"].fallbackChannel = "whatsapp";
+      assertInvalid(formFallback);
+
+      const formSupported = cloneRegistry();
+      formSupported.variants[
+        "hero.standard@v1"
+      ].actionCompatibility = { supportsPrimaryConversionForm: true };
+      assertInvalid(formSupported);
+    },
+  },
+  {
+    name: "unknown capability, variant and creation motivation fail closed",
+    run: () => {
+      const unknownCapability = cloneRegistry();
+      unknownCapability.variants["hero.standard@v1"].capabilities.push(
+        "carousel",
+      );
+      assertInvalid(unknownCapability);
+
+      const unknownVariant = cloneRegistry();
+      unknownVariant.variants["hero.campaign@v1"] = cloneVariant(
+        "hero.standard@v1",
+      );
+      unknownVariant.variants["hero.campaign@v1"].variantKey =
+        "hero.campaign@v1";
+      assertInvalid(unknownVariant);
+
+      for (const motivation of [
+        "taxon",
+        "copy",
+        "plan",
+        "campaign",
+        "asset",
+        "order",
+        "quantity",
+      ]) {
+        const motivatedVariant = cloneRegistry();
+        motivatedVariant.variants[
+          "hero.standard@v1"
+        ].creationMotivation = motivation;
+        assertInvalid(motivatedVariant);
+      }
+    },
+  },
+  {
+    name: "incomplete accordion accessibility and mismatched links fail closed",
+    run: () => {
+      for (const requirement of [
+        "keyboardOperable",
+        "exposesExpandedState",
+        "associatesControlAndRegion",
+        "preservesFocus",
+        "initiallyCollapsed",
+        "singleExpandedItem",
+      ]) {
+        const incompleteAccordion = cloneRegistry();
+        const accessibility = incompleteAccordion.variants[
+          "faq.accordion@v1"
+        ].accordionAccessibility;
+        assert.ok(accessibility);
+        accessibility[requirement] = false;
+        assertInvalid(incompleteAccordion);
+      }
+
+      const mismatchedModule = cloneRegistry();
+      mismatchedModule.variants["hero.standard@v1"].moduleKey = "faq";
+      assertInvalid(mismatchedModule);
+
+      const mismatchedFields = cloneRegistry();
+      mismatchedFields.variants["hero.standard@v1"].fieldContractKey =
+        "faq.standard@v1";
+      assertInvalid(mismatchedFields);
+    },
+  },
 ];
 
 for (const testCase of cases) {
@@ -312,6 +500,18 @@ function cloneField(
   ) as unknown as MutableField;
 }
 
+function cloneVariant(variantKey: LandingPageVariantKey): MutableVariant {
+  return structuredClone(
+    landingPageModuleCatalogRegistry.variants[variantKey],
+  ) as unknown as MutableVariant;
+}
+
+function normalizeFaqFieldPaths(value: unknown): unknown {
+  return JSON.parse(
+    JSON.stringify(value).replace(/faq\.(?:standard|accordion)/g, "faq.variant"),
+  );
+}
+
 function assertInvalid(catalog: MutableCatalog): void {
   assert.equal(landingPageModuleCatalogSchema.safeParse(catalog).success, false);
 }
@@ -340,6 +540,7 @@ type MutableCatalog = {
       fields: MutableField[];
     }
   >;
+  variants: Record<string, MutableVariant>;
 };
 
 type MutableField = {
@@ -354,5 +555,22 @@ type MutableField = {
   label?: MutableField;
   operationalBinding?: string;
   destination?: string;
+  [key: string]: unknown;
+};
+
+type MutableVariant = {
+  variantKey: string;
+  variantName: string;
+  variantVersion: number;
+  moduleKey: string;
+  moduleVersion: number;
+  fieldContractKey: string;
+  lifecycleStatus: string;
+  purpose: string;
+  capabilities: string[];
+  actionCompatibility?: { supportsPrimaryConversionForm: boolean };
+  accordionAccessibility?: Record<string, string | boolean>;
+  fallbackChannel?: string;
+  creationMotivation?: string;
   [key: string]: unknown;
 };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "validate:commercial-activation": "tsx lib/conversion-content/commercial-activation/validation-cases.ts",
     "validate:landing-page-root": "tsx lib/conversion-content/landing-page/root-validation-cases.ts",
     "validate:landing-page-research": "tsx lib/conversion-content/landing-page/research-resolution/validation-cases.ts",
-    "validate:landing-page-input-catalog": "tsx lib/conversion-content/landing-page/input-catalog/validation-cases.ts"
+    "validate:landing-page-input-catalog": "tsx lib/conversion-content/landing-page/input-catalog/validation-cases.ts",
+    "validate:landing-page-module-catalog": "tsx lib/conversion-content/landing-page/module-catalog/validation-cases.ts"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "1.1.7",


### PR DESCRIPTION
## Objetivo

Executar experimentalmente o plano-base v2 do PR #590, uma subseção canônica por checkpoint, na mesma branch e neste único PR draft.

## Contrato imutável

- plano: PR #590;
- head do plano: `04b21e8a4dfd08b2ef664c8d170db0e1d5d872b7`;
- blob do plano: `955c397923feb39740ca68be8afb35a3264a8c31`;
- modo: execução end-to-end autorizada somente até E18.5.5, sem merge.

## Checkpoints aprovados

### E18.5.3 — Módulos e funções estruturais

- commit: `39852fe1e4672dec2406a77b4b67396f9c631338`;
- base interna versionada, nove módulos, lifecycle e invariantes;
- gate final do Analista: `aprovado para avançar`.

### E18.5.4 — Campos, estruturas e cardinalidades

- commit: `f827944aa7e37a9fb0872337d28511d85088fe9b`;
- cinco field kinds, policies, supports, cardinalidades e dez contratos internos de fields;
- negativos para field, path, shape, cardinalidade, policy, coleção aninhada e destino concreto;
- gate do Analista: `aprovado para avançar`, sem correções.

### E18.5.5 — Variantes e critérios de criação

- commit: `b8a0ed1`;
- nove variantes `standard@v1` e `faq.accordion@v1`;
- capabilities limitadas a `primary_action`, `image_asset` e `accordion_interaction`;
- Hero e Final CTA expõem `supportsPrimaryConversionForm = false`, sem fallback;
- FAQ Accordion preserva FAQ Standard e declara o contrato abstrato WCAG 2.2;
- gate do Analista: `aprovado para avançar`, sem correções.

## Validações do checkpoint atual

- `npm ci`: aprovado; audit informativo com 13 vulnerabilidades;
- `npm run validate:landing-page-module-catalog`: aprovado, 16 casos;
- `npm run check`: aprovado; 0 erros e 24 warnings preexistentes fora do delta;
- `git diff --check`: aprovado.

## Limites

Não foram criados resolver, API pública, especialização da raiz, source maps ou profiles. A execução está parada após E18.5.5 e não autoriza E18.5.6 nem merge.