### PR TITLE
Executa atualização dos quatro catálogos sem gates intermediários

### DIFF
--- a/docs/workflow-atualizacao-updates.md
+++ b/docs/workflow-atualizacao-updates.md
@@ -1,11 +1,11 @@
-19/07/2026 — Workflow de Atualização dos Catálogos de Updates
+20/07/2026 — Workflow de Atualização dos Catálogos de Updates
 
 Fontes: chat, repositório e documentos indicados nos itens 2 e 3
 
 ## 1. Papel e objetivo
 
 - Manter os catálogos de updates atuais, úteis e baseados em fontes oficiais.
-- Concluir um catálogo por ciclo, com decisão humana entre o relatório e a alteração.
+- Entregar, em uma única execução, um draft PR independente para cada catálogo, sem aprovação humana intermediária.
 
 ## 2. Documentos-alvo e ordem
 
@@ -14,13 +14,13 @@ Fontes: chat, repositório e documentos indicados nos itens 2 e 3
 3. `docs/github-up.md`
 4. `docs/prod-up.md`
 
-Somente o documento-alvo pode ser alterado. Os demais catálogos são referências de leitura para detectar duplicações.
+Cada catálogo deve usar branch própria criada a partir do mesmo SHA inicial de `main`. Somente o documento-alvo pode ser alterado; os demais são referências de leitura para detectar duplicações.
 
 ## 3. Fontes
 
 Consultar:
 
-- o documento-alvo em `main`;
+- o documento-alvo no SHA inicial;
 - o repositório e os documentos técnicos relacionados aos itens avaliados;
 - fontes oficiais externas correspondentes.
 
@@ -28,17 +28,21 @@ Para Supabase, usar documentação, changelog e blog oficiais. Para Vercel, usar
 
 Fontes secundárias podem apoiar, mas não substituir a fonte oficial.
 
-## 4. Ciclo por catálogo
+## 4. Execução
 
-1. Ler o documento-alvo e suas regras de catálogo ativo e IDs.
-2. Verificar no repositório o estado real dos itens existentes e possíveis duplicações.
-3. Pesquisar nas fontes oficiais recursos novos, alterados, deprecados ou superados.
-4. Classificar os itens existentes como manter, ajustar ou remover.
-5. Classificar os recursos pesquisados como adicionar ou não adicionar.
-6. Entregar o relatório e aguardar aprovação humana.
-7. Após aprovação, alterar somente o documento-alvo e abrir um draft PR exclusivo.
-8. Conferir o diff, as fontes e as regras do catálogo.
-9. Aguardar o merge antes de iniciar o próximo ciclo.
+1. Congelar o SHA inicial de `main` e confirmar os quatro documentos-alvo.
+2. Para cada catálogo, na ordem do item 2:
+   - ler o documento e suas regras de catálogo ativo e IDs;
+   - verificar no repositório o estado real dos itens e possíveis duplicações;
+   - considerar os relatórios e diffs já produzidos nesta execução;
+   - pesquisar recursos novos, alterados, deprecados ou superados;
+   - classificar itens existentes como manter, ajustar ou remover;
+   - classificar recursos pesquisados como adicionar ou não adicionar;
+   - produzir o relatório obrigatório;
+   - criar branch independente, ajustar somente o documento-alvo e validar o diff;
+   - abrir um draft PR com o relatório no corpo.
+3. Seguir automaticamente ao próximo catálogo, sem aguardar aprovação ou merge.
+4. Ao final, entregar os quatro PRs e um resumo de bloqueios ou exceções.
 
 ## 5. Relatório obrigatório
 
@@ -46,17 +50,17 @@ Fontes secundárias podem apoiar, mas não substituir a fonte oficial.
 2. Fontes consultadas.
 3. Itens mantidos:
    - IDs.
-4. Itens a ajustar:
+4. Itens ajustados:
    - ID;
    - ajuste;
    - motivo;
    - fonte.
-5. Itens a remover:
+5. Itens removidos:
    - ID;
    - motivo;
    - evidência.
-6. Itens a adicionar:
-   - ID proposto;
+6. Itens adicionados:
+   - ID;
    - título;
    - valor para o projeto;
    - fonte;
@@ -65,11 +69,13 @@ Fontes secundárias podem apoiar, mas não substituir a fonte oficial.
    - recurso;
    - motivo.
 8. Pontos não validados.
-9. Próximo passo.
+9. Validação do diff.
 
 ## 6. Limites e parada
 
 - Não alterar código, roadmap, Base Técnica, schema, configuração ou outro catálogo.
 - Não transformar update pesquisado em implementação ou novo escopo do MVP.
 - Não adicionar item sem fonte oficial e valor concreto para o LP Factory 10.
-- Quando faltar fonte, houver conflito documental ou o estado do projeto não puder ser confirmado, declarar o limite e parar.
+- Não realizar merge dos PRs.
+- Não criar alteração artificial quando o catálogo não exigir ajuste; registrar a exceção no resumo final.
+- Quando faltar fonte obrigatória, houver conflito material ou faltar permissão, informar exatamente o bloqueio e parar.


### PR DESCRIPTION
## O que mudou

- Remove as aprovações humanas intermediárias do workflow.
- Define uma execução única para os quatro catálogos.
- Cria uma branch e um draft PR independente por catálogo.
- Usa o relatório correspondente como corpo do PR.
- Continua automaticamente ao próximo catálogo sem aguardar merge.

## Estratégia

Os quatro PRs partem do mesmo SHA inicial de `main`, permitindo revisão e merge independentes. Os relatórios e diffs anteriores continuam disponíveis como referência para evitar duplicações entre catálogos.

## Limites

- Nenhum PR é mergeado automaticamente.
- Não são criadas alterações artificiais quando um catálogo não exige ajuste.
- Fonte obrigatória ausente, conflito material ou falta de permissão permanecem bloqueios explícitos.

## Validação

- Diff restrito a `docs/workflow-atualizacao-updates.md`.
- Nenhuma alteração de catálogo, código, banco, agente ou infraestrutura.