### PR TITLE
Atualiza catálogo Supabase — 20/07/2026

### DIFF
--- a/docs/supa-up.md
+++ b/docs/supa-up.md
@@ -1637,11 +1637,12 @@ Integração do Supabase com agentes por meio do plugin MCP e das Agent Skills, 
 ## 60 — Supabase Changelog com RSS, tags e feed Markdown *(🟦 Estável)*
 
 2026-05-19
+Atualizado em 2026-07-20
 
 ### Status no Projeto
 
-- Status: Não implementado
-- Evidência: Supabase Update May 2026; ainda sem rotina formal do Gestor de Updates baseada nesses feeds.
+- Status: Em uso manual como fonte oficial; feeds não automatizados
+- Evidência: `docs/workflow-atualizacao-updates.md` formaliza a consulta de changelog, documentação e blog oficiais em cada rodada; não há consumidor RSS/Markdown nem automação desses feeds no repositório.
 
 ### Descrição
 
@@ -1659,17 +1660,17 @@ Melhorias no changelog da Supabase com RSS feeds, filtros por tag, feed `.md` e 
 
 ### Ações Recomendadas
 
-1. Avaliar uso como fonte recorrente do Gestor de Updates.
-2. Não automatizar decisões; usar como entrada de triagem.
-3. Registrar updates relevantes no `docs/supa-up.md` apenas após avaliação humana.
+1. Manter o changelog como fonte recorrente das rodadas do Gestor de Updates.
+2. Não criar consumidor RSS/Markdown ou automatizar decisões sem caso aprovado.
+3. Registrar no `docs/supa-up.md` somente updates com fonte oficial e valor concreto para o projeto.
 
 ### Registro (Tipo B — Tooling/Infra)
 
-- Status: PENDENTE
-- Verificado em: —
+- Status: PARCIAL
+- Verificado em: 2026-07-20
 - Ambiente: Supabase Changelog / RSS / Markdown feed
-- Evidência: —
-- Observação: recurso para governança de updates, não feature do produto.
+- Evidência: `docs/workflow-atualizacao-updates.md` e Supabase Changelog oficial.
+- Observação: a consulta manual está formalizada; RSS, feed Markdown e automação continuam não adotados. Recurso de governança de updates, não feature do produto.
 
 ---
 
@@ -1828,4 +1829,3 @@ A ferramenta ajuda a verificar o comportamento das políticas declaradas, mas n�
 
 - Nenhuma extensão, biblioteca, tabela, policy, rota, job, agente, automação ou infraestrutura foi criada.
 - Nenhuma configuração do projeto Supabase foi alterada.
-


### PR DESCRIPTION
## 1. Veredito

Catálogo atualizado. O uso manual do changelog oficial já está formalizado pelo workflow atual; RSS, feed Markdown e automação continuam não adotados.

## 2. Fontes consultadas

- `README.md`
- `docs/workflow-atualizacao-updates.md`
- `docs/supa-up.md`
- `docs/base-tecnica.md`
- `docs/roadmap.md`
- `docs/schema.md`
- `docs/platform-config.md`
- `docs/services.md`
- `docs/automations.md`
- `package.json` e `supabase/config.toml`
- [Supabase Changelog](https://supabase.com/changelog)
- [Envoy como gateway padrão no self-hosted](https://supabase.com/changelog/48048-self-hosted-supabase-envoy-becomes-the-default-api-gateway-breaking-change)
- [supabase-js exigirá TypeScript 5+](https://supabase.com/changelog/47812-deprecation-notice-supabase-supabase-js-will-require-typescript-5-0)

## 3. Itens mantidos

- IDs: supa#2, supa#3, supa#4, supa#5, supa#6, supa#7, supa#8, supa#9, supa#10, supa#12, supa#14, supa#15, supa#16, supa#18, supa#19, supa#20, supa#25, supa#26, supa#27, supa#28, supa#29, supa#30, supa#32, supa#33, supa#34, supa#35, supa#37, supa#39, supa#40, supa#41, supa#42, supa#43, supa#45, supa#46, supa#47, supa#48, supa#49, supa#50, supa#51, supa#52, supa#53, supa#54, supa#56, supa#57, supa#59, supa#61, supa#62 e supa#63.

## 4. Itens ajustados

- ID: supa#60.
- Ajuste: estado alterado de não implementado para uso manual como fonte oficial, com feeds não automatizados; ações e evidências alinhadas ao workflow vigente.
- Motivo: o workflow agora formaliza a consulta recorrente às fontes oficiais, mas o repositório não contém consumidor RSS/Markdown nem automação de decisão.
- Fonte: `docs/workflow-atualizacao-updates.md` e Supabase Changelog.

## 5. Itens removidos

- Nenhum.

## 6. Itens adicionados

- Nenhum.

## 7. Itens avaliados e não adicionados

- Envoy como gateway padrão no self-hosted: não afeta Supabase Cloud nem o ambiente local via CLI usado pelo projeto.
- TypeScript 5+ em supabase-js a partir de 31/01/2027: o projeto já usa TypeScript 5.5.4; não há ação pendente que justifique item ativo.

## 8. Pontos não validados

- Não foi verificado consumo real dos feeds RSS/Markdown fora do repositório.
- Nenhuma configuração do projeto Supabase foi alterada ou validada nesta rodada.

## 9. Validação do diff

- Base congelada: `79564571dc82a7629263b42d85cd669ee3c09db0`.
- Somente `docs/supa-up.md` foi alterado.
- `git diff --check`: aprovado.
- Revisão de secrets no diff: nenhum indício encontrado.
- `npm ci`: não aplicável, alteração exclusivamente documental.
- `npm run check`: não aplicável, alteração exclusivamente documental.