### PR TITLE
docs: separa governança de automação entre v1 e v2

### DIFF
--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -8,6 +8,9 @@ Você é o Estrategista do LP Factory 10. Sua função é transformar casos em p
 1. Debate do caso
    Antes do plano-base v1, debater com Analista e humano, consultando docs/roadmap.md e docs/template-roadmap.md, para definir problema, resultado esperado, usuários, limites, riscos, recorte do roadmap, subseções previstas e aplicação de automação/agentes.
 
+Regra:
+• quando houver possibilidade de automação, consultar o Gestor de Automação e submeter ao humano, antes do plano-base v1, a decisão sobre sua adoção e categoria; o detalhamento técnico fica para a v2.
+
 2. Definição do path do plano-base
    Definir o identificador do recorte conforme docs/template-roadmap.md e registrar o plano-base em:
 
@@ -34,7 +37,12 @@ Regra:
      3. Fases e próxima ação
      4. Escopo negativo e critérios de parada
    • fases executáveis;
-   • Automação: sim | não em cada fase.
+   • Automação: sim | não em cada fase;
+   • quando Automação: sim:
+     • Categoria: [categoria aprovada conforme docs/gestor-automations.md]
+     • Objetivo: [resultado esperado]
+     • Limites: [restrições essenciais]
+   • quando Automação: não, não criar categoria técnica.
 
 Regra:
 • criar somente fases executáveis e necessárias ao recorte aprovado;
@@ -42,14 +50,16 @@ Regra:
 • não usar X.Y.1 e X.Y.2 como fases; entregas implementáveis usam X.Y.3 até X.Y.n, conforme docs/template-roadmap.md;
 • não criar fase administrativa, de governança, handoff, revisão, fechamento ou documentação final;
 • validação entra como critério de aceite da fase, salvo risco técnico próprio;
-• identificadores previstos no plano-base não atualizam docs/roadmap.md automaticamente.
+• identificadores previstos no plano-base não atualizam docs/roadmap.md automaticamente;
+• não antecipar na v1 o detalhamento técnico da automação nem criar fase administrativa apenas para essa decisão.
 
 5. Avaliação única do plano-base v1 por especialistas
    Solicitar uma avaliação do plano completo no PR antes da execução.
 
 Regra:
 • não chamar especialistas a cada fase;
-• especialistas só voltam se houver mudança relevante de escopo, estrutura, automação ou risco técnico.
+• especialistas só voltam se houver mudança relevante de escopo, estrutura, automação ou risco técnico;
+• a consulta preliminar ao Gestor de Automação antes da v1 não substitui sua avaliação formal posterior do plano-base v1; nessa avaliação, ele detalha a solução dentro da categoria aprovada.
 
 5.1 Destinatários
 Analista: sempre.
@@ -70,7 +80,7 @@ Gestor de Updates
 Use $lp-factory-avaliar-plano-updates no PR [URL_DO_PR].
 
 Gestor de Automação
-Avalie no PR [URL_DO_PR] o plano-base docs/lousa-plano-base-EXX-YY.md completo, com todas as fases. Consulte antes docs/gestor-automations.md, docs/automations.md e docs/services.md. Avalie apenas automações, services, integrações, workflows, agentes, jobs ou rotinas recorrentes aplicáveis ao plano.
+Avalie o plano dentro da categoria aprovada na v1, conforme docs/gestor-automations.md, docs/automations.md e docs/services.md, e detalhe a solução para a v2. Se a categoria não atender ao requisito, devolva a necessidade de nova decisão humana.
 
 Regra: entregar somente as mensagens aplicáveis, substituindo apenas o path e a URL do PR, salvo pedido humano explícito.
 
@@ -82,6 +92,8 @@ Regra:
 • classificar os pontos como aceito, rejeitado, pendente ou já coberto;
 • alterar somente o plano-base do caso;
 • não abrir novo escopo sem decisão humana explícita;
+• detalhar na v2 a automação dentro da categoria aprovada na v1;
+• se algum parecer demonstrar que a categoria não atende ao requisito, interromper a consolidação desse ponto e submeter a mudança ao humano antes de alterar a categoria;
 • após a consolidação, solicitar ao humano o merge do PR;
 • não seguir ao item 7 antes da confirmação do merge.
 

--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -106,7 +106,7 @@ Regra: entregar somente as mensagens aplicáveis, substituindo apenas o path e a
 Regra:
 • consolidar todos os retornos em uma única análise;
 • classificar os pontos como aceito, rejeitado, pendente ou já coberto;
-• alterar somente o plano-base do caso;
+• fora da atualização prevista do roadmap, alterar somente o plano-base do caso;
 • no processo atual, após consolidar a v2, repetir com o Executor a atualização de `docs/roadmap.md` no mesmo PR, conforme `docs/prompt-abc.md` e `docs/template-roadmap.md`, usando a v2 como fonte;
 • não abrir novo escopo sem decisão humana explícita;
 • detalhar na v2 a automação dentro da categoria aprovada na v1;

--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -53,6 +53,23 @@ Regra:
 • identificadores previstos no plano-base não atualizam docs/roadmap.md automaticamente;
 • não antecipar na v1 o detalhamento técnico da automação nem criar fase administrativa apenas para essa decisão.
 
+4.1 Escolha do processo após o plano-base v1
+
+Após concluir o item 4, apresentar ao humano as opções aplicáveis:
+
+• Opção 1 — Processo atual com coordenação manual: seguir normalmente para o item 5 e continuar este fluxo.
+
+• Opção 2 — Processo automatizado no Codex App: entregar ao humano a instrução abaixo para envio ao Executor Orquestrador e suspender a continuidade pelos itens seguintes deste fluxo.
+
+Instrução ao Executor Orquestrador
+
+[CONTEÚDO DA INSTRUÇÃO A DEFINIR COM O CRIADOR DO PROCESSO AUTOMATIZADO]
+
+Regra:
+• a escolha do processo depende de decisão humana explícita;
+• por decisão humana, os processos podem ser desenvolvidos paralelamente, como já ocorreu para testes;
+• qualquer mutação do processo automatizado depende de o plano-base v1 já estar incorporado à main.
+
 5. Avaliação única do plano-base v1 por especialistas
    Solicitar uma avaliação do plano completo no PR antes da execução.
 

--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -36,6 +36,7 @@ Regra:
      2. Contrato do caso
      3. Fases e próxima ação
      4. Escopo negativo e critérios de parada
+   • Plano conceitual: [path ou URL] | N/A
    • fases executáveis;
    • Automação: sim | não em cada fase;
    • quando Automação: sim:
@@ -55,15 +56,13 @@ Regra:
 
 4.1 Escolha do processo após o plano-base v1
 
-Após concluir o item 4, apresentar ao humano as opções aplicáveis:
+Após concluir o item 4, apresentar ao humano as duas opções:
 
-• Opção 1 — Processo atual com coordenação manual: seguir normalmente para o item 5 e continuar este fluxo.
+• Opção 1 — Processo atual: seguir para o item 5.
 
-• Opção 2 — Processo automatizado no Codex App: entregar ao humano a instrução abaixo para envio ao Executor Orquestrador e suspender a continuidade pelos itens seguintes deste fluxo.
+• Opção 2 — Processo automatizado: após o merge da v1, entregar ao orquestrador somente:
 
-Instrução ao Executor Orquestrador
-
-[CONTEÚDO DA INSTRUÇÃO A DEFINIR COM O CRIADOR DO PROCESSO AUTOMATIZADO]
+Use Orquestrar plano-base no PR #[NÚMERO].
 
 Regra:
 • a escolha do processo depende de decisão humana explícita;
@@ -97,7 +96,7 @@ Gestor de Updates
 Use $lp-factory-avaliar-plano-updates no PR [URL_DO_PR].
 
 Gestor de Automação
-Avalie o plano dentro da categoria aprovada na v1, conforme docs/gestor-automations.md, docs/automations.md e docs/services.md, e detalhe a solução para a v2. Se a categoria não atender ao requisito, devolva a necessidade de nova decisão humana.
+Avalie no PR [URL_DO_PR] o plano-base `docs/lousa-plano-base-EXX-YY.md` dentro da categoria aprovada na v1, conforme docs/gestor-automations.md, docs/automations.md e docs/services.md, e detalhe a solução para a v2. Se a categoria não atender ao requisito, devolva a necessidade de nova decisão humana.
 
 Regra: entregar somente as mensagens aplicáveis, substituindo apenas o path e a URL do PR, salvo pedido humano explícito.
 

--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -51,7 +51,7 @@ Regra:
 • não usar X.Y.1 e X.Y.2 como fases; entregas implementáveis usam X.Y.3 até X.Y.n, conforme docs/template-roadmap.md;
 • não criar fase administrativa, de governança, handoff, revisão, fechamento ou documentação final;
 • validação entra como critério de aceite da fase, salvo risco técnico próprio;
-• identificadores previstos no plano-base não atualizam docs/roadmap.md automaticamente;
+• após concluir a v1, orientar o Executor a ajustar `docs/roadmap.md` no mesmo PR, conforme `docs/prompt-abc.md` e `docs/template-roadmap.md`, registrando somente seções, subseções, títulos, objetivos e status planejado, sem registros de implementação;
 • não antecipar na v1 o detalhamento técnico da automação nem criar fase administrativa apenas para essa decisão.
 
 4.1 Escolha do processo após o plano-base v1
@@ -107,6 +107,7 @@ Regra:
 • consolidar todos os retornos em uma única análise;
 • classificar os pontos como aceito, rejeitado, pendente ou já coberto;
 • alterar somente o plano-base do caso;
+• no processo atual, após consolidar a v2, repetir com o Executor a atualização de `docs/roadmap.md` no mesmo PR, conforme `docs/prompt-abc.md` e `docs/template-roadmap.md`, usando a v2 como fonte;
 • não abrir novo escopo sem decisão humana explícita;
 • detalhar na v2 a automação dentro da categoria aprovada na v1;
 • se algum parecer demonstrar que a categoria não atende ao requisito, interromper a consolidação desse ponto e submeter a mudança ao humano antes de alterar a categoria;


### PR DESCRIPTION
### Motivation

- Separate strategic decision about adopting an automation (recorded in plano-base v1) from the technical implementation details (consolidated in plano-base v2) to avoid premature technical design in v1.
- Ensure the decision about adoption and category involves the Gestor de Automação and the human before v1 while preserving existing structure, numbering and version of the document.

### Description

- Updated only `docs/prompt-estrategista.md` to apply the requested scope edits in items 1, 4, 5, 5.2 and 6 while preserving the document header/version and overall structure. 
- Item 1: added a short rule requiring consultation with the `Gestor de Automação` and submission to the human for the adoption-and-category decision before the plano-base v1, leaving technical detail to v2. 
- Item 4 (checklist v1): kept `Automação: sim | não` and, when `sim`, added `Categoria`, `Objetivo` and `Limites`, forbidding creation of a technical category when `Automação: não` and forbidding anticipation of technical details or administrative phases in v1. 
- Item 5 and 5.2: clarified that a preliminary consultation with the `Gestor de Automação` does not replace the formal v1 evaluation, and changed the message to the Gestor to request detailing the solution within the approved category and to return to the human if the category is insufficient. 
- Item 6: added consolidation rules requiring the v2 to detail the automation within the category approved in v1 and to gate any category change with a new human decision. 
- Branch used: `docs/automation-governance-strategist`; file changed: `docs/prompt-estrategista.md`; PR metadata prepared with the title in this PR. No other files modified. 

### Testing

- Ran a `python` verification script that asserts presence of all required phrases and that the document header/version were preserved, and it passed. 
- Ran `git diff --check` and checks that only `docs/prompt-estrategista.md` was modified, both passed. 
- Confirmed repository workspace status with `git status --short --branch` and `git log -1 --oneline` after committing the change. 
- `git push` was not executed because no remote is configured in the environment, and `npm ci` / `npm run check` are not applicable for an exclusively documentary change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60e6fd2a408329a5b1c82605198876)