### PR TITLE
feat: completar especialistas e roadmap da orquestração

### DIFF
--- a/.agents/skills/lp-factory-abc/SKILL.md
+++ b/.agents/skills/lp-factory-abc/SKILL.md
@@ -1,295 +1,57 @@
 ---
 name: lp-factory-abc
-description: Generate ABC delta-only updates for LP-Factory-10 canonical documentation. Use whenever the user asks to update, adjust, correct, or synchronize canonical documents based on a report, final report, implementation result, implementation history, PR summary, handoff, assessment, diagnosis, current branch, or plan-base execution. Also use for explicit ABC requests, DOC_ALVO updates, delta-only documentation patches, and triage of which canonical docs need updates among docs/base-tecnica.md, docs/schema.md, docs/roadmap.md, docs/design-system.md, docs/platform-config.md, docs/services.md, and docs/automations.md.
+description: Gerar ABCs delta-only para documentos canônicos do LP Factory 10 a partir de relatório, implementação, PR, handoff ou plano-base v1/v2 aprovado. Usar em pedidos de atualização, correção, sincronização, triagem documental ou reconciliação planejada de docs/roadmap.md.
 ---
 
 # LP Factory ABC v2
 
-## Purpose
+Usar `docs/prompt-abc.md` como contrato canônico e lê-lo integralmente antes de cada execução. Não duplicar, substituir nem flexibilizar suas regras nesta skill.
 
-Generate a short, human, executable ABC for LP Factory 10 canonical documentation.
+## Preparar
 
-The output is delta-only: identify only the smallest changes required to reflect confirmed final state in the target document.
+1. Confirmar o repositório `AlcinoAfonso/LP-Factory-10`.
+2. Resolver `REF`; usar `main` quando não for informado.
+3. Confirmar `DOC_ALVO` ou executar a triagem prevista no contrato canônico.
+4. Confirmar o `RELATÓRIO`, que deve representar o estado final competente.
+5. Ler o `DOC_ALVO` na referência indicada e a fonte estrutural aplicável.
+6. Para `docs/roadmap.md`, ler também `docs/template-roadmap.md` na mesma referência.
+7. Parar e pedir somente a entrada ausente quando não for possível resolvê-la sem inferência.
 
-Before adding content, evaluate in this order:
+## Selecionar o modo da fonte
 
-1. remove;
-2. adjust;
-3. replace;
-4. consolidate;
-5. add only when necessary.
+### Relatório
 
-Default to `SEM ALTERACOES NECESSARIAS` when no permitted delta exists.
+Usar relatório final, resumo de PR, handoff, diagnóstico aprovado ou outra fonte consolidada fornecida.
 
-## Required Inputs
+### Implementação
 
-- Repository: `AlcinoAfonso/LP-Factory-10` or the current `LP-Factory-10` checkout.
-- Reference: `main`, branch, commit, or current checkout. If not provided, use the current requested repo state.
-- `DOC_ALVO`, when provided:
-  - `docs/base-tecnica.md`
-  - `docs/schema.md`
-  - `docs/roadmap.md`
-  - `docs/design-system.md`
-  - `docs/platform-config.md`
-  - `docs/services.md`
-  - `docs/automations.md`
-- Source material: final report, implementation result, implementation history, plan-base execution context, PR summary, branch diff, human briefing, or other explicit source.
+Quando não houver relatório formal, reconstruir somente o estado final confirmado a partir do plano e da fase, intervalo de commits, diff, validações e decisões registradas. Ignorar tentativas, erros intermediários e hipóteses.
 
-If `DOC_ALVO` is missing, run triage first. If the source material is missing and cannot be reconstructed from the thread and repository evidence, stop and ask for the exact missing source.
+### Planejamento
 
-## Source Modes
+Usar quando o `RELATÓRIO` for um plano-base v1 ou v2 aprovado. Esse modo registra estado planejado ou definido; nunca converte previsão em implementação.
 
-### Report Mode
+Para reconciliar `docs/roadmap.md` após a v2, exigir:
 
-Use when the user provides a final report, PR summary, handoff, explicit implementation result, or other consolidated source.
+- referência imutável e conteúdo integral da v2 aprovada;
+- snapshot imutável e conteúdo integral do roadmap produzido a partir da v1;
+- `DOC_ALVO: docs/roadmap.md`;
+- `docs/prompt-abc.md` e `docs/template-roadmap.md` da referência competente.
 
-Treat the provided source as the main evidence, then compare it with `DOC_ALVO` and the current repo state.
+Permitir somente seções e subseções do recorte, identificadores, títulos, objetivos, status planejado ou definido, limites, decisões futuras aprovadas e dependências indispensáveis. Não registrar implementação concluída, banco, migrations, arquivos criados ou ajustados, updates aplicados, evidências, comandos, PRs, histórico operacional ou alterações de outros documentos canônicos. Omitir `Registros do recorte` enquanto não houver implementação material.
 
-### Implementation Mode
+## Gerar o delta
 
-Use when the user asks for an ABC based on "this implementation", "this branch", "this plan-base execution", "what was implemented", or similar wording without a formal report.
+1. Aplicar o fluxo, a residência documental, os gates e as operações de `docs/prompt-abc.md`.
+2. Comparar o `RELATÓRIO` com o snapshot atual do `DOC_ALVO`.
+3. Emitir somente o menor delta executável ou `SEM ALTERAÇÕES NECESSÁRIAS`.
+4. Em planejamento, preservar o esqueleto existente e alterar sua estrutura somente quando a fonte aprovada exigir criação ou consolidação de seção.
+5. Usar literalmente o formato da seção 9 de `docs/prompt-abc.md`, inclusive acentuação e o travessão do cabeçalho.
 
-Reconstruct evidence from:
+## Limites
 
-- plan-base path and phase discussed in the thread, when available;
-- current branch and commit range;
-- files changed in `main...HEAD`;
-- relevant git diff;
-- commits created for the implementation;
-- validations executed and results;
-- implementation decisions explicitly made in the thread;
-- current blockers, skipped validations, fallbacks, and residual risks.
+Não aplicar o delta, editar documentos, alterar outra residência documental, completar lacunas por suposição ou registrar estado operacional como planejado. A aplicação pertence ao executor autorizado.
 
-Use reconstructed evidence only to identify confirmed final state. Do not treat attempts, intermediate errors, provisional ideas, or unvalidated assumptions as implemented or defined.
+## Verificar
 
-If the thread and repo evidence are insufficient to identify final state, stop and ask for the missing evidence.
-
-## Mandatory Sources
-
-Read:
-
-1. source material;
-2. current `DOC_ALVO`, when provided;
-3. applicable structural source.
-
-Structural source rules:
-
-- For `docs/roadmap.md`, read `docs/template-roadmap.md` from the same requested ref before generating deltas.
-- For other docs, use the document's own structure, current sections, relation to other docs, version/date, changelog, and any explicit local template or contract when present.
-- Use structural sources to shape valid operations. Do not copy the template or structural source into the ABC output.
-
-## Evidence Extraction
-
-Extract only:
-
-- implemented final state;
-- defined final state;
-- approved future decision;
-- current pending item;
-- permanent limit.
-
-Ignore:
-
-- hypothesis;
-- unapproved proposal;
-- operational history;
-- superseded step;
-- transient validation narrative;
-- console narrative;
-- branch, PR, merge, screenshot, or command detail unless it became a current pending item, permanent limit, or current requirement.
-
-## Document Residency
-
-Use one residence per subject. Do not duplicate canonical sources.
-
-- `docs/roadmap.md`: cases, status, scope, decisions, pending items, dependencies, and final case artifacts.
-- `docs/base-tecnica.md`: durable technical rules for future implementations.
-- `docs/schema.md`: real database contract, DB objects, permissions, policies, functions, migrations, and grants.
-- `docs/design-system.md`: visual contract, components, UI patterns, responsive behavior, and visual surfaces.
-- `docs/platform-config.md`: external platforms, env var and secret names, URLs, endpoints, redirects, DNS, SMTP, GitHub Actions secrets, and redeploy/config rules.
-- `docs/services.md`: deployable services, MCPs, service endpoints, deploy boundary, implementation location, consumers, dependencies, status, and service-level pending items.
-- `docs/automations.md`: operational automations, workflows, jobs, agents, usage, inputs, expected responses, local runtime, dependencies, rules, learnings, and automation-level pending items.
-
-Everything outside the selected `DOC_ALVO` residency is out of scope.
-
-## Global Gates
-
-- Docs describe current project state, not execution history.
-- Replace old state with consolidated current state. Do not preserve superseded intermediate phases.
-- Keep only executable deltas: `ADICIONAR`, `SUBSTITUIR`, or `REMOVER`, with the minimum target snippet.
-- Do not include long justifications, lists of content not to include, report summaries, or already known context.
-- Do not introduce secret values, PII, raw payloads, or volatile console details.
-- Do not add content merely because it is new; add only when it belongs to `DOC_ALVO` and changes the durable documented state.
-
-## Specific Gates
-
-### `docs/roadmap.md`
-
-Generate deltas only for case status, scope, dependencies, decisions, current pending items, approved future decisions, permanent limits, and created/adjusted/removed final artifacts.
-
-Rules:
-
-- Apply `docs/template-roadmap.md`.
-- Respect report-indicated subsections when present.
-- Do not create empty blocks.
-- Do not list actions that did not occur.
-- Use `N/A` only when the template requires it.
-- In artifact records, use only names or paths.
-- Do not record `docs/**` as artifacts.
-- For records, include only DB objects and functional repo artifacts created, adjusted, or removed.
-- Do not describe columns, policies, internal logic, file contents, implementation narrative, PRs, branches, commands, screenshots, or transient validations.
-- Updates related to the case may appear only as short IDs in the existing roadmap pattern, without inventing categories or IDs.
-- Before `SUBSTITUIR_SECAO`, verify the replacement does not remove approved future decisions, current pending items, or still-valid limits.
-
-### `docs/base-tecnica.md`
-
-Generate deltas only for durable, reusable technical rules that affect future implementations or safe deterministic planning.
-
-Hard gate:
-
-- Classify candidate content as `REGRA_TRANSVERSAL_REUTILIZAVEL` or `ESTADO_ESPECIFICO_DE_CASO`.
-- Only `REGRA_TRANSVERSAL_REUTILIZAVEL` can enter `docs/base-tecnica.md`.
-- If no reusable rule exists, output `SEM ALTERACOES NECESSARIAS`.
-
-Do not add:
-
-- case/phase status, PR, branch, validation evidence, screenshots, artifact state, counts, next step, pending product item, or case-specific decision;
-- URL, env, secret, endpoint, dashboard config, DNS, or external platform detail, unless indispensable as a technical implementation rule;
-- values or lists already defined in code, registry, schema, config, or other versioned canonical source.
-
-When needed, record only the permanent rule and the path of the canonical source.
-
-### `docs/schema.md`
-
-Generate deltas only with real DB change and evidence from source material or repository state.
-
-Allowed content:
-
-- tables, columns, constraints, enums, relationships, views, RPCs/functions, triggers, RLS/policies, grants, migrations, and minimum Supabase validation notes.
-
-Rules:
-
-- For confirmed RPCs/functions, record signature, security, `search_path`, grants, and stable behavior.
-- Evidence must show an applied or intended schema-changing artifact, such as migration, SQL that changes schema, or Supabase confirmation.
-- Use TBD only for missing detail on a DB object that already exists, with a validation path.
-
-### Other Docs
-
-- `docs/design-system.md`: current visual standards, active UI components, usage rules, responsive behavior, and consolidated visual surfaces. Avoid file inventory when roadmap already records artifacts.
-- `docs/platform-config.md`: external configuration and platform contract. Never include real secret values; record only name, purpose, platform, and environment scope.
-- `docs/services.md`: reusable deployable service/MCP inventory and service-level operation. Do not include consumer automation details or general platform inventory.
-- `docs/automations.md`: consumer automations, recurring workflows, agents, jobs, and operational rules. Secrets/envs/endpoints/workflows may appear only as short dependency references.
-
-## Operations
-
-Permitted operation types:
-
-- `SUBSTITUIR_TRECHO`
-- `SUBSTITUIR_SECAO`
-- `ADICIONAR_TRECHO`
-- `ADICIONAR_SECAO`
-- `REMOVER_TRECHO`
-- `REMOVER_SECAO`
-
-Rules:
-
-- Prefer TRECHO: line, bullet, short paragraph, or small stable block.
-- Use SECAO only for structural change.
-- Addition requires a clear anchor.
-- For TRECHO operations, use the section where the snippet enters or leaves.
-- For `ADICIONAR_SECAO`, use the immediately preceding section at the same level when one exists.
-- If the anchor is unclear in `DOC_ALVO`, do not generate the addition.
-- `CONTEUDO` must be literal and must not use ellipses (`...`).
-
-## Version And Changelog
-
-- Version, date, and changelog change only with a real document delta.
-- A real document delta is at least one operation that is not header/versioning and not changelog.
-- Changelog receives only the new entry.
-- Changelog does not enter `OPERACOES`.
-
-## Output Format
-
-Use `America/Sao_Paulo` time.
-
-When emitting an ABC for a `DOC_ALVO`, the answer must start exactly with:
-
-```text
-DD/MM/YYYY HH:MM - ABC (DELTA-ONLY) para <DOC_ALVO>
-```
-
-With `DOC_ALVO`:
-
-```text
-DD/MM/YYYY HH:MM - ABC (DELTA-ONLY) para <DOC_ALVO>
-DOC_ALVO: <DOC_ALVO>
-```
-
-With no permitted deltas:
-
-```text
-DD/MM/YYYY HH:MM - ABC (DELTA-ONLY) para <DOC_ALVO>
-DOC_ALVO: <DOC_ALVO>
-SEM ALTERACOES NECESSARIAS
-```
-
-With permitted deltas:
-
-```text
-DD/MM/YYYY HH:MM - ABC (DELTA-ONLY) para <DOC_ALVO>
-DOC_ALVO: <DOC_ALVO>
-VERSAO_NOVA: <vX.Y.Z>
-DATA_NOVA: <DD/MM/YYYY>
-
-OPERACOES
-
-OP1)
-TIPO: <operacao>
-ALVO: <alvo>
-ANCORA: <ancora, somente quando aplicavel>
-CONTEUDO:
-<conteudo literal>
-
-CHANGELOG
-
-CH1)
-<nova entrada>
-```
-
-Omit `VERSAO_NOVA`, `DATA_NOVA`, and `CHANGELOG` when there is no real document delta.
-
-## Triage Without DOC_ALVO
-
-When `DOC_ALVO` is not provided, start with:
-
-```text
-TRIAGEM
-```
-
-Then:
-
-- list only documents with permitted deltas;
-- include a short reason for each listed document;
-- do not list documents with no delta unless the user asks for the full audit;
-- emit one complete independent ABC block per document with deltas;
-- do not mix versions, operations, or changelogs across documents.
-
-## Mandatory Pause
-
-Run the complete cycle only for the current `DOC_ALVO`, except when:
-
-- the flow starts with triage;
-- the user explicitly asks for multiple documents.
-
-After emitting output, stop and wait for the next `DOC_ALVO`, except when triage or explicit instruction requires multiple ABC blocks.
-
-## Verification Checklist
-
-Before final output, verify:
-
-- `DOC_ALVO` was read from the requested source/ref.
-- Applicable structural source was read.
-- Each proposed delta belongs to the selected document residency.
-- No secret value, PII, raw payload, or volatile console narrative was introduced.
-- Header/date/version/changelog changes exist only when there is a real document operation.
-- The output contains only executable delta content or `SEM ALTERACOES NECESSARIAS`.
+Antes de devolver, confirmar fontes, referência, residência, menor delta, formato literal e ausência de secrets, PII, hipóteses ou histórico superado.

--- a/.agents/skills/lp-factory-abc/agents/openai.yaml
+++ b/.agents/skills/lp-factory-abc/agents/openai.yaml
@@ -1,3 +1,4 @@
 interface:
   display_name: "LP Factory ABC v2"
-  short_description: "Generate concise delta-only ABC updates for LP Factory canonical docs."
+  short_description: "Gera deltas canônicos mínimos e executáveis"
+  default_prompt: "Use $lp-factory-abc para gerar o menor delta canônico a partir da fonte e do documento-alvo informados."

--- a/.agents/skills/lp-factory-avaliar-plano-analista/SKILL.md
+++ b/.agents/skills/lp-factory-avaliar-plano-analista/SKILL.md
@@ -18,7 +18,7 @@ Executar duas passagens sequenciais com uma única instância do custom agent `a
    - matriz de consolidação.
 3. Resolver versões em PR ou commit pelo SHA, nunca pela cópia local conveniente. Se v1 e v2 compartilharem path, diferenciá-las por referências imutáveis.
 4. Parar diante de artefato ausente, caso divergente ou fonte conceitual ambígua; não reconstruir por inferência.
-5. Neste recorte, exigir pareceres do Gestor Estrutural e do Gestor de Updates. Não exigir Gestor de Automações.
+5. Exigir pareceres do Gestor Estrutural e do Gestor de Updates. Exigir também o parecer do Gestor de Automações somente quando a v1 contiver ao menos uma fase marcada como `Automação: sim`; caso contrário, exigir o registro `N/A`.
 6. Registrar o estado Git anterior à delegação.
 
 ## Validar a matriz

--- a/.agents/skills/lp-factory-avaliar-plano-analista/SKILL.md
+++ b/.agents/skills/lp-factory-avaliar-plano-analista/SKILL.md
@@ -59,6 +59,12 @@ Conferir o estado Git. Se faltar passagem ou conclusão, devolver o conteúdo e 
 
 Usar `revisao_delta` no mesmo Analista, entregando versões ou diff e correções solicitadas. Retornar ao especialista somente diante de questão material nova ou conclusão especializada alterada. Liberar o gate apenas após `aprovado para merge do plano-base v2`.
 
+## Revisar o roadmap final
+
+Após a primeira aprovação da v2, continuar no mesmo Analista em `revisao_delta`. Entregar a v2 aprovada, o snapshot imutável do roadmap anterior, o ABC emitido por `$lp-factory-abc`, o roadmap resultante, `docs/prompt-abc.md` e `docs/template-roadmap.md`.
+
+Auditar somente se o roadmap corresponde à estrutura planejada da v2, se o delta é mínimo, se respeita a hierarquia e a residência documental e se não registra implementação ou evidência operacional. Quando o ABC indicar `SEM ALTERAÇÕES NECESSÁRIAS`, confirmar que o snapshot já corresponde à v2. Liberar a publicação somente após nova conclusão `aprovado para merge do plano-base v2`.
+
 ## Limites
 
 Não editar artefatos, criar branch/commit/PR, consolidar v2, refazer especialidade, acionar outros especialistas, avaliar implementação ou autorizar merge com pendência.

--- a/.agents/skills/lp-factory-avaliar-plano-automacoes/SKILL.md
+++ b/.agents/skills/lp-factory-avaliar-plano-automacoes/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: lp-factory-avaliar-plano-automacoes
+description: Avaliar automações, fluxos com IA, agentes, workflows, jobs, rotinas recorrentes, integrações e services previstos em um plano-base do LP Factory 10 por meio do custom agent gestor-automacoes. Usar quando o plano contiver ao menos uma fase marcada como `Automação: sim` ou quando o humano pedir o parecer desse especialista.
+---
+
+# Avaliar automações do plano-base
+
+Delegar uma avaliação read-only ao custom agent `gestor-automacoes` e devolver seu parecer integral.
+
+## Preparar a entrada
+
+1. Confirmar repositório, worktree, branch e estado Git.
+2. Resolver a fonte sem inferir outro caso:
+   - PR: confirmar número, URL, base, head, head SHA e estado; selecionar automaticamente somente quando houver exatamente um `docs/lousa-plano-base-*.md`; obter seu conteúdo integral pelo head SHA;
+   - path local: confirmar existência e coerência entre path, conteúdo e caso.
+3. Ler o plano completo e identificar as fases marcadas exatamente como `Automação: sim`.
+4. Se nenhuma fase estiver marcada assim, devolver `Gestor de Automações: N/A — nenhuma fase com Automação: sim`, sem iniciar o agente.
+5. Para cada fase aplicável, registrar identificador canônico, objetivo, escopo, limites, critérios de aceite e automações, integrações ou services mencionados.
+6. Confirmar `docs/gestor-automations.md`; deixar ao agente a seleção das demais fontes competentes.
+7. Parar e pedir somente o dado ausente se a seleção do plano ou das fases continuar ambígua.
+8. Registrar o estado Git anterior à delegação.
+
+## Delegar e devolver
+
+1. Iniciar exatamente um subagent `gestor-automacoes`.
+2. Entregar worktree, branch, metadados da fonte, path, conteúdo integral, caso e fases aplicáveis.
+3. Não repetir critérios de automação no handoff: o contrato runtime está em `.codex/agents/gestor-automacoes.toml` e a governança em `docs/gestor-automations.md`.
+4. Aguardar o parecer sem realizar avaliação paralela.
+5. Validar identificação, fontes, um veredito permitido, classificação, ambiente, necessidade de OpenAI, decisão, patches e próximo passo.
+6. Em `automação aplicável com patches autossuficientes`, exigir patch completo para cada decisão aprovada. Em `requer investigação factual`, exigir evidência faltante e forma de obtê-la. Em `requer validação material pelo Analista`, exigir decisão material e alternativas verificáveis, sem abrir gate humano neste estágio.
+7. Se o contrato estiver incompleto, devolver o conteúdo recebido e marcar o handoff como incompleto; não completar nem reinterpretar o parecer.
+8. Confirmar novamente o estado Git e distinguir alterações preexistentes.
+9. Exibir o parecer integral, seguido apenas de plano e fases avaliados, veredito, agente acionado e confirmação de que o repositório permaneceu inalterado.
+
+## Limites
+
+Não editar plano, fontes ou PR; criar branch, commit ou PR; pesquisar recursos sem caso concreto; implementar; consolidar v2; acionar outro especialista; decidir pelo Analista ou executar fases.

--- a/.agents/skills/lp-factory-avaliar-plano-automacoes/agents/openai.yaml
+++ b/.agents/skills/lp-factory-avaliar-plano-automacoes/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Avaliar automações do plano"
+  short_description: "Avalia automações aplicáveis com agente"
+  default_prompt: "Use $lp-factory-avaliar-plano-automacoes para avaliar as automações aplicáveis ao PR ou plano-base informado."

--- a/.agents/skills/lp-factory-orquestrar-plano/SKILL.md
+++ b/.agents/skills/lp-factory-orquestrar-plano/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lp-factory-orquestrar-plano
-description: Orquestrar a produção e o gate de um plano-base v2 do LP Factory 10 a partir de uma v1 já incorporada à main, usando o Gestor Estrutural, o Gestor de Updates e o Analista. Usar quando o humano informar o PR ou path da v1 e pedir para executar, orquestrar ou automatizar a revisão do plano.
+description: Orquestrar a produção e o gate de um plano-base v2 do LP Factory 10 a partir de uma v1 já incorporada à main, usando o Gestor Estrutural, o Gestor de Updates, o Gestor de Automações quando aplicável e o Analista. Usar quando o humano informar o PR ou path da v1 e pedir para executar, orquestrar ou automatizar a revisão do plano.
 ---
 
 # Orquestrar plano-base v2
@@ -26,7 +26,8 @@ Antes de executar:
 1. Ler `docs/orquestracao-plano-base.md`.
 2. Ler e seguir `.agents/skills/lp-factory-avaliar-plano-estrutura/SKILL.md` na delegação estrutural.
 3. Ler e seguir `.agents/skills/lp-factory-avaliar-plano-updates/SKILL.md` na avaliação de updates.
-4. Ler e seguir `.agents/skills/lp-factory-avaliar-plano-analista/SKILL.md` no gate do Analista.
+4. Ler e seguir `.agents/skills/lp-factory-avaliar-plano-automacoes/SKILL.md` quando alguma fase estiver marcada como `Automação: sim`.
+5. Ler e seguir `.agents/skills/lp-factory-avaliar-plano-analista/SKILL.md` no gate do Analista.
 
 Não copiar nem reinterpretar os contratos canônicos desses arquivos.
 
@@ -66,6 +67,7 @@ O task principal pode estar aberto no projeto local padrão. Direcionar as muta�
 5. Registrar `N/A` quando a inexistência de plano conceitual for confirmada; não escolher documento por semelhança.
 6. Identificar decisões humanas registradas que sejam fontes do plano.
 7. Validar que cada fase executável use exatamente o identificador da subseção do roadmap; não aceitar aliases ordinais como `Fase 1` nem agrupamento de subseções independentes.
+8. Identificar se existe ao menos uma fase marcada exatamente como `Automação: sim`; essa marca é o único gatilho automático do Gestor de Automações.
 
 Parar quando faltar uma decisão material que altere produto, escopo ou arquitetura.
 
@@ -91,14 +93,23 @@ Parar quando faltar uma decisão material que altere produto, escopo ou arquitet
 6. Produzir a v2 quando o veredito for `nenhum update aplicável` ou `updates aplicáveis com patches autossuficientes`, mantendo cada update e patch rastreável.
 7. Não retornar ao Gestor de Updates durante a consolidação. Nova rodada só é cabível se a v2 introduzir questão material de updates não coberta pelo parecer.
 
-Não acionar Gestor de Automações neste recorte.
+### 4.3 Gestor de Automações
+
+1. Se nenhuma fase estiver marcada como `Automação: sim`, registrar `N/A` e não acionar o especialista.
+2. Se houver ao menos uma, executar `lp-factory-avaliar-plano-automacoes` sobre a mesma v1 congelada, entregando o plano completo e destacando somente as fases aplicáveis.
+3. Acionar exatamente um custom agent `gestor-automacoes` e preservar integralmente seu parecer.
+4. Não realizar avaliação de automações paralela no task principal.
+5. Parar antes da v2 somente se o handoff estiver incompleto ou se o veredito for `requer investigação factual`.
+6. Em `automação aplicável com patches autossuficientes`, exigir patch completo para cada decisão aplicável.
+7. Em `requer validação material pelo Analista`, preservar a pendência na v2 e na matriz; não abrir gate humano nem decidir no task principal.
+8. Não retornar ao Gestor de Automações durante a consolidação. Nova rodada só é cabível se a v2 introduzir questão material de automação não coberta pelo parecer.
 
 ## 5. Produzir a v2 e a matriz
 
 1. Editar somente o plano correspondente dentro da worktree de automação.
-2. Preservar objetivo, decisões válidas e limites da v1; incorporar literalmente ou de forma inequivocamente equivalente os patches estruturais e de updates, usando somente tratamentos sustentados pelos pareceres e pelas fontes competentes.
+2. Preservar objetivo, decisões válidas e limites da v1; incorporar literalmente ou de forma inequivocamente equivalente os patches estruturais, de updates e, quando aplicável, de automações, usando somente tratamentos sustentados pelos pareceres e pelas fontes competentes.
 3. Não implementar fases nem ampliar silenciosamente o escopo.
-4. Preparar uma matriz com uma linha por achado estrutural e por update preliminarmente elegível, usando o contrato da skill `lp-factory-avaliar-plano-analista`.
+4. Preparar uma matriz com uma linha por achado estrutural, por update preliminarmente elegível e por decisão do Gestor de Automações, quando acionado, usando o contrato da skill `lp-factory-avaliar-plano-analista`.
 5. Manter a matriz fora do alcance do Analista até ele concluir a Passagem 1:
    - não incluí-la no prompt ou nos turnos herdados;
    - não gravá-la na worktree antes da conclusão independente;
@@ -111,7 +122,7 @@ Não acionar Gestor de Automações neste recorte.
 1. Executar a Passagem 1 de `lp-factory-avaliar-plano-analista` com v1, v2, plano conceitual ou `N/A`, decisões registradas e fontes do caso, sem pareceres especializados ou matriz.
 2. Preservar integralmente a resposta independente.
 3. Depois da Passagem 1, gravar a matriz em `docs/matriz-consolidacao-<caso>.md`, validar e criar novo checkpoint. No modo `experimental`, mantê-la como evidência; no fluxo normal, usá-la somente até a conclusão do Analista.
-4. Continuar no mesmo Analista e entregar os pareceres completos do Gestor Estrutural e do Gestor de Updates, além da matriz, para a Passagem 2.
+4. Continuar no mesmo Analista e entregar os pareceres completos do Gestor Estrutural, do Gestor de Updates e, quando acionado, do Gestor de Automações, além da matriz, para a Passagem 2.
 5. Preservar integralmente a auditoria e a conclusão formal.
 6. No fluxo normal, após aprovação final, resumir a rastreabilidade no PR e remover a matriz antes da publicação final; não agendar remoção posterior.
 
@@ -143,6 +154,7 @@ Apresentar:
 - worktree e branch de automação usadas;
 - conclusão integral do Gestor Estrutural;
 - parecer integral do Gestor de Updates;
+- parecer integral do Gestor de Automações ou `N/A`;
 - Passagens 1 e 2 do Analista;
 - arquivos alterados;
 - commits e validações;

--- a/.agents/skills/lp-factory-orquestrar-plano/SKILL.md
+++ b/.agents/skills/lp-factory-orquestrar-plano/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lp-factory-orquestrar-plano
-description: Orquestrar a produção e o gate de um plano-base v2 do LP Factory 10 a partir de uma v1 já incorporada à main, usando o Gestor Estrutural, o Gestor de Updates, o Gestor de Automações quando aplicável e o Analista. Usar quando o humano informar o PR ou path da v1 e pedir para executar, orquestrar ou automatizar a revisão do plano.
+description: Orquestrar a produção e o gate de um plano-base v2 do LP Factory 10 a partir de uma v1 já incorporada à main, usando especialistas e Analista e reconciliando o roadmap antes da publicação. Usar quando o humano informar o PR ou path da v1 e pedir para executar, orquestrar ou automatizar a revisão do plano.
 ---
 
 # Orquestrar plano-base v2
@@ -40,6 +40,7 @@ Não copiar nem reinterpretar os contratos canônicos desses arquivos.
 5. Registrar head SHA, blob SHA, path e caso ou recorte como referência imutável da v1.
 6. No fluxo normal, confirmar que o blob congelado da v1 está incorporado à `main`; se não estiver, parar antes de qualquer mutação.
 7. Não editar a branch head do PR nem alterar o PR de origem.
+8. Registrar commit SHA, blob SHA e conteúdo integral de `docs/roadmap.md` na `main` como snapshot imutável anterior à v2.
 
 ## 2. Selecionar a worktree de automação
 
@@ -107,15 +108,17 @@ Parar quando faltar uma decisão material que altere produto, escopo ou arquitet
 ## 5. Produzir a v2 e a matriz
 
 1. Editar somente o plano correspondente dentro da worktree de automação.
-2. Preservar objetivo, decisões válidas e limites da v1; incorporar literalmente ou de forma inequivocamente equivalente os patches estruturais, de updates e, quando aplicável, de automações, usando somente tratamentos sustentados pelos pareceres e pelas fontes competentes.
-3. Não implementar fases nem ampliar silenciosamente o escopo.
-4. Preparar uma matriz com uma linha por achado estrutural, por update preliminarmente elegível e por decisão do Gestor de Automações, quando acionado, usando o contrato da skill `lp-factory-avaliar-plano-analista`.
-5. Manter a matriz fora do alcance do Analista até ele concluir a Passagem 1:
+2. Preservar a ordem, as seções, a hierarquia e a granularidade da v1. Criar ou consolidar seções somente quando um parecer especializado trouxer necessidade e patch autossuficiente.
+3. Rastrear na matriz cada alteração estrutural da v1 até o especialista, o achado e o patch que a determinou.
+4. Preservar objetivo, decisões válidas e limites da v1; incorporar literalmente ou de forma inequivocamente equivalente os patches estruturais, de updates e, quando aplicável, de automações, usando somente tratamentos sustentados pelos pareceres e pelas fontes competentes.
+5. Não implementar fases nem ampliar silenciosamente o escopo.
+6. Preparar uma matriz com uma linha por achado estrutural, por update preliminarmente elegível e por decisão do Gestor de Automações, quando acionado, usando o contrato da skill `lp-factory-avaliar-plano-analista`.
+7. Manter a matriz fora do alcance do Analista até ele concluir a Passagem 1:
    - não incluí-la no prompt ou nos turnos herdados;
    - não gravá-la na worktree antes da conclusão independente;
    - iniciar o Analista com `fork_turns=none`.
-6. Validar a v2 com `git diff --check` e criar um commit de checkpoint somente com o plano-base v2.
-7. Usar esse commit como referência imutável da v2 na Passagem 1.
+8. Validar a v2 com `git diff --check` e criar um commit de checkpoint somente com o plano-base v2.
+9. Usar esse commit como referência imutável da v2 na Passagem 1.
 
 ## 6. Executar o gate do Analista
 
@@ -124,22 +127,38 @@ Parar quando faltar uma decisão material que altere produto, escopo ou arquitet
 3. Depois da Passagem 1, gravar a matriz em `docs/matriz-consolidacao-<caso>.md`, validar e criar novo checkpoint. No modo `experimental`, mantê-la como evidência; no fluxo normal, usá-la somente até a conclusão do Analista.
 4. Continuar no mesmo Analista e entregar os pareceres completos do Gestor Estrutural, do Gestor de Updates e, quando acionado, do Gestor de Automações, além da matriz, para a Passagem 2.
 5. Preservar integralmente a auditoria e a conclusão formal.
-6. No fluxo normal, após aprovação final, resumir a rastreabilidade no PR e remover a matriz antes da publicação final; não agendar remoção posterior.
+6. No fluxo normal, após aprovação da v2, resumir a rastreabilidade no PR e manter a matriz somente até a revisão delta do roadmap.
 
 ## 7. Tratar a conclusão
 
-- `aprovado para merge do plano-base v2`: avançar para publicação.
+- `aprovado para merge do plano-base v2`: avançar para a reconciliação do roadmap.
 - `aprovado com correções obrigatórias`: corrigir a v2 e a matriz, criar nova referência imutável e solicitar `revisao_delta` ao mesmo Analista.
 - `requer nova rodada especializada`: retornar somente ao especialista do domínio indicado quando o Analista identificar questão material nova ou mudança fora do parecer original; nos demais casos, parar e apontar a incompatibilidade da conclusão.
 - `bloqueado por decisão humana`: parar e apresentar somente a decisão necessária, sem escolher pelo humano.
 
 Repetir o ciclo somente enquanto houver correções objetivas dentro do escopo. Não usar nova rodada especializada para revalidar patches já cobertos nem converter decisão material ausente em correção editorial.
 
-## 8. Publicar para decisão humana
+## 8. Reconciliar o roadmap
 
 Somente após `aprovado para merge do plano-base v2`:
 
-1. Confirmar que o diff contém apenas o plano v2 e, somente no modo `experimental`, sua matriz.
+1. Invocar `$lp-factory-abc` em modo planejamento com `DOC_ALVO: docs/roadmap.md`, usando a v2 aprovada como `RELATÓRIO` e o snapshot imutável anterior à v2 como estado inicial do documento-alvo.
+2. Exigir que a skill leia `docs/prompt-abc.md` e `docs/template-roadmap.md` e devolva o menor delta ou `SEM ALTERAÇÕES NECESSÁRIAS`.
+3. Aplicar literalmente somente as operações do ABC ao roadmap. Não alterar os demais documentos canônicos.
+4. Limitar o delta a seções e subseções do recorte, identificadores, títulos, objetivos, status planejado ou definido, limites, decisões futuras aprovadas e dependências indispensáveis.
+5. Não registrar implementação concluída, banco, migrations, arquivos, updates aplicados, evidências, comandos, PRs ou histórico operacional. Omitir `Registros do recorte` enquanto não houver implementação material.
+6. Validar com `git diff --check` e criar referência imutável da v2 aprovada com o roadmap resultante.
+7. Continuar no mesmo Analista em `revisao_delta`, entregando v2 aprovada, snapshot do roadmap, ABC emitido, roadmap resultante, `docs/prompt-abc.md` e `docs/template-roadmap.md`.
+8. Solicitar somente a auditoria da correspondência entre v2 e roadmap. Corrigir e reenviar apenas divergências objetivas; questão material nova segue a seção 7.
+9. Mesmo quando o ABC retornar `SEM ALTERAÇÕES NECESSÁRIAS`, exigir confirmação do Analista de que o snapshot já corresponde à v2.
+10. Liberar a publicação somente após nova conclusão `aprovado para merge do plano-base v2`.
+11. No fluxo normal, remover a matriz temporária antes da publicação e preservar sua rastreabilidade apenas no resumo do PR.
+
+## 9. Publicar para decisão humana
+
+Somente após a aprovação da v2 e da revisão delta do roadmap:
+
+1. Confirmar que o diff contém apenas o plano v2, `docs/roadmap.md` e, somente no modo `experimental`, sua matriz.
 2. Verificar alterações acidentais, secrets, `.env`, banco e workflows.
 3. Executar `git diff --check`; tratar `npm ci` e `npm run check` como não aplicáveis quando o diff for exclusivamente documental.
 4. Commitar a versão final e publicar a branch de automação.
@@ -156,6 +175,8 @@ Apresentar:
 - parecer integral do Gestor de Updates;
 - parecer integral do Gestor de Automações ou `N/A`;
 - Passagens 1 e 2 do Analista;
+- snapshot inicial, ABC e delta aplicado em `docs/roadmap.md`;
+- revisão delta final do roadmap pelo mesmo Analista;
 - arquivos alterados;
 - commits e validações;
 - PR draft ou link de criação;
@@ -169,5 +190,6 @@ Apresentar:
 - Não acionar especialistas fora do recorte.
 - Não permitir que custom agents editem arquivos.
 - Não executar fases do plano.
+- Não alterar outros documentos canônicos durante a reconciliação do roadmap.
 - Não avaliar implementação ou PR de código; encaminhar a execução aprovada para `$lp-factory-executar-plano`.
 - Não fazer merge nem substituir decisão humana.

--- a/.codex/agents/analista.toml
+++ b/.codex/agents/analista.toml
@@ -21,7 +21,7 @@ Em `auditoria_consolidacao`:
 - identifique omissões, incorporações aparentes, conflitos entre tratamentos e riscos novos;
 - não refaça a especialidade nem substitua sua conclusão.
 
-Em `revisao_delta`, verifique apenas as correções solicitadas e se elas criaram conflito, ampliação de escopo ou alteração material de domínio especializado. Requeira nova rodada especializada somente diante de questão material nova ou conclusão especializada efetivamente alterada.
+Em `revisao_delta`, verifique apenas as correções solicitadas e se elas criaram conflito, ampliação de escopo ou alteração material de domínio especializado. Quando o alvo for a reconciliação final do roadmap, receba a v2 já aprovada, o snapshot anterior, o ABC, o roadmap resultante e os contratos aplicáveis; audite somente correspondência, menor delta, hierarquia, residência documental e ausência de estado de implementação. Requeira nova rodada especializada somente diante de questão material nova ou conclusão especializada efetivamente alterada.
 
 Em `revisao_implementacao`, receba o trecho integral de uma única subseção canônica, o SHA do plano aprovado, o diff desde o checkpoint anterior, critérios de aceite e evidências. Verifique aderência à subseção, escopo do diff, integração com consumidores relevantes, regressões, segurança, validações e pendências documentais. Não antecipe a subseção seguinte nem reavalie especialidades já resolvidas.
 

--- a/.codex/agents/gestor-automacoes.toml
+++ b/.codex/agents/gestor-automacoes.toml
@@ -1,0 +1,48 @@
+name = "gestor-automacoes"
+description = "Avalia automações, fluxos com IA, agentes, workflows, jobs, rotinas, integrações e services previstos em planos-base do LP Factory 10."
+model = "gpt-5.6-sol"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+developer_instructions = """
+Atue exclusivamente como Gestor de Automações read-only do LP Factory 10. Avalie somente as fases recebidas que estejam marcadas como `Automação: sim` e entregue decisão suficiente para o orquestrador consolidar a v2 sem refazer sua análise.
+
+Confirme worktree, branch, repositório, PR ou referência, head SHA, path, caso e fases aplicáveis. Leia integralmente o plano e `docs/gestor-automations.md`, que é a fonte canônica de governança da especialidade. Consulte por busca direcionada `docs/automations.md`, `docs/services.md`, `docs/platform-config.md`, `docs/base-tecnica.md`, `docs/roadmap.md` e o código real somente quando forem competentes para o caso. Liste apenas fontes efetivamente inspecionadas. Em conflito, prevalece a fonte competente pelo assunto.
+
+Para cada fase aplicável, determine: natureza da solução; ambiente de execução; necessidade de OpenAI; solução mínima suficiente; benefício; custo e risco; segurança; observabilidade; manutenção; aprovação humana operacional aplicável; situação; e destino documental. Compare sempre não automatizar, automação determinística sem OpenAI, IA em fluxo controlado e comportamento agentic. Não use IA ou comportamento agentic quando solução determinística suficiente existir.
+
+Quando o caso concreto puder exigir OpenAI, consulte a documentação oficial atual usando a skill oficial disponível, confirme disponibilidade, status, superfície, limitações, guardrails e custo relevante, compare a alternativa determinística e registre as fontes oficiais. Não pesquise novidades sem necessidade concreta.
+
+Não transforme aprovação humana operacional em parada automática da orquestração. Registre-a como requisito do plano. Quando faltar uma escolha material de produto, stack, arquitetura, infraestrutura ou escopo, use `requer validação material pelo Analista`, exponha alternativas e evidências e deixe o Analista decidir se existe bloqueio humano.
+
+Use exatamente um veredito:
+- `nenhuma automação aplicável`;
+- `automação aplicável com patches autossuficientes`;
+- `requer investigação factual`;
+- `requer validação material pelo Analista`.
+
+Use `automação aplicável com patches autossuficientes` somente quando cada decisão tiver tratamento determinável pelas fontes e patch completo. Use `requer investigação factual` somente para evidência verificável ausente, informando como obtê-la. Use `requer validação material pelo Analista` quando as fontes permitirem mais de uma decisão material; não escolha pelo humano nem interrompa diretamente o workflow.
+
+Não edite arquivos, implemente, consolide, crie branch, commit ou PR, acione agentes, amplie o recorte ou mantenha documentos canônicos.
+
+Entregue:
+
+# Parecer do Gestor de Automações
+## Plano e fases avaliados
+Repositório, PR ou referência, head SHA, path, caso, fases, branch e worktree; use N/A quando necessário.
+## Fontes consultadas
+Somente fontes efetivamente inspecionadas, incluindo fontes oficiais atuais quando OpenAI for considerada.
+## Veredito
+Um veredito permitido.
+## Decisões por fase
+Para cada fase: ID estável, classificação, ambiente, necessidade de OpenAI, solução mínima recomendada, motivo e benefício, custo e risco, segurança e observabilidade, aprovação humana operacional, situação e destino documental.
+## Patches aplicáveis pelo orquestrador
+Para cada decisão aplicável: ID, seção-alvo, operação (`adicionar`, `substituir` ou `remover`), texto normativo exato ou regra inequívoca e critério de validação. Use N/A quando não houver.
+## Investigação factual
+Evidência faltante e como obtê-la; ou N/A.
+## Validação material pelo Analista
+Decisão, alternativas sustentadas pelas fontes e razão pela qual o especialista não deve escolher; ou N/A.
+## Riscos e limites
+Use N/A quando não houver.
+## Próximo passo mínimo e seguro
+Uma ação objetiva ao orquestrador.
+"""

--- a/docs/orquestracao-plano-base.md
+++ b/docs/orquestracao-plano-base.md
@@ -1,8 +1,8 @@
 # Orquestração de planos-base no Codex
 
-Data: 20/07/2026
-Versão: v0.8
-Status: Fluxos de plano e execução validados no experimento E18.5; fluxo normal corrigido para operar sem PRs empilhados; fechamento documental pendente de decisão.
+Data: 22/07/2026
+Versão: v0.9
+Status: Fluxos de plano e execução validados no experimento E18.5; Gestor de Automações integrado de forma condicional e pendente de teste próprio; fechamento documental pendente de decisão.
 
 ## 1. Objetivo e função deste documento
 
@@ -23,7 +23,7 @@ O resultado esperado é reduzir coordenação manual e cópia de contexto entre 
 
 Este documento será a fonte humana do desenho aprovado. A skill executará o workflow definido aqui; cada custom agent aplicará seu contrato runtime; e o task principal permanecerá responsável pela coordenação, pelas alterações no repositório e pela entrega ao humano.
 
-O teste estrutural isolado da seção 2 foi validado. Os contratos do Gestor Estrutural e do Analista foram otimizados, o Gestor de Updates foi integrado e a execução E18.5.3–E18.5.9 foi concluída com gates por subseção e gate final de testes. Os PRs empilhados usados nessa comparação são exceção histórica e não integram o fluxo normal.
+O teste estrutural isolado da seção 2 foi validado. Os contratos do Gestor Estrutural e do Analista foram otimizados, o Gestor de Updates foi integrado, o Gestor de Automações foi adicionado condicionalmente e a execução E18.5.3–E18.5.9 foi concluída com gates por subseção e gate final de testes. Os PRs empilhados usados nessa comparação são exceção histórica e não integram o fluxo normal.
 
 ## 2. Primeiro passo: teste do Gestor Estrutural
 
@@ -199,7 +199,7 @@ Este passo não inclui:
 
 O terceiro passo reúne os dois testes anteriores em uma única entrada humana. Foi criada a skill `lp-factory-orquestrar-plano`, localizada em `.agents/skills/lp-factory-orquestrar-plano/`.
 
-Ela não cria um custom agent de orquestração. O task comum permanece como orquestrador e executor, enquanto `gestor-estrutural`, `gestor-updates` e `analista` permanecem read-only e aplicam seus contratos runtime.
+Ela não cria um custom agent de orquestração. O task comum permanece como orquestrador e executor, enquanto `gestor-estrutural`, `gestor-updates`, `gestor-automacoes` e `analista` permanecem read-only e aplicam seus contratos runtime.
 
 ### 4.1 Entrada mínima
 
@@ -227,19 +227,28 @@ No experimento E18.5, o destino usado foi:
 2. Atualizar a `main` e criar a branch da v2 no checkout simples ou selecionar uma única worktree de automação quando houver frente paralela.
 3. Acionar o Gestor Estrutural e preservar o parecer integral.
 4. Acionar o Gestor de Updates sobre a mesma v1 e preservar o parecer integral.
-5. Aplicar os patches autossuficientes dos dois especialistas, produzir a v2 e preparar a matriz de consolidação, sem nova rodada especializada padrão.
-6. Criar referência imutável da v2 e acionar o Analista sem pareceres ou matriz.
-7. Depois da Passagem 1, gravar a matriz e entregá-la com os dois pareceres ao mesmo Analista.
-8. Corrigir ou encaminhar pendências conforme a conclusão formal.
-9. No fluxo normal, publicar um único PR draft da v2 contra `main` somente após aprovação do Analista.
+5. Acionar o Gestor de Automações somente se alguma fase estiver marcada como `Automação: sim`; caso contrário, registrar `N/A`.
+6. Aplicar os patches autossuficientes dos especialistas acionados, produzir a v2 e preparar a matriz de consolidação, sem nova rodada especializada padrão.
+7. Criar referência imutável da v2 e acionar o Analista sem pareceres ou matriz.
+8. Depois da Passagem 1, gravar a matriz e entregá-la com os pareceres dos especialistas acionados ao mesmo Analista.
+9. Corrigir ou encaminhar pendências conforme a conclusão formal.
+10. No fluxo normal, publicar um único PR draft da v2 contra `main` somente após aprovação do Analista.
 
 A matriz não é gravada antes da Passagem 1. Isso impede que a avaliação independente seja contaminada por um arquivo acessível na própria worktree.
 
 ### 4.4 Limites do fluxo de plano integrado
 
-Este recorte inclui Gestor Estrutural, Gestor de Updates, consolidação pelo orquestrador e gate do Analista. O Gestor de Updates consulta obrigatoriamente os quatro catálogos vigentes, mas não os mantém nem pesquisa novos updates fora deles. Gestor de Automações continua fora do fluxo até teste próprio.
+Este recorte inclui Gestor Estrutural, Gestor de Updates, Gestor de Automações quando aplicável, consolidação pelo orquestrador e gate do Analista. O Gestor de Updates consulta obrigatoriamente os quatro catálogos vigentes, mas não os mantém nem pesquisa novos updates fora deles. O Gestor de Automações é acionado exclusivamente por `Automação: sim`, avalia somente essas fases e não pesquisa recursos sem caso concreto.
 
 O teste E18.5 foi considerado válido porque uma instrução humana curta produziu dois pareceres especializados rastreáveis, uma v2 rastreável e duas passagens não contaminadas do Analista, sem edição feita pelos custom agents. O PR filho usado na comparação permanece como evidência excepcional; o workflow não permite novos PRs empilhados. O modo experimental altera apenas os checkpoints e também exige a versão do plano incorporada à `main` antes de qualquer mutação.
+
+### 4.5 Entidades do Gestor de Automações
+
+1. `.codex/agents/gestor-automacoes.toml`: contrato runtime read-only, baseado na governança de `docs/gestor-automations.md`.
+2. `.agents/skills/lp-factory-avaliar-plano-automacoes/`: seleção das fases aplicáveis, delegação, validação e devolução do parecer.
+3. `.agents/skills/lp-factory-orquestrar-plano/SKILL.md`: gatilho condicional, consolidação e encaminhamento ao Analista.
+
+Aprovação humana operacional indicada pelo especialista vira requisito do plano e não interrompe automaticamente a orquestração. Escolhas materiais são registradas para avaliação do Analista, que decide se existe bloqueio humano.
 
 ## 5. Quarto passo: execução end-to-end do plano aprovado
 

--- a/docs/orquestracao-plano-base.md
+++ b/docs/orquestracao-plano-base.md
@@ -1,8 +1,8 @@
 # Orquestração de planos-base no Codex
 
 Data: 22/07/2026
-Versão: v0.9
-Status: Fluxos de plano e execução validados no experimento E18.5; Gestor de Automações integrado de forma condicional e pendente de teste próprio; fechamento documental pendente de decisão.
+Versão: v0.10
+Status: Fluxos de plano e execução validados no experimento E18.5; Gestor de Automações integrado de forma condicional; reconciliação planejada do roadmap incorporada e pendente de teste próprio; fechamento documental da implementação pendente de decisão.
 
 ## 1. Objetivo e função deste documento
 
@@ -14,16 +14,17 @@ Seu objetivo é estabelecer, antes da implementação, um contrato humano verifi
 2. coordena as avaliações dos especialistas aplicáveis;
 3. orienta o orquestrador a transformar o plano-base v1 em v2 e registrar uma matriz de consolidação dos pareceres;
 4. entrega v1 e v2 ao Analista para avaliação independente e, depois, entrega pareceres e matriz para auditoria da consolidação;
-5. conduz a execução de uma subseção canônica por vez, na mesma branch e PR de implementação;
-6. devolve cada checkpoint e a entrega final ao Analista antes do avanço ou merge;
-7. interrompe o fluxo nos pontos que exigem decisão humana ou teste humano;
-8. permite retomar a mesma frente sem merge entre subseções.
+5. reconcilia o roadmap com a v2 aprovada e submete o delta ao mesmo Analista;
+6. conduz a execução de uma subseção canônica por vez, na mesma branch e PR de implementação;
+7. devolve cada checkpoint e a entrega final ao Analista antes do avanço ou merge;
+8. interrompe o fluxo nos pontos que exigem decisão humana ou teste humano;
+9. permite retomar a mesma frente sem merge entre subseções.
 
 O resultado esperado é reduzir coordenação manual e cópia de contexto entre tarefas, sem transferir ao Codex decisões que pertencem ao humano e sem permitir que agentes especializados alterem o repositório.
 
 Este documento será a fonte humana do desenho aprovado. A skill executará o workflow definido aqui; cada custom agent aplicará seu contrato runtime; e o task principal permanecerá responsável pela coordenação, pelas alterações no repositório e pela entrega ao humano.
 
-O teste estrutural isolado da seção 2 foi validado. Os contratos do Gestor Estrutural e do Analista foram otimizados, o Gestor de Updates foi integrado, o Gestor de Automações foi adicionado condicionalmente e a execução E18.5.3–E18.5.9 foi concluída com gates por subseção e gate final de testes. Os PRs empilhados usados nessa comparação são exceção histórica e não integram o fluxo normal.
+O teste estrutural isolado da seção 2 foi validado. Os contratos do Gestor Estrutural e do Analista foram otimizados, o Gestor de Updates foi integrado, o Gestor de Automações foi adicionado condicionalmente e a reconciliação planejada do roadmap foi incorporada ao fluxo da v2. A execução E18.5.3–E18.5.9 foi concluída com gates por subseção e gate final de testes. Os PRs empilhados usados nessa comparação são exceção histórica e não integram o fluxo normal.
 
 ## 2. Primeiro passo: teste do Gestor Estrutural
 
@@ -223,22 +224,24 @@ No experimento E18.5, o destino usado foi:
 
 ### 4.3 Sequência integrada
 
-1. Congelar a v1 pelo head SHA e blob do PR informado.
+1. Congelar a v1 pelo head SHA e blob do PR informado e registrar snapshot imutável do roadmap já atualizado pela entrega da v1.
 2. Atualizar a `main` e criar a branch da v2 no checkout simples ou selecionar uma única worktree de automação quando houver frente paralela.
 3. Acionar o Gestor Estrutural e preservar o parecer integral.
 4. Acionar o Gestor de Updates sobre a mesma v1 e preservar o parecer integral.
 5. Acionar o Gestor de Automações somente se alguma fase estiver marcada como `Automação: sim`; caso contrário, registrar `N/A`.
-6. Aplicar os patches autossuficientes dos especialistas acionados, produzir a v2 e preparar a matriz de consolidação, sem nova rodada especializada padrão.
+6. Aplicar os patches autossuficientes dos especialistas acionados, produzir a v2 preservando a estrutura da v1 salvo alteração estrutural especializada rastreável e preparar a matriz de consolidação, sem nova rodada especializada padrão.
 7. Criar referência imutável da v2 e acionar o Analista sem pareceres ou matriz.
 8. Depois da Passagem 1, gravar a matriz e entregá-la com os pareceres dos especialistas acionados ao mesmo Analista.
 9. Corrigir ou encaminhar pendências conforme a conclusão formal.
-10. No fluxo normal, publicar um único PR draft da v2 contra `main` somente após aprovação do Analista.
+10. Usar `$lp-factory-abc` em modo planejamento para reconciliar o snapshot do roadmap com a v2 aprovada.
+11. Submeter o roadmap resultante ao mesmo Analista em revisão delta.
+12. No fluxo normal, publicar um único PR draft da v2 contra `main` somente após aprovação da v2 e do roadmap reconciliado.
 
 A matriz não é gravada antes da Passagem 1. Isso impede que a avaliação independente seja contaminada por um arquivo acessível na própria worktree.
 
 ### 4.4 Limites do fluxo de plano integrado
 
-Este recorte inclui Gestor Estrutural, Gestor de Updates, Gestor de Automações quando aplicável, consolidação pelo orquestrador e gate do Analista. O Gestor de Updates consulta obrigatoriamente os quatro catálogos vigentes, mas não os mantém nem pesquisa novos updates fora deles. O Gestor de Automações é acionado exclusivamente por `Automação: sim`, avalia somente essas fases e não pesquisa recursos sem caso concreto.
+Este recorte inclui Gestor Estrutural, Gestor de Updates, Gestor de Automações quando aplicável, consolidação pelo orquestrador, gate do Analista e reconciliação final do roadmap. O Gestor de Updates consulta obrigatoriamente os quatro catálogos vigentes, mas não os mantém nem pesquisa novos updates fora deles. O Gestor de Automações é acionado exclusivamente por `Automação: sim`, avalia somente essas fases e não pesquisa recursos sem caso concreto.
 
 O teste E18.5 foi considerado válido porque uma instrução humana curta produziu dois pareceres especializados rastreáveis, uma v2 rastreável e duas passagens não contaminadas do Analista, sem edição feita pelos custom agents. O PR filho usado na comparação permanece como evidência excepcional; o workflow não permite novos PRs empilhados. O modo experimental altera apenas os checkpoints e também exige a versão do plano incorporada à `main` antes de qualquer mutação.
 
@@ -249,6 +252,20 @@ O teste E18.5 foi considerado válido porque uma instrução humana curta produz
 3. `.agents/skills/lp-factory-orquestrar-plano/SKILL.md`: gatilho condicional, consolidação e encaminhamento ao Analista.
 
 Aprovação humana operacional indicada pelo especialista vira requisito do plano e não interrompe automaticamente a orquestração. Escolhas materiais são registradas para avaliação do Analista, que decide se existe bloqueio humano.
+
+### 4.6 Preservação da v1 e reconciliação do roadmap
+
+A v2 mantém ordem, seções, hierarquia e granularidade da v1. Criar ou consolidar seção exige parecer especializado com achado e patch autossuficiente rastreados na matriz.
+
+Depois de `aprovado para merge do plano-base v2`, o orquestrador usa:
+
+1. a v2 aprovada como `RELATÓRIO`;
+2. o snapshot imutável de `docs/roadmap.md` produzido após a v1;
+3. `$lp-factory-abc` em modo planejamento, regida por `docs/prompt-abc.md` e `docs/template-roadmap.md`.
+
+O menor delta pode registrar somente estrutura do recorte, identificadores, títulos, objetivos, status planejado ou definido, limites, decisões futuras aprovadas e dependências indispensáveis. Não registra implementação, banco, migrations, arquivos, updates, evidências, comandos, PRs ou histórico operacional e não altera outros documentos canônicos.
+
+O mesmo Analista recebe v2, snapshot, ABC e roadmap resultante em `revisao_delta`. A publicação só é liberada após confirmação de alinhamento, inclusive quando o ABC concluir `SEM ALTERAÇÕES NECESSÁRIAS`. No fluxo normal, o PR final contém apenas plano-base v2 e roadmap; a matriz temporária é removida antes da publicação.
 
 ## 5. Quarto passo: execução end-to-end do plano aprovado
 


### PR DESCRIPTION
## Objetivo
Completar o fluxo automático de plano-base v2 com Gestor de Automações, preservação estrutural da v1 e reconciliação final do roadmap.

## Mudanças
- cria o custom agent read-only `gestor-automacoes` e sua skill;
- aciona esse especialista somente com `Automação: sim`;
- preserva ordem, seções, hierarquia e granularidade da v1;
- permite criar ou consolidar seção somente por patch especializado rastreável;
- reduz `$lp-factory-abc` de 295 para 57 linhas e torna `docs/prompt-abc.md` seu contrato canônico;
- adiciona modo planejamento para plano-base v1/v2;
- registra snapshot imutável do roadmap anterior à v2;
- após aprovação da v2, gera o menor delta do roadmap usando v2 + snapshot + ABC;
- submete o roadmap resultante ao mesmo Analista em `revisao_delta`;
- mantém outros documentos canônicos e a implementação fora desse PR.

## Validação
- TOML do Analista parseado com sucesso;
- frontmatter e metadados da skill ABC verificados;
- cláusulas críticas dos três contratos verificadas;
- `git diff --check` aprovado;
- `npm ci` e `npm run check`: não aplicáveis.

O `quick_validate.py` não pôde executar porque o runtime não contém `PyYAML`; foram realizadas verificações estruturais equivalentes.