### PR TITLE
docs: atualizar catálogo Supabase em 22/07/2026

### DIFF
--- a/docs/supa-up.md
+++ b/docs/supa-up.md
@@ -1817,7 +1817,7 @@ A ferramenta ajuda a verificar o comportamento das políticas declaradas, mas n�
 
 ### Descrição
 
-Supabase Pipelines é um serviço gerenciado de change data capture (CDC) que replica alterações do Postgres para destinos analíticos em quase tempo real. Na public alpha, BigQuery é o destino aberto a todos os planos pagos; ClickHouse, Snowflake e DuckLake dependem de acesso antecipado.
+Supabase Pipelines é um serviço gerenciado de change data capture (CDC), apresentado oficialmente em dezembro de 2025 e disponibilizado em public alpha em 21/07/2026, que replica alterações do Postgres para destinos analíticos em quase tempo real. Na public alpha, BigQuery é o destino aberto a todos os planos pagos; ClickHouse, Snowflake e DuckLake dependem de acesso antecipado.
 
 A entrega é ao menos uma vez, inclui cópia inicial, filtros por tabela, coluna ou linha, suporte a mudanças de schema selecionadas e monitoramento pelo Dashboard. Os dados são replicados sem transformação.
 
@@ -1836,6 +1836,7 @@ A entrega é ao menos uma vez, inclui cópia inicial, filtros por tabela, coluna
 
 - Não criar BigQuery, warehouse, replication slot, pipeline, credencial, job ou nova infraestrutura.
 - Public alpha, somente em planos pagos e com cobrança por hora e por volume replicado.
+- No destino BigQuery, cada tabela de origem precisa de chave primária incluída na publicação; colunas geradas não são suportadas e tipos customizados são replicados como texto.
 - Entrega ao menos uma vez exige tratamento de duplicidade no destino.
 - Replicação sem transformação não substitui modelagem, governança, LGPD, controle de acesso ou política de retenção.
 - Avaliar carga no WAL, recuperação, mudanças de schema, exposição de dados, região e dependência do destino.
@@ -1859,14 +1860,15 @@ Avaliar somente quando houver:
 
 ### Fonte Oficial
 
-- [Supabase Changelog — Supabase Pipelines](https://supabase.com/changelog)
+- [Supabase Changelog — Public Alpha: Supabase Pipelines](https://supabase.com/changelog/48158-public-alpha-supabase-pipelines)
+- [Supabase Blog — Introducing Supabase Pipelines](https://supabase.com/blog/introducing-supabase-pipelines)
 
 ### Registro (Tipo C — Infra/Dados)
 
 - Status: PENDENTE
 - Verificado em: 2026-07-22
 - Ambiente futuro: Supabase Pipelines + destino analítico aprovado
-- Evidência: changelog oficial de 21/07/2026 e ausência de warehouse/CDC no repositório
+- Evidência: changelog oficial de 21/07/2026, anúncio oficial de dezembro de 2025 e ausência de warehouse/CDC no repositório
 - Observação: o registro não autoriza implementação, mudança de stack ou nova infraestrutura.
 
 ---
@@ -1890,6 +1892,8 @@ Avaliar somente quando houver:
 - `log_connections` off por padrão: configuração operacional a ser tratada no Supabase e em `docs/platform-config.md`, não item permanente do catálogo.
 - Connect para `@supabase/server`: SDK não adotado; o projeto usa `@supabase/ssr`.
 - Docker self-hosted: projeto usa Supabase Cloud; configuração local já está em Postgres 17 e contempla `/auth/v1`.
+- Envoy como gateway padrão do Supabase self-hosted: não afeta o projeto hospedado no Supabase Cloud e não constitui capacidade aproveitável separada.
+- `@supabase/supabase-js` exigirá TypeScript 5.0+ a partir de 31/01/2027: o projeto já fixa TypeScript `5.5.4`, portanto não há ação nem item permanente de catálogo.
 - Heym: workflow engine sem caso aprovado e com dependência/licenciamento próprios.
 
 ### Limite da rodada

--- a/docs/supa-up.md
+++ b/docs/supa-up.md
@@ -1805,10 +1805,77 @@ A ferramenta ajuda a verificar o comportamento das políticas declaradas, mas n�
 
 ---
 
+
+## 64 — Supabase Pipelines para CDC analítico *(🧪 Public alpha; adoção condicional)*
+
+2026-07-21
+
+### Status no Projeto
+
+- Status: Não implementado — capacidade futura condicionada a destino analítico aprovado
+- Evidência: o LP Factory 10 usa Supabase Postgres como base transacional, mas não possui BigQuery, warehouse ou pipeline CDC aprovado no roadmap, na Base Técnica ou em `docs/services.md`
+
+### Descrição
+
+Supabase Pipelines é um serviço gerenciado de change data capture (CDC) que replica alterações do Postgres para destinos analíticos em quase tempo real. Na public alpha, BigQuery é o destino aberto a todos os planos pagos; ClickHouse, Snowflake e DuckLake dependem de acesso antecipado.
+
+A entrega é ao menos uma vez, inclui cópia inicial, filtros por tabela, coluna ou linha, suporte a mudanças de schema selecionadas e monitoramento pelo Dashboard. Os dados são replicados sem transformação.
+
+### Valor para o Projeto
+
+- Pode isolar consultas analíticas pesadas do banco transacional quando volume e relatórios futuros justificarem um warehouse.
+- Preserva uma alternativa gerenciada a exportações e pipelines CDC próprios.
+- Pode apoiar analytics históricos ou planos superiores sem alterar a stack transacional do Core.
+- Complementa o Supabase Postgres; não substitui agregações simples, exports pontuais nem a arquitetura atual.
+
+### Valor para o Usuário
+
+- Futuro e indireto: relatórios mais amplos sem transferir carga analítica pesada para o runtime transacional.
+
+### Limites no MVP
+
+- Não criar BigQuery, warehouse, replication slot, pipeline, credencial, job ou nova infraestrutura.
+- Public alpha, somente em planos pagos e com cobrança por hora e por volume replicado.
+- Entrega ao menos uma vez exige tratamento de duplicidade no destino.
+- Replicação sem transformação não substitui modelagem, governança, LGPD, controle de acesso ou política de retenção.
+- Avaliar carga no WAL, recuperação, mudanças de schema, exposição de dados, região e dependência do destino.
+- Não usar para resolver analytics que continuem simples e seguros no Postgres.
+
+### Gatilho futuro de avaliação
+
+Avaliar somente quando houver:
+
+1. destino analítico aprovado e responsável operacional definido;
+2. volume ou consulta analítica que gere impacto mensurável no banco transacional;
+3. vantagem comprovada sobre agregações internas, exportação pontual ou job simples;
+4. custo, região, segurança, retenção, duplicidade e recuperação formalmente avaliados.
+
+### Ações Recomendadas
+
+1. Manter como opção futura e condicional.
+2. Não implementar no MVP atual.
+3. Reavaliar maturidade, destinos e preços quando surgir caso analítico real.
+4. Comparar com alternativas mais simples antes de adotar.
+
+### Fonte Oficial
+
+- [Supabase Changelog — Supabase Pipelines](https://supabase.com/changelog)
+
+### Registro (Tipo C — Infra/Dados)
+
+- Status: PENDENTE
+- Verificado em: 2026-07-22
+- Ambiente futuro: Supabase Pipelines + destino analítico aprovado
+- Evidência: changelog oficial de 21/07/2026 e ausência de warehouse/CDC no repositório
+- Observação: o registro não autoriza implementação, mudança de stack ou nova infraestrutura.
+
+---
+
 ## Registro da rodada — Supabase Update July 2026
 
 ### Updates incorporados ao catálogo ativo
 
+- Supabase Pipelines: criado como `supa#64`, condicionado a destino analítico e carga real que justifiquem CDC.
 - MongoDB Foreign Data Wrapper: incorporado ao `supa#4`.
 - Realtime Broadcast com payload binário: registrado como nota complementar do `supa#26`, com maturidade e eventual adoção separadas.
 - Audit Log Drains: incorporado ao `supa#46`.


### PR DESCRIPTION
## 1. Veredito

- Reavaliação do catálogo Supabase concluída isoladamente, antes do início dos demais catálogos.
- Comparação com a primeira execução: a decisão de adicionar `supa#64` foi confirmada, mas o relatório anterior omitiu o aviso sobre TypeScript 5.0+.
- Manter os itens ativos existentes.
- Adicionar `supa#64`, Supabase Pipelines, como capacidade futura e condicional.
- Não remover item.
- Atualizar o registro da rodada com os recursos avaliados e não adicionados.

## 2. Fontes consultadas

- `README.md`.
- `docs/workflow-atualizacao-updates.md`.
- `docs/supa-up.md` no SHA inicial.
- `docs/base-tecnica.md`, `docs/platform-config.md`, `docs/services.md`, `docs/automations.md` e `docs/roadmap.md`.
- `package.json`.
- Supabase Changelog oficial: https://supabase.com/changelog
- Public Alpha: Supabase Pipelines: https://supabase.com/changelog/48158-public-alpha-supabase-pipelines
- Introducing Supabase Pipelines: https://supabase.com/blog/introducing-supabase-pipelines
- Envoy como gateway padrão do self-hosted: https://supabase.com/changelog/48048-self-hosted-supabase-envoy-becomes-the-default-api-gateway-breaking-change
- Aviso de TypeScript 5.0+: https://supabase.com/changelog/47812-deprecation-notice-supabase-supabase-js-will-require-typescript-5-0

## 3. Itens mantidos

- IDs: `supa#2`, `supa#3`, `supa#4`, `supa#5`, `supa#6`, `supa#7`, `supa#8`, `supa#9`, `supa#10`, `supa#12`, `supa#14`, `supa#15`, `supa#16`, `supa#18`, `supa#19`, `supa#20`, `supa#25`, `supa#26`, `supa#27`, `supa#28`, `supa#29`, `supa#30`, `supa#32`, `supa#33`, `supa#34`, `supa#35`, `supa#37`, `supa#39`, `supa#40`, `supa#41`, `supa#42`, `supa#43`, `supa#45`, `supa#46`, `supa#47`, `supa#48`, `supa#49`, `supa#50`, `supa#51`, `supa#52`, `supa#53`, `supa#54`, `supa#56`, `supa#57`, `supa#59`, `supa#60`, `supa#61`, `supa#62` e `supa#63`.

## 4. Itens ajustados

- Nenhum item ativo anterior foi ajustado.
- O registro da rodada foi ampliado para explicitar o Envoy self-hosted e o aviso de TypeScript 5.0+ entre os recursos avaliados e não adicionados.
- O novo `supa#64` recebeu fontes diretas e limitações oficiais do destino BigQuery.

## 5. Itens removidos

- Nenhum.

## 6. Itens adicionados

### 6.1 `supa#64` — Supabase Pipelines para CDC analítico

- Natureza de uso: infraestrutura de dados e operação analítica futura.
- Relação com a stack e a arquitetura: complementar ao Supabase Postgres e parcialmente sobreposto a exports e pipelines CDC próprios.
- Horizonte: futuro e condicional.
- Valor: separar carga analítica pesada do banco transacional e preservar uma alternativa gerenciada à construção antecipada de CDC próprio.
- Gatilho: destino analítico aprovado, impacto mensurável no banco transacional e vantagem comprovada sobre agregações internas, exportação pontual ou job simples.
- Fontes: changelog oficial de 21/07/2026 e anúncio oficial de dezembro de 2025.
- Dependências: plano pago, destino analítico, credenciais, governança, região e responsável operacional.
- Riscos e limites: public alpha, custo por hora e volume, entrega ao menos uma vez, duplicidade, replicação sem transformação, WAL, LGPD e dependência do destino. Para BigQuery, as tabelas precisam de chave primária; colunas geradas não são suportadas e tipos customizados são replicados como texto.
- Confirmação: o registro não autoriza BigQuery, warehouse, pipeline, replication slot, credencial, job ou qualquer implementação.

## 7. Itens avaliados e não adicionados

### 7.1 Envoy como gateway padrão no Supabase self-hosted

- Motivo objetivo: o projeto usa Supabase Cloud; a mudança é específica do pacote self-hosted.
- Não foi rejeitado por estar fora do MVP, mas por incompatibilidade com o modo de hospedagem real.

### 7.2 Requisito futuro de TypeScript 5.0+ no `@supabase/supabase-js`

- Motivo objetivo: o projeto já fixa TypeScript `5.5.4`; o requisito previsto para 31/01/2027 já está atendido e não representa capacidade aproveitável para o catálogo.
- O aviso foi verificado e não exige alteração técnica ou novo item.

### 7.3 Destinos ClickHouse, Snowflake e DuckLake como itens separados

- Motivo objetivo: são destinos do próprio `supa#64`, com acesso antecipado; itens separados duplicariam a mesma capacidade.
- Não foram rejeitados por estarem fora do MVP.

## 8. Pontos não validados ou lacunas documentais

### 8.1 Estado do Supabase Pipelines no Dashboard

- Evidência faltante: inspeção direta da conta para confirmar disponibilidade regional e eventual habilitação.
- Forma de validação: verificar o Dashboard somente se o gatilho futuro for atingido.
- A ausência de warehouse e CDC no repositório é suficiente para classificá-lo agora como não implementado.

## 9. Validação do diff

- Branch originada do SHA inicial comum `6fd5530fbf33a6aef9c15494162f72ee3fc0fe77`, que continua sendo a `main`.
- Apenas `docs/supa-up.md` foi alterado.
- Maior ID histórico identificado antes da inclusão: `supa#63`.
- Novo ID: `supa#64`.
- Lacunas históricas preservadas: `1`, `11`, `13`, `17`, `21–24`, `31`, `36`, `38`, `44`, `55` e `58`.
- Não houve renumeração, reutilização de ID ou remoção sem evidência.
- O conteúdo segue a política tecnológica do `README.md`.
- Nenhum item foi adicionado apenas por ser novo ou moderno.
- Nenhum recurso foi descartado somente por estar fora do MVP.
- Catalogação não autoriza implementação, mudança de stack, nova infraestrutura ou ampliação de escopo.
