### PR TITLE
docs: atualizar catálogo GitHub em 22/07/2026

### DIFF
--- a/docs/github-up.md
+++ b/docs/github-up.md
@@ -34,27 +34,39 @@ Antes de registrar um item, confirmar fonte oficial, valor para o projeto, plano
 ## github#4 — Workflows em PRs criados por bots após aprovação *(🟩 Estável)*
 
 2026-06-13
+Atualizado em 2026-07-22
 
 ### Status no Projeto
 
-- Status: Não implementado.
+- Status: Aplicável — automação existente; validação operacional pendente.
+- Evidência: `.github/workflows/pipeline-docs-apply-report.yml` usa `peter-evans/create-pull-request@v6` com `contents: write` e `pull-requests: write` para criar PRs automáticos; `.github/workflows/security.yml` executa em `pull_request` para `main` e `macro`.
 
 ### Descrição
 
-PRs criados por `github-actions[bot]` agora podem executar workflows de CI/CD após aprovação de um usuário com permissão de escrita no repositório.
+PRs criados por `github-actions[bot]` podem executar workflows de CI/CD após aprovação de um usuário com permissão de escrita no repositório. A aprovação libera a execução antes impedida pelas proteções contra automações recursivas; ela não aprova nem faz merge do PR.
 
 ### Valor para o Projeto
 
-- Permite que PRs criados pelo bot executem workflows após revisão e aprovação humana.
+- O caso deixou de ser apenas hipotético: o pipeline documental já cria PRs por automação.
+- Permite que checks de PR, incluindo o workflow de segurança quando aplicável, sejam executados após aprovação humana.
+- Preserva revisão humana e evita ampliar permissões ou usar credencial alternativa apenas para disparar workflows.
 
 ### Ações Recomendadas
 
-1. Avaliar somente quando automações do projeto criarem PRs pelo bot.
+1. Na próxima execução real do `pipeline-docs-apply-report`, verificar se o PR criado pelo bot solicita aprovação de workflows.
+2. Quando solicitado, um usuário com permissão de escrita deve revisar a origem do PR e aprovar apenas a execução dos checks esperados.
+3. Registrar o comportamento operacional depois da primeira validação real.
+4. Não usar este recurso para aprovação automática, merge automático ou ampliação de permissões.
+
+### Limites
+
+- A aprovação do workflow não substitui revisão do diff nem autorização de merge.
+- O comportamento só é relevante para PR criado pelo bot que precise disparar outro workflow.
+- O registro não autoriza alterar workflows ou tokens.
 
 ### Fonte Oficial
 
 - [Bot-created pull requests can run workflows if approved](https://github.blog/changelog/2026-06-11-bot-created-pull-requests-can-run-workflows-if-approved/)
-
 ---
 
 ## github#5 — Copilot CLI em GitHub Actions com GITHUB_TOKEN *(🟨 Avaliação futura)*

--- a/docs/github-up.md
+++ b/docs/github-up.md
@@ -229,3 +229,60 @@ O Dependabot passou a aguardar por padrão três dias após a publicação de um
 ### Fonte Oficial
 
 - [Dependabot version updates introduce default package cooldown](https://github.blog/changelog/2026-07-14-dependabot-version-updates-introduce-default-package-cooldown/)
+
+---
+
+## github#10 — Workflow execution protections por ator e evento *(🧪 Public preview; adoção condicional)*
+
+2026-06-18
+Verificado em 2026-07-22
+
+### Status no Projeto
+
+- Status: Não implementado — disponibilidade e configuração pendentes de validação.
+- Evidência: o repositório possui workflows acionados por `pull_request` e `workflow_dispatch`, incluindo `pipeline-docs-apply-report.yml` com permissões de escrita; não há registro de Actions policy ou workflow execution protection configurada.
+
+### Descrição
+
+As workflow execution protections permitem criar uma allow list para controlar quais atores podem iniciar GitHub Actions e quais eventos podem disparar workflows. As primeiras regras cobrem atores — usuários, papéis, GitHub Apps, Copilot e Dependabot — e eventos como `push`, `pull_request`, `pull_request_target` e `workflow_dispatch`.
+
+O recurso usa a estrutura de rulesets e oferece modo de avaliação antes da aplicação obrigatória.
+
+### Valor para o Projeto
+
+- Pode restringir `workflow_dispatch` e outros eventos sensíveis a responsáveis autorizados.
+- Pode impedir que um ator não confiável execute workflow modificado e alcance permissões ou secrets.
+- Complementa permissões mínimas no YAML e revisão humana; não substitui essas proteções.
+- Tem caso concreto porque o repositório já opera múltiplos workflows e um pipeline documental com `contents: write` e `pull-requests: write`.
+
+### Valor para o Usuário
+
+- Benefício indireto por reduzir risco de execução indevida, alteração do repositório e consumo desnecessário de Actions.
+
+### Limites
+
+- Recurso em public preview e sujeito a mudanças.
+- A disponibilidade depende do nível de configuração, do plano e da visibilidade do repositório; deve ser confirmada novamente se o repositório se tornar privado.
+- Não bloquear eventos ou atores antes de testar em modo de avaliação e mapear os workflows legítimos.
+- O registro não autoriza criar ruleset, alterar workflow, permissões, secrets ou plano do GitHub.
+
+### Gatilho de avaliação
+
+Avaliar configuração somente quando:
+
+1. a opção estiver disponível na conta e no repositório;
+2. os eventos e atores legítimos estiverem inventariados;
+3. o efeito sobre PRs humanos, PRs de bot, Dependabot e `workflow_dispatch` estiver documentado;
+4. houver modo de avaliação ou teste reversível antes da aplicação obrigatória.
+
+### Ações Recomendadas
+
+1. Verificar a disponibilidade em Settings → Actions → Policies.
+2. Se disponível, mapear primeiro atores e eventos atuais sem alterar o comportamento.
+3. Usar modo de avaliação antes de qualquer bloqueio.
+4. Revalidar plano e disponibilidade após eventual mudança do repositório para privado.
+
+### Fontes Oficiais
+
+- [GitHub Changelog — Control who and what triggers GitHub Actions workflows](https://github.blog/changelog/2026-06-18-control-who-and-what-triggers-github-actions-workflows/)
+- [GitHub Docs — About Actions policies](https://docs.github.com/en/enterprise-cloud@latest/admin/enforcing-policies/enforcing-policies-for-your-enterprise/actions-policies/about-actions-policies)


### PR DESCRIPTION
## 1. Veredito

- Reavaliação do catálogo GitHub concluída isoladamente após o fechamento de Vercel/Next.js.
- Comparação com a primeira execução: o ajuste de `github#4` foi confirmado, mas a capacidade de workflow execution protections havia sido omitida.
- Ajustar `github#4`: o caso deixou de ser hipotético porque o repositório já possui automação que cria PRs.
- Adicionar `github#10` como capacidade de segurança atual e condicional.
- Manter os demais itens e não remover ID.

## 2. Fontes consultadas

- `README.md`.
- `docs/workflow-atualizacao-updates.md`.
- `docs/github-up.md` no SHA inicial.
- `docs/base-tecnica.md`, `docs/platform-config.md`, `docs/services.md`, `docs/automations.md` e `docs/roadmap.md`.
- `.github/workflows/pipeline-docs-apply-report.yml`.
- `.github/workflows/security.yml`.
- GitHub Changelog oficial: https://github.blog/changelog/
- PRs criados por bot: https://github.blog/changelog/2026-06-11-bot-created-pull-requests-can-run-workflows-if-approved/
- Workflow execution protections: https://github.blog/changelog/2026-06-18-control-who-and-what-triggers-github-actions-workflows/
- Actions policies: https://docs.github.com/en/enterprise-cloud@latest/admin/enforcing-policies/enforcing-policies-for-your-enterprise/actions-policies/about-actions-policies
- Rulesets e disponibilidade: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets

## 3. Itens mantidos

- IDs: `github#5`, `github#6`, `github#7`, `github#8` e `github#9`.

## 4. Itens ajustados

### 4.1 `github#4` — Workflows em PRs criados por bots após aprovação

- Ajuste: status alterado de não implementado para aplicável com automação existente e validação operacional pendente.
- Motivo: `pipeline-docs-apply-report.yml` usa `peter-evans/create-pull-request@v6` para criar PR automático; `security.yml` escuta `pull_request`.
- Fonte: repositório no SHA inicial e changelog oficial sobre execução de workflows em PRs criados por bot após aprovação.
- Limite: a aprovação libera checks; não aprova nem faz merge do PR e não autoriza ampliar tokens.

## 5. Itens removidos

- Nenhum.

## 6. Itens adicionados

### 6.1 `github#10` — Workflow execution protections por ator e evento

- Natureza de uso: segurança e governança operacional do GitHub Actions.
- Relação com a stack e a arquitetura: complementar aos workflows e permissões mínimas existentes.
- Horizonte: atual e condicional à disponibilidade na conta, no plano e na visibilidade do repositório.
- Valor: controlar quais atores podem iniciar workflows e quais eventos — como `pull_request` e `workflow_dispatch` — podem executá-los.
- Caso concreto: o repositório possui múltiplos workflows e um pipeline documental com `contents: write` e `pull-requests: write`.
- Gatilho: opção disponível em Settings → Actions → Policies, inventário dos atores/eventos legítimos e teste reversível em modo de avaliação.
- Fontes: changelog oficial de 18/06/2026 e documentação oficial de Actions policies.
- Dependências, riscos e limites: public preview, rulesets, possibilidade de bloquear fluxos legítimos e disponibilidade dependente do plano/visibilidade; revalidar se o repositório se tornar privado.
- Confirmação: o registro não autoriza criar ruleset, alterar workflow, permissões, secrets ou plano do GitHub.

## 7. Itens avaliados e não adicionados

### 7.1 GitHub Code Quality GA

- Motivo objetivo: disponível em GitHub Team e Enterprise Cloud como produto pago separado, a US$ 10 por committer ativo/mês, mais uso de IA e compute do Actions.
- O projeto está em conta pessoal GitHub Free e possui checks mais simples; custo e complexidade são desproporcionais no horizonte atual.
- Não foi rejeitado somente por estar fora do MVP; pode ser reavaliado com mudança de plano, equipe e volume de código.

### 7.2 Gemini 3.6 Flash no GitHub Copilot

- Motivo objetivo: disponibilidade de modelo não cria caso de uso, vantagem mensurável ou adoção de Copilot no fluxo do projeto.
- Novidade de modelo, isoladamente, não justifica entrada.

### 7.3 Copilot usage metrics impact dashboard

- Motivo objetivo: recurso para administradores Enterprise e owners de organizações com métricas Copilot.
- Incompatível com a conta pessoal Free e sem utilidade operacional atual.

### 7.4 Mudança de support bundles no GHES

- Motivo objetivo: o projeto usa GitHub Cloud, não GitHub Enterprise Server.
- Incompatível com a hospedagem real.

### 7.5 AI credit pools e métricas de billing do Copilot

- Motivo objetivo: dependem de organização ou Enterprise e gestão de uso Copilot não adotada.
- Sem caso concreto ou custo atual a governar.

### 7.6 Security review no GitHub Copilot app

- Motivo objetivo: o projeto não adota o GitHub Copilot app como ferramenta de revisão; já possui fluxo próprio de segurança e revisão.
- Pode ser reavaliado somente diante de adoção real do Copilot; não foi descartado por estar fora do MVP.

### 7.7 Novo dashboard de pull requests

- Motivo objetivo: melhoria global da interface do GitHub, absorvida automaticamente e sem decisão ou configuração própria do projeto.
- Não exige item permanente no catálogo ativo.

## 8. Pontos não validados ou lacunas documentais

### 8.1 Primeira execução real de checks em PR criado pelo bot

- Evidência faltante: run real posterior ao novo comportamento do GitHub.
- Forma de validação: executar o pipeline documental quando houver report válido, observar a solicitação de aprovação e confirmar os checks esperados.
- O catálogo registra aplicabilidade, não validação concluída.

### 8.2 Disponibilidade das workflow execution protections

- Evidência faltante: inspeção da conta em Settings → Actions → Policies.
- Forma de validação: verificar a opção na situação atual e revalidar após eventual mudança do repositório para privado.
- Não presumir que a disponibilidade de rulesets será idêntica entre repositório público e privado na conta Free.

## 9. Validação do diff

- Branch originada do SHA inicial comum `6fd5530fbf33a6aef9c15494162f72ee3fc0fe77`, que continua sendo a `main`.
- Apenas `docs/github-up.md` foi alterado.
- Maior ID histórico identificado antes da inclusão: `github#9`.
- Novo ID: `github#10`.
- Lacunas históricas `github#1`, `github#2` e `github#3` preservadas.
- Não houve renumeração, reutilização de ID ou remoção sem evidência.
- O conteúdo segue a política tecnológica do `README.md`.
- Nenhum item foi adicionado apenas por ser novo ou moderno.
- Nenhum recurso foi descartado somente por estar fora do MVP.
- Catalogação não autoriza implementação, mudança de stack, nova infraestrutura ou ampliação de escopo.
