### PR TITLE
docs: tornar workflow de updates outcome-first e sequencial

### DIFF
--- a/docs/workflow-atualizacao-updates.md
+++ b/docs/workflow-atualizacao-updates.md
@@ -1,28 +1,83 @@
-21/07/2026 — Workflow de Atualização dos Catálogos de Updates
+22/07/2026 — Workflow de Atualização dos Catálogos de Updates
 
 Fontes: chat, repositório e documentos indicados nos itens 2 e 3
 
-## 1. Papel e objetivo
+Referência de estrutura: `docs/template-prompts.md`, com abordagem outcome-first
+
+## 1. Resultado obrigatório e papel
+
+### 1.1. Resultado obrigatório
+
+Ao final de uma única execução, o estado esperado é:
+
+- quatro análises completas, realizadas na ordem do item 2;
+- cada catálogo concluído como ciclo fechado antes do início da análise do seguinte;
+- um draft PR independente para cada catálogo que exigir ajuste real;
+- uma exceção registrada no resumo final para cada catálogo que não exigir ajuste, sem criar alteração artificial;
+- todas as branches criadas a partir do mesmo SHA inicial de `main`;
+- somente o documento-alvo alterado em cada branch;
+- IDs e lacunas históricas preservados, sem renumeração ou reutilização;
+- nenhum PR mergeado e nenhuma catalogação transformada em implementação.
+
+A execução somente pode ser declarada integralmente aderente quando a auditoria final confirmar que a sequência realmente executada corresponde a este workflow.
+
+### 1.2. Papel
 
 - Manter os catálogos de updates atuais, úteis e baseados em fontes oficiais.
-- Entregar, em uma única execução, um draft PR independente para cada catálogo, sem aprovação humana intermediária.
+- Executar o workflow sem aprovação humana intermediária entre os catálogos, respeitando a unidade e a ordem obrigatórias.
 
-## 2. Documentos-alvo e ordem
+### 1.3. Critérios de conclusão
+
+- Os quatro catálogos foram analisados do início ao fim, um de cada vez.
+- Cada catálogo possui checkpoint concluído antes do início do seguinte.
+- Cada ajuste real possui diff validado e draft PR próprio.
+- Cada ausência de ajuste está justificada no resumo final.
+- A auditoria final da base, arquivos, IDs, PRs e sequência não encontrou divergência.
+- Bloqueios ou exceções estão identificados de forma exata.
+
+## 2. Documentos-alvo, ordem e unidade de execução
+
+### 2.1. Ordem obrigatória
 
 1. `docs/supa-up.md`
 2. `docs/vercel-up.md`
 3. `docs/github-up.md`
 4. `docs/prod-up.md`
 
+### 2.2. Unidade indivisível
+
+Para cada catálogo, a unidade de execução é o ciclo completo:
+
+- leitura;
+- verificação dos IDs e das lacunas históricas;
+- verificação do repositório e de possíveis duplicações;
+- pesquisa;
+- avaliação e classificação;
+- relatório;
+- criação da branch;
+- alteração do documento, quando necessária;
+- validação do diff;
+- abertura do draft PR, quando houver ajuste;
+- checkpoint do catálogo.
+
+O ciclo deve ser concluído antes de iniciar leitura analítica, pesquisa, classificação, edição, branch ou PR do catálogo seguinte.
+
+Não é permitido agrupar, paralelizar ou reorganizar etapas entre catálogos. O mesmo SHA inicial serve apenas como base comum das branches e não autoriza processamento em lote.
+
+A consulta pontual aos outros catálogos para detectar duplicações não inicia a análise deles. A análise completa de cada um continua restrita à sua posição na ordem obrigatória.
+
+### 2.3. Isolamento das branches
+
 Cada catálogo deve usar branch própria criada a partir do mesmo SHA inicial de `main`. Somente o documento-alvo pode ser alterado; os demais são referências de leitura para detectar duplicações.
 
 ## 3. Fontes
 
-Consultar:
+Consultar, dentro do ciclo do catálogo atual:
 
 - o `README.md`, como política geral de avaliação tecnológica;
 - o documento-alvo no SHA inicial;
 - o repositório e os documentos técnicos relacionados aos itens avaliados;
+- os relatórios e diffs dos catálogos anteriores já concluídos nesta execução;
 - fontes oficiais externas correspondentes.
 
 Para Supabase, usar documentação, changelog e blog oficiais. Para Vercel, usar fontes oficiais da Vercel, Next.js e React. Para GitHub e produto, seguir as fontes prioritárias definidas nos próprios catálogos.
@@ -31,30 +86,75 @@ Fontes secundárias podem apoiar, mas não substituir a fonte oficial.
 
 ## 4. Execução
 
-1. Congelar o SHA inicial de `main` e confirmar o `README.md` e os quatro documentos-alvo.
-2. Para cada catálogo, na ordem do item 2:
-   - ler o `README.md`, o documento-alvo e suas regras de catálogo ativo e IDs; preservar IDs e lacunas históricas, sem renumerar ou reutilizar ID, e atribuir novo ID somente acima do maior ID histórico identificado;
-   - verificar no repositório o estado real dos itens e possíveis duplicações, incluindo o uso global e seu registro na Base Técnica;
-   - considerar os relatórios e diffs já produzidos nesta execução;
-   - pesquisar recursos novos, alterados, deprecados ou superados;
-   - para cada item existente ou recurso pesquisado, identificar:
-     - função no projeto e natureza de uso: produto, operação ou desenvolvimento;
-     - relação com a stack e a arquitetura: complementar, sobreposto, substituto ou incompatível;
-     - caso de uso e valor concreto;
-     - maturidade e qualidade das fontes;
-     - custo, complexidade, segurança, manutenção, dependências e riscos;
-     - horizonte plausível: atual, futuro ou condicional;
-     - hipótese de superioridade e gatilho objetivo de comparação ou adoção, quando sobreposto ou substituto;
-   - classificar itens existentes como manter, ajustar ou remover; remover item globalmente usado somente quando esse uso estiver registrado na Base Técnica; se houver uso real sem registro, classificá-lo como lacuna documental e mantê-lo no catálogo;
-   - classificar recursos pesquisados como adicionar, não adicionar ou não validado;
-   - adicionar somente recurso compatível com a política do `README.md`, com fonte oficial, valor concreto e horizonte plausível; um recurso futuro ou condicional pode entrar no catálogo mesmo fora do MVP, sem autorizar implementação;
-   - não adicionar, ou remover quando aplicável, recurso incompatível, duplicado, absorvido, deprecado, superado, sem caso de uso ou valor concreto, com custo ou risco desproporcional sem horizonte plausível, ou sobreposto/substituto sem hipótese concreta de superioridade e gatilho objetivo;
-   - classificar como não validado quando a fonte oficial ou a evidência necessária para a decisão do item for insuficiente, sem presumir adoção ou descarte;
-   - produzir o relatório obrigatório;
-   - criar branch independente, ajustar somente o documento-alvo e validar o diff;
-   - abrir um draft PR com o relatório no corpo.
-3. Seguir automaticamente ao próximo catálogo, sem aguardar aprovação ou merge.
-4. Ao final, entregar os quatro PRs e um resumo de bloqueios ou exceções.
+### 4.1. Preparação única
+
+- Congelar o SHA inicial de `main`.
+- Confirmar o `README.md` e a existência dos quatro documentos-alvo.
+- Registrar a ordem obrigatória.
+- Não iniciar leitura analítica ou pesquisa de nenhum catálogo nesta preparação.
+
+### 4.2. Ciclo obrigatório por catálogo
+
+Para cada catálogo, na ordem do item 2:
+
+- ler o `README.md`, o documento-alvo e suas regras de catálogo ativo e IDs;
+- identificar o maior ID histórico e todas as lacunas antes de decidir qualquer novo ID;
+- preservar IDs e lacunas históricas, sem renumerar ou reutilizar ID, e atribuir novo ID somente acima do maior ID histórico identificado;
+- verificar no repositório o estado real dos itens e possíveis duplicações, incluindo o uso global e seu registro na Base Técnica;
+- considerar somente os relatórios e diffs dos catálogos anteriores já concluídos nesta execução;
+- pesquisar recursos novos, alterados, deprecados ou superados;
+- para cada item existente ou recurso pesquisado, identificar:
+  - função no projeto e natureza de uso: produto, operação ou desenvolvimento;
+  - relação com a stack e a arquitetura: complementar, sobreposto, substituto ou incompatível;
+  - caso de uso e valor concreto;
+  - maturidade e qualidade das fontes;
+  - custo, complexidade, segurança, manutenção, dependências e riscos;
+  - horizonte plausível: atual, futuro ou condicional;
+  - hipótese de superioridade e gatilho objetivo de comparação ou adoção, quando sobreposto ou substituto;
+- classificar itens existentes como manter, ajustar ou remover;
+- remover item globalmente usado somente quando esse uso estiver registrado na Base Técnica;
+- quando houver uso real sem registro, classificar como lacuna documental e manter o item no catálogo;
+- classificar recursos pesquisados como adicionar, não adicionar ou não validado;
+- adicionar somente recurso compatível com a política do `README.md`, com fonte oficial, valor concreto e horizonte plausível;
+- permitir que recurso futuro ou condicional entre no catálogo mesmo fora do MVP, sem autorizar implementação;
+- não adicionar, ou remover quando aplicável, recurso incompatível, duplicado, absorvido, deprecado, superado, sem caso de uso ou valor concreto, com custo ou risco desproporcional sem horizonte plausível, ou sobreposto/substituto sem hipótese concreta de superioridade e gatilho objetivo;
+- classificar como não validado quando a fonte oficial ou a evidência necessária para a decisão do item for insuficiente, sem presumir adoção ou descarte;
+- produzir o relatório obrigatório;
+- criar branch independente a partir do SHA inicial;
+- ajustar somente o documento-alvo, quando houver alteração real;
+- validar o diff;
+- abrir um draft PR com o relatório no corpo, quando houver ajuste;
+- concluir o checkpoint do catálogo.
+
+### 4.3. Checkpoint obrigatório por catálogo
+
+Antes de iniciar o catálogo seguinte, registrar:
+
+- catálogo e documento analisados;
+- SHA inicial comum;
+- maior ID histórico e lacunas preservadas;
+- itens mantidos, ajustados, removidos, adicionados, não adicionados e não validados;
+- branch criada, quando houver ajuste;
+- confirmação de que somente o documento-alvo foi alterado;
+- resultado da validação do diff;
+- URL do draft PR ou justificativa para ausência de alteração;
+- confirmação de que nenhuma etapa analítica do catálogo seguinte foi iniciada.
+
+Somente depois de concluir esse checkpoint, seguir automaticamente ao próximo catálogo, sem aguardar aprovação ou merge.
+
+### 4.4. Auditoria final
+
+Ao final dos quatro ciclos:
+
+- comparar a sequência realmente executada com a ordem e a unidade definidas no item 2;
+- confirmar que as quatro análises partiram do mesmo SHA inicial;
+- confirmar que cada branch altera somente seu documento-alvo;
+- confirmar que os IDs e as lacunas históricas foram preservados;
+- confirmar que os PRs permanecem em draft e não foram mergeados;
+- confirmar que não houve implementação, mudança de stack, nova infraestrutura ou ampliação de escopo;
+- entregar os PRs e um resumo de bloqueios ou exceções.
+
+Se a sequência executada divergir do workflow, não declarar execução integralmente aderente. Informar a divergência e refazer de forma sequencial os ciclos afetados antes da conclusão.
 
 ## 5. Relatório obrigatório
 
@@ -95,6 +195,9 @@ Fontes secundárias podem apoiar, mas não substituir a fonte oficial.
    - confirmar aderência à política de avaliação tecnológica do `README.md`;
    - confirmar que nenhum item foi adicionado apenas por ser novo ou moderno;
    - confirmar que nenhum recurso foi descartado somente por estar fora do MVP.
+10. Checkpoint de execução:
+    - confirmar que o catálogo foi concluído antes do início da análise do seguinte;
+    - informar branch e draft PR ou justificar a ausência de alteração.
 
 ## 6. Limites e parada
 
@@ -103,6 +206,8 @@ Fontes secundárias podem apoiar, mas não substituir a fonte oficial.
 - Não tratar catalogação como decisão de aplicação a um plano-base, fase ou recorte; essa aplicabilidade será recomendada pelo Gestor de Updates e consolidada pelo Estrategista no fluxo competente.
 - Não adicionar item sem fonte oficial, valor concreto e compatibilidade com a política tecnológica do `README.md`.
 - Não rejeitar item somente por estar fora do MVP; novidade ou modernidade, isoladamente, também não justificam sua entrada.
+- Não renumerar IDs nem reutilizar lacunas deixadas por itens excluídos.
+- Não pesquisar, analisar, editar ou publicar catálogos em lote ou em paralelo.
 - Não realizar merge dos PRs.
 - Não criar alteração artificial quando o catálogo não exigir ajuste; registrar a exceção no resumo final.
 - Quando faltar fonte obrigatória do workflow, houver conflito material ou faltar permissão, informar exatamente o bloqueio e parar.

--- a/docs/workflow-atualizacao-updates.md
+++ b/docs/workflow-atualizacao-updates.md
@@ -4,75 +4,35 @@ Fontes: chat, repositório e documentos indicados nos itens 2 e 3
 
 Referência de estrutura: `docs/template-prompts.md`, com abordagem outcome-first
 
-## 1. Resultado obrigatório e papel
+## 1. Resultado esperado e papel
 
-### 1.1. Resultado obrigatório
+### 1.1. Resultado esperado
 
-Ao final de uma única execução, o estado esperado é:
+Ao final de uma única execução:
 
-- quatro análises completas, realizadas na ordem do item 2;
-- cada catálogo concluído como ciclo fechado antes do início da análise do seguinte;
-- um draft PR independente para cada catálogo que exigir ajuste real;
-- uma exceção registrada no resumo final para cada catálogo que não exigir ajuste, sem criar alteração artificial;
-- todas as branches criadas a partir do mesmo SHA inicial de `main`;
-- somente o documento-alvo alterado em cada branch;
-- IDs e lacunas históricas preservados, sem renumeração ou reutilização;
-- nenhum PR mergeado e nenhuma catalogação transformada em implementação.
-
-A execução somente pode ser declarada integralmente aderente quando a auditoria final confirmar que a sequência realmente executada corresponde a este workflow.
+- os quatro catálogos foram analisados na ordem do item 2;
+- cada catálogo foi concluído da leitura ao relatório e ao draft PR ou à justificativa antes do início da análise do seguinte, sem processamento em lote ou paralelo;
+- cada ajuste real está em branch própria criada do mesmo SHA inicial de `main`, alterando somente o documento-alvo;
+- IDs e lacunas históricas foram preservados, sem renumeração ou reutilização;
+- ausências de ajuste, bloqueios e exceções foram registradas;
+- nenhum PR foi mergeado nem a catalogação transformada em implementação.
 
 ### 1.2. Papel
 
-- Manter os catálogos de updates atuais, úteis e baseados em fontes oficiais.
-- Executar o workflow sem aprovação humana intermediária entre os catálogos, respeitando a unidade e a ordem obrigatórias.
+- Manter os catálogos de updates atuais, úteis e baseados em fontes oficiais, sem aprovação humana intermediária entre eles.
 
-### 1.3. Critérios de conclusão
-
-- Os quatro catálogos foram analisados do início ao fim, um de cada vez.
-- Cada catálogo possui checkpoint concluído antes do início do seguinte.
-- Cada ajuste real possui diff validado e draft PR próprio.
-- Cada ausência de ajuste está justificada no resumo final.
-- A auditoria final da base, arquivos, IDs, PRs e sequência não encontrou divergência.
-- Bloqueios ou exceções estão identificados de forma exata.
-
-## 2. Documentos-alvo, ordem e unidade de execução
-
-### 2.1. Ordem obrigatória
+## 2. Documentos-alvo e ordem
 
 1. `docs/supa-up.md`
 2. `docs/vercel-up.md`
 3. `docs/github-up.md`
 4. `docs/prod-up.md`
 
-### 2.2. Unidade indivisível
-
-Para cada catálogo, a unidade de execução é o ciclo completo:
-
-- leitura;
-- verificação dos IDs e das lacunas históricas;
-- verificação do repositório e de possíveis duplicações;
-- pesquisa;
-- avaliação e classificação;
-- relatório;
-- criação da branch;
-- alteração do documento, quando necessária;
-- validação do diff;
-- abertura do draft PR, quando houver ajuste;
-- checkpoint do catálogo.
-
-O ciclo deve ser concluído antes de iniciar leitura analítica, pesquisa, classificação, edição, branch ou PR do catálogo seguinte.
-
-Não é permitido agrupar, paralelizar ou reorganizar etapas entre catálogos. O mesmo SHA inicial serve apenas como base comum das branches e não autoriza processamento em lote.
-
-A consulta pontual aos outros catálogos para detectar duplicações não inicia a análise deles. A análise completa de cada um continua restrita à sua posição na ordem obrigatória.
-
-### 2.3. Isolamento das branches
-
-Cada catálogo deve usar branch própria criada a partir do mesmo SHA inicial de `main`. Somente o documento-alvo pode ser alterado; os demais são referências de leitura para detectar duplicações.
+Os demais catálogos podem ser consultados apenas para detectar duplicações. Isso não inicia sua análise.
 
 ## 3. Fontes
 
-Consultar, dentro do ciclo do catálogo atual:
+Consultar, para o catálogo em execução:
 
 - o `README.md`, como política geral de avaliação tecnológica;
 - o documento-alvo no SHA inicial;
@@ -86,75 +46,25 @@ Fontes secundárias podem apoiar, mas não substituir a fonte oficial.
 
 ## 4. Execução
 
-### 4.1. Preparação única
-
-- Congelar o SHA inicial de `main`.
-- Confirmar o `README.md` e a existência dos quatro documentos-alvo.
-- Registrar a ordem obrigatória.
-- Não iniciar leitura analítica ou pesquisa de nenhum catálogo nesta preparação.
-
-### 4.2. Ciclo obrigatório por catálogo
-
-Para cada catálogo, na ordem do item 2:
-
-- ler o `README.md`, o documento-alvo e suas regras de catálogo ativo e IDs;
-- identificar o maior ID histórico e todas as lacunas antes de decidir qualquer novo ID;
-- preservar IDs e lacunas históricas, sem renumerar ou reutilizar ID, e atribuir novo ID somente acima do maior ID histórico identificado;
-- verificar no repositório o estado real dos itens e possíveis duplicações, incluindo o uso global e seu registro na Base Técnica;
-- considerar somente os relatórios e diffs dos catálogos anteriores já concluídos nesta execução;
-- pesquisar recursos novos, alterados, deprecados ou superados;
-- para cada item existente ou recurso pesquisado, identificar:
-  - função no projeto e natureza de uso: produto, operação ou desenvolvimento;
-  - relação com a stack e a arquitetura: complementar, sobreposto, substituto ou incompatível;
-  - caso de uso e valor concreto;
-  - maturidade e qualidade das fontes;
-  - custo, complexidade, segurança, manutenção, dependências e riscos;
-  - horizonte plausível: atual, futuro ou condicional;
-  - hipótese de superioridade e gatilho objetivo de comparação ou adoção, quando sobreposto ou substituto;
-- classificar itens existentes como manter, ajustar ou remover;
-- remover item globalmente usado somente quando esse uso estiver registrado na Base Técnica;
-- quando houver uso real sem registro, classificar como lacuna documental e manter o item no catálogo;
-- classificar recursos pesquisados como adicionar, não adicionar ou não validado;
-- adicionar somente recurso compatível com a política do `README.md`, com fonte oficial, valor concreto e horizonte plausível;
-- permitir que recurso futuro ou condicional entre no catálogo mesmo fora do MVP, sem autorizar implementação;
-- não adicionar, ou remover quando aplicável, recurso incompatível, duplicado, absorvido, deprecado, superado, sem caso de uso ou valor concreto, com custo ou risco desproporcional sem horizonte plausível, ou sobreposto/substituto sem hipótese concreta de superioridade e gatilho objetivo;
-- classificar como não validado quando a fonte oficial ou a evidência necessária para a decisão do item for insuficiente, sem presumir adoção ou descarte;
-- produzir o relatório obrigatório;
-- criar branch independente a partir do SHA inicial;
-- ajustar somente o documento-alvo, quando houver alteração real;
-- validar o diff;
-- abrir um draft PR com o relatório no corpo, quando houver ajuste;
-- concluir o checkpoint do catálogo.
-
-### 4.3. Checkpoint obrigatório por catálogo
-
-Antes de iniciar o catálogo seguinte, registrar:
-
-- catálogo e documento analisados;
-- SHA inicial comum;
-- maior ID histórico e lacunas preservadas;
-- itens mantidos, ajustados, removidos, adicionados, não adicionados e não validados;
-- branch criada, quando houver ajuste;
-- confirmação de que somente o documento-alvo foi alterado;
-- resultado da validação do diff;
-- URL do draft PR ou justificativa para ausência de alteração;
-- confirmação de que nenhuma etapa analítica do catálogo seguinte foi iniciada.
-
-Somente depois de concluir esse checkpoint, seguir automaticamente ao próximo catálogo, sem aguardar aprovação ou merge.
-
-### 4.4. Auditoria final
-
-Ao final dos quatro ciclos:
-
-- comparar a sequência realmente executada com a ordem e a unidade definidas no item 2;
-- confirmar que as quatro análises partiram do mesmo SHA inicial;
-- confirmar que cada branch altera somente seu documento-alvo;
-- confirmar que os IDs e as lacunas históricas foram preservados;
-- confirmar que os PRs permanecem em draft e não foram mergeados;
-- confirmar que não houve implementação, mudança de stack, nova infraestrutura ou ampliação de escopo;
-- entregar os PRs e um resumo de bloqueios ou exceções.
-
-Se a sequência executada divergir do workflow, não declarar execução integralmente aderente. Informar a divergência e refazer de forma sequencial os ciclos afetados antes da conclusão.
+1. Congelar o SHA inicial de `main` e confirmar o `README.md` e os quatro documentos-alvo.
+2. Para cada catálogo, na ordem do item 2, concluir todo o ciclo antes de iniciar a análise do seguinte:
+   - ler as fontes aplicáveis e as regras do catálogo;
+   - identificar o maior ID histórico e preservar todos os IDs e lacunas, atribuindo novo ID somente acima do maior já utilizado;
+   - verificar no repositório o estado real dos itens, duplicações, uso global e registro na Base Técnica;
+   - pesquisar recursos novos, alterados, deprecados ou superados;
+   - avaliar função, natureza de uso, relação com a stack, caso de uso, valor, maturidade das fontes, custo, complexidade, segurança, manutenção, dependências, riscos e horizonte;
+   - exigir hipótese de superioridade e gatilho objetivo para recurso sobreposto ou substituto;
+   - classificar itens existentes como manter, ajustar ou remover, e recursos pesquisados como adicionar, não adicionar ou não validado;
+   - manter item com uso real sem registro na Base Técnica como lacuna documental; remover item usado globalmente somente quando esse uso estiver documentado;
+   - adicionar somente recurso compatível com o `README.md`, com fonte oficial, valor concreto e horizonte plausível; recurso futuro ou condicional pode entrar sem autorizar implementação;
+   - não adicionar ou remover, conforme aplicável, recurso incompatível, duplicado, absorvido, deprecado, superado, sem valor concreto ou com custo ou risco desproporcional;
+   - classificar como não validado quando faltar fonte oficial ou evidência suficiente;
+   - produzir o relatório obrigatório;
+   - quando houver ajuste, criar branch do SHA inicial, alterar somente o documento-alvo, validar o diff e abrir draft PR com o relatório;
+   - quando não houver ajuste, registrar a justificativa sem criar alteração artificial;
+   - confirmar documento, IDs e lacunas, resultado do diff e URL do PR ou justificativa antes de seguir.
+3. Seguir automaticamente ao próximo catálogo, sem aguardar aprovação ou merge.
+4. Ao final, conferir a sequência executada, a base comum, os arquivos alterados, os IDs e o estado dos PRs. Se houver divergência, informá-la e não declarar execução integralmente aderente.
 
 ## 5. Relatório obrigatório
 
@@ -190,24 +100,18 @@ Se a sequência executada divergir do workflow, não declarar execução integra
    - item;
    - evidência faltante;
    - forma de validação.
-9. Validação do diff:
-   - confirmar que não houve renumeração, reutilização de ID ou remoção sem evidência documental suficiente;
-   - confirmar aderência à política de avaliação tecnológica do `README.md`;
-   - confirmar que nenhum item foi adicionado apenas por ser novo ou moderno;
-   - confirmar que nenhum recurso foi descartado somente por estar fora do MVP.
-10. Checkpoint de execução:
-    - confirmar que o catálogo foi concluído antes do início da análise do seguinte;
-    - informar branch e draft PR ou justificar a ausência de alteração.
+9. Validação:
+   - confirmar que o catálogo foi concluído antes do início da análise do seguinte;
+   - informar branch e draft PR ou justificar a ausência de alteração;
+   - confirmar que não houve renumeração, reutilização de ID ou remoção sem evidência suficiente;
+   - confirmar aderência ao `README.md`;
+   - confirmar que novidade, modernidade ou distância do MVP não determinaram isoladamente a decisão.
 
 ## 6. Limites e parada
 
 - Não alterar código, roadmap, Base Técnica, schema, configuração ou outro catálogo.
-- Não transformar update pesquisado em implementação, mudança de stack, nova infraestrutura ou novo escopo do MVP.
-- Não tratar catalogação como decisão de aplicação a um plano-base, fase ou recorte; essa aplicabilidade será recomendada pelo Gestor de Updates e consolidada pelo Estrategista no fluxo competente.
-- Não adicionar item sem fonte oficial, valor concreto e compatibilidade com a política tecnológica do `README.md`.
-- Não rejeitar item somente por estar fora do MVP; novidade ou modernidade, isoladamente, também não justificam sua entrada.
-- Não renumerar IDs nem reutilizar lacunas deixadas por itens excluídos.
-- Não pesquisar, analisar, editar ou publicar catálogos em lote ou em paralelo.
+- Não transformar catalogação em implementação, mudança de stack, nova infraestrutura ou novo escopo do MVP.
+- Não decidir aplicação em plano-base, fase ou recorte; o Gestor de Updates recomenda e o Estrategista consolida no fluxo competente.
+- Não adicionar item sem fonte oficial, valor concreto e compatibilidade com o `README.md`.
 - Não realizar merge dos PRs.
-- Não criar alteração artificial quando o catálogo não exigir ajuste; registrar a exceção no resumo final.
-- Quando faltar fonte obrigatória do workflow, houver conflito material ou faltar permissão, informar exatamente o bloqueio e parar.
+- Quando faltar fonte obrigatória, houver conflito material ou faltar permissão, informar exatamente o bloqueio e parar.


### PR DESCRIPTION
## 1. Resultado

Reorganiza e reduz `docs/workflow-atualizacao-updates.md` para aplicar outcome-first sem repetir controles em várias seções.

## 2. O que mudou

- declara no início o estado final esperado;
- exige concluir um catálogo da leitura ao relatório e ao draft PR ou justificativa antes de iniciar o seguinte;
- proíbe processamento em lote ou paralelo nessa regra única;
- preserva IDs e lacunas históricas e atribui novos IDs somente acima do maior já utilizado;
- mantém a mesma base, isolamento por documento, relatório, limites e parada;
- elimina blocos redundantes de critérios, unidade indivisível, checkpoint e auditoria.

## 3. Motivo

A primeira versão do PR repetia as mesmas proteções e aumentava o workflow de 109 para 214 linhas. A versão atual concentra cada regra no ponto em que ela é executada e mantém somente os controles necessários para evitar a falha anterior.

## 4. Fontes do projeto

- `README.md`
- `AGENTS.md`
- `docs/template-prompts.md`
- `docs/workflow-atualizacao-updates.md`

## 5. Validação

- documento reduzido de 214 para 118 linhas;
- diferença líquida de apenas 9 linhas em relação à versão da `main`;
- um único arquivo alterado: `docs/workflow-atualizacao-updates.md`;
- PR permanece draft, aberto e sem merge;
- nenhum catálogo, código, configuração, schema ou infraestrutura foi alterado;
- `npm ci`: não aplicável, alteração exclusivamente documental;
- `npm run check`: não aplicável, alteração exclusivamente documental.
