### PR TITLE
docs: atualiza estado do GitHub CLI

### DIFF
--- a/docs/gestor-codex.md
+++ b/docs/gestor-codex.md
@@ -39,11 +39,11 @@ Configurações sustentam o fluxo local adotado para editar, validar e publicar 
 
 ### GitHub CLI (`gh`)
 
-**Aptidão:** criar PRs e consultar recursos do GitHub pelo terminal.
-**Estado:** não adotado; indisponível no teste de publicação que retornou `gh` não reconhecido.
-**Valor:** pode reduzir etapas manuais ao criar PRs, consultar PRs, checks e diffs depois do `git push`.
-**Limite:** não é dependência obrigatória do fluxo local; não instalar ferramenta nem alterar autenticação durante tarefas do Executor.
-**Fallback:** quando `gh` estiver indisponível, seguir `AGENTS.md`: concluir commit/push e entregar link de criação do PR.
+**Aptidão:** criar PRs e consultar PRs, checks e diffs pelo terminal.
+**Estado:** instalado e autenticado localmente.
+**Uso:** teste controlado.
+**Valor:** agiliza a criação de PRs e a consulta de PRs, checks e diffs pelo terminal.
+**Limite:** seguir as regras operacionais de `AGENTS.md`.
 
 **Outras configurações:** GitHub Web é a fonte de verdade para PRs, Actions, preview e merge; GitHub Desktop está fora do fluxo principal; não há hooks, conexões ou worktrees ativos.
 


### PR DESCRIPTION
### Motivation

- Registrar que o GitHub CLI (`gh`) está instalado e autenticado localmente e que seu uso será em teste controlado.
- Reduzir redundância ao remover regras já cobertas pelo `AGENTS.md` e manter apenas uma referência curta a ele.
- Limitar a alteração apenas à seção sobre `GitHub CLI (gh)` em `docs/gestor-codex.md` conforme escopo solicitado.

### Description

- Atualizei exclusivamente a seção `GitHub CLI (gh)` em `docs/gestor-codex.md` para refletir `Estado: instalado e autenticado localmente`, `Uso: teste controlado`, e ajustar `Aptidão`, `Valor` e `Limite` conforme solicitado.
- Removi texto redundante sobre regras operacionais e referenciei `AGENTS.md` em vez de repetir regras de branch/PR/merge/publicação.
- Arquivo alterado: `docs/gestor-codex.md`.
- Branch usada para a alteração: `docs/atualiza-github-cli`.

### Testing

- Executados: `git diff --check` e verificação de diff do commit, ambos concluídos com sucesso e confirmando que a alteração é restrita a `docs/gestor-codex.md`.
- Executados: verificação de arquivos alterados e `git status --short --branch`, ambos indicando apenas `docs/gestor-codex.md` modificado na branch dedicada.
- `npm ci`: não aplicável (alteração exclusivamente documental).
- `npm run check`: não aplicável (alteração exclusivamente documental).
- Publicação: tentativa de envio da branch falhou automaticamente porque o clone não possui um remote `origin` configurado, então a branch não foi publicada (push não concluído).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62554c05988329b785a2d275dd4711)