### PR TITLE
fix: unificar orquestração e execução no mesmo PR

### DIFF
--- a/.agents/skills/lp-factory-executar-plano/SKILL.md
+++ b/.agents/skills/lp-factory-executar-plano/SKILL.md
@@ -1,28 +1,41 @@
 ---
 name: lp-factory-executar-plano
-description: Executar end-to-end um plano-base v2 aprovado e incorporado à main do LP Factory 10, uma subseção canônica do roadmap por vez, na mesma branch e PR de implementação, com validação e gate do Analista. Usar após o merge humano da v2 ou em experimento explicitamente autorizado.
+description: "Executar end-to-end um plano-base v2 aprovado do LP Factory 10, uma subseção canônica do roadmap por vez, com validação e gate do Analista. Usar como subfluxo interno de lp-factory-orquestrar-plano na mesma branch e PR da v2 ou, de forma independente, quando a v2 já estiver incorporada à main."
 ---
 
 # Executar plano-base aprovado
 
-Manter o task principal como orquestrador e executor. No fluxo normal, criar uma única branch a partir da `main` atualizada e um único PR de implementação contra `main`; subseções são checkpoints internos, nunca PRs ou merges intermediários.
+Manter o task principal como orquestrador e executor. No handoff interno, continuar na branch e no PR únicos já abertos pela orquestração. Na execução independente, criar uma única branch a partir da `main` atualizada e um único PR de implementação contra `main`. Subseções são checkpoints internos, nunca PRs ou merges intermediários.
 
 ## Entrada
 
-Aceitar como comando suficiente a referência do plano-base v2:
+Na execução independente, aceitar como comando suficiente a referência do plano-base v2:
 
 `Use $lp-factory-executar-plano no plano-base aprovado do PR #<número>.`
 
+No handoff interno de `$lp-factory-orquestrar-plano`, não exigir nova instrução humana. Receber o checkpoint `LP-Factory-Stage: plan-v2-approved` e continuar no mesmo task.
+
 Usar `end-to-end` por padrão no fluxo normal. Exigir `experimental` explícito para parar nos checkpoints solicitados pelo humano.
 
-Exigir que a v2 esteja na `main` antes de qualquer implementação. O modo experimental altera somente os checkpoints; não autoriza mutação sobre v2 não incorporada. Nunca criar PR empilhado.
+Exigir que a v2 esteja na `main` somente na execução independente. No handoff interno, aceitar a v2 aprovada pelo Analista no checkpoint `plan-v2-approved` da mesma branch e PR contra `main`. Nunca criar PR empilhado.
+
+## Handoff interno
+
+Quando invocada por `$lp-factory-orquestrar-plano`:
+
+1. Confirmar que branch, worktree e PR são os mesmos usados para produzir a v2.
+2. Confirmar o checkpoint `plan-v2-approved` e usar esse commit como contrato imutável.
+3. Não criar branch, PR ou pedido de merge intermediário.
+4. Não acionar Gestor Estrutural, Gestor de Updates ou Gestor de Automações; usar somente o Analista nos gates de implementação.
+5. Reutilizar checkpoints `LP-Factory-Phase: <identificador>` e continuar na próxima subseção pendente.
+6. Se houver mudança material fora da v2 aprovada, encaminhar ao Analista e, se necessário, ao humano; não reiniciar especialistas.
 
 ## Preparar
 
-1. Confirmar repositório, worktree, branch, estado Git limpo, plano, SHA e caso; no fluxo normal, confirmar que o plano está na `main` atualizada.
+1. Confirmar repositório, worktree, branch, estado Git limpo, plano, SHA e caso; na execução independente, confirmar que o plano está na `main` atualizada; no handoff interno, confirmar o checkpoint `plan-v2-approved` no PR único.
 2. Ler o plano integral, a seção competente de `docs/roadmap.md`, `docs/base-tecnica.md` e somente fontes adicionais exigidas pela subseção atual.
 3. Validar que cada fase executável use exatamente o identificador do roadmap, como `E18.5.3 — título`; rejeitar aliases ordinais como `Fase 1` e agrupamentos de subseções independentes.
-4. Criar ou selecionar uma única branch `codex-app/<caso>-implementacao` a partir da `main` e um único PR draft contra `main` para todo o recorte. Recusar base diferente de `main` e nunca criar branch ou PR por subseção.
+4. No handoff interno, reutilizar a branch e o PR existentes. Na execução independente, criar ou selecionar uma única branch `codex-app/<caso>-implementacao` a partir da `main` e um único PR draft contra `main`. Recusar base diferente de `main` e nunca criar branch ou PR por subseção.
 5. Registrar o SHA do plano como contrato imutável. Se houver execução anterior, identificar o último checkpoint pelo trailer de commit `LP-Factory-Phase: <identificador>`; se não for possível determinar unicamente a próxima subseção, parar e pedir o identificador.
 
 ## Executar uma subseção
@@ -59,4 +72,6 @@ O resumo do PR deve refletir sempre o checkpoint publicado. O formato do registr
 - Não iniciar a fase seguinte sem checkpoint aprovado.
 - Não criar matriz de consolidação durante a implementação; ela pertence apenas à revisão do plano v2.
 - Não criar PR empilhado.
+- Não criar segundo PR quando houver handoff da orquestração.
+- Não acionar novamente os especialistas do plano durante a implementação.
 - Não substituir gate humano, decisão material ou teste humano exigido.

--- a/.agents/skills/lp-factory-executar-plano/agents/openai.yaml
+++ b/.agents/skills/lp-factory-executar-plano/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Executar plano-base"
-  short_description: "Executa fases aprovadas com gates"
-  default_prompt: "Use $lp-factory-executar-plano para executar o plano-base aprovado informado."
+  short_description: "Executa fases aprovadas no PR existente"
+  default_prompt: "Use $lp-factory-executar-plano para executar o plano aprovado, reutilizando o PR da orquestração quando houver."

--- a/.agents/skills/lp-factory-orquestrar-plano/SKILL.md
+++ b/.agents/skills/lp-factory-orquestrar-plano/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: lp-factory-orquestrar-plano
-description: Orquestrar a produção e o gate de um plano-base v2 do LP Factory 10 a partir de uma v1 já incorporada à main, usando especialistas e Analista e reconciliando o roadmap antes da publicação. Usar quando o humano informar o PR ou path da v1 e pedir para executar, orquestrar ou automatizar a revisão do plano.
+description: "Orquestrar end-to-end um plano-base do LP Factory 10 a partir de uma v1 incorporada à main: produzir e aprovar a v2, reconciliar o roadmap e executar todas as subseções na mesma branch e no mesmo PR, usando especialistas uma única vez antes da v2 e o Analista nos gates. Usar quando o humano informar o PR ou path da v1 e pedir para orquestrar, automatizar ou executar o plano completo."
 ---
 
-# Orquestrar plano-base v2
+# Orquestrar plano-base end-to-end
 
-Conduzir o primeiro fluxo integrado de revisão do plano-base. Manter o task principal como orquestrador e executor; usar os custom agents somente para avaliações read-only.
+Conduzir com uma única instrução humana a revisão do plano-base e sua implementação. Manter o task principal como orquestrador e executor; usar os custom agents somente para avaliações read-only.
 
 ## Entrada humana
 
@@ -13,11 +13,11 @@ Aceitar como comando suficiente o número, a URL do PR ou o path da v1, por exem
 
 `Use $lp-factory-orquestrar-plano no PR #577.`
 
-Usar o fluxo normal por padrão. Nele, exigir que a v1 esteja na `main` atualizada e publicar a v2 em uma única branch e PR contra `main`.
+Usar o fluxo normal `end-to-end` por padrão. Exigir que a v1 esteja na `main` atualizada e usar uma única branch e um único PR contra `main` para v2, roadmap, implementação, validações e fechamento aplicável. Não exigir nova instrução humana entre a aprovação da v2 e sua execução.
 
 Aceitar `modo experimental` somente quando explícito e apenas para controlar checkpoints. Se a v1 ainda não estiver na `main`, limitar-se à avaliação read-only e parar; qualquer mutação exige primeiro sua incorporação à `main`. Nunca criar PR empilhado.
 
-Não exigir do humano nomes de agentes, paths, branches, matriz ou etapas internas. Pedir informação adicional somente diante de ambiguidade que impeça selecionar com segurança o plano ou a worktree de destino.
+Não exigir do humano nomes de agentes, paths, branches, matriz, etapas internas ou invocação separada da skill de execução. Pedir informação adicional somente diante de ambiguidade que impeça selecionar com segurança o plano, o estado de retomada ou a worktree de destino.
 
 ## Fontes obrigatórias
 
@@ -28,8 +28,22 @@ Antes de executar:
 3. Ler e seguir `.agents/skills/lp-factory-avaliar-plano-updates/SKILL.md` na avaliação de updates.
 4. Ler e seguir `.agents/skills/lp-factory-avaliar-plano-automacoes/SKILL.md` quando alguma fase estiver marcada como `Automação: sim`.
 5. Ler e seguir `.agents/skills/lp-factory-avaliar-plano-analista/SKILL.md` no gate do Analista.
+6. Ler e seguir `.agents/skills/lp-factory-executar-plano/SKILL.md` como subfluxo interno depois da aprovação da v2 e do roadmap.
+7. Ler e seguir `.agents/skills/lp-factory-avaliar-implementacao-analista/SKILL.md` nos gates da implementação.
 
 Não copiar nem reinterpretar os contratos canônicos desses arquivos.
+
+## Retomar antes de repetir
+
+Antes de iniciar qualquer especialista, identificar o estágio já concluído pelo task, Git e PR:
+
+1. Reutilizar pareceres completos já obtidos para o mesmo blob da v1; não acionar novamente o especialista correspondente.
+2. Se existir checkpoint inequívoco `LP-Factory-Stage: plan-v2-approved`, pular toda a produção da v2 e seguir diretamente para a execução.
+3. Se existir checkpoint de implementação `LP-Factory-Phase: <identificador>`, retomar na próxima subseção ainda não aprovada.
+4. Se a v2 estiver pronta, mas faltar somente a aprovação do Analista ou a reconciliação do roadmap, retomar exatamente nesse gate.
+5. Se o estágio não puder ser determinado unicamente, pedir somente a referência faltante; não reiniciar o fluxo por precaução.
+
+Parecer só é reutilizável quando estiver vinculado ao mesmo blob da v1 e seu conteúdo integral estiver disponível.
 
 ## 1. Congelar a fonte v1
 
@@ -50,11 +64,11 @@ O task principal pode estar aberto no projeto local padrão. Direcionar as muta�
 2. No fluxo normal, considerar candidatas somente worktrees:
    - limpas;
    - fora da `main`;
-   - em branch compatível com `codex-app/*-v2-orquestracao`;
+   - em branch compatível com `codex-app/*-orquestracao` ou `codex-app/*-v2-orquestracao`;
    - criadas ou realinhadas a partir da `main` que contém a v1 congelada;
    - cujo plano, antes das alterações, corresponda ao blob SHA congelado incorporado à `main`.
 3. Selecionar automaticamente quando existir exatamente uma candidata.
-4. Se não houver candidata e não existir frente paralela, usar o modo simples: atualizar `main` com `git pull --ff-only` e criar uma única branch `codex-app/<caso>-v2-orquestracao`.
+4. Se não houver candidata e não existir frente paralela, usar o modo simples: atualizar `main` com `git pull --ff-only` e criar uma única branch `codex-app/<caso>-orquestracao`.
 5. Se houver mais de uma candidata, pedir apenas o path da worktree de automação.
 6. Recusar worktree ou branch destinada ao processo atual/manual, incluindo branches compatíveis com `*-v2-processo-atual`.
 7. No modo experimental com v1 ainda não incorporada à `main`, não selecionar nem criar destino mutável; exigir primeiro sua incorporação à `main`.
@@ -117,7 +131,7 @@ Parar quando faltar uma decisão material que altere produto, escopo ou arquitet
    - não incluí-la no prompt ou nos turnos herdados;
    - não gravá-la na worktree antes da conclusão independente;
    - iniciar o Analista com `fork_turns=none`.
-8. Validar a v2 com `git diff --check` e criar um commit de checkpoint somente com o plano-base v2.
+8. Validar a v2 com `git diff --check` e criar um commit de checkpoint somente com o plano-base v2, usando o trailer `LP-Factory-Stage: plan-v2`.
 9. Usar esse commit como referência imutável da v2 na Passagem 1.
 
 ## 6. Executar o gate do Analista
@@ -151,19 +165,29 @@ Somente após `aprovado para merge do plano-base v2`:
 7. Continuar no mesmo Analista em `revisao_delta`, entregando v2 aprovada, snapshot do roadmap, ABC emitido, roadmap resultante, `docs/prompt-abc.md` e `docs/template-roadmap.md`.
 8. Solicitar somente a auditoria da correspondência entre v2 e roadmap. Corrigir e reenviar apenas divergências objetivas; questão material nova segue a seção 7.
 9. Mesmo quando o ABC retornar `SEM ALTERAÇÕES NECESSÁRIAS`, exigir confirmação do Analista de que o snapshot já corresponde à v2.
-10. Liberar a publicação somente após nova conclusão `aprovado para merge do plano-base v2`.
-11. No fluxo normal, remover a matriz temporária antes da publicação e preservar sua rastreabilidade apenas no resumo do PR.
+10. Liberar a execução somente após nova conclusão `aprovado para merge do plano-base v2`.
+11. No fluxo normal, remover a matriz temporária, preservar sua rastreabilidade no resumo do PR e criar o checkpoint `LP-Factory-Stage: plan-v2-approved` com plano e roadmap aprovados.
 
-## 9. Publicar para decisão humana
+## 9. Abrir o PR único
 
 Somente após a aprovação da v2 e da revisão delta do roadmap:
 
 1. Confirmar que o diff contém apenas o plano v2, `docs/roadmap.md` e, somente no modo `experimental`, sua matriz.
 2. Verificar alterações acidentais, secrets, `.env`, banco e workflows.
 3. Executar `git diff --check`; tratar `npm ci` e `npm run check` como não aplicáveis quando o diff for exclusivamente documental.
-4. Commitar a versão final e publicar a branch de automação.
-5. Abrir um único PR draft contra `main`; recusar qualquer base diferente de `main`. Se a criação automática não estiver disponível, entregar o link de comparação com base e head preenchidos.
-6. Não fazer merge. O humano compara, decide e realiza o merge pelo GitHub Web.
+4. Publicar o checkpoint `plan-v2-approved` na branch de automação.
+5. Abrir ou atualizar um único PR draft contra `main`; recusar qualquer base diferente de `main`. Se a criação automática não estiver disponível, entregar o link de comparação com base e head preenchidos.
+6. Não encerrar o fluxo nem pedir merge neste ponto. Continuar a implementação na mesma branch e no mesmo PR.
+
+## 10. Executar a v2 no mesmo PR
+
+1. Invocar internamente `$lp-factory-executar-plano` com o checkpoint `plan-v2-approved`; não pedir ao humano uma nova instrução.
+2. Usar o modo de handoff interno da skill de execução: preservar branch, worktree e PR atuais, mesmo que a v2 ainda não esteja na `main`.
+3. Não acionar novamente Gestor Estrutural, Gestor de Updates ou Gestor de Automações. Durante a implementação, usar somente o Analista nos gates por subseção e no gate final.
+4. Se o Analista encontrar mudança material fora da v2 aprovada, parar e pedir a decisão humana necessária; não reiniciar especialistas automaticamente.
+5. Executar todas as subseções no fluxo normal `end-to-end`, reutilizando checkpoints existentes e mantendo o mesmo PR draft atualizado.
+6. Realizar as validações e o fechamento definidos na skill de execução.
+7. Somente após `aprovado para merge da implementação`, marcar o PR único como pronto e entregá-lo para merge humano pelo GitHub Web.
 
 ## Devolução ao humano
 
@@ -177,9 +201,11 @@ Apresentar:
 - Passagens 1 e 2 do Analista;
 - snapshot inicial, ABC e delta aplicado em `docs/roadmap.md`;
 - revisão delta final do roadmap pelo mesmo Analista;
+- checkpoints e pareceres do Analista durante a implementação;
+- validações integradas e decisão sobre teste humano;
 - arquivos alterados;
 - commits e validações;
-- PR draft ou link de criação;
+- PR único e seu estado final;
 - eventual decisão ou bloqueio pendente.
 
 ## Limites
@@ -187,9 +213,10 @@ Apresentar:
 - Não alterar a v1 nem o PR de origem.
 - Não editar ou commitar na `main`.
 - Não criar PR empilhado.
+- Não criar segunda branch ou segundo PR entre v2 e implementação.
 - Não acionar especialistas fora do recorte.
 - Não permitir que custom agents editem arquivos.
-- Não executar fases do plano.
+- Não repetir especialistas já concluídos para o mesmo blob da v1.
 - Não alterar outros documentos canônicos durante a reconciliação do roadmap.
-- Não avaliar implementação ou PR de código; encaminhar a execução aprovada para `$lp-factory-executar-plano`.
+- Não encerrar o fluxo após a v2; encaminhar internamente a execução aprovada para `$lp-factory-executar-plano`.
 - Não fazer merge nem substituir decisão humana.

--- a/.agents/skills/lp-factory-orquestrar-plano/agents/openai.yaml
+++ b/.agents/skills/lp-factory-orquestrar-plano/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Orquestrar plano-base"
-  short_description: "Produz e valida a v2 com especialistas"
-  default_prompt: "Use $lp-factory-orquestrar-plano no plano-base v1 informado, já incorporado à main."
+  short_description: "Produz a v2 e executa o plano no mesmo PR"
+  default_prompt: "Use $lp-factory-orquestrar-plano no PR informado para produzir a v2 e executar o plano completo."
 
 policy:
   allow_implicit_invocation: false

--- a/docs/orquestracao-plano-base.md
+++ b/docs/orquestracao-plano-base.md
@@ -1,8 +1,8 @@
 # Orquestração de planos-base no Codex
 
-Data: 22/07/2026
-Versão: v0.10
-Status: Fluxos de plano e execução validados no experimento E18.5; Gestor de Automações integrado de forma condicional; reconciliação planejada do roadmap incorporada e pendente de teste próprio; fechamento documental da implementação pendente de decisão.
+Data: 23/07/2026
+Versão: v0.11
+Status: Fluxo end-to-end unificado em uma instrução, uma branch e um PR; retomada por checkpoints incorporada; fechamento documental da implementação pendente de decisão.
 
 ## 1. Objetivo e função deste documento
 
@@ -18,9 +18,10 @@ Seu objetivo é estabelecer, antes da implementação, um contrato humano verifi
 6. conduz a execução de uma subseção canônica por vez, na mesma branch e PR de implementação;
 7. devolve cada checkpoint e a entrega final ao Analista antes do avanço ou merge;
 8. interrompe o fluxo nos pontos que exigem decisão humana ou teste humano;
-9. permite retomar a mesma frente sem merge entre subseções.
+9. permite retomar a mesma frente sem repetir especialistas ou fases concluídas;
+10. entrega v2, roadmap e implementação na mesma branch e no mesmo PR contra `main`.
 
-O resultado esperado é reduzir coordenação manual e cópia de contexto entre tarefas, sem transferir ao Codex decisões que pertencem ao humano e sem permitir que agentes especializados alterem o repositório.
+O resultado esperado é reduzir coordenação manual e cópia de contexto entre tarefas, sem transferir ao Codex decisões que pertencem ao humano e sem permitir que agentes especializados alterem o repositório. Uma única instrução inicia o fluxo; a skill de execução é um subfluxo interno e não exige novo comando humano.
 
 Este documento será a fonte humana do desenho aprovado. A skill executará o workflow definido aqui; cada custom agent aplicará seu contrato runtime; e o task principal permanecerá responsável pela coordenação, pelas alterações no repositório e pela entrega ao humano.
 
@@ -171,7 +172,7 @@ As conclusões permitidas são:
 - `requer nova rodada especializada`;
 - `bloqueado por decisão humana`.
 
-Somente a primeira libera o pedido de merge. Nas demais, o orquestrador corrige ou encaminha a pendência e devolve o delta ao Analista. Não há retorno padrão ao Gestor Estrutural: ele só é reacionado se a v2 introduzir questão material não coberta pelo parecer original ou se o Analista identificar explicitamente essa novidade.
+No teste isolado, somente a primeira liberava o pedido de merge. No fluxo end-to-end atual, ela libera o checkpoint `plan-v2-approved` e a execução na mesma branch e PR. Nas demais conclusões, o orquestrador corrige ou encaminha a pendência e devolve o delta ao Analista.
 
 ### 3.6 Critérios de sucesso
 
@@ -196,9 +197,9 @@ Este passo não inclui:
 - alteração dos contratos dos demais especialistas antes de seus trabalhos próprios;
 - merge automático ou decisão humana delegada ao Codex.
 
-## 4. Terceiro passo: skill de orquestração integrada
+## 4. Terceiro passo: skill de orquestração end-to-end
 
-O terceiro passo reúne os dois testes anteriores em uma única entrada humana. Foi criada a skill `lp-factory-orquestrar-plano`, localizada em `.agents/skills/lp-factory-orquestrar-plano/`.
+O terceiro passo reúne revisão do plano e implementação em uma única entrada humana. A skill principal é `lp-factory-orquestrar-plano`, localizada em `.agents/skills/lp-factory-orquestrar-plano/`.
 
 Ela não cria um custom agent de orquestração. O task comum permanece como orquestrador e executor, enquanto `gestor-estrutural`, `gestor-updates`, `gestor-automacoes` e `analista` permanecem read-only e aplicam seus contratos runtime.
 
@@ -210,11 +211,13 @@ O humano informa somente o PR que contém o plano-base v1 e invoca explicitament
 
 Paths, branches, agentes e etapas internas são resolvidos pela skill. Informação adicional só pode ser solicitada quando houver ambiguidade real que impeça selecionar o plano ou a worktree correta.
 
+Essa instrução produz a v2 e executa suas subseções. O humano não precisa invocar separadamente `lp-factory-executar-plano`.
+
 ### 4.2 Destino das alterações
 
-A skill nunca edita diretamente a `main`, a branch do processo atual ou a branch head do PR da v1. No fluxo normal, exige a v1 já incorporada à `main`, atualiza a base e cria uma única branch da v2 contra `main`.
+A skill nunca edita diretamente a `main`, a branch do processo atual ou a branch head do PR da v1. No fluxo normal, exige a v1 já incorporada à `main`, atualiza a base e cria uma única branch contra `main`, reutilizada da produção da v2 até a conclusão da implementação.
 
-Usar o modo simples quando não houver frente paralela. Uma worktree existente só pode ser selecionada automaticamente quando estiver limpa, usar branch `codex-app/*-v2-orquestracao` baseada na `main` competente e possuir o mesmo blob da v1 congelada. Se houver mais de uma candidata, o fluxo pede somente o path correto.
+Usar o modo simples quando não houver frente paralela. Uma worktree existente só pode ser selecionada automaticamente quando estiver limpa, usar branch `codex-app/*-orquestracao` ou `codex-app/*-v2-orquestracao` baseada na `main` competente e possuir o mesmo blob da v1 congelada. Se houver mais de uma candidata, o fluxo pede somente o path correto.
 
 No experimento E18.5, o destino usado foi:
 
@@ -235,13 +238,16 @@ No experimento E18.5, o destino usado foi:
 9. Corrigir ou encaminhar pendências conforme a conclusão formal.
 10. Usar `$lp-factory-abc` em modo planejamento para reconciliar o snapshot do roadmap com a v2 aprovada.
 11. Submeter o roadmap resultante ao mesmo Analista em revisão delta.
-12. No fluxo normal, publicar um único PR draft da v2 contra `main` somente após aprovação da v2 e do roadmap reconciliado.
+12. Criar o checkpoint `LP-Factory-Stage: plan-v2-approved`, remover a matriz temporária e abrir um único PR draft contra `main`.
+13. Invocar internamente `lp-factory-executar-plano`, sem novo comando humano, preservando branch, worktree e PR.
+14. Executar todas as subseções com gates do Analista, validações integradas e eventual teste humano.
+15. Marcar o mesmo PR como pronto somente após `aprovado para merge da implementação`.
 
-A matriz não é gravada antes da Passagem 1. Isso impede que a avaliação independente seja contaminada por um arquivo acessível na própria worktree.
+A matriz não é gravada antes da Passagem 1. Isso impede que a avaliação independente seja contaminada por um arquivo acessível na própria worktree. Depois do checkpoint da v2 aprovada, a matriz é removida e não participa da implementação.
 
 ### 4.4 Limites do fluxo de plano integrado
 
-Este recorte inclui Gestor Estrutural, Gestor de Updates, Gestor de Automações quando aplicável, consolidação pelo orquestrador, gate do Analista e reconciliação final do roadmap. O Gestor de Updates consulta obrigatoriamente os quatro catálogos vigentes, mas não os mantém nem pesquisa novos updates fora deles. O Gestor de Automações é acionado exclusivamente por `Automação: sim`, avalia somente essas fases e não pesquisa recursos sem caso concreto.
+Este recorte inclui Gestor Estrutural, Gestor de Updates, Gestor de Automações quando aplicável, consolidação pelo orquestrador, gates do Analista, reconciliação do roadmap e execução. O Gestor de Updates consulta obrigatoriamente os quatro catálogos vigentes, mas não os mantém nem pesquisa novos updates fora deles. O Gestor de Automações é acionado exclusivamente por `Automação: sim`, avalia somente essas fases e não pesquisa recursos sem caso concreto. Depois da v2 aprovada, os especialistas não são reacionados; mudança material é avaliada pelo Analista e, quando necessário, encaminhada ao humano.
 
 O teste E18.5 foi considerado válido porque uma instrução humana curta produziu dois pareceres especializados rastreáveis, uma v2 rastreável e duas passagens não contaminadas do Analista, sem edição feita pelos custom agents. O PR filho usado na comparação permanece como evidência excepcional; o workflow não permite novos PRs empilhados. O modo experimental altera apenas os checkpoints e também exige a versão do plano incorporada à `main` antes de qualquer mutação.
 
@@ -265,11 +271,11 @@ Depois de `aprovado para merge do plano-base v2`, o orquestrador usa:
 
 O menor delta pode registrar somente estrutura do recorte, identificadores, títulos, objetivos, status planejado ou definido, limites, decisões futuras aprovadas e dependências indispensáveis. Não registra implementação, banco, migrations, arquivos, updates, evidências, comandos, PRs ou histórico operacional e não altera outros documentos canônicos.
 
-O mesmo Analista recebe v2, snapshot, ABC e roadmap resultante em `revisao_delta`. A publicação só é liberada após confirmação de alinhamento, inclusive quando o ABC concluir `SEM ALTERAÇÕES NECESSÁRIAS`. No fluxo normal, o PR final contém apenas plano-base v2 e roadmap; a matriz temporária é removida antes da publicação.
+O mesmo Analista recebe v2, snapshot, ABC e roadmap resultante em `revisao_delta`. A implementação só é liberada após confirmação de alinhamento, inclusive quando o ABC concluir `SEM ALTERAÇÕES NECESSÁRIAS`. No fluxo normal, o PR único acumula plano-base v2, roadmap e implementação; a matriz temporária é removida antes da execução.
 
 ## 5. Quarto passo: execução end-to-end do plano aprovado
 
-Depois do merge humano do plano-base v2 na `main`, o mesmo task passa a atuar como executor. A skill `lp-factory-executar-plano` atualiza a `main` e cria ou reutiliza uma única branch e um único PR draft contra `main` para todo o recorte. Não há PR empilhado nem merge entre subseções.
+Depois do checkpoint aprovado do plano-base v2, o mesmo task passa a atuar como executor. A skill `lp-factory-executar-plano` é invocada internamente e reutiliza a mesma branch e o mesmo PR draft contra `main`; a v2 não precisa de merge intermediário. Em uso independente, essa skill continua exigindo uma v2 já incorporada à `main`. Não há PR empilhado, segundo PR ou merge entre subseções.
 
 ### 5.1 Contrato de fases
 
@@ -294,4 +300,14 @@ Somente a conclusão `aprovado para merge da implementação` libera o PR para d
 
 ### 5.4 Matriz de consolidação
 
-A matriz pertence exclusivamente à etapa de revisão do plano-base v2: ela permite ao orquestrador registrar o tratamento dos pareceres e ao Analista auditar essa consolidação. Em modo experimental, fica como evidência. No fluxo normal, é temporária, é resumida no PR e removida antes da publicação final da v2. Não há remoção agendada nem matriz durante a implementação.
+A matriz pertence exclusivamente à etapa de revisão do plano-base v2: ela permite ao orquestrador registrar o tratamento dos pareceres e ao Analista auditar essa consolidação. Em modo experimental, fica como evidência. No fluxo normal, é temporária, é resumida no PR e removida antes da implementação. Não há remoção agendada nem matriz durante a implementação.
+
+### 5.5 Retomada sem repetição
+
+O task determina o estágio por evidências do mesmo PR e pelos trailers:
+
+- `LP-Factory-Stage: plan-v2` — v2 produzida, ainda em gates documentais;
+- `LP-Factory-Stage: plan-v2-approved` — v2 e roadmap aprovados, liberar execução;
+- `LP-Factory-Phase: <identificador>` — subseção implementada e aprovada.
+
+Pareceres completos podem ser reutilizados somente para o mesmo blob da v1. Havendo checkpoint inequívoco, o fluxo retoma no próximo gate ou subseção e não reinicia especialistas por precaução.


### PR DESCRIPTION
Transforma Orquestrar plano-base no fluxo end-to-end: produz e aprova a v2, reconcilia o roadmap e executa todas as subseções na mesma branch e no mesmo PR. Adiciona retomada por checkpoints, reutilização de pareceres e proíbe repetir especialistas durante a implementação; o subfluxo de execução passa a aceitar handoff interno sem novo comando humano.