### PR TITLE
docs: padroniza uso nativo do GitHub CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,18 @@ Não editar nem commitar na `main`; usar branch dedicada por tarefa ou etapa. Ao
 
 Publicar com `git push`. Não alterar configurações SSH durante a tarefa; se o push falhar, parar e informar o erro exato. Se a GitHub CLI estiver indisponível, entregar o link de criação do PR.
 
+## GitHub CLI no Codex App local
+
+Para consultar ou operar pull requests, reviews, comentários, checks, Actions e diffs no GitHub:
+
+1. Usar primeiro os comandos nativos da GitHub CLI (`gh`).
+2. Preferir `gh pr`, `gh run` e `gh api`, usando os recursos nativos de JSON, `--jq` ou `--template` quando necessário.
+3. Não usar Python, instalar runtimes, alterar `PATH`, aliases, página de código ou configurações do Windows apenas para processar resultados do GitHub.
+4. Se o acesso pelo `gh` funcionar, mas um script auxiliar falhar, abandonar o script e repetir a operação somente com recursos nativos do `gh`.
+5. Não testar runtimes ou caminhos alternativos sucessivamente sem necessidade explícita do caso.
+6. Se o `gh` não concluir a operação, usar GitHub Plugin ou GitHub Web como fallback.
+7. Se nenhum caminho aprovado funcionar, parar e informar o erro ou a limitação exata.
+
 ## Modo simples
 
 Usar por padrão quando não houver necessidade real de worktree.

--- a/docs/gestor-codex.md
+++ b/docs/gestor-codex.md
@@ -44,6 +44,7 @@ Configurações sustentam o fluxo local adotado para editar, validar e publicar 
 **Uso:** teste controlado.
 **Valor:** agiliza a criação de PRs e a consulta de PRs, checks e diffs pelo terminal.
 **Limite:** seguir as regras operacionais de `AGENTS.md`.
+**Aprendizado:** para operações GitHub no ambiente local, usar diretamente os recursos nativos do `gh`; scripts auxiliares em Python não foram adotados. O fluxo operacional está definido no `AGENTS.md`.
 
 **Outras configurações:** GitHub Web é a fonte de verdade para PRs, Actions, preview e merge; GitHub Desktop está fora do fluxo principal; não há hooks, conexões ou worktrees ativos.
 


### PR DESCRIPTION
## 1. Objetivo

Evitar que o Codex App perca tempo testando Python, runtimes ou ajustes locais quando a GitHub CLI já consegue acessar o GitHub.

## 2. Documentação usada

- `AGENTS.md`
- `docs/gestor-codex.md`
- `docs/prompt-executor.md`

## 3. Alterações

- adiciona ao `AGENTS.md` o fluxo operacional automático para usar primeiro comandos nativos do `gh`;
- orienta o uso de `gh pr`, `gh run`, `gh api`, JSON, `--jq` e `--template`;
- impede instalação ou ajuste de Python, `PATH`, aliases, página de código ou Windows apenas para processar resultados do GitHub;
- define GitHub Plugin ou GitHub Web como fallback;
- registra em `docs/gestor-codex.md` que scripts auxiliares em Python não foram adotados.

## 4. Escopo e validação

- diff restrito a `AGENTS.md` e `docs/gestor-codex.md`;
- 13 inserções e nenhuma remoção;
- `npm ci`: não aplicável;
- `npm run check`: não aplicável;
- merge permanece exclusivamente humano pelo GitHub Web.