### PR TITLE
fix: mantém matriz até o gate final da implementação

### DIFF
--- a/.agents/skills/lp-factory-avaliar-implementacao-analista/SKILL.md
+++ b/.agents/skills/lp-factory-avaliar-implementacao-analista/SKILL.md
@@ -11,7 +11,7 @@ Usar exatamente um custom agent `analista` read-only por revisão. O task princi
 
 1. Confirmar repositório, worktree, branch, estado Git, SHA do plano aprovado e identificador exato da subseção.
 2. Entregar ao Analista o trecho integral da subseção, critérios de aceite, diff desde o checkpoint anterior, arquivos alterados, validações executadas e fontes técnicas necessárias. No handoff da orquestração, incluir a matriz e os pareceres especializados nela referenciados que forem pertinentes à subseção.
-3. Para revisão final, entregar todos os checkpoints, diff acumulado, resultados integrados, delta documental, matriz, pareceres especializados preservados e eventuais evidências de teste humano.
+3. Para revisão final solicitada fora do fluxo automatizado, entregar todos os checkpoints, diff acumulado, resultados integrados, delta documental, matriz, pareceres especializados preservados e eventuais evidências de teste humano.
 4. Parar se plano, fase, diff ou evidência forem ambíguos; não reconstruir o escopo por inferência.
 
 ## Delegar
@@ -20,6 +20,8 @@ Usar exatamente um custom agent `analista` read-only por revisão. O task princi
 2. Usar a matriz como índice de rastreabilidade. Em revisão de subseção, expor somente os pareceres de plano nela referenciados que sejam pertinentes; na revisão final, disponibilizar a matriz e todos os pareceres preservados. O Analista não refaz os especialistas.
 3. Preservar a resposta integral e o estado Git antes e depois da delegação.
 
+No fluxo de `$lp-factory-orquestrar-plano`, usar esta skill somente nos gates por subseção. Depois que o Executor declarar a entrega completa, não acionar nenhuma revisão do Analista; a avaliação seguinte pertence ao Estrategista acionado pelo humano.
+
 ## Tratar a conclusão
 
 - `aprovado para avançar`: permitir somente o checkpoint da subseção atual.
@@ -27,8 +29,6 @@ Usar exatamente um custom agent `analista` read-only por revisão. O task princi
 - `requer teste humano`: parar e apresentar os passos e a evidência mínima solicitada.
 - `bloqueado por decisão humana`: parar e apresentar apenas a decisão necessária.
 - `aprovado para merge da implementação`: permitido somente na revisão final, depois de todas as subseções, testes e documentação.
-
-Depois da primeira conclusão `aprovado para merge da implementação`, revisar a remoção da matriz em `revisao_delta_implementacao`. Confirmar a mesma conclusão somente quando o delta remover exclusivamente esse arquivo e o resumo do PR preservar sua rastreabilidade.
 
 ## Limites
 

--- a/.agents/skills/lp-factory-avaliar-implementacao-analista/SKILL.md
+++ b/.agents/skills/lp-factory-avaliar-implementacao-analista/SKILL.md
@@ -10,14 +10,14 @@ Usar exatamente um custom agent `analista` read-only por revisão. O task princi
 ## Preparar
 
 1. Confirmar repositório, worktree, branch, estado Git, SHA do plano aprovado e identificador exato da subseção.
-2. Entregar ao Analista o trecho integral da subseção, critérios de aceite, diff desde o checkpoint anterior, arquivos alterados, validações executadas e fontes técnicas necessárias.
-3. Para revisão final, entregar todos os checkpoints, diff acumulado, resultados integrados, delta documental e eventuais evidências de teste humano.
+2. Entregar ao Analista o trecho integral da subseção, critérios de aceite, diff desde o checkpoint anterior, arquivos alterados, validações executadas e fontes técnicas necessárias. No handoff da orquestração, incluir a matriz e os pareceres especializados nela referenciados que forem pertinentes à subseção.
+3. Para revisão final, entregar todos os checkpoints, diff acumulado, resultados integrados, delta documental, matriz, pareceres especializados preservados e eventuais evidências de teste humano.
 4. Parar se plano, fase, diff ou evidência forem ambíguos; não reconstruir o escopo por inferência.
 
 ## Delegar
 
 1. Acionar o `analista` em `revisao_implementacao` ou `revisao_final_implementacao`.
-2. Não expor pareceres de plano que não sejam necessários à subseção; o Analista não refaz Gestor Estrutural ou Gestor de Updates.
+2. Usar a matriz como índice de rastreabilidade. Em revisão de subseção, expor somente os pareceres de plano nela referenciados que sejam pertinentes; na revisão final, disponibilizar a matriz e todos os pareceres preservados. O Analista não refaz os especialistas.
 3. Preservar a resposta integral e o estado Git antes e depois da delegação.
 
 ## Tratar a conclusão
@@ -27,6 +27,8 @@ Usar exatamente um custom agent `analista` read-only por revisão. O task princi
 - `requer teste humano`: parar e apresentar os passos e a evidência mínima solicitada.
 - `bloqueado por decisão humana`: parar e apresentar apenas a decisão necessária.
 - `aprovado para merge da implementação`: permitido somente na revisão final, depois de todas as subseções, testes e documentação.
+
+Depois da primeira conclusão `aprovado para merge da implementação`, revisar a remoção da matriz em `revisao_delta_implementacao`. Confirmar a mesma conclusão somente quando o delta remover exclusivamente esse arquivo e o resumo do PR preservar sua rastreabilidade.
 
 ## Limites
 

--- a/.agents/skills/lp-factory-executar-plano/SKILL.md
+++ b/.agents/skills/lp-factory-executar-plano/SKILL.md
@@ -57,22 +57,23 @@ No modo `experimental`, parar somente nos checkpoints solicitados pelo humano. N
 Depois do último checkpoint:
 
 1. Executar validações integradas e corrigir regressões.
-2. Acionar o Analista em `revisao_final_implementacao` com a matriz e os pareceres especializados preservados para avaliar o conjunto contra o plano aprovado.
-3. Avaliar explicitamente a necessidade de teste humano. Se exigido, parar e pedir a evidência; se `N/A`, registrar a justificativa.
-4. Enquanto o fechamento documental permanecer sem decisão canônica entre relatório e `$lp-factory-abc`, parar neste gate mesmo quando o teste humano for `N/A`; não gerar relatório nem alterar documentação. Considerar a decisão canônica somente após atualização correspondente desta skill e de `docs/orquestracao-plano-base.md` incorporada à `main`.
-5. Depois que o fechamento documental for definido, aplicar somente o workflow aprovado, submeter seu delta ao Analista e atualizar título e resumo do PR.
-6. Somente após `aprovado para merge da implementação`, remover a matriz, preservar no resumo do PR sua referência, os especialistas consultados e os tratamentos incorporados, e submeter esse delta de limpeza ao mesmo Analista em `revisao_delta_implementacao`.
-7. Publicar o mesmo PR como pronto para merge somente após o Analista confirmar novamente `aprovado para merge da implementação`, verificando que o último delta removeu apenas a matriz e não alterou plano, roadmap, código ou demais documentos.
+2. Avaliar explicitamente a necessidade de teste humano. Se exigido, parar e pedir a evidência; se `N/A`, registrar a justificativa.
+3. Atualizar o PR com checkpoints, arquivos, validações, decisão sobre teste humano, matriz e pendências; declarar a entrega completa e parar.
+4. Depois dessa declaração, não acionar `revisao_final_implementacao`, `revisao_delta_implementacao` nem qualquer outro gate do Analista.
+5. Não acionar nem fazer handoff ao Estrategista. Ele será instruído pelo humano e consultará diretamente o repositório. Se o humano devolver seu relatório com correções, aplicar somente esse delta, atualizar a entrega e parar novamente, sem Analista.
+6. Manter a matriz disponível. Removê-la somente quando o humano solicitar durante o ciclo externo de avaliação, preservando sua rastreabilidade no resumo e no histórico do PR.
 
-O resumo do PR deve refletir sempre o checkpoint publicado. O formato do registro operacional final permanece pendente da decisão sobre o fechamento documental.
+O resumo do PR deve refletir sempre o checkpoint publicado e a entrega completa. A decisão de merge ocorre fora desta skill, depois da avaliação do Estrategista acionada pelo humano.
 
 ## Limites
 
 - Não alterar a `main` nem fazer merge.
 - Não executar fase fora do plano ou fora da ordem do roadmap.
 - Não iniciar a fase seguinte sem checkpoint aprovado.
-- Não recriar, resumir nem alterar a matriz durante a implementação, salvo correção de rastreabilidade exigida pelo Analista; preservá-la desde o handoff até a aprovação final e removê-la somente no fechamento definido acima.
+- Não recriar, resumir nem alterar a matriz durante a implementação, salvo correção de rastreabilidade exigida pelo Analista; preservá-la até a entrega completa e removê-la depois somente por instrução humana.
 - Não criar PR empilhado.
 - Não criar segundo PR quando houver handoff da orquestração.
 - Não acionar novamente os especialistas do plano durante a implementação.
+- Não acionar o Analista depois de declarar a entrega completa.
+- Não acionar o Estrategista nem simular handoff para ele.
 - Não substituir gate humano, decisão material ou teste humano exigido.

--- a/.agents/skills/lp-factory-executar-plano/SKILL.md
+++ b/.agents/skills/lp-factory-executar-plano/SKILL.md
@@ -24,7 +24,7 @@ Exigir que a v2 esteja na `main` somente na execução independente. No handoff 
 Quando invocada por `$lp-factory-orquestrar-plano`:
 
 1. Confirmar que branch, worktree e PR são os mesmos usados para produzir a v2.
-2. Confirmar o checkpoint `plan-v2-approved` e usar esse commit como contrato imutável.
+2. Confirmar o checkpoint `plan-v2-approved`, a matriz versionada no mesmo PR e usar esse commit como contrato imutável.
 3. Não criar branch, PR ou pedido de merge intermediário.
 4. Não acionar Gestor Estrutural, Gestor de Updates ou Gestor de Automações; usar somente o Analista nos gates de implementação.
 5. Reutilizar checkpoints `LP-Factory-Phase: <identificador>` e continuar na próxima subseção pendente.
@@ -33,7 +33,7 @@ Quando invocada por `$lp-factory-orquestrar-plano`:
 ## Preparar
 
 1. Confirmar repositório, worktree, branch, estado Git limpo, plano, SHA e caso; na execução independente, confirmar que o plano está na `main` atualizada; no handoff interno, confirmar o checkpoint `plan-v2-approved` no PR único.
-2. Ler o plano integral, a seção competente de `docs/roadmap.md`, `docs/base-tecnica.md` e somente fontes adicionais exigidas pela subseção atual.
+2. Ler o plano integral, a seção competente de `docs/roadmap.md`, `docs/base-tecnica.md` e somente fontes adicionais exigidas pela subseção atual. No handoff interno, preservar `docs/matriz-consolidacao-<caso>.md` até o fechamento final; ela serve à rastreabilidade do Analista e não amplia o plano aprovado.
 3. Validar que cada fase executável use exatamente o identificador do roadmap, como `E18.5.3 — título`; rejeitar aliases ordinais como `Fase 1` e agrupamentos de subseções independentes.
 4. No handoff interno, reutilizar a branch e o PR existentes. Na execução independente, criar ou selecionar uma única branch `codex-app/<caso>-implementacao` a partir da `main` e um único PR draft contra `main`. Recusar base diferente de `main` e nunca criar branch ou PR por subseção.
 5. Registrar o SHA do plano como contrato imutável. Se houver execução anterior, identificar o último checkpoint pelo trailer de commit `LP-Factory-Phase: <identificador>`; se não for possível determinar unicamente a próxima subseção, parar e pedir o identificador.
@@ -45,7 +45,7 @@ Para a próxima subseção ainda não aprovada:
 1. Confirmar objetivo, arquivos prováveis, escopo negativo e critérios de aceite do plano. Antes de editar, confrontar o plano com o repositório real; se conflito, drift ou dependência alterar objetivo, escopo, arquitetura, banco ou comportamento do produto, não improvisar e encaminhar a incompatibilidade ao Analista no próprio workflow.
 2. Implementar somente o necessário para essa subseção; não antecipar a próxima.
 3. Executar as validações aplicáveis. Para código, executar `npm ci` uma vez no início do lote contínuo e repeti-lo somente se `package-lock.json`, dependências ou o estado de instalação mudarem; executar a validação própria e `npm run check` antes de cada gate. Para alterações exclusivamente documentais, justificar esses comandos como não aplicáveis. Quando aplicável, incluir no gate do Analista evidências de observabilidade mínima e smoke ou QA funcional; se a evidência não puder ser obtida automaticamente, o Analista decide se exige teste humano.
-4. Invocar `$lp-factory-avaliar-implementacao-analista` com o plano, o identificador, o diff e as evidências.
+4. Invocar `$lp-factory-avaliar-implementacao-analista` com o plano, o identificador, o diff, as evidências, a matriz e os pareceres especializados nela referenciados que forem pertinentes à subseção.
 5. Tratar `aprovado para avançar` como checkpoint: commitar com o trailer `LP-Factory-Phase: <identificador>` e atualizar código, título e resumo do mesmo PR draft para refletir o último checkpoint efetivamente publicado.
 6. Tratar `aprovado com correções obrigatórias` corrigindo somente o delta indicado e retornando ao mesmo Analista em `revisao_delta_implementacao`.
 7. Tratar `requer teste humano` ou `bloqueado por decisão humana` como gate: parar e pedir apenas a evidência ou decisão necessária.
@@ -57,11 +57,12 @@ No modo `experimental`, parar somente nos checkpoints solicitados pelo humano. N
 Depois do último checkpoint:
 
 1. Executar validações integradas e corrigir regressões.
-2. Acionar o Analista em `revisao_final_implementacao` para avaliar o conjunto contra o plano aprovado.
+2. Acionar o Analista em `revisao_final_implementacao` com a matriz e os pareceres especializados preservados para avaliar o conjunto contra o plano aprovado.
 3. Avaliar explicitamente a necessidade de teste humano. Se exigido, parar e pedir a evidência; se `N/A`, registrar a justificativa.
 4. Enquanto o fechamento documental permanecer sem decisão canônica entre relatório e `$lp-factory-abc`, parar neste gate mesmo quando o teste humano for `N/A`; não gerar relatório nem alterar documentação. Considerar a decisão canônica somente após atualização correspondente desta skill e de `docs/orquestracao-plano-base.md` incorporada à `main`.
 5. Depois que o fechamento documental for definido, aplicar somente o workflow aprovado, submeter seu delta ao Analista e atualizar título e resumo do PR.
-6. Publicar o mesmo PR como pronto para merge somente com `aprovado para merge da implementação` e sem pendências.
+6. Somente após `aprovado para merge da implementação`, remover a matriz, preservar no resumo do PR sua referência, os especialistas consultados e os tratamentos incorporados, e submeter esse delta de limpeza ao mesmo Analista em `revisao_delta_implementacao`.
+7. Publicar o mesmo PR como pronto para merge somente após o Analista confirmar novamente `aprovado para merge da implementação`, verificando que o último delta removeu apenas a matriz e não alterou plano, roadmap, código ou demais documentos.
 
 O resumo do PR deve refletir sempre o checkpoint publicado. O formato do registro operacional final permanece pendente da decisão sobre o fechamento documental.
 
@@ -70,7 +71,7 @@ O resumo do PR deve refletir sempre o checkpoint publicado. O formato do registr
 - Não alterar a `main` nem fazer merge.
 - Não executar fase fora do plano ou fora da ordem do roadmap.
 - Não iniciar a fase seguinte sem checkpoint aprovado.
-- Não criar matriz de consolidação durante a implementação; ela pertence apenas à revisão do plano v2.
+- Não recriar, resumir nem alterar a matriz durante a implementação, salvo correção de rastreabilidade exigida pelo Analista; preservá-la desde o handoff até a aprovação final e removê-la somente no fechamento definido acima.
 - Não criar PR empilhado.
 - Não criar segundo PR quando houver handoff da orquestração.
 - Não acionar novamente os especialistas do plano durante a implementação.

--- a/.agents/skills/lp-factory-orquestrar-plano/SKILL.md
+++ b/.agents/skills/lp-factory-orquestrar-plano/SKILL.md
@@ -138,7 +138,7 @@ Parar quando faltar uma decisão material que altere produto, escopo ou arquitet
 
 1. Executar a Passagem 1 de `lp-factory-avaliar-plano-analista` com v1, v2, plano conceitual ou `N/A`, decisões registradas e fontes do caso, sem pareceres especializados ou matriz.
 2. Preservar integralmente a resposta independente.
-3. Depois da Passagem 1, gravar a matriz em `docs/matriz-consolidacao-<caso>.md`, validar e criar novo checkpoint. Mantê-la versionada e acessível até a aprovação final da implementação.
+3. Depois da Passagem 1, gravar a matriz em `docs/matriz-consolidacao-<caso>.md`, validar e criar novo checkpoint. Mantê-la versionada e acessível até o Executor declarar a entrega completa.
 4. Continuar no mesmo Analista e entregar os pareceres completos do Gestor Estrutural, do Gestor de Updates e, quando acionado, do Gestor de Automações, além da matriz, para a Passagem 2.
 5. Preservar integralmente a auditoria e a conclusão formal.
 6. Após a aprovação da v2, resumir a rastreabilidade no PR e preservar a matriz no mesmo PR durante toda a implementação.
@@ -183,11 +183,12 @@ Somente após a aprovação da v2 e da revisão delta do roadmap:
 
 1. Invocar internamente `$lp-factory-executar-plano` com o checkpoint `plan-v2-approved`; não pedir ao humano uma nova instrução.
 2. Usar o modo de handoff interno da skill de execução: preservar branch, worktree e PR atuais, mesmo que a v2 ainda não esteja na `main`.
-3. Não acionar novamente Gestor Estrutural, Gestor de Updates ou Gestor de Automações. Durante a implementação, usar somente o Analista nos gates por subseção e no gate final, entregando a matriz e os pareceres especializados pertinentes ao recorte avaliado.
+3. Não acionar novamente Gestor Estrutural, Gestor de Updates ou Gestor de Automações. Durante a implementação, usar o Analista somente nos gates por subseção, entregando a matriz e os pareceres especializados pertinentes ao recorte avaliado.
 4. Se o Analista encontrar mudança material fora da v2 aprovada, parar e pedir a decisão humana necessária; não reiniciar especialistas automaticamente.
 5. Executar todas as subseções no fluxo normal `end-to-end`, reutilizando checkpoints existentes e mantendo o mesmo PR draft atualizado.
-6. Realizar as validações e o fechamento definidos na skill de execução. Manter a matriz até o Analista concluir `aprovado para merge da implementação`; depois removê-la e submeter somente esse delta de limpeza ao mesmo Analista.
-7. Somente após a confirmação de que a limpeza removeu apenas a matriz e preservou sua rastreabilidade no resumo do PR, marcar o PR único como pronto e entregá-lo para merge humano pelo GitHub Web.
+6. Depois da última subseção e das validações aplicáveis, declarar a entrega completa no PR e parar. Não acionar `revisao_final_implementacao`, `revisao_delta_implementacao` nem qualquer outro gate do Analista após essa declaração.
+7. Não acionar nem fazer handoff ao Estrategista. Ele só atua por instrução humana e acessa diretamente o repositório e o PR. Se o humano devolver correções do Estrategista, aplicá-las, republicar a entrega e parar novamente, sem chamar o Analista; o mesmo Estrategista reavalia somente quando o humano o instruir.
+8. Manter a matriz disponível na entrega. Removê-la depois somente por instrução humana decorrente desse ciclo externo, sem transformar a remoção em novo gate do Analista.
 
 ## Devolução ao humano
 
@@ -219,4 +220,6 @@ Apresentar:
 - Não repetir especialistas já concluídos para o mesmo blob da v1.
 - Não alterar outros documentos canônicos durante a reconciliação do roadmap.
 - Não encerrar o fluxo após a v2; encaminhar internamente a execução aprovada para `$lp-factory-executar-plano`.
+- Não acionar o Analista depois que o Executor declarar a entrega completa.
+- Não acionar o Estrategista; sua avaliação pré-merge depende de instrução humana externa a esta skill.
 - Não fazer merge nem substituir decisão humana.

--- a/.agents/skills/lp-factory-orquestrar-plano/SKILL.md
+++ b/.agents/skills/lp-factory-orquestrar-plano/SKILL.md
@@ -138,10 +138,10 @@ Parar quando faltar uma decisão material que altere produto, escopo ou arquitet
 
 1. Executar a Passagem 1 de `lp-factory-avaliar-plano-analista` com v1, v2, plano conceitual ou `N/A`, decisões registradas e fontes do caso, sem pareceres especializados ou matriz.
 2. Preservar integralmente a resposta independente.
-3. Depois da Passagem 1, gravar a matriz em `docs/matriz-consolidacao-<caso>.md`, validar e criar novo checkpoint. No modo `experimental`, mantê-la como evidência; no fluxo normal, usá-la somente até a conclusão do Analista.
+3. Depois da Passagem 1, gravar a matriz em `docs/matriz-consolidacao-<caso>.md`, validar e criar novo checkpoint. Mantê-la versionada e acessível até a aprovação final da implementação.
 4. Continuar no mesmo Analista e entregar os pareceres completos do Gestor Estrutural, do Gestor de Updates e, quando acionado, do Gestor de Automações, além da matriz, para a Passagem 2.
 5. Preservar integralmente a auditoria e a conclusão formal.
-6. No fluxo normal, após aprovação da v2, resumir a rastreabilidade no PR e manter a matriz somente até a revisão delta do roadmap.
+6. Após a aprovação da v2, resumir a rastreabilidade no PR e preservar a matriz no mesmo PR durante toda a implementação.
 
 ## 7. Tratar a conclusão
 
@@ -166,13 +166,13 @@ Somente após `aprovado para merge do plano-base v2`:
 8. Solicitar somente a auditoria da correspondência entre v2 e roadmap. Corrigir e reenviar apenas divergências objetivas; questão material nova segue a seção 7.
 9. Mesmo quando o ABC retornar `SEM ALTERAÇÕES NECESSÁRIAS`, exigir confirmação do Analista de que o snapshot já corresponde à v2.
 10. Liberar a execução somente após nova conclusão `aprovado para merge do plano-base v2`.
-11. No fluxo normal, remover a matriz temporária, preservar sua rastreabilidade no resumo do PR e criar o checkpoint `LP-Factory-Stage: plan-v2-approved` com plano e roadmap aprovados.
+11. Criar o checkpoint `LP-Factory-Stage: plan-v2-approved` com plano, roadmap e matriz aprovados. Não remover a matriz neste estágio.
 
 ## 9. Abrir o PR único
 
 Somente após a aprovação da v2 e da revisão delta do roadmap:
 
-1. Confirmar que o diff contém apenas o plano v2, `docs/roadmap.md` e, somente no modo `experimental`, sua matriz.
+1. Confirmar que o diff contém apenas o plano v2, `docs/roadmap.md` e a matriz de consolidação.
 2. Verificar alterações acidentais, secrets, `.env`, banco e workflows.
 3. Executar `git diff --check`; tratar `npm ci` e `npm run check` como não aplicáveis quando o diff for exclusivamente documental.
 4. Publicar o checkpoint `plan-v2-approved` na branch de automação.
@@ -183,11 +183,11 @@ Somente após a aprovação da v2 e da revisão delta do roadmap:
 
 1. Invocar internamente `$lp-factory-executar-plano` com o checkpoint `plan-v2-approved`; não pedir ao humano uma nova instrução.
 2. Usar o modo de handoff interno da skill de execução: preservar branch, worktree e PR atuais, mesmo que a v2 ainda não esteja na `main`.
-3. Não acionar novamente Gestor Estrutural, Gestor de Updates ou Gestor de Automações. Durante a implementação, usar somente o Analista nos gates por subseção e no gate final.
+3. Não acionar novamente Gestor Estrutural, Gestor de Updates ou Gestor de Automações. Durante a implementação, usar somente o Analista nos gates por subseção e no gate final, entregando a matriz e os pareceres especializados pertinentes ao recorte avaliado.
 4. Se o Analista encontrar mudança material fora da v2 aprovada, parar e pedir a decisão humana necessária; não reiniciar especialistas automaticamente.
 5. Executar todas as subseções no fluxo normal `end-to-end`, reutilizando checkpoints existentes e mantendo o mesmo PR draft atualizado.
-6. Realizar as validações e o fechamento definidos na skill de execução.
-7. Somente após `aprovado para merge da implementação`, marcar o PR único como pronto e entregá-lo para merge humano pelo GitHub Web.
+6. Realizar as validações e o fechamento definidos na skill de execução. Manter a matriz até o Analista concluir `aprovado para merge da implementação`; depois removê-la e submeter somente esse delta de limpeza ao mesmo Analista.
+7. Somente após a confirmação de que a limpeza removeu apenas a matriz e preservou sua rastreabilidade no resumo do PR, marcar o PR único como pronto e entregá-lo para merge humano pelo GitHub Web.
 
 ## Devolução ao humano
 

--- a/.codex/agents/analista.toml
+++ b/.codex/agents/analista.toml
@@ -23,11 +23,11 @@ Em `auditoria_consolidacao`:
 
 Em `revisao_delta`, verifique apenas as correções solicitadas e se elas criaram conflito, ampliação de escopo ou alteração material de domínio especializado. Quando o alvo for a reconciliação final do roadmap, receba a v2 já aprovada, o snapshot anterior, o ABC, o roadmap resultante e os contratos aplicáveis; audite somente correspondência, menor delta, hierarquia, residência documental e ausência de estado de implementação. Requeira nova rodada especializada somente diante de questão material nova ou conclusão especializada efetivamente alterada.
 
-Em `revisao_implementacao`, receba o trecho integral de uma única subseção canônica, o SHA do plano aprovado, o diff desde o checkpoint anterior, critérios de aceite e evidências. Verifique aderência à subseção, escopo do diff, integração com consumidores relevantes, regressões, segurança, validações e pendências documentais. Não antecipe a subseção seguinte nem reavalie especialidades já resolvidas.
+Em `revisao_implementacao`, receba o trecho integral de uma única subseção canônica, o SHA do plano aprovado, o diff desde o checkpoint anterior, critérios de aceite e evidências. Quando houver handoff da orquestração, receba também a matriz e os pareceres especializados nela referenciados pertinentes à subseção; use-os apenas para rastrear os tratamentos aprovados, sem refazer as especialidades. Verifique aderência à subseção, escopo do diff, integração com consumidores relevantes, regressões, segurança, validações e pendências documentais. Não antecipe a subseção seguinte.
 
-Em `revisao_delta_implementacao`, verifique somente as correções pedidas e efeitos regressivos do delta.
+Em `revisao_delta_implementacao`, verifique somente as correções pedidas e efeitos regressivos do delta. Depois da aprovação final, quando o delta for a remoção da matriz temporária, confirme que somente esse arquivo saiu e que o resumo do PR preserva especialistas, achados e tratamentos; então repita `aprovado para merge da implementação`.
 
-Em `revisao_final_implementacao`, verifique a entrega acumulada, todos os checkpoints, validações integradas, testes humanos quando aplicáveis e delta documental contra o plano aprovado. Não aprove merge se qualquer subseção, evidência ou gate estiver pendente.
+Em `revisao_final_implementacao`, verifique a entrega acumulada, todos os checkpoints, validações integradas, testes humanos quando aplicáveis, delta documental, matriz e pareceres especializados preservados contra o plano aprovado. Não aprove merge se qualquer subseção, evidência ou gate estiver pendente.
 
 Não edite arquivos, implemente, consolide, crie branch, commit ou PR, acione agentes ou escolha uma decisão material pelo humano.
 
@@ -73,7 +73,7 @@ Em modos de implementação, use exatamente uma conclusão:
 - `aprovado com correções obrigatórias`: há correções objetivas no delta;
 - `requer teste humano`: é necessária evidência humana identificada;
 - `bloqueado por decisão humana`: existe escolha material sem fonte determinante;
-- `aprovado para merge da implementação`: somente em `revisao_final_implementacao`, sem pendências.
+- `aprovado para merge da implementação`: em `revisao_final_implementacao`, sem pendências, e novamente em `revisao_delta_implementacao` após confirmar a limpeza exclusiva da matriz.
 
 Somente a conclusão própria do modo libera o gate. Finalize com `## Próximo passo mínimo e seguro`.
 """

--- a/.codex/agents/analista.toml
+++ b/.codex/agents/analista.toml
@@ -25,7 +25,7 @@ Em `revisao_delta`, verifique apenas as correções solicitadas e se elas criara
 
 Em `revisao_implementacao`, receba o trecho integral de uma única subseção canônica, o SHA do plano aprovado, o diff desde o checkpoint anterior, critérios de aceite e evidências. Quando houver handoff da orquestração, receba também a matriz e os pareceres especializados nela referenciados pertinentes à subseção; use-os apenas para rastrear os tratamentos aprovados, sem refazer as especialidades. Verifique aderência à subseção, escopo do diff, integração com consumidores relevantes, regressões, segurança, validações e pendências documentais. Não antecipe a subseção seguinte.
 
-Em `revisao_delta_implementacao`, verifique somente as correções pedidas e efeitos regressivos do delta. Depois da aprovação final, quando o delta for a remoção da matriz temporária, confirme que somente esse arquivo saiu e que o resumo do PR preserva especialistas, achados e tratamentos; então repita `aprovado para merge da implementação`.
+Em `revisao_delta_implementacao`, verifique somente as correções pedidas e efeitos regressivos do delta.
 
 Em `revisao_final_implementacao`, verifique a entrega acumulada, todos os checkpoints, validações integradas, testes humanos quando aplicáveis, delta documental, matriz e pareceres especializados preservados contra o plano aprovado. Não aprove merge se qualquer subseção, evidência ou gate estiver pendente.
 
@@ -73,7 +73,7 @@ Em modos de implementação, use exatamente uma conclusão:
 - `aprovado com correções obrigatórias`: há correções objetivas no delta;
 - `requer teste humano`: é necessária evidência humana identificada;
 - `bloqueado por decisão humana`: existe escolha material sem fonte determinante;
-- `aprovado para merge da implementação`: em `revisao_final_implementacao`, sem pendências, e novamente em `revisao_delta_implementacao` após confirmar a limpeza exclusiva da matriz.
+- `aprovado para merge da implementação`: somente em `revisao_final_implementacao`, sem pendências.
 
 Somente a conclusão própria do modo libera o gate. Finalize com `## Próximo passo mínimo e seguro`.
 """

--- a/docs/orquestracao-plano-base.md
+++ b/docs/orquestracao-plano-base.md
@@ -1,8 +1,8 @@
 # Orquestração de planos-base no Codex
 
 Data: 23/07/2026
-Versão: v0.12
-Status: Fluxo end-to-end unificado em uma instrução, uma branch e um PR; retomada por checkpoints incorporada; fechamento documental da implementação pendente de decisão.
+Versão: v0.13
+Status: Fluxo end-to-end unificado até a entrega completa; avaliação pré-merge pelo Estrategista ocorre fora da automação e somente por instrução humana.
 
 ## 1. Objetivo e função deste documento
 
@@ -16,7 +16,7 @@ Seu objetivo é estabelecer, antes da implementação, um contrato humano verifi
 4. entrega v1 e v2 ao Analista para avaliação independente e, depois, entrega pareceres e matriz para auditoria da consolidação;
 5. reconcilia o roadmap com a v2 aprovada e submete o delta ao mesmo Analista;
 6. conduz a execução de uma subseção canônica por vez, na mesma branch e PR de implementação;
-7. devolve cada checkpoint e a entrega final ao Analista antes do avanço ou merge;
+7. devolve cada checkpoint de subseção ao Analista antes do avanço e encerra sua participação quando o Executor declara a entrega completa;
 8. interrompe o fluxo nos pontos que exigem decisão humana ou teste humano;
 9. permite retomar a mesma frente sem repetir especialistas ou fases concluídas;
 10. entrega v2, roadmap e implementação na mesma branch e no mesmo PR contra `main`.
@@ -240,10 +240,10 @@ No experimento E18.5, o destino usado foi:
 11. Submeter o roadmap resultante ao mesmo Analista em revisão delta.
 12. Criar o checkpoint `LP-Factory-Stage: plan-v2-approved` com a matriz versionada e abrir um único PR draft contra `main`.
 13. Invocar internamente `lp-factory-executar-plano`, sem novo comando humano, preservando branch, worktree e PR.
-14. Executar todas as subseções com gates do Analista, validações integradas e eventual teste humano.
-15. Após `aprovado para merge da implementação`, remover a matriz, submeter somente esse delta ao mesmo Analista e marcar o PR como pronto apenas quando ele confirmar novamente a aprovação.
+14. Executar todas as subseções com gates do Analista por subseção, validações integradas e eventual teste humano.
+15. Declarar a entrega completa no PR, manter a matriz disponível e encerrar a automação sem revisão final do Analista.
 
-A matriz não é gravada antes da Passagem 1. Isso impede que a avaliação independente seja contaminada por um arquivo acessível na própria worktree. Depois da Passagem 2, ela permanece versionada durante toda a implementação para que o Analista rastreie os pareceres até o gate final.
+A matriz não é gravada antes da Passagem 1. Isso impede que a avaliação independente seja contaminada por um arquivo acessível na própria worktree. Depois da Passagem 2, ela permanece versionada durante toda a implementação e disponível na entrega completa.
 
 ### 4.4 Limites do fluxo de plano integrado
 
@@ -292,15 +292,15 @@ Cada fase deve representar exatamente uma subseção executável do roadmap, ide
 
 ### 5.3 Testes, documentação e merge
 
-Após a última subseção, o executor realiza validações integradas, solicita a revisão final do Analista e avalia explicitamente a necessidade de teste humano. Quando o teste humano for `N/A`, registra a justificativa.
+Após a última subseção, o Executor realiza validações integradas e avalia explicitamente a necessidade de teste humano. Quando o teste humano for `N/A`, registra a justificativa.
 
-Enquanto não houver decisão canônica entre relatório e aplicação direta de `$lp-factory-abc`, o executor para após esse gate, mesmo com teste humano `N/A`, sem gerar relatório nem alterar documentação. A decisão só se torna canônica quando este documento e a skill de execução forem atualizados e incorporados à `main`. Depois disso, executará apenas o fechamento aprovado, pedirá revisão delta do Analista e atualizará título e resumo do mesmo PR.
+Depois dos testes, o Executor atualiza o PR, declara a entrega completa e para. A automação não aciona o Estrategista nem faz handoff: o humano instrui o mesmo Estrategista, que acessa diretamente o repositório e devolve seu relatório ao humano. Se o humano encaminhar correções ao Executor, ele aplica o delta, atualiza a entrega e para novamente; o Estrategista reavalia somente por nova instrução humana.
 
-Após a conclusão `aprovado para merge da implementação`, o executor remove a matriz e preserva sua rastreabilidade no resumo do PR. O mesmo Analista audita esse delta e deve confirmar novamente a aprovação antes de o PR ser liberado para decisão humana. O formato do registro operacional final permanece pendente da decisão sobre o fechamento documental.
+Depois da entrega completa, nenhum modo do Analista deste processo pode ser acionado. O ciclo pré-merge ocorre exclusivamente entre o humano, o Estrategista e o Executor até a solução dos problemas apontados.
 
 ### 5.4 Matriz de consolidação
 
-A matriz nasce na revisão do plano-base v2 e permanece como artefato temporário de rastreabilidade durante toda a implementação. O Analista a recebe nos gates junto aos pareceres pertinentes, sem reabrir decisões especializadas já aprovadas. Depois da aprovação final, o executor preserva seu resumo no PR, remove o arquivo e submete exclusivamente essa limpeza ao mesmo Analista; o histórico dos commits mantém a evidência auditável.
+A matriz nasce na revisão do plano-base v2 e permanece como artefato temporário de rastreabilidade durante toda a implementação e na entrega completa. O Analista a recebe somente nos gates por subseção, junto aos pareceres pertinentes, sem reabrir decisões especializadas já aprovadas. Sua remoção pode ocorrer depois, por instrução humana decorrente da avaliação do Estrategista; não gera novo gate do Analista, e o histórico dos commits preserva a evidência auditável.
 
 ### 5.5 Retomada sem repetição
 

--- a/docs/orquestracao-plano-base.md
+++ b/docs/orquestracao-plano-base.md
@@ -1,7 +1,7 @@
 # Orquestração de planos-base no Codex
 
 Data: 23/07/2026
-Versão: v0.11
+Versão: v0.12
 Status: Fluxo end-to-end unificado em uma instrução, uma branch e um PR; retomada por checkpoints incorporada; fechamento documental da implementação pendente de decisão.
 
 ## 1. Objetivo e função deste documento
@@ -238,12 +238,12 @@ No experimento E18.5, o destino usado foi:
 9. Corrigir ou encaminhar pendências conforme a conclusão formal.
 10. Usar `$lp-factory-abc` em modo planejamento para reconciliar o snapshot do roadmap com a v2 aprovada.
 11. Submeter o roadmap resultante ao mesmo Analista em revisão delta.
-12. Criar o checkpoint `LP-Factory-Stage: plan-v2-approved`, remover a matriz temporária e abrir um único PR draft contra `main`.
+12. Criar o checkpoint `LP-Factory-Stage: plan-v2-approved` com a matriz versionada e abrir um único PR draft contra `main`.
 13. Invocar internamente `lp-factory-executar-plano`, sem novo comando humano, preservando branch, worktree e PR.
 14. Executar todas as subseções com gates do Analista, validações integradas e eventual teste humano.
-15. Marcar o mesmo PR como pronto somente após `aprovado para merge da implementação`.
+15. Após `aprovado para merge da implementação`, remover a matriz, submeter somente esse delta ao mesmo Analista e marcar o PR como pronto apenas quando ele confirmar novamente a aprovação.
 
-A matriz não é gravada antes da Passagem 1. Isso impede que a avaliação independente seja contaminada por um arquivo acessível na própria worktree. Depois do checkpoint da v2 aprovada, a matriz é removida e não participa da implementação.
+A matriz não é gravada antes da Passagem 1. Isso impede que a avaliação independente seja contaminada por um arquivo acessível na própria worktree. Depois da Passagem 2, ela permanece versionada durante toda a implementação para que o Analista rastreie os pareceres até o gate final.
 
 ### 4.4 Limites do fluxo de plano integrado
 
@@ -271,7 +271,7 @@ Depois de `aprovado para merge do plano-base v2`, o orquestrador usa:
 
 O menor delta pode registrar somente estrutura do recorte, identificadores, títulos, objetivos, status planejado ou definido, limites, decisões futuras aprovadas e dependências indispensáveis. Não registra implementação, banco, migrations, arquivos, updates, evidências, comandos, PRs ou histórico operacional e não altera outros documentos canônicos.
 
-O mesmo Analista recebe v2, snapshot, ABC e roadmap resultante em `revisao_delta`. A implementação só é liberada após confirmação de alinhamento, inclusive quando o ABC concluir `SEM ALTERAÇÕES NECESSÁRIAS`. No fluxo normal, o PR único acumula plano-base v2, roadmap e implementação; a matriz temporária é removida antes da execução.
+O mesmo Analista recebe v2, snapshot, ABC e roadmap resultante em `revisao_delta`. A implementação só é liberada após confirmação de alinhamento, inclusive quando o ABC concluir `SEM ALTERAÇÕES NECESSÁRIAS`. No fluxo normal, o PR único acumula plano-base v2, roadmap, matriz e implementação até o gate final.
 
 ## 5. Quarto passo: execução end-to-end do plano aprovado
 
@@ -286,7 +286,7 @@ Cada fase deve representar exatamente uma subseção executável do roadmap, ide
 1. Confirmar a subseção, critérios de aceite, escopo negativo e fontes competentes.
 2. Implementar somente o necessário para a subseção.
 3. Executar `npm ci` uma vez por lote contínuo quando o lockfile e as dependências não mudarem, além das validações automáticas aplicáveis a cada subseção.
-4. Acionar o Analista em modo de revisão de implementação.
+4. Acionar o Analista em modo de revisão de implementação com a matriz e os pareceres nela referenciados pertinentes à subseção.
 5. Corrigir o delta ou parar para teste humano ou decisão humana quando exigido.
 6. Após `aprovado para avançar`, criar checkpoint, atualizar título e resumo do mesmo PR e, no modo experimental, parar somente no checkpoint solicitado; no fluxo normal end-to-end, seguir para a próxima subseção.
 
@@ -296,11 +296,11 @@ Após a última subseção, o executor realiza validações integradas, solicita
 
 Enquanto não houver decisão canônica entre relatório e aplicação direta de `$lp-factory-abc`, o executor para após esse gate, mesmo com teste humano `N/A`, sem gerar relatório nem alterar documentação. A decisão só se torna canônica quando este documento e a skill de execução forem atualizados e incorporados à `main`. Depois disso, executará apenas o fechamento aprovado, pedirá revisão delta do Analista e atualizará título e resumo do mesmo PR.
 
-Somente a conclusão `aprovado para merge da implementação` libera o PR para decisão humana. O formato do registro operacional final permanece pendente da decisão sobre o fechamento documental.
+Após a conclusão `aprovado para merge da implementação`, o executor remove a matriz e preserva sua rastreabilidade no resumo do PR. O mesmo Analista audita esse delta e deve confirmar novamente a aprovação antes de o PR ser liberado para decisão humana. O formato do registro operacional final permanece pendente da decisão sobre o fechamento documental.
 
 ### 5.4 Matriz de consolidação
 
-A matriz pertence exclusivamente à etapa de revisão do plano-base v2: ela permite ao orquestrador registrar o tratamento dos pareceres e ao Analista auditar essa consolidação. Em modo experimental, fica como evidência. No fluxo normal, é temporária, é resumida no PR e removida antes da implementação. Não há remoção agendada nem matriz durante a implementação.
+A matriz nasce na revisão do plano-base v2 e permanece como artefato temporário de rastreabilidade durante toda a implementação. O Analista a recebe nos gates junto aos pareceres pertinentes, sem reabrir decisões especializadas já aprovadas. Depois da aprovação final, o executor preserva seu resumo no PR, remove o arquivo e submete exclusivamente essa limpeza ao mesmo Analista; o histórico dos commits mantém a evidência auditável.
 
 ### 5.5 Retomada sem repetição
 


### PR DESCRIPTION
## Objetivo

Preservar a matriz durante a execução e eliminar a duplicidade de revisão após a entrega completa do Executor.

## Ajustes

- mantém a matriz versionada durante toda a implementação e disponível na entrega;
- entrega matriz e pareceres pertinentes ao Analista somente nos gates por subseção;
- encerra o uso do Analista quando o Executor declara a entrega completa;
- não aciona nem faz handoff ao Estrategista;
- registra que o humano instrui o Estrategista, que consulta diretamente o PR;
- correções posteriores circulam entre humano, Estrategista e Executor, sem novo Analista;
- permite remover a matriz posteriormente por instrução humana, preservando seu histórico.

## Validação

- contratos das três skills validados;
- `analista.toml` validado;
- `git diff --check` aprovado;
- `npm ci` e `npm run check`: não aplicáveis (somente contratos e documentação).