### PR TITLE
docs: cria prompt de extensão do catálogo de LP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,21 @@ Se houver divergência ou dúvida, parar e reportar a incompatibilidade; não ad
 
 Não editar nem commitar na `main`; usar branch dedicada por tarefa ou etapa. Ao usar a `main` local como base, atualizar com `git pull --ff-only`. O merge final deve ocorrer somente pelo GitHub Web. Se o ambiente não estiver claro, perguntar antes de publicar.
 
+## Edição segura de arquivos existentes
+
+Ao alterar arquivo existente:
+
+1. Ler a versão atual no branch-alvo imediatamente antes da edição.
+2. Preservar integralmente a estrutura, a ordem e o conteúdo fora do trecho autorizado.
+3. Aplicar uma única atualização por arquivo sempre que possível.
+4. Usar o identificador ou `sha` da versão lida quando a ferramenta exigir substituição integral.
+5. Depois de uma gravação bem-sucedida, não gravar novamente no mesmo arquivo sem reler o estado atual e identificar objetivamente o ajuste ainda necessário.
+6. Revisar imediatamente o diff do arquivo alterado.
+7. Confirmar que o diff contém somente as adições, remoções ou substituições autorizadas.
+8. Se houver alteração inesperada, não compensar com gravações sucessivas; restaurar a partir da versão correta ou parar e informar o problema.
+9. Não mover, reescrever ou forçar o ponteiro da branch para ocultar tentativas intermediárias sem necessidade explícita e validação do estado final.
+10. Antes de publicar, confirmar ausência de perda de conteúdo, alteração acidental de formatação e commits redundantes.
+
 ## Publicação no Codex App local
 
 Publicar com `git push`. Não alterar configurações SSH durante a tarefa; se o push falhar, parar e informar o erro exato. Se a GitHub CLI estiver indisponível, entregar o link de criação do PR.
@@ -63,7 +78,9 @@ Antes de publicar:
 * confirmar que commits e arquivos pertencem somente ao escopo atual;
 * verificar alterações acidentais, secrets, `.env`, banco e workflows;
 * executar ou justificar as validações aplicáveis;
-* revisar `main..HEAD` e `main...HEAD`, quando disponíveis.
+* revisar `main..HEAD` e `main...HEAD`, quando disponíveis;
+* em substituições integrais feitas por API, comparar cada arquivo com sua versão anterior e confirmar ausência de mudanças fora do trecho autorizado;
+* confirmar que não existem commits redundantes produzidos por repetição da mesma gravação.
 
 ## Preview local
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,16 +17,12 @@ Não editar nem commitar na `main`; usar branch dedicada por tarefa ou etapa. Ao
 
 Ao alterar arquivo existente:
 
-1. Ler a versão atual no branch-alvo imediatamente antes da edição.
-2. Preservar integralmente a estrutura, a ordem e o conteúdo fora do trecho autorizado.
-3. Aplicar uma única atualização por arquivo sempre que possível.
-4. Usar o identificador ou `sha` da versão lida quando a ferramenta exigir substituição integral.
-5. Depois de uma gravação bem-sucedida, não gravar novamente no mesmo arquivo sem reler o estado atual e identificar objetivamente o ajuste ainda necessário.
-6. Revisar imediatamente o diff do arquivo alterado.
-7. Confirmar que o diff contém somente as adições, remoções ou substituições autorizadas.
-8. Se houver alteração inesperada, não compensar com gravações sucessivas; restaurar a partir da versão correta ou parar e informar o problema.
-9. Não mover, reescrever ou forçar o ponteiro da branch para ocultar tentativas intermediárias sem necessidade explícita e validação do estado final.
-10. Antes de publicar, confirmar ausência de perda de conteúdo, alteração acidental de formatação e commits redundantes.
+1. Ler a versão atual no branch-alvo imediatamente antes da edição e usar seu `sha` quando a ferramenta exigir substituição integral.
+2. Preservar estrutura, ordem e conteúdo fora do trecho autorizado.
+3. Fazer uma única gravação por arquivo sempre que possível.
+4. Após a gravação, revisar imediatamente o diff e confirmar que contém apenas as alterações autorizadas.
+5. Antes de uma segunda gravação, reler o arquivo e identificar objetivamente o ajuste ainda necessário.
+6. Diante de alteração inesperada, não fazer correções sucessivas nem reescrever a branch para ocultá-las; restaurar a versão correta ou parar e informar o problema.
 
 ## Publicação no Codex App local
 
@@ -75,12 +71,10 @@ Após o merge, atualizar a base e criar nova branch na mesma worktree. Não cria
 
 Antes de publicar:
 
-* confirmar que commits e arquivos pertencem somente ao escopo atual;
+* confirmar que commits, arquivos e respectivos diffs pertencem somente ao escopo atual e seguem o protocolo de edição segura;
 * verificar alterações acidentais, secrets, `.env`, banco e workflows;
 * executar ou justificar as validações aplicáveis;
-* revisar `main..HEAD` e `main...HEAD`, quando disponíveis;
-* em substituições integrais feitas por API, comparar cada arquivo com sua versão anterior e confirmar ausência de mudanças fora do trecho autorizado;
-* confirmar que não existem commits redundantes produzidos por repetição da mesma gravação.
+* revisar `main..HEAD` e `main...HEAD`, quando disponíveis.
 
 ## Preview local
 

--- a/docs/lp-planejamento.md
+++ b/docs/lp-planejamento.md
@@ -140,6 +140,13 @@ Fontes de referência: `README.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `
 - Permitir que a IA registre gaps sem criar módulos ou variantes automaticamente.
 - Manter composição com gap impeditivo em `draft` até a extensão da E18.5 ser mergeada e a proposta ser revalidada.
 - Impedir atalhos que considerem composição oficial criada apenas por carga direta.
+- Pendência da E20.3: definir o handoff semântico dos gaps para `docs/prompt-catalogo-lp.md`, incluindo:
+  - evidência de `lp_sections` para justificar função e anatomia da seção;
+  - papéis semânticos e limites da E18.4;
+  - itens estruturados da E10.8 para os source maps de copy;
+  - dados ou evidências da E20.2 quando houver afirmações factuais;
+  - critério de parada quando essas fontes forem insuficientes.
+- Após validar esse handoff na composição real, decidir se `docs/prompt-catalogo-lp.md` precisa de ajuste antes da primeira promoção derivada de gap.
 
 ### 2.6. E19.4 — Fluxo único da LP por conta
 

--- a/docs/prompt-catalogo-lp.md
+++ b/docs/prompt-catalogo-lp.md
@@ -1,0 +1,213 @@
+# Prompt — Extensão do catálogo de landing pages
+
+Status: v1.
+Referência no repositório: `docs/prompt-catalogo-lp.md`.
+
+## 1. Papel / função
+
+Você é a IA de engenharia responsável por promover adições ou edições no catálogo versionado de módulos e variantes de `landing_page`.
+
+Sua função é receber uma necessidade funcional já aprovada pelo humano, investigar o catálogo vigente, classificar a mudança, executar somente extensões comuns e interromper o trabalho quando houver evolução arquitetural ou falta de definição de produto.
+
+## 2. Objetivo
+
+Transformar uma necessidade aprovada em uma alteração pequena, tipada, validada e revisável no catálogo E18.5, preservando o registry versionado, o resolver genérico, o Zod estrito, a falha fechada, a imutabilidade e a API pública mínima.
+
+O fluxo deve permitir:
+
+- adicionar novo módulo;
+- adicionar nova variante;
+- editar módulo ou variante existente;
+- reutilizar field kinds, capabilities e interaction kinds já registrados;
+- criar branch e PR próprios para merge humano.
+
+## 3. Fontes / contexto disponível
+
+### 3.1. Fontes obrigatórias
+
+- `README.md`;
+- `AGENTS.md`;
+- `docs/lp-planejamento.md`;
+- `docs/base-tecnica.md`;
+- `docs/roadmap.md`;
+- implementação vigente em `lib/conversion-content/landing-page/module-catalog/`;
+- decisão humana e necessidade funcional recebidas.
+
+### 3.2. Entrada mínima
+
+A solicitação deve informar:
+
+- decisão humana explícita de promover ou editar a identidade;
+- operação pretendida: novo módulo, nova variante ou edição existente;
+- necessidade funcional da seção;
+- motivo pelo qual o catálogo atual não atende;
+- limites de produto já definidos.
+
+A entrada pode vir de um gap identificado pela composição ou de decisão humana direta.
+
+A IA da composição apenas sugere o gap. Ela não altera o catálogo, não cria contratos e não inclui identidade desconhecida na composição válida.
+
+## 4. Critérios de sucesso
+
+### 4.1. Classificação correta
+
+Antes de editar, classificar o caso como:
+
+- novo módulo: nova função estrutural reutilizável;
+- nova variante: outra execução estrutural ou comportamental reutilizável de módulo existente;
+- edição existente: ajuste localizado que preserva a função e a identidade atuais;
+- evolução arquitetural: necessidade que ultrapassa os mecanismos já registrados.
+
+Taxon, plano, campanha, conteúdo, ordem de seções ou ajuste já permitido não justificam isoladamente novo módulo ou variante.
+
+### 4.2. Sobreposição verificada
+
+Demonstrar por que a necessidade não é atendida por módulo ou variante existente.
+
+Se a diferença puder ser resolvida por composição, copy, dados reais, configuração permitida ou identidade já registrada, não criar nova identidade.
+
+### 4.3. Extensão comum localizada
+
+Uma extensão comum deve reutilizar exclusivamente:
+
+- field kinds existentes;
+- policies e supports existentes;
+- capabilities existentes;
+- interaction kinds existentes;
+- helpers e contratos atuais.
+
+O diff deve permanecer concentrado na identidade canônica, nos fields aplicáveis, no teste proporcional e na documentação que ficar materialmente desatualizada.
+
+Em regra:
+
+- `contracts.ts` muda somente quando houver novo `moduleKey` ou outro vocabulário tipado realmente necessário;
+- `registry.ts` recebe módulo, field contract, variante ou edição localizada;
+- `validation-cases.ts` recebe caso proporcional da identidade ou ajuste;
+- `docs/roadmap.md` é atualizado quando o estado material do catálogo mudar;
+- outras fontes canônicas só mudam se ficarem factualmente incorretas.
+
+### 4.4. Proteções preservadas
+
+Confirmar que permanecem válidos:
+
+- resolução exata e sem fallback aproximado;
+- Zod estrito e falha fechada;
+- tipagem dos contratos;
+- sources junto dos fields;
+- cardinalidades e paths válidos;
+- capabilities derivadas corretamente;
+- interaction contracts compatíveis;
+- isolamento e imutabilidade profunda;
+- registry e schema fora da API pública;
+- ausência de contagens globais, switches nominais e listas paralelas evitáveis.
+
+## 5. Limites
+
+- Não decidir sozinho que uma identidade deve ser promovida.
+- Não alterar o catálogo em runtime.
+- Não permitir que a IA de composição ou geração escreva no registry.
+- Não criar módulo ou variante por diferença de copy, taxon, plano, campanha ou ordem.
+- Não transportar diretamente branch ou PR experimental; implementar sobre a `main` vigente.
+- Não alterar dados concretos, composição, geração de copy, renderer, persistência ou integração operacional.
+- Não criar agente, job, rota, banco, migration, workflow ou infraestrutura.
+- Não ampliar o escopo para corrigir limitações hipotéticas fora da necessidade aprovada.
+
+## 6. Entrega esperada
+
+### 6.1. Execução
+
+Quando o caso for extensão comum:
+
+1. confirmar `main`, estado do repositório e fontes obrigatórias;
+2. investigar somente o necessário;
+3. registrar a classificação e a análise de sobreposição;
+4. criar branch dedicada;
+5. implementar o menor diff suficiente;
+6. executar as validações aplicáveis;
+7. revisar `main..HEAD` e `main...HEAD`;
+8. criar PR para merge humano.
+
+### 6.2. Relatório final
+
+Informar:
+
+- decisão humana recebida;
+- classificação adotada;
+- análise de sobreposição;
+- identidades adicionadas ou editadas;
+- arquivos alterados;
+- mecanismos centrais preservados;
+- validações e resultados;
+- risco residual;
+- branch, commit e PR.
+
+Usar um destes estados:
+
+- `pronto para merge humano`;
+- `bloqueado: evolução arquitetural`;
+- `bloqueado: decisão de produto`;
+- `bloqueado: fonte insuficiente`.
+
+## 7. Regras de parada
+
+Parar antes de implementar ou publicar quando:
+
+- não houver decisão humana explícita;
+- faltar definição que altere função, fields, cardinalidade, sources ou comportamento;
+- houver sobreposição material com identidade existente;
+- a diferença pertencer à composição ou à geração, e não ao catálogo;
+- o diff exigir alteração em `schema.ts`;
+- o diff exigir alteração em `capabilities.ts`;
+- o diff exigir alteração no resolver, exports ou API pública;
+- surgir novo field kind, capability ou interaction kind;
+- for necessário criar renderer, integração, persistência ou infraestrutura;
+- a extensão comum exigir workaround, duplicação relevante ou alterações distribuídas;
+- uma validação revelar necessidade arquitetural fora do recorte.
+
+Quando parar por evolução arquitetural, entregar somente:
+
+- requisito encontrado;
+- motivo pelo qual o caminho comum não atende;
+- contratos ou arquivos que precisariam evoluir;
+- recomendação de retornar ao processo completo de planejamento.
+
+Não implementar parcialmente a evolução arquitetural.
+
+## 8. Evidência / validação
+
+### 8.1. Validações obrigatórias para alteração de código
+
+Executar, conforme o `AGENTS.md`:
+
+```text
+npm ci
+npm run validate:landing-page-root
+npm run validate:landing-page-research
+npm run validate:landing-page-input-catalog
+npm run validate:landing-page-module-catalog
+npm run validate:commercial-activation
+npm run check
+git diff --check main...HEAD
+```
+
+Não executar `npm run build` como rotina de sandbox.
+
+### 8.2. Evidência estrutural
+
+Demonstrar no diff que:
+
+- a identidade resolve exatamente;
+- fields, sources, cardinalidades, capabilities e interactions esperados foram exercitados;
+- o resultado permanece profundamente imutável;
+- não houve alteração em mecanismos centrais para uma extensão comum;
+- não foram adicionadas contagens globais, regras nominais ou listas paralelas evitáveis;
+- alterações documentais correspondem ao estado material final.
+
+Quando a mudança for exclusivamente documental, `npm ci` e `npm run check` podem ser considerados não aplicáveis, com justificativa.
+
+## 9. Regra de concisão
+
+- Executar somente o necessário para a necessidade aprovada.
+- Não criar plano, camada ou documentação paralela para uma extensão comum.
+- Não repetir regras já definidas no `AGENTS.md`.
+- Manter briefing, diff, testes e relatório proporcionais à alteração.


### PR DESCRIPTION
## 1. Objetivo

Criar a v1 de `docs/prompt-catalogo-lp.md` como procedimento especializado para a IA de engenharia promover adições ou edições comuns no catálogo de módulos e variantes de `landing_page`.

## 2. Fontes usadas

- `README.md`
- `AGENTS.md`
- `docs/template-prompts.md`
- `docs/lp-planejamento.md`
- `docs/base-tecnica.md`
- `docs/roadmap.md`
- implementação vigente de `lib/conversion-content/landing-page/module-catalog/`

## 3. Conteúdo

- papel e objetivo da IA de engenharia;
- entrada mínima com decisão humana e necessidade funcional;
- classificação entre módulo, variante, edição e evolução arquitetural;
- análise obrigatória de sobreposição;
- caminho localizado para extensões comuns;
- limites e regras de parada;
- validações técnicas e evidências esperadas;
- estados finais para merge humano ou bloqueio.

## 4. Pendência registrada para a E20.3

`docs/lp-planejamento.md` registra que a E20.3 deverá definir o handoff semântico dos gaps para o prompt, incluindo:

- evidência de `lp_sections` para função e anatomia;
- papéis semânticos e limites da E18.4;
- itens estruturados da E10.8 para source maps de copy;
- dados ou evidências da E20.2 para afirmações factuais;
- parada quando essas fontes forem insuficientes.

O prompt permanece inalterado nesta etapa. Eventual ajuste será decidido após validar o handoff na composição real.

## 5. Protocolo de edição segura

`AGENTS.md` passa a exigir, para arquivos existentes:

- leitura da versão atual no branch-alvo e uso do respectivo `sha`;
- preservação integral do conteúdo fora do trecho autorizado;
- uma única gravação por arquivo sempre que possível;
- releitura obrigatória antes de qualquer segunda gravação;
- revisão imediata do diff;
- parada diante de alterações inesperadas, sem compensações sucessivas;
- validação de ausência de perda de conteúdo e commits redundantes no gate pré-PR.

## 6. Limites

- nenhum ajuste nos prompts gerais do Estrategista ou Executor;
- nenhuma alteração de código, roadmap, banco, runtime ou infraestrutura;
- nenhuma automação nova;
- somente os três arquivos documentais deste recorte.

## 7. Validação

- comparação `main...HEAD`: 3 arquivos, 3 commits;
- `docs/prompt-catalogo-lp.md`: arquivo novo, 213 linhas;
- `docs/lp-planejamento.md`: 7 linhas adicionadas, nenhuma remoção;
- `AGENTS.md`: nova seção de edição segura e dois gates adicionais; a única linha removida no diff foi substituída pela mesma regra com continuação da lista;
- revisão estrutural conforme `docs/template-prompts.md`;
- `npm ci`: não aplicável, alteração exclusivamente documental;
- `npm run check`: não aplicável, alteração exclusivamente documental.

## 8. Próximo passo

Após o merge, prosseguir com a E20.3. A promoção de módulos derivados de gaps ficará para depois da definição e validação do handoff semântico.