### PR TITLE
docs: adiciona skills de prompts e briefing Codex

### DIFF
--- a/.agents/skills/lp-factory-briefing-codex/SKILL.md
+++ b/.agents/skills/lp-factory-briefing-codex/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: lp-factory-briefing-codex
+description: Criar briefings de implementação para o Codex trabalhar no repositório LP Factory 10, com contexto, objetivo, arquivos-alvo, limites, validações e entrega final. Usar quando o humano pedir briefing, task ou instrução para Codex ou executor realizar alterações em arquivos, código, banco, configuração, branch, commit ou PR.
+---
+
+# Criar briefing de implementação para Codex
+
+Produzir um briefing objetivo e executável para o Codex, sem implementar a tarefa descrita.
+
+## Roteamento obrigatório
+
+1. Usar esta skill quando o destinatário for Codex, Codex App ou executor responsável por alterações no repositório.
+2. Esta skill tem precedência sobre `$lp-factory-criar-prompt` quando o pedido envolver arquivos-alvo, implementação, validação técnica, branch, commit ou PR.
+3. Para prompts de análise, pesquisa, avaliação, estratégia, UX, documentação ou outro trabalho sem mutação do repositório, usar `$lp-factory-criar-prompt` e não continuar nesta skill.
+4. Se o pedido for ambíguo, resolver pelas fontes e pelo resultado esperado. Perguntar somente quando não for possível determinar se haverá implementação no repositório.
+
+## Fontes obrigatórias
+
+Antes de produzir o briefing:
+
+1. Ler `README.md`.
+2. Ler `AGENTS.md` na versão vigente.
+3. Ler `docs/template-briefing-codex.md` na versão vigente.
+4. Usar `docs/template-prompts.md` apenas como princípio outcome-first, sem substituir a estrutura específica do briefing.
+5. Ler os documentos, arquivos, código, PRs e decisões diretamente relacionados ao recorte.
+6. Consultar o GitHub antes de declarar ausência de documentação do projeto.
+
+Não usar cópia incorporada ou memória como substituta das fontes canônicas do repositório.
+
+## Preparar o briefing
+
+Confirmar no material disponível:
+
+1. fonte ou estado atual;
+2. problema ou necessidade;
+3. resultado esperado;
+4. critérios de sucesso;
+5. arquivos a criar ou alterar;
+6. arquivos, áreas e comportamentos que não podem ser alterados;
+7. impacto visual ou frontend, somente quando aplicável;
+8. limites e regras de parada;
+9. validações aplicáveis;
+10. evidências exigidas na entrega final.
+
+Confirmar que o briefing pertence ao caso, fase, branch e arquivos-alvo corretos. Não adaptar briefing de outro caso por inferência.
+
+Se faltar fonte, permissão, decisão ou contexto indispensável, parar e pedir exatamente o dado ausente.
+
+## Produzir o briefing
+
+1. Aplicar a estrutura vigente de `docs/template-briefing-codex.md`.
+2. Descrever o resultado esperado, sem prescrever implementação não sustentada pelas fontes.
+3. Informar paths concretos quando forem conhecidos.
+4. Preencher a seção visual somente quando houver impacto visual ou frontend.
+5. Referenciar `AGENTS.md` para regras operacionais, Git e publicação; não duplicar seu conteúdo no briefing.
+6. Exigir apenas validações aplicáveis ao recorte e justificar as não aplicáveis.
+7. Incluir regras de parada específicas quando a tarefa depender de fonte, permissão ou decisão ainda ausente.
+8. Preservar estrutura, numeração e ordem de documentos existentes quando o briefing determinar sua alteração.
+9. Não inventar branch, rota, banco, job, agente, automação, engine ou infraestrutura.
+
+## Entrega
+
+Entregar:
+
+1. o briefing completo e pronto para ser enviado ao Codex;
+2. as fontes utilizadas, quando não estiverem suficientemente explícitas dentro do briefing;
+3. bloqueios ou dados faltantes, quando houver.
+
+## Limites
+
+Não executar a implementação; não criar ou alterar arquivos, branch, commit ou PR; não substituir `AGENTS.md`; não produzir prompt conceitual para outro papel; não ampliar o escopo além das fontes e decisões aprovadas.

--- a/.agents/skills/lp-factory-briefing-codex/agents/openai.yaml
+++ b/.agents/skills/lp-factory-briefing-codex/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Briefing para Codex"
+  short_description: "Cria briefings de implementação no repositório"
+  default_prompt: "Use $lp-factory-briefing-codex para criar um briefing de implementação para o Codex com contexto, arquivos-alvo, limites, validações e entrega final."

--- a/.agents/skills/lp-factory-criar-prompt/SKILL.md
+++ b/.agents/skills/lp-factory-criar-prompt/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: lp-factory-criar-prompt
+description: Criar prompts, instruções e handoffs outcome-first para papéis e IAs do LP Factory 10, exceto briefings de implementação destinados ao Codex. Usar quando o humano pedir prompt pronto, instrução para análise, pesquisa, avaliação, estratégia, UX, documentação ou outro papel que não executará alterações no repositório.
+---
+
+# Criar prompt outcome-first
+
+Produzir uma instrução completa e executável por outra IA, usando as fontes vigentes do LP Factory 10 e sem executar a tarefa descrita no prompt.
+
+## Roteamento obrigatório
+
+1. Usar esta skill quando o produto final for prompt, instrução ou handoff para análise, pesquisa, avaliação, decisão, estratégia, UX, documentação ou outro trabalho sem implementação no repositório.
+2. Se o destinatário for Codex, Codex App ou executor que alterará arquivos, código, banco, configuração, branch, commit ou PR, usar `$lp-factory-briefing-codex` e não continuar nesta skill.
+3. Se o pedido for ambíguo, resolver pelas fontes e pelo resultado esperado. Perguntar somente quando não for possível determinar se haverá implementação no repositório.
+
+## Fontes obrigatórias
+
+Antes de produzir o prompt:
+
+1. Ler `README.md`.
+2. Ler `docs/template-prompts.md` na versão vigente.
+3. Ler os documentos, arquivos, PRs e decisões diretamente relacionados ao recorte.
+4. Ler o prompt ou contrato vigente do papel destinatário quando existir.
+5. Consultar o GitHub antes de declarar ausência de documentação do projeto.
+
+Não usar cópia incorporada ou memória como substituta das fontes canônicas do repositório.
+
+## Preparar a instrução
+
+Confirmar no material disponível:
+
+1. papel ou função da IA destinatária;
+2. resultado esperado;
+3. fontes e contexto que podem ser usados;
+4. critérios de sucesso;
+5. limites do recorte;
+6. formato da entrega;
+7. regras de parada;
+8. evidências ou validações exigidas;
+9. nível de concisão adequado.
+
+Se faltar fonte, decisão ou definição indispensável, parar e pedir exatamente o dado ausente. Não completar lacunas críticas por suposição.
+
+## Produzir o prompt
+
+1. Aplicar a estrutura vigente de `docs/template-prompts.md`.
+2. Começar pelo resultado esperado e manter as instruções orientadas à entrega.
+3. Informar fontes concretas, evitando referências genéricas quando paths, PRs ou documentos forem conhecidos.
+4. Separar critérios de sucesso, limites e regras de parada.
+5. Exigir evidência proporcional ao resultado solicitado.
+6. Preservar estrutura, numeração e ordem de documento existente quando o pedido for ajuste de prompt já versionado.
+7. Remover repetições e processos que não aumentem a precisão da execução.
+
+## Entrega
+
+Entregar:
+
+1. o prompt completo e pronto para uso;
+2. as fontes utilizadas, quando não estiverem suficientemente explícitas dentro do próprio prompt;
+3. bloqueios ou dados faltantes, quando houver.
+
+## Limites
+
+Não executar a tarefa descrita no prompt; não criar implementação, branch, commit ou PR; não inventar rota, banco, job, agente, automação, engine ou infraestrutura; não transformar briefing de implementação para Codex em prompt geral.

--- a/.agents/skills/lp-factory-criar-prompt/agents/openai.yaml
+++ b/.agents/skills/lp-factory-criar-prompt/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Criar prompt LP Factory"
+  short_description: "Cria prompts outcome-first para outras IAs"
+  default_prompt: "Use $lp-factory-criar-prompt para criar um prompt ou instrução outcome-first para o papel informado, sem gerar briefing de implementação para Codex."


### PR DESCRIPTION
## 1. Objetivo

Versionar no repositório duas skills complementares para criação de instruções no LP Factory 10:

- `lp-factory-criar-prompt` para prompts e handoffs sem implementação no repositório;
- `lp-factory-briefing-codex` para briefings destinados ao Codex ou executor que alterará o repositório.

## 2. Fontes usadas

- `README.md`;
- `AGENTS.md`;
- `docs/template-prompts.md`;
- `docs/template-briefing-codex.md`;
- convenção vigente em `.agents/skills/`, incluindo `SKILL.md` e `agents/openai.yaml`.

## 3. Roteamento sem conflito

- A skill geral exclui explicitamente briefings de implementação para Codex.
- A skill de briefing tem precedência quando houver Codex, implementação, arquivos-alvo, validação técnica, branch, commit ou PR.
- Pedidos ambíguos devem ser resolvidos pelas fontes e pelo resultado esperado; pergunta ao humano ocorre somente quando não for possível determinar se haverá mutação do repositório.

## 4. Arquivos criados

- `.agents/skills/lp-factory-criar-prompt/SKILL.md`;
- `.agents/skills/lp-factory-criar-prompt/agents/openai.yaml`;
- `.agents/skills/lp-factory-briefing-codex/SKILL.md`;
- `.agents/skills/lp-factory-briefing-codex/agents/openai.yaml`.

## 5. Limites

- Nenhuma alteração em `README.md`, `AGENTS.md` ou nos templates canônicos.
- Nenhuma alteração de código, banco, configuração, runtime ou infraestrutura.
- As skills consultam as versões vigentes do repositório e não tratam cópias internas como fonte canônica.
- As skills produzem instruções, mas não executam a tarefa resultante.

## 6. Validação

- comparação `main...HEAD`: somente os quatro arquivos novos;
- 143 adições e nenhuma remoção;
- estrutura compatível com as skills existentes em `.agents/skills/`;
- `npm ci`: não aplicável, alteração exclusivamente documental;
- `npm run check`: não aplicável, alteração exclusivamente documental.

## 7. Uso após o merge

- No Codex App, as skills ficam disponíveis pelo projeto conforme a convenção `.agents/skills/`.
- Para uso como Skills instaladas no ChatGPT, a versão canônica do repositório deverá ser empacotada e importada separadamente.