### PR TITLE
feat: promove Comparison e Lead Capture na E18.5

### DIFF
--- a/docs/lp-planejamento.md
+++ b/docs/lp-planejamento.md
@@ -42,7 +42,7 @@ Fontes de referência: `README.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `
 - Form e Accordion usam uma moldura discriminada comum de interações; capability interativa é derivada do contrato declarado, e capabilities de ação ou imagem são derivadas dos fields quando seguro.
 - Código adicional permanece legítimo quando o primeiro caso real introduzir capability ou interaction kind realmente novo; nesse caso, contrato TypeScript, ramo discriminado, schema Zod e casos positivos e negativos próprios podem evoluir uma vez, sem criar propriedade isolada por variante.
 - O primeiro caso real de mídia avançada deve introduzir moldura discriminada própria; a E18.5 não antecipa vídeo, áudio, animação, visual interativo ou 3D sem caso material.
-- A otimização incorpora permanentemente `benefits@v1`, `benefits.standard@v1` e `hero.form@v1` e preserva os quatro testes de extensibilidade derivados do PR #617.
+- A otimização incorpora permanentemente `benefits@v1`, `benefits.standard@v1`, `hero.form@v1`, `comparison@v1`, `comparison.standard@v1`, `lead_capture@v1` e `lead_capture.form@v1` e preserva os quatro testes de extensibilidade derivados do PR #617.
 - A E18.5 não será substituída por catálogo apenas consultivo e não perderá as proteções comprovadas nos testes.
 - A E18.5 não implementa dados concretos, conteúdo final, composição, renderer, persistência ou integração operacional.
 
@@ -117,7 +117,7 @@ Fontes de referência: `README.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `
 ### 2.3. E18.5 — Otimização do catálogo executável
 
 - Preservar o núcleo executável incorporado pelo PR #590 e suas proteções comprovadas.
-- Incorporar `benefits@v1`, `benefits.standard@v1` e `hero.form@v1` como identidades permanentes.
+- Incorporar `benefits@v1`, `benefits.standard@v1`, `hero.form@v1`, `comparison@v1`, `comparison.standard@v1`, `lead_capture@v1` e `lead_capture.form@v1` como identidades permanentes.
 - Remover contagens globais fixas, declarar fontes junto dos fields, eliminar o `switch` paralelo por path e reduzir listas e identidades paralelas evitáveis.
 - Preferir relações Zod estruturais realmente genéricas a regras nominais vinculadas a variantes específicas.
 - Reutilizar interaction kinds existentes pela coleção discriminada da variante e derivar capabilities simples de interactions e fields, evitando booleanos ou propriedades paralelas como fontes canônicas.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1800,12 +1800,12 @@ Repositório — Ajustados
 - Status: Implementada.
 - Conteúdo:
   - Catálogo interno `landing_page@v1`, compatível com a parametrização raiz v1.
-  - Dez módulos versionados: `hero`, `trust_bar`, `problem_solution`, `offer`, `process`, `technical_assurance`, `social_proof`, `faq`, `final_cta` e `benefits`.
+  - Doze módulos versionados: `hero`, `trust_bar`, `problem_solution`, `offer`, `process`, `technical_assurance`, `social_proof`, `faq`, `final_cta`, `benefits`, `comparison` e `lead_capture`.
   - Cada módulo registra função estrutural, fronteiras, invariantes, lifecycle inicial `hypothesis` e propósito `controlled_test`.
   - Identidades e valores estruturais são fechados e imutáveis, sem colisão com `commercial_activation`.
   - Módulos não registram taxon, campanha, plano, copy, ativo, ordem, canal ou destino concreto.
 - Resultado da otimização:
-  - `benefits@v1` incorporado como módulo transversal, sem acoplamento ao catálogo da E20.2 e sem alteração do resolver;
+  - `benefits@v1`, `comparison@v1` e `lead_capture@v1` incorporados como módulos transversais, sem acoplamento ao catálogo da E20.2 e sem alteração do resolver;
   - contagens globais fixas removidas e identidades paralelas reduzidas por derivação segura.
 
 18.5.4 Campos, estruturas e cardinalidades
@@ -1823,7 +1823,7 @@ Repositório — Ajustados
 18.5.5 Variantes e critérios de criação
 - Status: Implementada.
 - Conteúdo:
-  - Dez variantes `standard@v1`, mais `faq.accordion@v1` e `hero.form@v1`.
+  - Onze variantes `standard@v1`, mais `faq.accordion@v1`, `hero.form@v1` e `lead_capture.form@v1`.
   - Cada variante pertence a um único módulo e versão compatível e aponta para seu próprio contrato de fields.
   - Variantes declaram `interactionContracts` como coleção de união discriminada estrita; os kinds atuais são `form` e `accordion`, únicos por variante.
   - Capabilities `embedded_form` e `accordion_interaction` são derivadas das interações; `primary_action` e `image_asset` são derivadas dos fields.
@@ -1831,7 +1831,7 @@ Repositório — Ajustados
   - Hero Standard permanece sem interação de formulário; Hero Form declara o interaction contract abstrato com fields, consentimento, privacidade, acessibilidade e binding operacional, sem fallback de canal.
   - Diferenças apenas de taxon, copy, plano, campanha, ativo, ordem ou quantidade não criam variante.
 - Resultado da otimização:
-  - `benefits.standard@v1` e `hero.form@v1` foram incorporados atomicamente com seus field contracts, records, fields, sources e interaction contracts;
+  - `benefits.standard@v1`, `comparison.standard@v1`, `hero.form@v1` e `lead_capture.form@v1` foram incorporados atomicamente com seus field contracts, records, fields, sources e interaction contracts;
   - sources permanecem junto dos fields, sem lookup nominal por path, construção paralela ou fallback;
   - propriedades isoladas e o booleano paralelo de compatibilidade foram removidos; `hero.standard@v1` permanece sem formulário e o resolver foi preservado.
 
@@ -1883,10 +1883,10 @@ Repositório — Ajustados
   - O resolver consulta o registry canônico, aplica as especializações da raiz e o delta do perfil e devolve somente o contrato completo da variante resolvida.
   - Lifecycle da raiz, do módulo e da variante usa o vocabulário canônico `hypothesis`, `validated` e `deprecated` e permanece registrado separadamente; a E18.5 não implementa enforcement de composição nem lifecycle efetivo.
   - Resultados são profundamente imutáveis, sem referência mutável compartilhada e sem fallback aproximado.
-  - Validação executável própria concluída com 32 casos, além das regressões de raiz, pesquisas, catálogo de entradas e ativação comercial.
+  - Validação executável própria concluída com 34 casos, além das regressões de raiz, pesquisas, catálogo de entradas e ativação comercial.
   - Comando canônico: `npm run validate:landing-page-module-catalog`.
 - Resultado da otimização:
-  - dez módulos e doze variantes consolidados, com lifecycle separado, API pública mínima, internalidade de registry/schema, ausência de fallback e imutabilidade profunda;
+  - doze módulos e quatorze variantes consolidados, com lifecycle separado, API pública mínima, internalidade de registry/schema, ausência de fallback e imutabilidade profunda;
   - quatro testes de extensibilidade e proteções positivas e negativas repetidos;
   - fixtures sintéticas reutilizam Form e Accordion sem registrar identidades permanentes nem alterar resolver, schema genérico, contratos de interação, listas globais, contagens ou regras nominais;
   - resolver inalterado e E18.5 independente do registry da E20.2.
@@ -2093,6 +2093,8 @@ Repositório — Ajustados
   * O recorte não cria banco, rota, API, Server Action, UI, adapter de banco, entitlement, integração Stripe, valor operacional, snapshot, automação, agente ou job.
 
 99. Changelog
+v1.5.101 — 25/07/2026 — Promovidos `comparison@v1`, `comparison.standard@v1`, `lead_capture@v1` e `lead_capture.form@v1` ao catálogo canônico da E18.5, totalizando doze módulos, quatorze variantes e 34 casos executáveis, com Form reutilizado e mecanismos centrais preservados.
+
 v1.5.100 — 23/07/2026 — Consolidada a moldura discriminada de interações da E18.5, com Form e Accordion, capabilities derivadas, fronteira coerente da Hero e prova sintética de reutilização sem ampliar os mecanismos arquiteturais.
 
 v1.5.99 — 23/07/2026 — Consolidada a implementação material da E18.5 com dez módulos e doze variantes, `benefits.standard@v1`, `hero.form@v1`, sources combinadas, proteções executáveis e `prod#17` ampliado ao contrato abstrato do Hero Form.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1772,11 +1772,11 @@ Repositório — Ajustados
 
 18.5.1 Objetivo e status
 - Objetivo: otimizar o catálogo versionado de módulos e variantes da família `landing_page`, preservando o núcleo executável vigente e reduzindo pontos distribuídos de manutenção.
-- Status: Implementada e aprovada no recorte repo-only, com dez módulos e doze variantes.
-- Estado material: `benefits@v1`, `benefits.standard@v1` e `hero.form@v1` incorporados ao registry canônico, sem alteração do resolver.
+- Status: Implementada e aprovada no recorte repo-only, com doze módulos e quatorze variantes.
+- Estado material: `benefits@v1`, `benefits.standard@v1`, `hero.form@v1`, `comparison@v1`, `comparison.standard@v1`, `lead_capture@v1` e `lead_capture.form@v1` incorporados ao registry canônico, sem alteração do resolver.
 - Proteções preservadas: registry versionado, resolver genérico, Zod estrito, falha fechada, contratos tipados, separação entre módulo, variante e fields, imutabilidade profunda, casos negativos, API pública mínima e ausência de fallback.
 - Limites preservados: sem payload de conteúdo, banco, migration, rota, UI, renderer, composição, persistência, automação, job ou consumo por E19/E20; a E18.4 permanece fora da otimização e E19, E20.2 e E20.3 não serão implementadas ou alteradas neste recorte.
-- Validação: 32 casos executáveis do catálogo, além das regressões de raiz, pesquisas, catálogo de entradas e ativação comercial.
+- Validação: 34 casos executáveis do catálogo, além das regressões de raiz, pesquisas, catálogo de entradas e ativação comercial.
 
 18.5.2 Registros do recorte
 - Banco: N/A.

--- a/lib/conversion-content/landing-page/module-catalog/contracts.ts
+++ b/lib/conversion-content/landing-page/module-catalog/contracts.ts
@@ -9,6 +9,8 @@ export const landingPageModuleKeys = [
   "problem_solution",
   "offer",
   "benefits",
+  "comparison",
+  "lead_capture",
   "process",
   "technical_assurance",
   "social_proof",

--- a/lib/conversion-content/landing-page/module-catalog/registry.ts
+++ b/lib/conversion-content/landing-page/module-catalog/registry.ts
@@ -146,6 +146,39 @@ const landingPageModuleCatalogDefinition = {
         "No taxon-specific key or dependency on an operational input registry.",
       ],
     ),
+    comparison: moduleDefinition(
+      "comparison",
+      "Compare alternatives or criteria in a neutral and structured way.",
+      [
+        "Present between two and four options.",
+        "Apply a coherent comparative basis across the options.",
+        "Keep the options clearly distinct.",
+        "Do not invent superiority, recommendation or result.",
+      ],
+      [
+        "No action, form or media.",
+        "No price or commercial condition.",
+        "No social proof, ranking or automatic recommendation.",
+      ],
+    ),
+    lead_capture: moduleDefinition(
+      "lead_capture",
+      "Present a focused contact-conversion section and lead to the primary conversion route.",
+      [
+        "There is one primary action.",
+        "The Form interaction is explicitly declared.",
+        "Consent, privacy and accessibility are preserved.",
+        "The operational destination remains abstract.",
+        "No response, approval or result is promised.",
+      ],
+      [
+        "No booking, schedule or availability.",
+        "No checkout, payment or CRM.",
+        "No functional submission, persistence or renderer.",
+        "No media or secondary action.",
+      ],
+      ["form"],
+    ),
     process: moduleDefinition(
       "process",
       "Explain a real progression through distinct steps.",
@@ -295,6 +328,24 @@ const landingPageModuleCatalogDefinition = {
         ]),
       ],
     },
+    "comparison.standard@v1": {
+      fieldContractKey: "comparison.standard@v1",
+      fields: [
+        text("comparison.standard.title", "title", "h2", 1, 1, "research_guided", research(["positioning_opportunity", "desire"], "objection")),
+        collection("comparison.standard.items", "items", 2, 4, [
+          text("comparison.standard.items[].optionTitle", "optionTitle", "card_title", 1, 1, "hybrid", research(["positioning_opportunity", "belief"], "desire"), "when_present"),
+          text("comparison.standard.items[].description", "description", "card_body", 1, 1, "hybrid", research(["belief", "objection"], "proof_type"), "when_present"),
+        ]),
+      ],
+    },
+    "lead_capture.form@v1": {
+      fieldContractKey: "lead_capture.form@v1",
+      fields: [
+        text("lead_capture.form.title", "title", "h2", 1, 1, "research_guided", research(["trigger", "desire"], "positioning_opportunity")),
+        text("lead_capture.form.body", "body", "paragraph", 1, 1, "hybrid", research(["desire", "objection"], "belief"), "when_factual"),
+        action("lead_capture.form.primaryCta", "primaryCta", research(["trigger", "desire"], "objection")),
+      ],
+    },
     "process.standard@v1": {
       fieldContractKey: "process.standard@v1",
       fields: [
@@ -374,6 +425,17 @@ const landingPageModuleCatalogDefinition = {
       "benefits.standard@v1",
       "standard",
       "benefits",
+    ),
+    "comparison.standard@v1": variant(
+      "comparison.standard@v1",
+      "standard",
+      "comparison",
+    ),
+    "lead_capture.form@v1": variant(
+      "lead_capture.form@v1",
+      "form",
+      "lead_capture",
+      [contactFormInteraction()],
     ),
     "process.standard@v1": variant(
       "process.standard@v1",

--- a/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
+++ b/lib/conversion-content/landing-page/module-catalog/validation-cases.ts
@@ -511,6 +511,80 @@ const cases: readonly Case[] = [
     },
   },
   {
+    name: "comparison standard resolves as a neutral non-interactive module",
+    run: () => {
+      const result = resolveLandingPageModuleCatalog({
+        moduleCatalogVersion: 1,
+        rootVersion: 1,
+        moduleKey: "comparison",
+        moduleVersion: 1,
+        variantName: "standard",
+        variantVersion: 1,
+        funnelProfileKey: "mofu",
+      });
+
+      assert.equal(result.ok, true);
+      if (!result.ok) return;
+      assert.equal(result.value.variant.variantKey, "comparison.standard@v1");
+      assert.deepEqual(result.value.module.permittedInteractionKinds, []);
+      assert.deepEqual(result.value.variant.interactionContracts, []);
+      assert.deepEqual(result.value.variant.capabilities, []);
+      assert.deepEqual(
+        result.value.fieldContract.fields.map((field) => field.path),
+        ["comparison.standard.title", "comparison.standard.items"],
+      );
+      const items = result.value.fieldContract.fields[1];
+      assert.equal(items?.fieldKind, "collection");
+      if (items?.fieldKind !== "collection") return;
+      assert.deepEqual(items.cardinality, { min: 2, max: 4 });
+      assert.deepEqual(
+        items.itemFields.map((field) => field.path),
+        [
+          "comparison.standard.items[].optionTitle",
+          "comparison.standard.items[].description",
+        ],
+      );
+      assertDeeplyFrozen(result.value);
+    },
+  },
+  {
+    name: "lead capture reuses the complete canonical form interaction",
+    run: () => {
+      const result = resolveLandingPageModuleCatalog({
+        moduleCatalogVersion: 1,
+        rootVersion: 1,
+        moduleKey: "lead_capture",
+        moduleVersion: 1,
+        variantName: "form",
+        variantVersion: 1,
+        funnelProfileKey: "bofu",
+      });
+
+      assert.equal(result.ok, true);
+      if (!result.ok) return;
+      assert.equal(result.value.variant.variantKey, "lead_capture.form@v1");
+      assert.deepEqual(result.value.module.permittedInteractionKinds, ["form"]);
+      assert.deepEqual(result.value.variant.capabilities, [
+        "primary_action",
+        "embedded_form",
+      ]);
+      assert.deepEqual(
+        result.value.fieldContract.fields.map((field) => field.path),
+        [
+          "lead_capture.form.title",
+          "lead_capture.form.body",
+          "lead_capture.form.primaryCta",
+        ],
+      );
+      assert.deepEqual(
+        result.value.variant.interactionContracts,
+        landingPageModuleCatalogRegistry.variants["hero.form@v1"]
+          .interactionContracts,
+      );
+      assertDeeplyFrozen(result.value);
+    },
+  },
+  {
     name: "hero form resolves with a complete abstract accessible form contract",
     run: () => {
       const result = resolveLandingPageModuleCatalog({


### PR DESCRIPTION
## Resumo

Promove ao catálogo canônico da E18.5 as quatro identidades:

- `comparison@v1`
- `comparison.standard@v1`
- `lead_capture@v1`
- `lead_capture.form@v1`

A implementação foi refeita sobre a `main` vigente. Os commits experimentais do PR #625 foram usados somente como evidência funcional validada do contrato encerrado, sem cherry-pick e sem reabrir ou alterar aquele PR.

## Contrato promovido

- Comparison preserva comparação neutra, cardinalidade de duas a quatro opções e ausência de interactions e capabilities.
- Lead Capture declara uma ação primária e reutiliza o Form canônico por `contactFormInteraction()`.
- Benefits permanece com cardinalidade `2..6`.
- Estado final: 12 módulos, 14 variantes e catálogo executável com 34/34 casos.

## Limites preservados

- Nenhuma alteração em `schema.ts`, `capabilities.ts`, `resolver.ts` ou na API pública.
- Nenhuma duplicação do objeto concreto de Form.
- Nenhuma alteração em prompts, mecanismos centrais, banco, rota, renderer, workflow ou infraestrutura.
- Nenhuma implementação de Admin Dashboard ou E20.3.

## Validação

- `npm ci`
- `npm run validate:landing-page-root`
- `npm run validate:landing-page-research`
- `npm run validate:landing-page-input-catalog`
- `npm run validate:landing-page-module-catalog` — 34/34
- `npm run validate:commercial-activation`
- `npm run check` — 0 erros; 24 warnings preexistentes
- `git diff --check main...HEAD`
- diff restrito aos cinco arquivos autorizados
- três ocorrências de `contactFormInteraction`
- `benefits.standard.items` preservado em `2..6`