### PR TITLE
docs: conclui plano-base v1 da E11

### DIFF
--- a/docs/lousa-plano-base-e11.md
+++ b/docs/lousa-plano-base-e11.md
@@ -1,0 +1,453 @@
+# Plano-base E11 — Gestão de Usuários e Convites
+
+- Versão: v1
+- Data: 25/07/2026
+- Status: aguardando avaliação única dos especialistas.
+- Recorte previsto para roadmap: `11.1 — Gestão de membros e convites`
+- Path canônico: `docs/lousa-plano-base-e11.md`
+- Plano conceitual: N/A — debate realizado entre Estrategista, Analista e humano antes da v1.
+- Fontes obrigatórias: `README.md`, `AGENTS.md`, `docs/prompt-estrategista.md`, `docs/template-roadmap.md`, `docs/prompt-executor.md`, `docs/prompt-abc.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/schema.md`, `docs/platform-config.md`, `docs/design-system.md`, `docs/lp-planejamento.md`, `docs/supa-up.md`, `app/auth/confirm/route.ts`, `app/a/home/page.tsx`, `app/a/[account]/actions.ts`, `lib/admin/adapters/adminAccountsAdapter.ts`, `supabase/migrations/20260611172930_remote_public_baseline.sql` e documentação oficial vigente do Supabase para `listUsers()`, `createUser()`, `updateUserById()`, `inviteUserByEmail()`, templates de Auth e redirects.
+
+## 1. Estado e decisões fixas
+
+### 1.1. Problema e resultado esperado
+
+- O banco já representa vínculos entre contas e usuários, mas o produto ainda não possui gestão funcional de membros e convites.
+- A E11 deve permitir que owner e admin administrem membros não-owner da conta pelo Account Dashboard.
+- O fluxo deve atender tanto um e-mail ainda inexistente no Supabase Auth quanto um usuário já cadastrado.
+- O aceite deve ativar somente o vínculo selecionado e nunca todos os vínculos pendentes do usuário.
+- O resultado deve permanecer simples para o MVP, dentro de Next.js, Supabase e TypeScript, sem envio próprio de e-mail e sem infraestrutura paralela.
+
+### 1.2. Estado real confirmado
+
+- `account_users` possui:
+  - unicidade por `(account_id, user_id)`;
+  - papéis `owner`, `admin`, `editor` e `viewer`;
+  - estados `pending`, `active`, `inactive` e `revoked`;
+  - `created_at` como referência temporal existente;
+  - proteção do último owner.
+- As policies atuais permitem leitura do próprio vínculo ou por owner/admin e reservam mutações diretas a owner/admin ou platform admin.
+- `accept_account_invite(account_id, ttl_days)` é invoker, identifica o vínculo por conta e usuário e depende de uma policy de update que o convidado não satisfaz.
+- `activate_user_from_auth_hook(event)` ativa todos os vínculos pendentes do usuário e não pode ser usado pela E11.
+- `/auth/confirm` confirma tokens no POST, com mitigação anti-scanner, mas atualmente não preserva contexto específico de convite nem ativa membership.
+- `/a/home` redireciona imediatamente o usuário logado para a última ou primeira conta ativa e não apresenta convites pendentes.
+- O projeto já possui `createServiceClient()` server-only e consulta `user_id → e-mail` por `auth.admin.getUserById()`.
+- Supabase Auth, SMTP via Resend, redirects e o template nativo `Invite user` pertencem à stack atual.
+- O ambiente Supabase foi limpo antes desta v1 e preserva somente a conta real e seu owner; a limpeza não integra o escopo funcional da E11.
+
+### 1.3. Decisões humanas encerradas
+
+- Automação: não.
+- Usuário já cadastrado e confirmado não recebe novo e-mail.
+- Ao entrar no produto, esse usuário vê o convite pendente e pode aceitar ou recusar.
+- Owner e admin acessam a gestão de membros.
+- Convites podem atribuir somente `admin`, `editor` ou `viewer`.
+- O owner não é transferido, rebaixado, desativado ou revogado na E11.
+- Não haverá e-mail customizado pelo Core.
+- Não haverá tabela, serviço, fila, job, agente ou engine de convite.
+
+### 1.4. Decisões funcionais consolidadas
+
+- Owner e admin podem listar membros e convites e administrar qualquer vínculo não-owner.
+- Owner e admin possuem o mesmo poder operacional sobre `admin`, `editor` e `viewer`; a diferença preservada é que somente o owner ocupa o papel protegido.
+- O ator não altera o próprio papel nem desativa o próprio vínculo na E11.
+- Membro ativo pode ter o papel alterado entre `admin`, `editor` e `viewer`.
+- Desativação aplica `active → inactive`; revogação aplica `pending → revoked`.
+- Convite duplicado não cria segundo membership:
+  - vínculo `active`: informar que o usuário já pertence à conta;
+  - vínculo `pending`: preservar o vínculo; usuário não confirmado pode receber reenvio e usuário confirmado continua com aceite interno;
+  - vínculo `inactive` ou `revoked`: iniciar novo ciclo de convite sem criar duplicidade permanente;
+  - vínculo pertencente a outra conta: não impede novo convite para a conta atual.
+- A identidade mínima exibida é o e-mail obtido server-side do Supabase Auth; nome não é requisito do MVP.
+- O prazo funcional do convite é de 7 dias e não pode ser escolhido pela UI ou pelo chamador.
+- Reenvio dentro do ciclo pendente não estende o prazo funcional.
+- Convite expirado não é aceito; novo convite deve iniciar novo ciclo temporal de forma auditável.
+- Usuário confirmado aceita ou recusa apenas um de seus próprios vínculos pendentes por vez.
+
+### 1.5. Decisões técnicas consolidadas
+
+- O boundary canônico será server-only em `lib/access/account-members/`.
+- `e-mail → user_id` será resolvido por adapter server-only com `auth.admin.listUsers()` paginado, depois da autorização do owner/admin.
+- A UI nunca recebe resultado que revele a existência global de um e-mail no Auth.
+- E-mail novo segue a ordem:
+  - normalizar e procurar o e-mail;
+  - criar usuário não confirmado com `auth.admin.createUser()`;
+  - criar o membership `pending`;
+  - gerar estado de convite versionado e assinado;
+  - gravar o estado opaco em `user_metadata`;
+  - enviar pelo `auth.admin.inviteUserByEmail()`.
+- O estado assinado deve conter no mínimo versão, `account_user_id`, `account_id` e `user_id`.
+- `user_metadata` serve somente como transporte para o template; nunca participa da autorização.
+- A assinatura usa HMAC e secret server-side `INVITE_STATE_SECRET`, sem valor versionado.
+- `/auth/confirm` deve preservar o estado do GET até o POST e validá-lo somente depois de o Supabase confirmar o usuário.
+- A ativação deve validar simultaneamente o usuário autenticado, a assinatura e a linha específica de `account_users`.
+- Aceite repetido da mesma linha já `active` retorna sucesso idempotente; divergência, expiração, `inactive`, `revoked` ou ausência falha fechada.
+- Usuário confirmado aceita ou recusa pela sessão autenticada e pelo `account_user_id` escolhido, sem `invite_state`.
+- Reenvio do usuário ainda não confirmado usa nova chamada a `inviteUserByEmail()`; `auth.resend()` não será usado como convite.
+- O hook amplo existente não será adotado.
+- O runtime não dependerá da função legada de aceite enquanto ela não garantir linha específica, autorização e confirmação de linha alterada.
+- Qualquer ajuste de função, grant ou policy deve ocorrer por migration versionada; esta v1 não autoriza tabela ou coluna nova.
+
+## 2. Contrato do caso
+
+### 2.1. Fluxo operacional — convite por owner/admin
+
+- Gatilho: owner ou admin envia e-mail normalizado e papel permitido em `/a/[account]/members`.
+- Entrada:
+  - conta resolvida pelo Access Context;
+  - ator autenticado e ativo como owner/admin;
+  - e-mail válido;
+  - papel `admin`, `editor` ou `viewer`.
+- Processamento:
+  - autorizar o ator antes de consultar o Auth;
+  - resolver o usuário por e-mail;
+  - classificar o vínculo atual;
+  - criar ou preparar um único ciclo `pending`;
+  - para usuário não confirmado, preparar estado assinado e enviar pelo template nativo;
+  - para usuário confirmado, não enviar e-mail e deixar o convite disponível no produto.
+- Validação:
+  - impedir owner como papel convidado;
+  - impedir duplicidade;
+  - impedir enumeração global de usuários;
+  - confirmar que o membership pertence à conta autorizada.
+- Persistência: `auth.users` e `public.account_users` existentes; nenhuma estrutura nova por padrão.
+- Consumo:
+  - e-mail nativo para usuário não confirmado;
+  - pendência interna para usuário confirmado;
+  - lista atualizada para owner/admin.
+- Fallback:
+  - falha no envio mantém estado recuperável e informa erro temporário;
+  - não enviar e-mail próprio;
+  - não apagar usuário Auth como compensação automática;
+  - permitir tentativa posterior dentro das regras do ciclo.
+
+### 2.2. Fluxo operacional — aceite por e-mail
+
+- Gatilho: usuário não confirmado abre o link do template `Invite user`.
+- Entrada: token ou code do Supabase, tipo `invite`, redirect seguro e `invite_state`.
+- Processamento:
+  - GET apresenta o intersticial sem consumir o token;
+  - POST confirma o token;
+  - obtém o usuário autenticado;
+  - valida assinatura e versão do estado;
+  - valida a linha específica por `account_user_id`, `account_id`, `user_id`, status e prazo;
+  - ativa somente essa linha.
+- Validação:
+  - parâmetros manipulados não alteram a conta;
+  - outro membership pendente do usuário permanece inalterado;
+  - estado já ativo é idempotente;
+  - redirect final é interno ou allowlisted.
+- Persistência: `pending → active` na linha específica.
+- Consumo: sessão válida e redirecionamento para a conta aceita.
+- Fallback:
+  - token inválido, estado inválido, vínculo divergente ou expirado falha fechado;
+  - não ativar por `account_id` isolado;
+  - não usar o hook amplo.
+
+### 2.3. Fluxo operacional — usuário já cadastrado
+
+- Gatilho: usuário confirmado entra em `/a/home`.
+- Entrada: sessão autenticada e vínculos próprios `pending`.
+- Processamento:
+  - verificar pendências antes do redirect automático para conta ativa;
+  - mostrar conta, papel proposto, prazo e ações aceitar ou recusar;
+  - processar uma linha selecionada por vez;
+  - validar `account_users.user_id = usuário autenticado`.
+- Validação:
+  - o usuário não acessa pendência de terceiro;
+  - convite expirado não pode ser aceito;
+  - aceite e recusa repetidos possuem resposta determinística.
+- Persistência:
+  - aceitar: `pending → active`;
+  - recusar: `pending → revoked`.
+- Consumo:
+  - após aceitar, permitir entrada na nova conta;
+  - após recusar, retirar a pendência da lista.
+- Fallback:
+  - sem pendências, preservar o redirect atual de `/a/home`;
+  - falha de leitura não concede acesso e apresenta feedback seguro.
+
+### 2.4. Fluxo operacional — gestão posterior ao aceite
+
+- Gatilho: owner/admin altera papel ou desativa membro ativo.
+- Entrada: conta autorizada, `account_user_id` não-owner e operação permitida.
+- Processamento:
+  - reler vínculo alvo;
+  - rejeitar owner e o próprio vínculo do ator;
+  - aplicar papel permitido ou `active → inactive`;
+  - atualizar listagem.
+- Validação:
+  - owner permanece intacto;
+  - nenhuma operação usa somente `user_id` sem conta e membership;
+  - estado concorrente diferente do esperado falha fechado.
+- Persistência: atualização da linha específica.
+- Consumo: lista de membros com estado e papel atuais.
+- Fallback: mensagem segura e nenhuma alteração parcial.
+
+### 2.5. Segurança e autorização
+
+- A página, Server Actions e adapters devem validar sessão, conta e papel antes de qualquer operação administrativa.
+- Código client não acessa `SUPABASE_SECRET_KEY`, Auth Admin ou mutações privilegiadas.
+- O service client fica restrito a módulos server-only.
+- Toda escrita privilegiada deve repetir autorização no servidor e validar a linha afetada.
+- Não confiar em `user_metadata`, query string, e-mail informado ou estado client para autorização.
+- Comparações de e-mail devem usar normalização única e igualdade exata.
+- Erros da UI devem evitar confirmar se um e-mail existe globalmente.
+- Logs não registram tokens, `invite_state`, secret, e-mail integral ou metadata Auth.
+- Migration relacionada deve revisar grants e remover do caminho público qualquer função legada incompatível com o contrato.
+- Se uma função `SECURITY DEFINER` se mostrar indispensável na v2, ela deve ficar fora do schema exposto quando viável, validar `auth.uid()`, fixar `search_path`, revogar `PUBLIC` e receber grants mínimos.
+
+### 2.6. Prazo, reenvio e consistência
+
+- Constante de domínio única: 7 dias.
+- A referência temporal do ciclo deve permanecer compatível com `invitation_expires_at()` e `account_users.created_at` enquanto não houver estrutura nova aprovada.
+- A v2 deve definir a operação mínima para reiniciar um ciclo `inactive`, `revoked` ou expirado sem preservar a data antiga como se fosse nova.
+- Reenvio válido:
+  - somente para membership `pending`;
+  - somente para usuário ainda não confirmado;
+  - mantém `account_user_id` e prazo do ciclo;
+  - gera envio novo pelo Supabase Auth.
+- Expiração:
+  - bloqueia aceite;
+  - converte o ciclo para `revoked` de forma determinística;
+  - exige novo ciclo para novo convite.
+- Falha entre Auth, membership e envio não possui transação distribuída:
+  - a ordem definida evita e-mail sem membership;
+  - a operação deve ser idempotente;
+  - retry não pode duplicar usuário ou vínculo;
+  - compensação destrutiva automática permanece proibida.
+
+### 2.7. UI e critérios visuais
+
+- Rota canônica: `/a/[account]/members`.
+- A navegação do Account Dashboard mostra a entrada somente para owner/admin.
+- A página usa os componentes existentes do design system:
+  - `Input`, `Select`, `Button`, `FormField`, `FeedbackMessage`, `EmptyState` e `LoadingState`;
+  - cards somente para blocos funcionais ou estado vazio.
+- Conteúdo mínimo:
+  - cabeçalho com título e descrição;
+  - formulário de convite;
+  - membros ativos;
+  - convites pendentes;
+  - e-mail, papel, estado e prazo aplicáveis;
+  - ações permitidas por linha.
+- Estados obrigatórios:
+  - carregando;
+  - vazio;
+  - sucesso;
+  - erro seguro;
+  - ação em andamento com botão desabilitado;
+  - convite expirado;
+  - usuário já pertencente à conta.
+- A interface deve funcionar em desktop e mobile sem tabela ilegível ou ações inacessíveis.
+- A confirmação de ação destrutiva deve nomear o efeito: revogar convite ou desativar membro.
+- Editor e viewer não veem a navegação e recebem bloqueio server-side ao tentar abrir a URL.
+
+### 2.8. Matriz mínima de validação
+
+- Owner e admin autorizados; editor e viewer bloqueados.
+- E-mail inválido bloqueado antes do Auth.
+- Papel owner bloqueado.
+- E-mail inexistente cria usuário não confirmado, membership e envio.
+- E-mail confirmado cria somente membership pendente e aparece em `/a/home`.
+- E-mail não confirmado já existente reutiliza o usuário sem duplicá-lo.
+- Membership ativo retorna “já pertence”.
+- Membership pendente não duplica.
+- Membership inactive, revoked ou expirado inicia novo ciclo válido.
+- Reenvio para não confirmado funciona no Supabase hospedado.
+- Reenvio preserva prazo e contexto da linha.
+- Segundo link e comportamento do primeiro link após reenvio são registrados como evidência.
+- Confirmação por e-mail ativa somente a linha assinada.
+- Manipulação de `account_id`, `account_user_id`, `user_id` ou assinatura falha.
+- Aceite repetido da linha ativa é idempotente.
+- Usuário confirmado aceita e recusa somente pendências próprias.
+- Alteração de papel admite apenas admin, editor e viewer.
+- Owner não é alterado nem desativado.
+- Ator não altera nem desativa o próprio vínculo.
+- Revogação afeta pending; desativação afeta active.
+- Erro ou zero linha alterada nunca retorna sucesso.
+- Nenhum token, estado assinado, secret ou e-mail integral aparece em logs.
+
+### 2.9. Dependências reais
+
+- E2 — sessão, Supabase Auth, SSR e Access Context.
+- E5/E6 — Account Dashboard, shell, navegação e componentes visuais existentes.
+- `account_users`, proteção do owner, RLS, funções de convite e auditoria existentes.
+- `/auth/confirm` e sua mitigação anti-scanner.
+- `/a/home` e sua precedência atual de redirect.
+- Supabase Auth Admin, template nativo `Invite user`, SMTP via Resend e Redirect URL allowlist.
+- Vercel Preview e Production para `INVITE_STATE_SECRET`, com redeploy após configuração.
+- Não há dependência de E12, limite por plano, Stripe, automações ou agentes.
+
+## 3. Fases e próxima ação
+
+### 3.1. E11.1.3 — Domínio server-side e ciclo seguro de vínculos
+
+- Status: planejada.
+- Objetivo: implementar contratos, autorização, resolução de identidade e transições seguras de `account_users`.
+- Automação: não.
+- Escopo executável:
+  - criar o boundary `lib/access/account-members/`;
+  - implementar contratos tipados e normalização de e-mail;
+  - implementar `listUsers()` paginado após autorização;
+  - implementar leitura de membros e convites com e-mail server-side;
+  - implementar classificação de active, pending, inactive e revoked;
+  - implementar convite, aceite interno, recusa, alteração de papel, revogação e desativação como operações idempotentes por `account_user_id`;
+  - criar migration mínima para corrigir ou retirar do caminho operacional as funções, grants e policies legadas incompatíveis;
+  - confirmar no Supabase que o hook amplo não está configurado antes de removê-lo ou restringi-lo;
+  - definir na v2 a forma mínima e auditável de reiniciar o ciclo temporal;
+  - criar casos executáveis da matriz aplicável.
+- Artefatos previstos:
+  - `lib/access/account-members/contracts.ts`;
+  - `lib/access/account-members/policy.ts`;
+  - `lib/access/account-members/adapter.ts`;
+  - `lib/access/account-members/validation-cases.ts`;
+  - `lib/access/account-members/index.ts`;
+  - migration incremental da E11, se confirmada pela investigação;
+  - script de validação em `package.json`.
+- Critérios de aceite:
+  - nenhuma operação administrativa ocorre antes do guard owner/admin;
+  - a busca por e-mail percorre todas as páginas necessárias;
+  - nenhum resultado permite enumeração global pela UI;
+  - transições e duplicidades seguem as seções 1.4 e 2.6;
+  - owner e vínculo do ator permanecem protegidos;
+  - zero linha alterada falha;
+  - nenhum client importa módulo privilegiado;
+  - nenhuma tabela ou coluna nova é criada sem retorno ao Estrategista.
+- Decisão da fase: executar após aprovação da v2.
+- Próxima ação: E11.1.4.
+
+### 3.2. E11.1.4 — Convite de novo usuário e confirmação específica
+
+- Status: planejada.
+- Objetivo: entregar o convite nativo por e-mail, o estado assinado e o aceite seguro de uma única linha.
+- Automação: não.
+- Escopo executável:
+  - implementar criação prévia do usuário não confirmado e membership;
+  - implementar HMAC versionado com `INVITE_STATE_SECRET`;
+  - gravar o estado opaco em metadata somente para transporte;
+  - ajustar o template `Invite user` para enviar token e estado à rota canônica;
+  - ajustar `/auth/confirm` para preservar o estado do GET ao POST;
+  - validar Auth, assinatura, linha, usuário, conta, estado e prazo antes da ativação;
+  - implementar reenvio por `inviteUserByEmail()`;
+  - validar Redirect URL em Preview e Production;
+  - executar teste hospedado ponta a ponta do envio, reenvio e aceite.
+- Artefatos previstos:
+  - `lib/access/account-members/invite-state.ts`;
+  - ajustes em `lib/access/account-members/adapter.ts`;
+  - ajuste em `app/auth/confirm/route.ts`;
+  - configuração externa do template `Invite user`;
+  - variável server-only `INVITE_STATE_SECRET` na Vercel;
+  - casos executáveis e evidência hospedada.
+- Critérios de aceite:
+  - o e-mail é enviado somente pelo Supabase Auth;
+  - o template não expõe secret nem usa metadata como autorização;
+  - scanner não consome o token no GET;
+  - outro vínculo pendente permanece inalterado;
+  - manipulação do estado falha;
+  - aceite repetido é idempotente;
+  - reenvio real entrega o segundo e-mail e possui comportamento documentado para ambos os links;
+  - falha de envio deixa retry recuperável sem duplicidade.
+- Decisão da fase: avançar se a prova hospedada confirmar o fluxo.
+- Próxima ação: E11.1.5.
+
+### 3.3. E11.1.5 — Gestão de membros no Account Dashboard
+
+- Status: planejada.
+- Objetivo: permitir que owner/admin listem e administrem membros e convites não-owner.
+- Automação: não.
+- Escopo executável:
+  - criar `/a/[account]/members`;
+  - criar Server Actions próprias da rota;
+  - adicionar navegação condicionada a owner/admin;
+  - implementar formulário de convite;
+  - listar membros ativos e convites pendentes;
+  - implementar reenvio, revogação, alteração de papel e desativação;
+  - aplicar estados visuais e responsividade da seção 2.7;
+  - manter bloqueio server-side para editor/viewer.
+- Artefatos previstos:
+  - `app/a/[account]/members/page.tsx`;
+  - `app/a/[account]/members/actions.ts`;
+  - componentes locais mínimos quando necessários;
+  - ajuste mínimo na navegação do Account Dashboard.
+- Critérios de aceite:
+  - owner/admin acessam e executam somente operações permitidas;
+  - editor/viewer não acessam a página nem as actions;
+  - lista identifica usuários por e-mail sem criar perfil;
+  - ações por linha nomeiam o efeito e exibem feedback;
+  - estados vazio, carregando, erro, sucesso e em andamento estão presentes;
+  - desktop e mobile permanecem utilizáveis;
+  - nenhuma regra de negócio fica somente no client.
+- Decisão da fase: avançar após validação funcional e visual.
+- Próxima ação: E11.1.6.
+
+### 3.4. E11.1.6 — Pendências do usuário já cadastrado
+
+- Status: planejada.
+- Objetivo: permitir que usuário confirmado veja, aceite ou recuse seus convites sem receber e-mail.
+- Automação: não.
+- Escopo executável:
+  - ajustar `/a/home` para verificar pendências próprias antes do redirect automático;
+  - exibir conta, papel proposto e prazo;
+  - criar ações autenticadas de aceitar e recusar uma linha;
+  - preservar o redirect atual quando não houver pendência;
+  - após aceite, permitir entrada na conta ativada;
+  - após recusa, remover a pendência da superfície.
+- Artefatos previstos:
+  - ajuste em `app/a/home/page.tsx`;
+  - action ou boundary server-side mínimo para aceite e recusa;
+  - componentes locais mínimos quando necessários.
+- Critérios de aceite:
+  - usuário com conta ativa ainda vê novo convite pendente antes do redirect;
+  - apenas pendências do usuário autenticado aparecem;
+  - aceite ativa uma linha e recusa revoga uma linha;
+  - convite expirado não concede acesso;
+  - sem pendências, o comportamento atual de `/a/home` é preservado;
+  - falha de leitura ou escrita não cria acesso parcial.
+- Decisão da fase: encerrar o recorte se toda a matriz estiver aprovada.
+- Próxima ação: N/A — plano implementado.
+
+## 4. Escopo negativo e critérios de parada
+
+### 4.1. Escopo negativo
+
+- Transferência de propriedade.
+- Convite ou criação de owner.
+- Permissões personalizadas ou edição de `permissions`.
+- Convite em massa.
+- Limites de usuários por plano.
+- Exclusão física de membro ativo como ação comum da UI.
+- Exclusão automática de usuário no Supabase Auth.
+- Perfil, nome, avatar ou tabela de identidade.
+- Busca pública ou client-side de usuários Auth.
+- E-mail enviado pelo Next.js, Resend SDK ou serviço próprio.
+- `auth.resend()` usado como convite.
+- Aceite por `account_id` isolado.
+- Confiança em `user_metadata` para autorização.
+- Uso do hook que ativa todos os vínculos pendentes.
+- Tabela, view, coluna, fila, job, agente, engine, cron ou serviço novo sem retorno ao Estrategista.
+- E12, Stripe, billing, plano comercial, automação ou agentes.
+- Redesign amplo do Account Dashboard.
+- Alteração de registros reais preservados na limpeza anterior, exceto dados de teste criados e autorizados para validar a E11.
+
+### 4.2. Critérios de parada
+
+- Parar se o estado real do Supabase divergir materialmente de `docs/schema.md` ou da baseline.
+- Parar se o hook amplo estiver configurado e sua retirada exigir decisão operacional não prevista.
+- Parar se `listUsers()` paginado não puder identificar o usuário de forma segura no volume atual.
+- Parar se o template nativo não conseguir transportar o estado assinado até `/auth/confirm`.
+- Parar se `inviteUserByEmail()` não reenviar no projeto hospedado para usuário ainda não confirmado.
+- Parar antes de criar e-mail próprio como fallback.
+- Parar se o aceite específico exigir ativar mais de um membership.
+- Parar se for necessária tabela ou coluna nova; demonstrar a necessidade e devolver ao Estrategista.
+- Parar se a referência temporal existente não permitir reiniciar o ciclo sem ambiguidade ou perda de auditabilidade.
+- Parar se a solução exigir transferir, rebaixar, revogar ou desativar owner.
+- Parar se a UI exigir nome ou perfil não existente para funcionar.
+- Parar se a implementação exigir automação, job, agente, fila ou infraestrutura nova.
+- Parar se os testes exigirem credencial humana principal ou exposição de secret.
+
+### 4.3. Decisão atual e próxima ação
+
+- Decisão: enviar a v1 para avaliação única do Analista, Gestor Estrutural e Gestor de Updates.
+- Gestor de Automação: não se aplica, pois todas as fases estão marcadas como `Automação: não`.
+- Próxima ação após os pareceres: consolidar a v2 no mesmo PR ou, após merge da v1, seguir o processo automatizado escolhido pelo humano.

--- a/docs/lousa-plano-base-e11.md
+++ b/docs/lousa-plano-base-e11.md
@@ -1,12 +1,12 @@
 # Plano-base E11 — Gestão de Usuários e Convites
 
-- Versão: v1
+- Versão: v2
 - Data: 25/07/2026
-- Status: aguardando avaliação única dos especialistas.
+- Status: ajustado após parecer técnico; aguardando reavaliação dos especialistas.
 - Recorte previsto para roadmap: `11.1 — Gestão de membros e convites`
 - Path canônico: `docs/lousa-plano-base-e11.md`
 - Plano conceitual: N/A — debate realizado entre Estrategista, Analista e humano antes da v1.
-- Fontes obrigatórias: `README.md`, `AGENTS.md`, `docs/prompt-estrategista.md`, `docs/template-roadmap.md`, `docs/prompt-executor.md`, `docs/prompt-abc.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/schema.md`, `docs/platform-config.md`, `docs/design-system.md`, `docs/lp-planejamento.md`, `docs/supa-up.md`, `app/auth/confirm/route.ts`, `app/a/home/page.tsx`, `app/a/[account]/actions.ts`, `lib/admin/adapters/adminAccountsAdapter.ts`, `supabase/migrations/20260611172930_remote_public_baseline.sql` e documentação oficial vigente do Supabase para `listUsers()`, `createUser()`, `updateUserById()`, `inviteUserByEmail()`, templates de Auth e redirects.
+- Fontes obrigatórias: `README.md`, `AGENTS.md`, `docs/prompt-estrategista.md`, `docs/template-roadmap.md`, `docs/prompt-executor.md`, `docs/prompt-abc.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/schema.md`, `docs/platform-config.md`, `docs/design-system.md`, `docs/lp-planejamento.md`, `docs/supa-up.md`, `app/auth/confirm/route.ts`, `app/auth/update-password/page.tsx`, `app/a/home/page.tsx`, `app/a/[account]/actions.ts`, `lib/admin/adapters/adminAccountsAdapter.ts`, `supabase/migrations/20260611172930_remote_public_baseline.sql` e documentação oficial vigente do Supabase para `listUsers()`, `createUser()`, `updateUserById()`, `inviteUserByEmail()`, templates de Auth e redirects.
 
 ## 1. Estado e decisões fixas
 
@@ -24,7 +24,7 @@
   - unicidade por `(account_id, user_id)`;
   - papéis `owner`, `admin`, `editor` e `viewer`;
   - estados `pending`, `active`, `inactive` e `revoked`;
-  - `created_at` como referência temporal existente;
+  - `created_at` como registro da criação da linha, sem representar a validade de cada link do Supabase Auth;
   - proteção do último owner.
 - As policies atuais permitem leitura do próprio vínculo ou por owner/admin e reservam mutações diretas a owner/admin ou platform admin.
 - `accept_account_invite(account_id, ttl_days)` é invoker, identifica o vínculo por conta e usuário e depende de uma policy de update que o convidado não satisfaz.
@@ -33,7 +33,7 @@
 - `/a/home` redireciona imediatamente o usuário logado para a última ou primeira conta ativa e não apresenta convites pendentes.
 - O projeto já possui `createServiceClient()` server-only e consulta `user_id → e-mail` por `auth.admin.getUserById()`.
 - Supabase Auth, SMTP via Resend, redirects e o template nativo `Invite user` pertencem à stack atual.
-- O ambiente Supabase foi limpo antes desta v1 e preserva somente a conta real e seu owner; a limpeza não integra o escopo funcional da E11.
+- O estado remoto é volátil e deve ser inspecionado antes da primeira migration e dos testes, sem assumir como contrato da E11 qualquer inventário anterior de contas ou usuários.
 
 ### 1.3. Decisões humanas encerradas
 
@@ -59,9 +59,10 @@
   - vínculo `inactive` ou `revoked`: iniciar novo ciclo de convite sem criar duplicidade permanente;
   - vínculo pertencente a outra conta: não impede novo convite para a conta atual.
 - A identidade mínima exibida é o e-mail obtido server-side do Supabase Auth; nome não é requisito do MVP.
-- O prazo funcional do convite é de 7 dias e não pode ser escolhido pela UI ou pelo chamador.
-- Reenvio dentro do ciclo pendente não estende o prazo funcional.
-- Convite expirado não é aceito; novo convite deve iniciar novo ciclo temporal de forma auditável.
+- Para usuário novo ou ainda não confirmado, a validade de cada link pertence exclusivamente ao Supabase Auth e à configuração vigente de Email OTP Expiration.
+- Reenvio gera um novo convite e um novo link do Auth, sem criar ou renovar prazo local do membership.
+- Para usuário já confirmado, o vínculo permanece `pending` até aceitar, recusar ou ser revogado por owner/admin.
+- O MVP não possui expiração automática local do membership, não converte `pending → revoked` pelo relógio e não exibe prazo exato sem fonte operacional verificada.
 - Usuário confirmado aceita ou recusa apenas um de seus próprios vínculos pendentes por vez.
 
 ### 1.5. Decisões técnicas consolidadas
@@ -80,8 +81,11 @@
 - `user_metadata` serve somente como transporte para o template; nunca participa da autorização.
 - A assinatura usa HMAC e secret server-side `INVITE_STATE_SECRET`, sem valor versionado.
 - `/auth/confirm` deve preservar o estado do GET até o POST e validá-lo somente depois de o Supabase confirmar o usuário.
-- A ativação deve validar simultaneamente o usuário autenticado, a assinatura e a linha específica de `account_users`.
-- Aceite repetido da mesma linha já `active` retorna sucesso idempotente; divergência, expiração, `inactive`, `revoked` ou ausência falha fechada.
+- Após a confirmação Auth, o usuário novo deve concluir o cadastro definindo senha em `/auth/update-password` com a sessão autenticada.
+- O `invite_state` deve permanecer disponível de forma segura durante a conclusão do cadastro, sem servir como autorização por si só.
+- Somente depois da senha definida, a ativação valida simultaneamente o usuário autenticado, a assinatura e a linha específica de `account_users`.
+- Aceite repetido da mesma linha já `active` retorna sucesso idempotente; divergência, `inactive`, `revoked` ou ausência falha fechada.
+- Se a senha for definida e a ativação falhar, o mesmo vínculo pode ser retomado por retry idempotente; enquanto permanecer `pending`, não concede acesso à conta.
 - Usuário confirmado aceita ou recusa pela sessão autenticada e pelo `account_user_id` escolhido, sem `invite_state`.
 - Reenvio do usuário ainda não confirmado usa nova chamada a `inviteUserByEmail()`; `auth.resend()` não será usado como convite.
 - O hook amplo existente não será adotado.
@@ -127,20 +131,29 @@
 - Entrada: token ou code do Supabase, tipo `invite`, redirect seguro e `invite_state`.
 - Processamento:
   - GET apresenta o intersticial sem consumir o token;
-  - POST confirma o token;
-  - obtém o usuário autenticado;
-  - valida assinatura e versão do estado;
-  - valida a linha específica por `account_user_id`, `account_id`, `user_id`, status e prazo;
-  - ativa somente essa linha.
+  - POST confirma o token e obtém a sessão do usuário;
+  - valida assinatura, versão e correspondência do estado com o usuário autenticado;
+  - direciona o usuário para concluir o cadastro em `/auth/update-password`;
+  - define a senha com a sessão autenticada;
+  - valida a linha específica por `account_user_id`, `account_id`, `user_id` e status;
+  - ativa somente essa linha;
+  - redireciona para a conta aceita.
 - Validação:
+  - a validade do token ou code é decidida pelo Supabase Auth;
   - parâmetros manipulados não alteram a conta;
   - outro membership pendente do usuário permanece inalterado;
   - estado já ativo é idempotente;
-  - redirect final é interno ou allowlisted.
-- Persistência: `pending → active` na linha específica.
-- Consumo: sessão válida e redirecionamento para a conta aceita.
+  - redirect final é interno ou allowlisted;
+  - logout e novo login por e-mail e senha funcionam após a conclusão.
+- Persistência:
+  - senha definida no Supabase Auth;
+  - `pending → active` na linha específica somente depois da senha.
+- Consumo: cadastro concluído, vínculo ativo, sessão válida e redirecionamento para a conta aceita.
 - Fallback:
-  - token inválido, estado inválido, vínculo divergente ou expirado falha fechado;
+  - token inválido ou expirado é rejeitado pelo Auth;
+  - estado inválido ou vínculo divergente falha fechado;
+  - abandono antes da senha mantém o vínculo `pending` e sem acesso;
+  - falha de ativação após a senha permite retry idempotente da mesma linha;
   - não ativar por `account_id` isolado;
   - não usar o hook amplo.
 
@@ -150,12 +163,12 @@
 - Entrada: sessão autenticada e vínculos próprios `pending`.
 - Processamento:
   - verificar pendências antes do redirect automático para conta ativa;
-  - mostrar conta, papel proposto, prazo e ações aceitar ou recusar;
+  - mostrar conta, papel proposto e ações aceitar ou recusar;
   - processar uma linha selecionada por vez;
   - validar `account_users.user_id = usuário autenticado`.
 - Validação:
   - o usuário não acessa pendência de terceiro;
-  - convite expirado não pode ser aceito;
+  - o vínculo permanece pendente sem expiração automática local;
   - aceite e recusa repetidos possuem resposta determinística.
 - Persistência:
   - aceitar: `pending → active`;
@@ -197,20 +210,19 @@
 - Migration relacionada deve revisar grants e remover do caminho público qualquer função legada incompatível com o contrato.
 - Se uma função `SECURITY DEFINER` se mostrar indispensável na v2, ela deve ficar fora do schema exposto quando viável, validar `auth.uid()`, fixar `search_path`, revogar `PUBLIC` e receber grants mínimos.
 
-### 2.6. Prazo, reenvio e consistência
+### 2.6. Validade do link, reenvio e consistência
 
-- Constante de domínio única: 7 dias.
-- A referência temporal do ciclo deve permanecer compatível com `invitation_expires_at()` e `account_users.created_at` enquanto não houver estrutura nova aprovada.
-- A v2 deve definir a operação mínima para reiniciar um ciclo `inactive`, `revoked` ou expirado sem preservar a data antiga como se fosse nova.
+- Para usuário novo ou ainda não confirmado, o Supabase Auth é a única fonte de validade do link, conforme Email OTP Expiration vigente no projeto.
+- O membership não possui prazo local no MVP e `account_users.created_at` não deve ser usado para calcular expiração de convite.
+- Usuário já confirmado permanece `pending` até aceitar, recusar ou ser revogado por owner/admin.
+- A UI não exibe prazo exato sem consultar uma fonte operacional real; não deriva prazo por constante local.
 - Reenvio válido:
   - somente para membership `pending`;
   - somente para usuário ainda não confirmado;
-  - mantém `account_user_id` e prazo do ciclo;
-  - gera envio novo pelo Supabase Auth.
-- Expiração:
-  - bloqueia aceite;
-  - converte o ciclo para `revoked` de forma determinística;
-  - exige novo ciclo para novo convite.
+  - mantém o mesmo `account_user_id`;
+  - gera novo convite e novo link pelo Supabase Auth;
+  - não usa `auth.resend()` como convite.
+- O runtime não converte `pending → revoked` por passagem do tempo.
 - Falha entre Auth, membership e envio não possui transação distribuída:
   - a ordem definida evita e-mail sem membership;
   - a operação deve ser idempotente;
@@ -229,7 +241,7 @@
   - formulário de convite;
   - membros ativos;
   - convites pendentes;
-  - e-mail, papel, estado e prazo aplicáveis;
+  - e-mail, papel e estado aplicáveis;
   - ações permitidas por linha.
 - Estados obrigatórios:
   - carregando;
@@ -237,7 +249,7 @@
   - sucesso;
   - erro seguro;
   - ação em andamento com botão desabilitado;
-  - convite expirado;
+  - link Auth inválido ou expirado no fluxo por e-mail;
   - usuário já pertencente à conta.
 - A interface deve funcionar em desktop e mobile sem tabela ilegível ou ações inacessíveis.
 - A confirmação de ação destrutiva deve nomear o efeito: revogar convite ou desativar membro.
@@ -253,11 +265,14 @@
 - E-mail não confirmado já existente reutiliza o usuário sem duplicá-lo.
 - Membership ativo retorna “já pertence”.
 - Membership pendente não duplica.
-- Membership inactive, revoked ou expirado inicia novo ciclo válido.
+- Membership inactive ou revoked pode iniciar novo ciclo válido sem duplicar a linha.
 - Reenvio para não confirmado funciona no Supabase hospedado.
-- Reenvio preserva prazo e contexto da linha.
+- Reenvio preserva o contexto da linha e gera novo link conforme a validade controlada pelo Auth.
 - Segundo link e comportamento do primeiro link após reenvio são registrados como evidência.
-- Confirmação por e-mail ativa somente a linha assinada.
+- Confirmação por e-mail cria sessão e conduz à definição de senha antes da ativação.
+- Conclusão do cadastro ativa somente a linha assinada.
+- Logout e novo login por e-mail e senha funcionam após o aceite.
+- Abandono antes da senha ou falha de ativação mantém o vínculo sem acesso e permite retomada segura.
 - Manipulação de `account_id`, `account_user_id`, `user_id` ou assinatura falha.
 - Aceite repetido da linha ativa é idempotente.
 - Usuário confirmado aceita e recusa somente pendências próprias.
@@ -273,7 +288,7 @@
 - E2 — sessão, Supabase Auth, SSR e Access Context.
 - E5/E6 — Account Dashboard, shell, navegação e componentes visuais existentes.
 - `account_users`, proteção do owner, RLS, funções de convite e auditoria existentes.
-- `/auth/confirm` e sua mitigação anti-scanner.
+- `/auth/confirm`, sua mitigação anti-scanner e `/auth/update-password` como base da conclusão do cadastro.
 - `/a/home` e sua precedência atual de redirect.
 - Supabase Auth Admin, template nativo `Invite user`, SMTP via Resend e Redirect URL allowlist.
 - Vercel Preview e Production para `INVITE_STATE_SECRET`, com redeploy após configuração.
@@ -295,7 +310,7 @@
   - implementar convite, aceite interno, recusa, alteração de papel, revogação e desativação como operações idempotentes por `account_user_id`;
   - criar migration mínima para corrigir ou retirar do caminho operacional as funções, grants e policies legadas incompatíveis;
   - confirmar no Supabase que o hook amplo não está configurado antes de removê-lo ou restringi-lo;
-  - definir na v2 a forma mínima e auditável de reiniciar o ciclo temporal;
+  - impedir expiração automática local do membership e uso de `created_at` como validade do link;
   - criar casos executáveis da matriz aplicável.
 - Artefatos previstos:
   - `lib/access/account-members/contracts.ts`;
@@ -317,25 +332,30 @@
 - Decisão da fase: executar após aprovação da v2.
 - Próxima ação: E11.1.4.
 
-### 3.2. E11.1.4 — Convite de novo usuário e confirmação específica
+### 3.2. E11.1.4 — Convite de novo usuário, conclusão do cadastro e confirmação específica
 
 - Status: planejada.
-- Objetivo: entregar o convite nativo por e-mail, o estado assinado e o aceite seguro de uma única linha.
+- Objetivo: entregar o convite nativo por e-mail, a definição de senha e o aceite seguro de uma única linha.
 - Automação: não.
 - Escopo executável:
   - implementar criação prévia do usuário não confirmado e membership;
   - implementar HMAC versionado com `INVITE_STATE_SECRET`;
   - gravar o estado opaco em metadata somente para transporte;
   - ajustar o template `Invite user` para enviar token e estado à rota canônica;
-  - ajustar `/auth/confirm` para preservar o estado do GET ao POST;
-  - validar Auth, assinatura, linha, usuário, conta, estado e prazo antes da ativação;
+  - ajustar `/auth/confirm` para preservar o estado do GET ao POST, confirmar o Auth e criar a sessão;
+  - reutilizar ou adaptar `/auth/update-password` para o contexto de convite;
+  - preservar com segurança o contexto específico até a conclusão do cadastro;
+  - definir a senha antes de ativar o membership;
+  - validar assinatura, linha, usuário, conta e estado antes da ativação;
+  - implementar retry idempotente da mesma linha se a ativação falhar após a senha;
   - implementar reenvio por `inviteUserByEmail()`;
-  - validar Redirect URL em Preview e Production;
-  - executar teste hospedado ponta a ponta do envio, reenvio e aceite.
+  - validar Email OTP Expiration e Redirect URL vigentes em Preview e Production, sem duplicar prazo local na aplicação;
+  - executar teste hospedado ponta a ponta do envio, reenvio, senha, aceite, logout e novo login.
 - Artefatos previstos:
   - `lib/access/account-members/invite-state.ts`;
   - ajustes em `lib/access/account-members/adapter.ts`;
   - ajuste em `app/auth/confirm/route.ts`;
+  - ajuste em `app/auth/update-password/page.tsx`;
   - configuração externa do template `Invite user`;
   - variável server-only `INVITE_STATE_SECRET` na Vercel;
   - casos executáveis e evidência hospedada.
@@ -343,12 +363,16 @@
   - o e-mail é enviado somente pelo Supabase Auth;
   - o template não expõe secret nem usa metadata como autorização;
   - scanner não consome o token no GET;
+  - validade do link é controlada pelo Auth, sem revogação automática local do membership;
+  - usuário define senha antes de receber acesso à conta;
   - outro vínculo pendente permanece inalterado;
   - manipulação do estado falha;
-  - aceite repetido é idempotente;
+  - aceite repetido e retry da ativação são idempotentes;
+  - abandono antes da senha mantém o membership `pending` e sem acesso;
+  - logout e novo login por e-mail e senha funcionam;
   - reenvio real entrega o segundo e-mail e possui comportamento documentado para ambos os links;
   - falha de envio deixa retry recuperável sem duplicidade.
-- Decisão da fase: avançar se a prova hospedada confirmar o fluxo.
+- Decisão da fase: avançar se a prova hospedada confirmar o fluxo completo.
 - Próxima ação: E11.1.5.
 
 ### 3.3. E11.1.5 — Gestão de membros no Account Dashboard
@@ -388,7 +412,7 @@
 - Automação: não.
 - Escopo executável:
   - ajustar `/a/home` para verificar pendências próprias antes do redirect automático;
-  - exibir conta, papel proposto e prazo;
+  - exibir conta e papel proposto;
   - criar ações autenticadas de aceitar e recusar uma linha;
   - preservar o redirect atual quando não houver pendência;
   - após aceite, permitir entrada na conta ativada;
@@ -401,7 +425,7 @@
   - usuário com conta ativa ainda vê novo convite pendente antes do redirect;
   - apenas pendências do usuário autenticado aparecem;
   - aceite ativa uma linha e recusa revoga uma linha;
-  - convite expirado não concede acesso;
+  - a pendência não expira automaticamente e só concede acesso após aceite;
   - sem pendências, o comportamento atual de `/a/home` é preservado;
   - falha de leitura ou escrita não cria acesso parcial.
 - Decisão da fase: encerrar o recorte se toda a matriz estiver aprovada.
@@ -428,7 +452,6 @@
 - Tabela, view, coluna, fila, job, agente, engine, cron ou serviço novo sem retorno ao Estrategista.
 - E12, Stripe, billing, plano comercial, automação ou agentes.
 - Redesign amplo do Account Dashboard.
-- Alteração de registros reais preservados na limpeza anterior, exceto dados de teste criados e autorizados para validar a E11.
 
 ### 4.2. Critérios de parada
 
@@ -440,7 +463,6 @@
 - Parar antes de criar e-mail próprio como fallback.
 - Parar se o aceite específico exigir ativar mais de um membership.
 - Parar se for necessária tabela ou coluna nova; demonstrar a necessidade e devolver ao Estrategista.
-- Parar se a referência temporal existente não permitir reiniciar o ciclo sem ambiguidade ou perda de auditabilidade.
 - Parar se a solução exigir transferir, rebaixar, revogar ou desativar owner.
 - Parar se a UI exigir nome ou perfil não existente para funcionar.
 - Parar se a implementação exigir automação, job, agente, fila ou infraestrutura nova.
@@ -448,6 +470,6 @@
 
 ### 4.3. Decisão atual e próxima ação
 
-- Decisão: enviar a v1 para avaliação única do Analista, Gestor Estrutural e Gestor de Updates.
+- Decisão: reapresentar a v2 ajustada ao Analista, Gestor Estrutural e Gestor de Updates.
 - Gestor de Automação: não se aplica, pois todas as fases estão marcadas como `Automação: não`.
-- Próxima ação após os pareceres: consolidar a v2 no mesmo PR ou, após merge da v1, seguir o processo automatizado escolhido pelo humano.
+- Próxima ação após a reavaliação: consolidar eventuais ajustes no mesmo PR ou liberar o plano para merge humano.

--- a/docs/lousa-plano-base-e11.md
+++ b/docs/lousa-plano-base-e11.md
@@ -90,7 +90,7 @@
 - Reenvio do usuário ainda não confirmado usa nova chamada a `inviteUserByEmail()`; `auth.resend()` não será usado como convite.
 - O hook amplo existente não será adotado.
 - O runtime não dependerá da função legada de aceite enquanto ela não garantir linha específica, autorização e confirmação de linha alterada.
-- Qualquer ajuste de função, grant ou policy deve ocorrer por migration versionada; esta v1 não autoriza tabela ou coluna nova.
+- Qualquer ajuste de função, grant ou policy deve ocorrer por migration versionada; esta v2 não autoriza tabela ou coluna nova.
 
 ## 2. Contrato do caso
 

--- a/docs/lousa-plano-base-e11.md
+++ b/docs/lousa-plano-base-e11.md
@@ -1,8 +1,8 @@
 # Plano-base E11 — Gestão de Usuários e Convites
 
-- Versão: v2
-- Data: 25/07/2026
-- Status: ajustado após parecer técnico; aguardando reavaliação dos especialistas.
+- Versão: v1
+- Data: 27/07/2026
+- Status: concluído; processo automatizado selecionado; aguardando incorporação à `main`.
 - Recorte previsto para roadmap: `11.1 — Gestão de membros e convites`
 - Path canônico: `docs/lousa-plano-base-e11.md`
 - Plano conceitual: N/A — debate realizado entre Estrategista, Analista e humano antes da v1.
@@ -470,6 +470,7 @@
 
 ### 4.3. Decisão atual e próxima ação
 
-- Decisão: reapresentar a v2 ajustada ao Analista, Gestor Estrutural e Gestor de Updates.
+- Decisão: plano-base v1 concluído após validação humana; as discussões posteriores não alteraram o recorte nem exigem novo papel, permissão ou infraestrutura na E11.1.
+- Processo selecionado: Opção 2 — processo automatizado.
 - Gestor de Automação: não se aplica, pois todas as fases estão marcadas como `Automação: não`.
-- Próxima ação após a reavaliação: consolidar eventuais ajustes no mesmo PR ou liberar o plano para merge humano.
+- Próxima ação: incorporar esta v1 à `main` e entregar o PR ao orquestrador conforme `docs/prompt-estrategista.md`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1164,16 +1164,19 @@ Repositório — Ajustados
   - boundary server-only para identidade, autorização e transições de `account_users`;
   - busca paginada de usuário por e-mail no Supabase Auth após autorização;
   - aceite, recusa, alteração de papel, revogação e desativação por membership específico;
-  - prazo funcional único de 7 dias e tratamento idempotente de duplicidade, expiração e novo ciclo;
+  - tratamento idempotente de duplicidade e reuso de vínculo, sem expiração automática local do membership;
   - correção ou retirada do caminho operacional das funções legadas incompatíveis, sem tabela ou coluna nova por padrão.
 
-11.1.4 Convite de novo usuário e confirmação específica
+11.1.4 Convite de novo usuário, conclusão do cadastro e confirmação específica
 - Status: Planejado.
 - Conteúdo:
   - usuário novo ou ainda não confirmado recebe o template nativo `Invite user`;
   - contexto versionado e assinado identifica um único `account_user_id`;
-  - `/auth/confirm` preserva a mitigação anti-scanner e ativa somente o vínculo validado;
-  - reenvio usa `inviteUserByEmail()` e exige evidência no Supabase hospedado;
+  - `/auth/confirm` preserva a mitigação anti-scanner, confirma o Auth e cria a sessão;
+  - `/auth/update-password` é reutilizada ou adaptada para definir senha antes da ativação do vínculo;
+  - a conclusão ativa somente o vínculo validado e admite retry idempotente da mesma linha;
+  - o happy path inclui logout e novo login por e-mail e senha;
+  - validade e reenvio do link pertencem ao Supabase Auth, sem prazo local do membership;
   - nenhum e-mail próprio, hook amplo, job ou automação.
 
 11.1.5 Gestão de membros no Account Dashboard
@@ -1191,6 +1194,7 @@ Repositório — Ajustados
   - usuário confirmado não recebe novo e-mail;
   - `/a/home` apresenta os próprios convites pendentes antes do redirect para conta ativa;
   - usuário pode aceitar ou recusar uma pendência por vez;
+  - membership permanece `pending` sem expiração automática local até aceite, recusa ou revogação;
   - sem pendências, permanece o comportamento atual de redirect.
 
 12. E12 — Admin Dashboard

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data: 25/07/2026
-• Versão: v1.5.101
+• Data: 26/07/2026
+• Versão: v1.5.102
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -2077,8 +2077,8 @@ Repositório — Ajustados
 
 20. E20 — Preparação e liberação de taxons para geração de landing pages
 
-* Objetivo: consolidar catálogo de entradas, composição base, herança, prontidão para teste e regras de liberação de taxons por plano antes da geração de LPs por conta.
-* Status: Em implementação por recortes; 20.2 concluído.
+* Objetivo: consolidar catálogo de entradas por taxon e plano, perfis versionados de orientação à geração, herança e, em recortes futuros, prontidão e liberação antes da geração de LPs por conta.
+* Status: Em implementação por recortes; 20.2 concluído e 20.3 aprovado para implementação em duas fases.
 
 20.2 Catálogo de entradas por taxon
 
@@ -2123,11 +2123,50 @@ Repositório — Ajustados
 * Conteúdo:
 
   * O resolver falha fechado para cadeia, camada, especialização, condição ou relação entre planos inválida.
-  * A E20.3 poderá consumir o catálogo resolvido e seu sinal de validade para os critérios de prontidão do taxon.
+  * A E20.3 é independente deste catálogo: orienta geração por identidade de módulo e variante da E18.5, sem consumir valores da E20.2 nem determinar prontidão.
   * A avaliação concreta das condições, a completude dos valores operacionais e o snapshot pertencem à futura E19.4.
   * O recorte não cria banco, rota, API, Server Action, UI, adapter de banco, entitlement, integração Stripe, valor operacional, snapshot, automação, agente ou job.
 
+20.3 Perfil de orientação para geração
+
+20.3.1 Objetivo e status
+
+* Objetivo: definir e resolver um perfil versionado por taxon que oriente a geração de `landing_page` com recomendações de módulos e variantes da E18.5, sem impor composição final ou prontidão.
+* Status: Implementação concluída no PR #644; pendente apenas de merge, apply automático da migration e verificação read-only pós-apply.
+
+20.3.3 Contrato e persistência mínima do perfil
+
+* Status: Implementada no PR #644, com aplicação da migration pendente do merge.
+* Conteúdo:
+
+  * Implementar o agregado versionado, as duas tabelas sem registros oficiais, a leitura server-side, o boundary único e as validações de contrato, estados, cadeia taxonômica, integridade e segurança.
+  * Nenhum consumidor, rota ou outro caminho runtime será ativado antes do apply da migration após merge humano e da verificação do estado final do banco.
+
+20.3.4 Validação E18.5 e resolução própria ou herdada
+
+* Status: Implementada e validada no PR #644.
+* Conteúdo:
+
+  * Estender minimamente a API pública TypeScript da E18.5 para validar identidade e versão de módulo e, quando informada, identidade e versão de variante e seu vínculo com o módulo, reutilizando o registry vigente.
+  * Preservar o resolver, o registry, o schema e todos os exports públicos preexistentes, sem rota, banco, serviço, novo catálogo, contexto artificial, refatoração ampla ou resolver paralelo.
+  * Implementar resolução determinística própria ou herdada, recomendações em ordem crescente e bloqueio de fallback distante quando o ancestral elegível mais próximo possuir perfil `active` inválido.
+  * A futura E12.4 tratará mutações e atomicidade do lifecycle; a futura E19.4 poderá consumir o perfil resolvido. A conclusão da E20.3 apenas libera o debate da E12.4, sem autorizar sua implementação.
+
+20.3.5 Contrato e limites
+
+* Status: Definido.
+* Conteúdo:
+
+  * O perfil pertence a um taxon, possui versão, estado e orientação geral e reúne itens com módulo e versão, variante e versão opcionais, prioridade `P1`, `P2` ou `P3`, ordem recomendada positiva e orientação específica opcional.
+  * Prioridade e ordem são orientação; não criam módulo obrigatório, composição final, seleção por plano, prontidão, autorização, revogação ou geração.
+  * Perfil e itens formam um agregado único, somente leitura server-side, persistido em exatamente duas tabelas e entregue por um único boundary, sem perfil oficial neste recorte.
+  * A resolução usa perfil `active` próprio ou do ancestral elegível mais próximo, preserva proveniência e falha fechado para cadeia, leitura, identidade ou perfil inválido; ausência legítima permanece distinta de erro.
+  * A E20.3 depende da taxonomia vigente e da identidade pública da E18.5, mas permanece independente do catálogo e dos valores da E20.2.
+  * Permanecem fora do recorte mutações e lifecycle operacional do perfil, terceira tabela de domínio, rota, API HTTP, Server Action, UI, composição, copy, geração, IA, automação, job, serviço e nova infraestrutura.
+
 99. Changelog
+v1.5.102 — 26/07/2026 — E20.3 implementada no PR #644: E20.3.3 concluída com migration versionada e aplicação pendente do merge; E20.3.4 implementada e validada; fechamento da fase pendente apenas de merge, apply automático e verificação read-only pós-apply.
+
 v1.5.101 — 25/07/2026 — Promovidos `comparison@v1`, `comparison.standard@v1`, `lead_capture@v1` e `lead_capture.form@v1` ao catálogo canônico da E18.5, totalizando doze módulos, quatorze variantes e 34 casos executáveis, com Form reutilizado e mecanismos centrais preservados.
 
 v1.5.100 — 23/07/2026 — Consolidada a moldura discriminada de interações da E18.5, com Form e Accordion, capabilities derivadas, fronteira coerente da Hero e prova sintética de reutilização sem ampliar os mecanismos arquiteturais.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data: 23/07/2026
-• Versão: v1.5.100
+• Data: 25/07/2026
+• Versão: v1.5.101
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -1149,18 +1149,49 @@ Repositório — Ajustados
   * E10.7, E18.4, E19, E20, automações, agentes e jobs permaneceram fora do recorte.
 
 11. E11 — Gestão de Usuários e Convites
+- Objetivo: permitir gestão segura de membros não-owner e convites por conta, usando Supabase Auth e o Account Dashboard.
+- Status: Planejado.
 
-11.1 Status
-• Planejado
+11.1 Gestão de membros e convites
 
-11.2 Escopo
-• UI /a/[account]/members
-• Convites via email com tokens
-• Controle de papéis (Admin, Editor, Viewer)
+11.1.1 Objetivo e status
+- Objetivo: permitir que owner e admin convidem, acompanhem e administrem membros com papéis admin, editor e viewer, preservando o owner e o isolamento multi-tenant.
+- Status: Planejado.
 
-11.3 Regras
-• Viewer não convida
-• Admin pode convidar e revogar
+11.1.3 Domínio server-side e ciclo seguro de vínculos
+- Status: Planejado.
+- Conteúdo:
+  - boundary server-only para identidade, autorização e transições de `account_users`;
+  - busca paginada de usuário por e-mail no Supabase Auth após autorização;
+  - aceite, recusa, alteração de papel, revogação e desativação por membership específico;
+  - prazo funcional único de 7 dias e tratamento idempotente de duplicidade, expiração e novo ciclo;
+  - correção ou retirada do caminho operacional das funções legadas incompatíveis, sem tabela ou coluna nova por padrão.
+
+11.1.4 Convite de novo usuário e confirmação específica
+- Status: Planejado.
+- Conteúdo:
+  - usuário novo ou ainda não confirmado recebe o template nativo `Invite user`;
+  - contexto versionado e assinado identifica um único `account_user_id`;
+  - `/auth/confirm` preserva a mitigação anti-scanner e ativa somente o vínculo validado;
+  - reenvio usa `inviteUserByEmail()` e exige evidência no Supabase hospedado;
+  - nenhum e-mail próprio, hook amplo, job ou automação.
+
+11.1.5 Gestão de membros no Account Dashboard
+- Status: Planejado.
+- Conteúdo:
+  - rota `/a/[account]/members` acessível somente a owner e admin;
+  - lista de membros ativos e convites pendentes;
+  - convite para admin, editor ou viewer;
+  - reenvio e revogação de pendente, alteração de papel e desativação de membro ativo;
+  - owner e vínculo do próprio ator protegidos.
+
+11.1.6 Pendências do usuário já cadastrado
+- Status: Planejado.
+- Conteúdo:
+  - usuário confirmado não recebe novo e-mail;
+  - `/a/home` apresenta os próprios convites pendentes antes do redirect para conta ativa;
+  - usuário pode aceitar ou recusar uma pendência por vez;
+  - sem pendências, permanece o comportamento atual de redirect.
 
 12. E12 — Admin Dashboard
 - Objetivo: Consolidar o Admin Dashboard como seção administrativa protegida, separada do Account Dashboard, com navegação própria e leitura operacional read-only.


### PR DESCRIPTION
## 1. O que mudou

- cria `docs/lousa-plano-base-e11.md` como plano-base v1 da Gestão de Usuários e Convites;
- organiza o recorte em quatro fases executáveis;
- registra `Automação: não` em todas as fases;
- atualiza somente a estrutura planejada da E11 em `docs/roadmap.md`.

## 2. Correções incorporadas ainda na v1

- remove o prazo local fixo de sete dias e atribui a validade do link exclusivamente ao Supabase Auth;
- mantém o membership `pending` sem expiração automática local;
- inclui conclusão do cadastro com definição de senha antes da ativação do vínculo;
- inclui retry idempotente da mesma linha e validação de logout e novo login;
- substitui a afirmação volátil sobre o ambiente limpo por inspeção remota antes de migrations e testes.

## 3. Decisões preservadas

- gestão disponível a owner e admin;
- usuário já cadastrado não recebe e-mail e aceita ou recusa o convite dentro do produto;
- usuário novo usa Supabase Auth e o template nativo `Invite user`;
- aceite vinculado a um único `account_user_id`;
- owner protegido e sem transferência na E11;
- nenhuma tabela, coluna, serviço, job, agente ou automação nova por padrão;
- as discussões posteriores sobre contas adicionais, publicação e criação assistida não ampliam o recorte da E11.1.

## 4. Estado

- plano-base v1 concluído;
- Opção 2 — processo automatizado selecionada pelo humano;
- diff limitado a `docs/lousa-plano-base-e11.md` e `docs/roadmap.md`;
- nenhuma implementação, migration ou configuração externa executada neste PR;
- após o merge, o PR será entregue ao orquestrador conforme `docs/prompt-estrategista.md`.
