### PR TITLE
fix: reconcilia migrations antecipadas da E20.3

### DIFF
--- a/supabase/migrations/20260725210305_e20_3_3_landing_page_compositions.sql
+++ b/supabase/migrations/20260725210305_e20_3_3_landing_page_compositions.sql
@@ -1,0 +1,413 @@
+begin;
+
+create table public.landing_page_taxon_policies (
+  taxon_id uuid primary key
+    references public.business_taxons(id) on update cascade on delete restrict,
+  inheritance_blocked boolean not null default false,
+  own_composition_allowed boolean not null default false,
+  decision_reason text,
+  created_by uuid not null
+    references auth.users(id) on update cascade on delete restrict,
+  updated_by uuid not null
+    references auth.users(id) on update cascade on delete restrict,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint landing_page_taxon_policies_reason_check
+    check (decision_reason is null or length(btrim(decision_reason)) between 3 and 500)
+);
+
+comment on table public.landing_page_taxon_policies is
+  'E20.3 policy for landing_page composition inheritance and explicit ultra-niche ownership.';
+
+create table public.landing_page_compositions (
+  id uuid primary key default gen_random_uuid(),
+  owner_taxon_id uuid not null
+    references public.business_taxons(id) on update cascade on delete restrict,
+  version integer not null,
+  status text not null default 'draft',
+  root_snapshot_json jsonb not null,
+  module_catalog_snapshot_json jsonb not null,
+  research_snapshot_json jsonb not null,
+  input_catalog_snapshot_json jsonb not null,
+  items_json jsonb not null,
+  gaps_json jsonb not null default '[]'::jsonb,
+  provenance_json jsonb not null,
+  validation_fingerprint text not null,
+  created_by uuid not null
+    references auth.users(id) on update cascade on delete restrict,
+  updated_by uuid not null
+    references auth.users(id) on update cascade on delete restrict,
+  activated_by uuid
+    references auth.users(id) on update cascade on delete restrict,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  activated_at timestamptz,
+  constraint landing_page_compositions_owner_version_key
+    unique (owner_taxon_id, version),
+  constraint landing_page_compositions_version_check
+    check (version > 0),
+  constraint landing_page_compositions_status_check
+    check (status in ('draft', 'active', 'archived')),
+  constraint landing_page_compositions_root_snapshot_check
+    check (jsonb_typeof(root_snapshot_json) = 'object'),
+  constraint landing_page_compositions_module_catalog_snapshot_check
+    check (jsonb_typeof(module_catalog_snapshot_json) = 'object'),
+  constraint landing_page_compositions_research_snapshot_check
+    check (jsonb_typeof(research_snapshot_json) = 'object'),
+  constraint landing_page_compositions_input_catalog_snapshot_check
+    check (jsonb_typeof(input_catalog_snapshot_json) = 'object'),
+  constraint landing_page_compositions_items_check
+    check (jsonb_typeof(items_json) = 'array' and jsonb_array_length(items_json) > 0),
+  constraint landing_page_compositions_gaps_check
+    check (jsonb_typeof(gaps_json) = 'array'),
+  constraint landing_page_compositions_provenance_check
+    check (jsonb_typeof(provenance_json) = 'object'),
+  constraint landing_page_compositions_fingerprint_check
+    check (length(btrim(validation_fingerprint)) between 16 and 256),
+  constraint landing_page_compositions_activation_check
+    check (
+      (status = 'draft' and activated_by is null and activated_at is null)
+      or (status in ('active', 'archived') and activated_by is not null and activated_at is not null)
+    )
+);
+
+create unique index landing_page_compositions_one_active_per_owner_idx
+  on public.landing_page_compositions(owner_taxon_id)
+  where status = 'active';
+
+create index landing_page_compositions_owner_status_version_idx
+  on public.landing_page_compositions(owner_taxon_id, status, version desc);
+
+comment on table public.landing_page_compositions is
+  'Versioned E20.3 landing_page compositions with frozen source snapshots, ordered items, gaps and provenance.';
+
+create or replace function public.validate_landing_page_taxon_policy()
+returns trigger
+language plpgsql
+set search_path = public, pg_temp
+as $$
+declare
+  v_level text;
+begin
+  select level into v_level
+  from public.business_taxons
+  where id = new.taxon_id;
+
+  if v_level is null then
+    raise exception 'landing_page taxon policy requires an existing taxon'
+      using errcode = '23503';
+  end if;
+
+  if new.own_composition_allowed and v_level <> 'ultra_niche' then
+    raise exception 'own_composition_allowed is reserved for ultra_niche taxons'
+      using errcode = '23514';
+  end if;
+
+  if tg_op = 'UPDATE' then
+    new.updated_at := now();
+  end if;
+
+  return new;
+end;
+$$;
+
+create trigger landing_page_taxon_policies_validate
+before insert or update on public.landing_page_taxon_policies
+for each row execute function public.validate_landing_page_taxon_policy();
+
+create or replace function public.validate_landing_page_composition_owner()
+returns trigger
+language plpgsql
+set search_path = public, pg_temp
+as $$
+declare
+  v_level text;
+  v_is_active boolean;
+  v_own_composition_allowed boolean;
+begin
+  select level, is_active
+    into v_level, v_is_active
+  from public.business_taxons
+  where id = new.owner_taxon_id;
+
+  if v_level is null then
+    raise exception 'landing_page composition requires an existing owner taxon'
+      using errcode = '23503';
+  end if;
+
+  if not v_is_active then
+    raise exception 'landing_page composition owner taxon must be active'
+      using errcode = '23514';
+  end if;
+
+  if v_level not in ('segment', 'niche', 'ultra_niche') then
+    raise exception 'landing_page composition owner taxon level is not eligible'
+      using errcode = '23514';
+  end if;
+
+  if v_level = 'ultra_niche' then
+    select own_composition_allowed
+      into v_own_composition_allowed
+    from public.landing_page_taxon_policies
+    where taxon_id = new.owner_taxon_id;
+
+    if coalesce(v_own_composition_allowed, false) is not true then
+      raise exception 'ultra_niche composition ownership requires explicit policy'
+        using errcode = '23514';
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+create trigger landing_page_compositions_validate_owner
+before insert or update of owner_taxon_id on public.landing_page_compositions
+for each row execute function public.validate_landing_page_composition_owner();
+
+create or replace function public.protect_landing_page_composition_lifecycle()
+returns trigger
+language plpgsql
+set search_path = public, pg_temp
+as $$
+begin
+  if tg_op = 'DELETE' then
+    raise exception 'landing_page compositions cannot be deleted'
+      using errcode = '23514';
+  end if;
+
+  if new.owner_taxon_id is distinct from old.owner_taxon_id
+    or new.version is distinct from old.version
+    or new.created_by is distinct from old.created_by
+    or new.created_at is distinct from old.created_at then
+    raise exception 'landing_page composition identity is immutable'
+      using errcode = '23514';
+  end if;
+
+  if old.status = 'archived' then
+    raise exception 'archived landing_page compositions are immutable'
+      using errcode = '23514';
+  end if;
+
+  if old.status = 'active' then
+    if new.status <> 'archived'
+      or new.root_snapshot_json is distinct from old.root_snapshot_json
+      or new.module_catalog_snapshot_json is distinct from old.module_catalog_snapshot_json
+      or new.research_snapshot_json is distinct from old.research_snapshot_json
+      or new.input_catalog_snapshot_json is distinct from old.input_catalog_snapshot_json
+      or new.items_json is distinct from old.items_json
+      or new.gaps_json is distinct from old.gaps_json
+      or new.provenance_json is distinct from old.provenance_json
+      or new.validation_fingerprint is distinct from old.validation_fingerprint
+      or new.activated_by is distinct from old.activated_by
+      or new.activated_at is distinct from old.activated_at then
+      raise exception 'active landing_page composition payload is immutable'
+        using errcode = '23514';
+    end if;
+  elsif old.status = 'draft' and new.status not in ('draft', 'active') then
+    raise exception 'draft landing_page composition can only remain draft or become active'
+      using errcode = '23514';
+  end if;
+
+  new.updated_at := now();
+  return new;
+end;
+$$;
+
+create trigger landing_page_compositions_protect_lifecycle
+before update or delete on public.landing_page_compositions
+for each row execute function public.protect_landing_page_composition_lifecycle();
+
+create or replace function public.activate_landing_page_composition(
+  p_composition_id uuid,
+  p_expected_fingerprint text,
+  p_expected_updated_at timestamptz
+)
+returns public.landing_page_compositions
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_draft public.landing_page_compositions%rowtype;
+  v_result public.landing_page_compositions%rowtype;
+  v_now timestamptz := now();
+begin
+  if v_actor is null or not (
+    coalesce(public.is_platform_admin(), false)
+    or coalesce(public.is_super_admin(), false)
+  ) then
+    raise exception 'activate_landing_page_composition requires platform admin privileges'
+      using errcode = '42501';
+  end if;
+
+  select * into v_draft
+  from public.landing_page_compositions
+  where id = p_composition_id
+  for update;
+
+  if not found then
+    raise exception 'landing_page composition not found'
+      using errcode = 'P0002';
+  end if;
+
+  if v_draft.status <> 'draft' then
+    raise exception 'landing_page composition must be draft to activate'
+      using errcode = '23514';
+  end if;
+
+  if v_draft.validation_fingerprint is distinct from p_expected_fingerprint
+    or v_draft.updated_at is distinct from p_expected_updated_at then
+    raise exception 'landing_page composition changed after validation'
+      using errcode = '40001';
+  end if;
+
+  if exists (
+    select 1
+    from jsonb_array_elements(v_draft.gaps_json) as gap
+    where coalesce((gap ->> 'blocking')::boolean, false)
+      or gap ->> 'humanDecision' = 'blocking'
+  ) then
+    raise exception 'landing_page composition has a blocking gap'
+      using errcode = '23514';
+  end if;
+
+  perform 1
+  from public.landing_page_compositions
+  where owner_taxon_id = v_draft.owner_taxon_id
+    and status = 'active'
+  for update;
+
+  update public.landing_page_compositions
+  set status = 'archived',
+      updated_by = v_actor
+  where owner_taxon_id = v_draft.owner_taxon_id
+    and status = 'active';
+
+  update public.landing_page_compositions
+  set status = 'active',
+      activated_by = v_actor,
+      activated_at = v_now,
+      updated_by = v_actor
+  where id = v_draft.id
+    and status = 'draft'
+    and validation_fingerprint = p_expected_fingerprint
+    and updated_at = p_expected_updated_at
+  returning * into v_result;
+
+  if not found then
+    raise exception 'landing_page composition activation lost its validated snapshot'
+      using errcode = '40001';
+  end if;
+
+  perform public.audit_context_event(
+    'landing_page_composition_activated',
+    'landing_page_compositions',
+    v_result.id,
+    jsonb_build_object(
+      'owner_taxon_id', v_result.owner_taxon_id,
+      'version', v_result.version,
+      'previous_status', 'draft',
+      'status', 'active'
+    ),
+    null
+  );
+
+  return v_result;
+end;
+$$;
+
+alter table public.landing_page_taxon_policies enable row level security;
+alter table public.landing_page_compositions enable row level security;
+
+create policy landing_page_taxon_policies_select_admin
+on public.landing_page_taxon_policies
+for select to authenticated
+using (
+  (select public.is_platform_admin())
+  or (select public.is_super_admin())
+);
+
+create policy landing_page_taxon_policies_insert_admin
+on public.landing_page_taxon_policies
+for insert to authenticated
+with check (
+  (select public.is_platform_admin())
+  or (select public.is_super_admin())
+);
+
+create policy landing_page_taxon_policies_update_admin
+on public.landing_page_taxon_policies
+for update to authenticated
+using (
+  (select public.is_platform_admin())
+  or (select public.is_super_admin())
+)
+with check (
+  (select public.is_platform_admin())
+  or (select public.is_super_admin())
+);
+
+create policy landing_page_compositions_select_admin
+on public.landing_page_compositions
+for select to authenticated
+using (
+  (select public.is_platform_admin())
+  or (select public.is_super_admin())
+);
+
+create policy landing_page_compositions_insert_admin
+on public.landing_page_compositions
+for insert to authenticated
+with check (
+  (select public.is_platform_admin())
+  or (select public.is_super_admin())
+);
+
+create policy landing_page_compositions_update_admin
+on public.landing_page_compositions
+for update to authenticated
+using (
+  (select public.is_platform_admin())
+  or (select public.is_super_admin())
+)
+with check (
+  (select public.is_platform_admin())
+  or (select public.is_super_admin())
+);
+
+revoke all on table public.landing_page_taxon_policies from public, anon, authenticated;
+revoke all on table public.landing_page_compositions from public, anon, authenticated;
+
+grant select, insert on table public.landing_page_taxon_policies to service_role;
+grant update (
+  inheritance_blocked,
+  own_composition_allowed,
+  decision_reason,
+  updated_by
+) on table public.landing_page_taxon_policies to service_role;
+
+grant select, insert on table public.landing_page_compositions to service_role;
+grant update (
+  root_snapshot_json,
+  module_catalog_snapshot_json,
+  research_snapshot_json,
+  input_catalog_snapshot_json,
+  items_json,
+  gaps_json,
+  provenance_json,
+  validation_fingerprint,
+  updated_by
+) on table public.landing_page_compositions to service_role;
+
+revoke all on function public.validate_landing_page_taxon_policy() from public, anon, authenticated;
+revoke all on function public.validate_landing_page_composition_owner() from public, anon, authenticated;
+revoke all on function public.protect_landing_page_composition_lifecycle() from public, anon, authenticated;
+revoke all on function public.activate_landing_page_composition(uuid, text, timestamptz) from public, anon;
+grant execute on function public.activate_landing_page_composition(uuid, text, timestamptz) to authenticated;
+
+comment on function public.activate_landing_page_composition(uuid, text, timestamptz) is
+  'Activates the exact E20.3 draft snapshot validated by a platform admin and archives the prior active composition atomically.';
+
+commit;

--- a/supabase/migrations/20260725212930_e20_3_3_activation_owner_revalidation.sql
+++ b/supabase/migrations/20260725212930_e20_3_3_activation_owner_revalidation.sql
@@ -1,0 +1,141 @@
+-- E20.3.3 correction: revalidate mutable owner eligibility under the activation lock.
+
+create or replace function public.activate_landing_page_composition(
+  p_composition_id uuid,
+  p_expected_fingerprint text,
+  p_expected_updated_at timestamptz
+)
+returns public.landing_page_compositions
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_draft public.landing_page_compositions%rowtype;
+  v_result public.landing_page_compositions%rowtype;
+  v_owner_level text;
+  v_owner_active boolean;
+  v_own_composition_allowed boolean;
+  v_now timestamptz := now();
+begin
+  if v_actor is null or not (
+    coalesce(public.is_platform_admin(), false)
+    or coalesce(public.is_super_admin(), false)
+  ) then
+    raise exception 'activate_landing_page_composition requires platform admin privileges'
+      using errcode = '42501';
+  end if;
+
+  select * into v_draft
+  from public.landing_page_compositions
+  where id = p_composition_id
+  for update;
+
+  if not found then
+    raise exception 'landing_page composition not found'
+      using errcode = 'P0002';
+  end if;
+
+  if v_draft.status <> 'draft' then
+    raise exception 'landing_page composition must be draft to activate'
+      using errcode = '23514';
+  end if;
+
+  if v_draft.validation_fingerprint is distinct from p_expected_fingerprint
+    or v_draft.updated_at is distinct from p_expected_updated_at then
+    raise exception 'landing_page composition changed after validation'
+      using errcode = '40001';
+  end if;
+
+  select taxons.level::text, taxons.is_active
+    into v_owner_level, v_owner_active
+  from public.business_taxons taxons
+  where taxons.id = v_draft.owner_taxon_id
+  for update;
+
+  if not found or v_owner_active is not true then
+    raise exception 'landing_page composition owner taxon must remain active'
+      using errcode = '23514';
+  end if;
+
+  if v_owner_level not in ('segment', 'niche', 'ultra_niche') then
+    raise exception 'landing_page composition owner taxon level is not eligible'
+      using errcode = '23514';
+  end if;
+
+  if v_owner_level = 'ultra_niche' then
+    select policies.own_composition_allowed
+      into v_own_composition_allowed
+    from public.landing_page_taxon_policies policies
+    where policies.taxon_id = v_draft.owner_taxon_id
+    for update;
+
+    if coalesce(v_own_composition_allowed, false) is not true then
+      raise exception 'ultra_niche composition ownership requires current explicit policy'
+        using errcode = '23514';
+    end if;
+  end if;
+
+  if exists (
+    select 1
+    from jsonb_array_elements(v_draft.gaps_json) as gap
+    where coalesce((gap ->> 'blocking')::boolean, false)
+      or gap ->> 'humanDecision' = 'blocking'
+  ) then
+    raise exception 'landing_page composition has a blocking gap'
+      using errcode = '23514';
+  end if;
+
+  perform 1
+  from public.landing_page_compositions
+  where owner_taxon_id = v_draft.owner_taxon_id
+    and status = 'active'
+  for update;
+
+  update public.landing_page_compositions
+  set status = 'archived',
+      updated_by = v_actor
+  where owner_taxon_id = v_draft.owner_taxon_id
+    and status = 'active';
+
+  update public.landing_page_compositions
+  set status = 'active',
+      activated_by = v_actor,
+      activated_at = v_now,
+      updated_by = v_actor
+  where id = v_draft.id
+    and status = 'draft'
+    and validation_fingerprint = p_expected_fingerprint
+    and updated_at = p_expected_updated_at
+  returning * into v_result;
+
+  if not found then
+    raise exception 'landing_page composition activation lost its validated snapshot'
+      using errcode = '40001';
+  end if;
+
+  perform public.audit_context_event(
+    'landing_page_composition_activated',
+    'landing_page_compositions',
+    v_result.id,
+    jsonb_build_object(
+      'owner_taxon_id', v_result.owner_taxon_id,
+      'version', v_result.version,
+      'previous_status', 'draft',
+      'status', 'active'
+    ),
+    null
+  );
+
+  return v_result;
+end;
+$$;
+
+revoke all on function public.activate_landing_page_composition(uuid, text, timestamptz)
+  from public, anon;
+grant execute on function public.activate_landing_page_composition(uuid, text, timestamptz)
+  to authenticated;
+
+comment on function public.activate_landing_page_composition(uuid, text, timestamptz) is
+  'Activates a validated landing-page composition atomically after locking and revalidating its mutable owner eligibility.';

--- a/supabase/migrations/20260725213816_e20_3_4_landing_page_readiness_evaluations.sql
+++ b/supabase/migrations/20260725213816_e20_3_4_landing_page_readiness_evaluations.sql
@@ -1,0 +1,143 @@
+create table public.landing_page_readiness_evaluations (
+  id uuid primary key default gen_random_uuid(),
+  served_taxon_id uuid not null,
+  plan_key text not null,
+  composition_id uuid,
+  composition_version integer,
+  result text not null,
+  checks_json jsonb not null,
+  codes_json jsonb not null,
+  evaluation_fingerprint text not null,
+  evaluated_by uuid not null,
+  evaluated_at timestamptz not null default now(),
+  constraint landing_page_readiness_evaluations_served_taxon_id_fkey
+    foreign key (served_taxon_id) references public.business_taxons(id)
+    on update cascade on delete restrict,
+  constraint landing_page_readiness_evaluations_composition_id_fkey
+    foreign key (composition_id) references public.landing_page_compositions(id)
+    on update cascade on delete restrict,
+  constraint landing_page_readiness_evaluations_evaluated_by_fkey
+    foreign key (evaluated_by) references auth.users(id)
+    on update cascade on delete restrict,
+  constraint landing_page_readiness_evaluations_plan_key_check
+    check (plan_key in ('starter', 'lite', 'pro', 'ultra')),
+  constraint landing_page_readiness_evaluations_composition_reference_check
+    check (
+      (composition_id is null and composition_version is null)
+      or (composition_id is not null and composition_version > 0)
+    ),
+  constraint landing_page_readiness_evaluations_result_check
+    check (result in ('ready', 'blocked')),
+  constraint landing_page_readiness_evaluations_checks_check
+    check (
+      jsonb_typeof(checks_json) = 'array'
+      and jsonb_array_length(checks_json) > 0
+    ),
+  constraint landing_page_readiness_evaluations_codes_check
+    check (jsonb_typeof(codes_json) = 'array'),
+  constraint landing_page_readiness_evaluations_result_codes_check
+    check (
+      (result = 'ready' and composition_id is not null and jsonb_array_length(codes_json) = 0)
+      or (result = 'blocked' and jsonb_array_length(codes_json) > 0)
+    ),
+  constraint landing_page_readiness_evaluations_fingerprint_check
+    check (evaluation_fingerprint ~ '^[0-9a-f]{64}$')
+);
+
+create index landing_page_readiness_evaluations_latest_idx
+  on public.landing_page_readiness_evaluations(
+    served_taxon_id,
+    plan_key,
+    evaluated_at desc,
+    id desc
+  );
+
+create index landing_page_readiness_evaluations_composition_id_idx
+  on public.landing_page_readiness_evaluations(composition_id)
+  where composition_id is not null;
+
+create index landing_page_readiness_evaluations_evaluated_by_idx
+  on public.landing_page_readiness_evaluations(evaluated_by);
+
+comment on table public.landing_page_readiness_evaluations is
+  'Append-only evidence of deterministic E20.3 landing-page readiness evaluations; never an authorization cache.';
+
+create or replace function public.validate_landing_page_readiness_evaluation()
+returns trigger
+language plpgsql
+set search_path = public, pg_temp
+as $$
+declare
+  v_composition_version integer;
+  v_composition_status text;
+begin
+  if new.composition_id is not null then
+    select compositions.version, compositions.status
+      into v_composition_version, v_composition_status
+    from public.landing_page_compositions compositions
+    where compositions.id = new.composition_id
+    for share;
+
+    if not found
+      or v_composition_version is distinct from new.composition_version
+      or v_composition_status <> 'active' then
+      raise exception 'readiness evaluation must reference the current active composition version'
+        using errcode = '23514';
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+create trigger landing_page_readiness_evaluations_validate
+before insert on public.landing_page_readiness_evaluations
+for each row execute function public.validate_landing_page_readiness_evaluation();
+
+create or replace function public.protect_landing_page_readiness_evaluation()
+returns trigger
+language plpgsql
+set search_path = public, pg_temp
+as $$
+begin
+  raise exception 'landing_page readiness evaluations are append-only'
+    using errcode = '23514';
+end;
+$$;
+
+create trigger landing_page_readiness_evaluations_append_only
+before update or delete on public.landing_page_readiness_evaluations
+for each row execute function public.protect_landing_page_readiness_evaluation();
+
+alter table public.landing_page_readiness_evaluations enable row level security;
+
+create policy landing_page_readiness_evaluations_select_admin
+on public.landing_page_readiness_evaluations
+for select
+to authenticated
+using (
+  (select public.is_platform_admin())
+  or (select public.is_super_admin())
+);
+
+create policy landing_page_readiness_evaluations_insert_admin
+on public.landing_page_readiness_evaluations
+for insert
+to authenticated
+with check (
+  (
+    (select public.is_platform_admin())
+    or (select public.is_super_admin())
+  )
+  and evaluated_by = (select auth.uid())
+);
+
+revoke all on table public.landing_page_readiness_evaluations
+  from public, anon, authenticated;
+grant select, insert on table public.landing_page_readiness_evaluations
+  to service_role;
+
+revoke all on function public.validate_landing_page_readiness_evaluation()
+  from public, anon, authenticated;
+revoke all on function public.protect_landing_page_readiness_evaluation()
+  from public, anon, authenticated;

--- a/supabase/migrations/20260726000348_reconcile_remove_abandoned_e20_3_objects.sql
+++ b/supabase/migrations/20260726000348_reconcile_remove_abandoned_e20_3_objects.sql
@@ -1,0 +1,186 @@
+begin;
+
+do $$
+declare
+  v_actual text[];
+  v_expected text[];
+begin
+  if to_regclass('public.landing_page_taxon_policies') is null
+    or to_regclass('public.landing_page_compositions') is null
+    or to_regclass('public.landing_page_readiness_evaluations') is null then
+    raise exception 'E20.3 reconciliation aborted: an abandoned table is missing';
+  end if;
+
+  if (select count(*) from public.landing_page_taxon_policies) <> 0
+    or (select count(*) from public.landing_page_compositions) <> 0
+    or (select count(*) from public.landing_page_readiness_evaluations) <> 0 then
+    raise exception 'E20.3 reconciliation aborted: an abandoned table is not empty';
+  end if;
+
+  v_expected := array[
+    '20260725210305:e20_3_3_landing_page_compositions',
+    '20260725212930:e20_3_3_activation_owner_revalidation',
+    '20260725213816:e20_3_4_landing_page_readiness_evaluations'
+  ]::text[];
+
+  select array_agg(migrations.version || ':' || migrations.name order by migrations.version)
+    into v_actual
+  from supabase_migrations.schema_migrations as migrations
+  where migrations.version in ('20260725210305', '20260725212930', '20260725213816');
+
+  if v_actual is distinct from v_expected then
+    raise exception 'E20.3 reconciliation aborted: historical migrations differ: %', v_actual;
+  end if;
+
+  v_expected := array[
+    'landing_page_compositions.landing_page_compositions_insert_admin',
+    'landing_page_compositions.landing_page_compositions_select_admin',
+    'landing_page_compositions.landing_page_compositions_update_admin',
+    'landing_page_readiness_evaluations.landing_page_readiness_evaluations_insert_admin',
+    'landing_page_readiness_evaluations.landing_page_readiness_evaluations_select_admin',
+    'landing_page_taxon_policies.landing_page_taxon_policies_insert_admin',
+    'landing_page_taxon_policies.landing_page_taxon_policies_select_admin',
+    'landing_page_taxon_policies.landing_page_taxon_policies_update_admin'
+  ]::text[];
+
+  select array_agg(policies.tablename || '.' || policies.policyname order by policies.tablename, policies.policyname)
+    into v_actual
+  from pg_policies as policies
+  where policies.schemaname = 'public'
+    and policies.tablename in (
+      'landing_page_taxon_policies',
+      'landing_page_compositions',
+      'landing_page_readiness_evaluations'
+    );
+
+  if v_actual is distinct from v_expected then
+    raise exception 'E20.3 reconciliation aborted: policies differ: %', v_actual;
+  end if;
+
+  v_expected := array[
+    'landing_page_compositions.landing_page_compositions_protect_lifecycle',
+    'landing_page_compositions.landing_page_compositions_validate_owner',
+    'landing_page_readiness_evaluations.landing_page_readiness_evaluations_append_only',
+    'landing_page_readiness_evaluations.landing_page_readiness_evaluations_validate',
+    'landing_page_taxon_policies.landing_page_taxon_policies_validate'
+  ]::text[];
+
+  select array_agg(tables.relname || '.' || triggers.tgname order by tables.relname, triggers.tgname)
+    into v_actual
+  from pg_trigger as triggers
+  join pg_class as tables on tables.oid = triggers.tgrelid
+  join pg_namespace as schemas on schemas.oid = tables.relnamespace
+  where not triggers.tgisinternal
+    and schemas.nspname = 'public'
+    and tables.relname in (
+      'landing_page_taxon_policies',
+      'landing_page_compositions',
+      'landing_page_readiness_evaluations'
+    );
+
+  if v_actual is distinct from v_expected then
+    raise exception 'E20.3 reconciliation aborted: triggers differ: %', v_actual;
+  end if;
+
+  v_expected := array[
+    'activate_landing_page_composition(p_composition_id uuid, p_expected_fingerprint text, p_expected_updated_at timestamp with time zone)',
+    'protect_landing_page_composition_lifecycle()',
+    'protect_landing_page_readiness_evaluation()',
+    'validate_landing_page_composition_owner()',
+    'validate_landing_page_readiness_evaluation()',
+    'validate_landing_page_taxon_policy()'
+  ]::text[];
+
+  select array_agg(
+      functions.proname || '(' || pg_get_function_identity_arguments(functions.oid) || ')'
+      order by functions.proname
+    )
+    into v_actual
+  from pg_proc as functions
+  join pg_namespace as schemas on schemas.oid = functions.pronamespace
+  where schemas.nspname = 'public'
+    and functions.proname in (
+      'activate_landing_page_composition',
+      'protect_landing_page_composition_lifecycle',
+      'protect_landing_page_readiness_evaluation',
+      'validate_landing_page_composition_owner',
+      'validate_landing_page_readiness_evaluation',
+      'validate_landing_page_taxon_policy'
+    );
+
+  if v_actual is distinct from v_expected then
+    raise exception 'E20.3 reconciliation aborted: functions differ: %', v_actual;
+  end if;
+
+  v_expected := array[
+    'landing_page_compositions_one_active_per_owner_idx',
+    'landing_page_compositions_owner_status_version_idx',
+    'landing_page_readiness_evaluations_composition_id_idx',
+    'landing_page_readiness_evaluations_evaluated_by_idx',
+    'landing_page_readiness_evaluations_latest_idx'
+  ]::text[];
+
+  select array_agg(indexes.relname order by indexes.relname)
+    into v_actual
+  from pg_class as indexes
+  join pg_namespace as schemas on schemas.oid = indexes.relnamespace
+  where schemas.nspname = 'public'
+    and indexes.relkind = 'i'
+    and indexes.relname = any(v_expected);
+
+  if v_actual is distinct from v_expected then
+    raise exception 'E20.3 reconciliation aborted: specific indexes differ: %', v_actual;
+  end if;
+
+  if to_regclass('public.business_taxons') is null
+    or to_regclass('auth.users') is null
+    or to_regprocedure('public.audit_context_event(text,text,uuid,jsonb,uuid)') is null then
+    raise exception 'E20.3 reconciliation aborted: a shared object is missing';
+  end if;
+end;
+$$;
+
+drop policy landing_page_taxon_policies_select_admin
+  on public.landing_page_taxon_policies;
+drop policy landing_page_taxon_policies_insert_admin
+  on public.landing_page_taxon_policies;
+drop policy landing_page_taxon_policies_update_admin
+  on public.landing_page_taxon_policies;
+
+drop policy landing_page_compositions_select_admin
+  on public.landing_page_compositions;
+drop policy landing_page_compositions_insert_admin
+  on public.landing_page_compositions;
+drop policy landing_page_compositions_update_admin
+  on public.landing_page_compositions;
+
+drop policy landing_page_readiness_evaluations_select_admin
+  on public.landing_page_readiness_evaluations;
+drop policy landing_page_readiness_evaluations_insert_admin
+  on public.landing_page_readiness_evaluations;
+
+drop trigger landing_page_taxon_policies_validate
+  on public.landing_page_taxon_policies;
+
+drop trigger landing_page_compositions_validate_owner
+  on public.landing_page_compositions;
+drop trigger landing_page_compositions_protect_lifecycle
+  on public.landing_page_compositions;
+
+drop trigger landing_page_readiness_evaluations_validate
+  on public.landing_page_readiness_evaluations;
+drop trigger landing_page_readiness_evaluations_append_only
+  on public.landing_page_readiness_evaluations;
+
+drop function public.activate_landing_page_composition(uuid, text, timestamptz);
+drop function public.protect_landing_page_composition_lifecycle();
+drop function public.protect_landing_page_readiness_evaluation();
+drop function public.validate_landing_page_composition_owner();
+drop function public.validate_landing_page_readiness_evaluation();
+drop function public.validate_landing_page_taxon_policy();
+
+drop table public.landing_page_readiness_evaluations;
+drop table public.landing_page_compositions;
+drop table public.landing_page_taxon_policies;
+
+commit;

--- a/supabase/snippets/e20_3_reconciliation_verify.sql
+++ b/supabase/snippets/e20_3_reconciliation_verify.sql
@@ -1,0 +1,122 @@
+begin;
+set transaction read only;
+
+do $$
+declare
+  v_has_rows boolean;
+  v_table text;
+begin
+  foreach v_table in array array[
+    'public.landing_page_taxon_policies',
+    'public.landing_page_compositions',
+    'public.landing_page_readiness_evaluations'
+  ]::text[] loop
+    if to_regclass(v_table) is not null then
+      execute format(
+        'select exists (select 1 from %s)',
+        to_regclass(v_table)
+      ) into v_has_rows;
+
+      if v_has_rows then
+        raise exception 'E20.3 reconciliation verification failed: % is not empty', v_table;
+      end if;
+    end if;
+  end loop;
+end;
+$$;
+
+with inventory as (
+  select
+    (select count(*)
+      from supabase_migrations.schema_migrations
+      where version in ('20260725210305', '20260725212930', '20260725213816')) as historical_migrations,
+    (select count(*)
+      from supabase_migrations.schema_migrations
+      where version = '20260726000348') as cleanup_migration,
+    (select count(*)
+      from pg_class as tables
+      join pg_namespace as schemas on schemas.oid = tables.relnamespace
+      where schemas.nspname = 'public'
+        and tables.relkind = 'r'
+        and tables.relname in (
+          'landing_page_taxon_policies',
+          'landing_page_compositions',
+          'landing_page_readiness_evaluations'
+        )) as abandoned_tables,
+    (select count(*)
+      from pg_policies
+      where schemaname = 'public'
+        and tablename in (
+          'landing_page_taxon_policies',
+          'landing_page_compositions',
+          'landing_page_readiness_evaluations'
+        )) as abandoned_policies,
+    (select count(*)
+      from pg_trigger as triggers
+      join pg_class as tables on tables.oid = triggers.tgrelid
+      join pg_namespace as schemas on schemas.oid = tables.relnamespace
+      where not triggers.tgisinternal
+        and schemas.nspname = 'public'
+        and tables.relname in (
+          'landing_page_taxon_policies',
+          'landing_page_compositions',
+          'landing_page_readiness_evaluations'
+        )) as abandoned_triggers,
+    (select count(*)
+      from pg_proc as functions
+      join pg_namespace as schemas on schemas.oid = functions.pronamespace
+      where schemas.nspname = 'public'
+        and functions.proname in (
+          'activate_landing_page_composition',
+          'protect_landing_page_composition_lifecycle',
+          'protect_landing_page_readiness_evaluation',
+          'validate_landing_page_composition_owner',
+          'validate_landing_page_readiness_evaluation',
+          'validate_landing_page_taxon_policy'
+        )) as abandoned_functions,
+    (select count(*)
+      from pg_class as indexes
+      join pg_namespace as schemas on schemas.oid = indexes.relnamespace
+      where schemas.nspname = 'public'
+        and indexes.relkind = 'i'
+        and indexes.relname in (
+          'landing_page_compositions_one_active_per_owner_idx',
+          'landing_page_compositions_owner_status_version_idx',
+          'landing_page_readiness_evaluations_composition_id_idx',
+          'landing_page_readiness_evaluations_evaluated_by_idx',
+          'landing_page_readiness_evaluations_latest_idx'
+        )) as abandoned_specific_indexes,
+    to_regclass('public.business_taxons') is not null as business_taxons_preserved,
+    to_regclass('auth.users') is not null as auth_users_preserved,
+    to_regprocedure('public.audit_context_event(text,text,uuid,jsonb,uuid)') is not null as audit_function_preserved
+)
+select
+  case
+    when historical_migrations = 3
+      and cleanup_migration = 0
+      and abandoned_tables = 3
+      and abandoned_policies = 8
+      and abandoned_triggers = 5
+      and abandoned_functions = 6
+      and abandoned_specific_indexes = 5
+      and business_taxons_preserved
+      and auth_users_preserved
+      and audit_function_preserved
+      then 'pre_merge_pending'
+    when historical_migrations = 3
+      and cleanup_migration = 1
+      and abandoned_tables = 0
+      and abandoned_policies = 0
+      and abandoned_triggers = 0
+      and abandoned_functions = 0
+      and abandoned_specific_indexes = 0
+      and business_taxons_preserved
+      and auth_users_preserved
+      and audit_function_preserved
+      then 'post_merge_reconciled'
+    else 'unexpected'
+  end as reconciliation_state,
+  inventory.*
+from inventory;
+
+rollback;


### PR DESCRIPTION
## 1. Objetivo

Reconcilia o histórico Git/Supabase após a aplicação antecipada de três migrations da E20.3 no PR draft #631, preservando o histórico real e removendo os objetos abandonados por migration forward-only.

Este PR não contém implementação funcional da E20.3.

## 2. Conteúdo

- preserva `20260725210305_e20_3_3_landing_page_compositions.sql`;
- preserva `20260725212930_e20_3_3_activation_owner_revalidation.sql`;
- preserva `20260725213816_e20_3_4_landing_page_readiness_evaluations.sql`;
- adiciona `20260726000348_reconcile_remove_abandoned_e20_3_objects.sql`;
- adiciona o snippet read-only `e20_3_reconciliation_verify.sql`.

## 3. Equivalência histórica

As três migrations históricas foram comparadas com `supabase_migrations.schema_migrations.statements` no projeto `dpikmjgiteuafsbaubue`.

- `20260725210305`: equivalência executável confirmada; diferença somente em final de linha/whitespace terminal.
- `20260725212930`: igualdade byte a byte.
- `20260725213816`: igualdade byte a byte.

Nenhum token SQL, comando, nome, assinatura, constraint, grant ou policy foi alterado.

## 4. Limpeza forward-only

A quarta migration:

- usa transação explícita;
- não usa `CASCADE`;
- não usa `IF EXISTS`;
- exige as três tabelas vazias;
- valida as três migrations históricas;
- valida inventário exato de 8 policies, 5 triggers, 6 funções e 5 índices específicos;
- preserva `business_taxons`, `auth.users` e `audit_context_event`;
- remove explicitamente os objetos abandonados na ordem segura de dependências.

## 5. Validação concluída

A migration de limpeza foi executada no Supabase principal dentro de transação controlada, com validação dos objetos removidos e `ROLLBACK` obrigatório.

Resultados:

- validação interna: `validated_and_rolled_back`;
- estado posterior: `pre_merge_pending_validated`;
- 3 tabelas permanecem presentes e vazias;
- 3 migrations históricas permanecem registradas;
- migration `20260726000348` ainda não foi aplicada;
- objetos compartilhados foram preservados;
- nenhuma alteração persistente ocorreu.

Para este incidente específico, essa validação transacional substitui excepcionalmente a reconstrução isolada e o dry-run indisponíveis no ambiente. A exceção não altera a regra geral da Base Técnica para migrations futuras.

## 6. Checks

- `Security Checks`: sucesso;
- Preview Vercel: sucesso;
- `git diff --check`: sucesso;
- `npm ci`: N/A — diff restrito a SQL;
- `npm run check`: N/A — diff restrito a SQL;
- nenhum bloqueio técnico restante.

## 7. Pós-merge obrigatório

Após o merge:

- confirmar sucesso do workflow `Pipeline Supabase — Apply Migrations`;
- confirmar registro de `20260726000348`;
- executar `e20_3_reconciliation_verify.sql`;
- exigir resultado `post_merge_reconciled`;
- confirmar ausência dos objetos abandonados e preservação dos objetos compartilhados.

## 8. PR #631

O PR #631 foi abandonado por redução humana de escopo e deve ser fechado sem merge. A E20.3 será replanejada em recorte mínimo.