### PR TITLE
docs: define plano-base v1 do perfil E20.3

### DIFF
--- a/docs/lousa-plano-base-e20-3.md
+++ b/docs/lousa-plano-base-e20-3.md
@@ -1,10 +1,9 @@
-# Plano-base — E20.3 e E12.4.3–E12.4.4
+# Plano-base — E20.3 — Composição estrutural mínima
 
 - Data: 25/07/2026.
-- Versão: v1.
-- Status: plano-base v1 para avaliação única dos especialistas.
-- Recorte principal previsto para o roadmap: `20.3 — Composição base, prontidão e autorização de geração`.
-- Recorte administrativo complementar: `12.4 — Operação administrativa da E20.3`.
+- Versão: v1 substitutiva após o PR #635.
+- Status: plano-base v1 para avaliação única do Analista.
+- Recorte previsto para o roadmap: `20.3 — Composição estrutural mínima de landing_page`.
 - Path canônico: `docs/lousa-plano-base-e20-3.md`.
 - Plano conceitual: `docs/lp-planejamento.md`.
 
@@ -13,21 +12,22 @@
 ### 1.1. Problema e resultado esperado
 
 - O projeto já possui:
-  - taxonomia ativa e administrável;
-  - pesquisas estruturadas resolvidas pela E10.8 para `end_customer` e `business_buyer`;
+  - pesquisas estruturadas resolvidas pela E10.8;
   - parametrização raiz versionada da E18.4;
-  - catálogo canônico da E18.5 com doze módulos, quatorze variantes e 34 casos executáveis;
+  - catálogo executável de módulos e variantes da E18.5;
   - catálogo declarativo de entradas da E20.2.
-- Ainda não existe o terceiro critério operacional de preparação do taxon: uma composição base oficial que determine módulos, variantes e ordem para futuras LPs.
-- O resultado esperado é permitir que um administrador, no Admin Dashboard:
-  - solicite à IA uma proposta de composição;
-  - revise e ajuste a proposta;
-  - trate gaps;
-  - salve e ative uma versão válida;
-  - confira a prontidão separadamente por plano;
-  - autorize ou revogue o uso por uma conta específica.
-- A E20.3 define e persiste os contratos e estados; a E12.4.3–E12.4.4 opera as decisões humanas no Admin Dashboard.
-- Este recorte não gera, renderiza, publica ou mede uma LP. A geração real permanece para a E19.4.
+- Ainda não existe a composição estrutural canônica que determine, por taxon proprietário e versão:
+  - módulos;
+  - variantes;
+  - ordem;
+  - obrigatoriedade quando aplicável.
+- O resultado esperado da E20.3 é:
+  - representar e persistir minimamente essa composição;
+  - preservar estados e versões;
+  - validar as identidades contra a E18.5;
+  - resolver composição própria ou herdada.
+- A E20.3 não cria composição oficial nesta etapa.
+- A futura E12.4 operará proposta, revisão, aprovação e ativação da primeira composição oficial.
 
 ### 1.2. Fontes usadas
 
@@ -35,527 +35,351 @@
 - `docs/prompt-estrategista.md`.
 - `docs/template-roadmap.md`.
 - `docs/roadmap.md`.
-- `docs/lp-planejamento.md`.
+- `docs/lp-planejamento.md`, após o merge do PR #635.
 - `docs/base-tecnica.md`.
-- `docs/platform-config.md`.
 - `docs/schema.md`.
-- `docs/design-system.md`.
-- `docs/lousa-plano-base-e18-4.md`.
 - `docs/lousa-plano-base-e18-5.md`.
 - `docs/lousa-plano-base-e20-2.md`.
-- Contratos e implementações reais da E10.8, E18.4, E18.5, E20.2, Admin Dashboard e integrações OpenAI server-side.
-- PR #628, mergeado na `main` pelo commit `9ad815ab1315d74b413e7b11835f085fe90c553a`.
-- Documentação oficial da OpenAI sobre Responses API e Structured Outputs:
-  - `https://developers.openai.com/api/docs/guides/structured-outputs`;
-  - `https://developers.openai.com/api/docs/guides/migrate-to-responses`.
+- Implementação vigente em:
+  - `lib/conversion-content/landing-page/module-catalog/`;
+  - `lib/conversion-content/landing-page/input-catalog/`;
+  - `lib/conversion-content/index.ts`.
+- Estado pós-reconciliação do PR #636:
+  - as migrations antecipadas permanecem no histórico;
+  - os objetos abandonados foram removidos;
+  - nenhuma estrutura da implementação superdimensionada permanece vigente.
 
 ### 1.3. Decisões funcionais fixas
 
-- Os três critérios de preparação do taxon são:
-  - taxon ativo;
-  - pesquisas estruturadas válidas dos dois `audienceScope`;
-  - composição base ativa própria ou herdada.
-- `commercial_activation` não participa desses três critérios e não será reutilizado como domínio da E20.3.
-- Existe uma composição canônica por `taxon proprietário + versão`, reutilizada entre planos.
-- A prontidão é avaliada separadamente por `taxon atendido + plano + versão da composição resolvida`.
-- A autorização humana é específica para `conta + taxon atendido + plano`.
-- Lifecycle da composição:
-  - `draft`: editável e revalidável;
-  - `active`: aprovada, imutável e disponível para resolução;
-  - `archived`: preservada para histórico.
-- “Aprovar” é a ação humana que ativa um `draft`; não existe estado persistente `approved`.
-- Uma nova versão pode permanecer `draft` enquanto a versão ativa anterior continua atendendo.
-- Cada módulo pode ocorrer no máximo uma vez na composição v1.
-- Cada ocorrência possui variante fixa; a futura geração não escolhe outra variante.
-- A composição pode preservar apenas escolhas expressamente permitidas pelo contrato raiz ou pela variante, sem criar parâmetros livres.
-- A composição v1 aceita no máximo uma variante com interação `form`, validada pela capability estrutural da E18.5, sem regra nominal exclusiva para `hero.form@v1` ou `lead_capture.form@v1`.
-- Gaps não criam módulos ou variantes automaticamente.
-- Um gap impeditivo mantém a composição em `draft`; um gap não impeditivo só pode ser adiado por decisão humana justificada.
+- Existe uma composição canônica por `taxon proprietário + versão`.
+- A composição é reutilizada entre planos.
+- Cada item da composição referencia:
+  - módulo e versão;
+  - variante e versão;
+  - posição ordenada;
+  - obrigatoriedade quando aplicável.
+- Somente identidades oficialmente registradas na E18.5 são válidas.
+- O lifecycle mínimo distingue:
+  - `draft`;
+  - `active`;
+  - `archived`.
+- Uma versão `active` não é editada diretamente.
+- Uma mudança aprovada cria nova versão e preserva as anteriores.
+- No máximo uma versão pode estar `active` por taxon proprietário.
+- Na ausência de composição própria ativa, a resolução usa o ancestral elegível mais próximo, salvo bloqueio explícito de herança.
+- Não existe composição universal implícita.
+- A composição própria de ultranicho permanece excepcional e depende de permissão explícita no contrato mínimo de política do taxon.
 - Automação: não.
 
 ### 1.4. Fronteiras de responsabilidade
 
-- A E10.8 resolve pesquisas e proveniência; a E20.3 consome o resultado sem recalcular sua herança.
-- A E18.4 define a base raiz; a E20.3 não altera seus contratos.
-- A E18.5 define módulos e variantes oficiais; a E20.3 somente referencia identidades e versões válidas.
-- A E20.2 define entradas declarativas; a E20.3 consome sua validade por plano sem coletar valores.
-- A E12.4.3 opera proposta, revisão, ativação e leitura de prontidão.
-- A E12.4.4 opera autorização e revogação.
-- A E9 continua sendo a fonte do entitlement comercial da conta.
-- A E19.4 será o único fluxo de geração de LP por conta.
-- A E20.4 e a E12.4.5–E12.4.6 permanecem responsáveis pela avaliação da LP real e liberação futura.
+- A E18.5 define módulos e variantes; a E20.3 apenas referencia e valida suas identidades versionadas.
+- A E20.2 permanece responsável pelo catálogo de entradas e não integra o payload da composição.
+- A E20.3 fornece:
+  - contrato estrutural;
+  - persistência mínima;
+  - lifecycle e versões;
+  - validação;
+  - resolução própria ou herdada.
+- A futura E12.4 operará:
+  - proposta;
+  - revisão;
+  - aprovação;
+  - ativação;
+  - primeiro cadastro oficial.
+- Planos posteriores tratarão:
+  - IA;
+  - gaps persistidos;
+  - prontidão;
+  - autorização;
+  - revogação;
+  - geração e publicação de LP.
 
 ## 2. Contrato do caso
 
 ### 2.1. Fluxo operacional
 
 - Gatilho:
-  - administrador seleciona um taxon elegível em `/admin/templates/landing-page`;
-  - administrador abre a operação do taxon em `/admin/templates/landing-page/[taxonSlug]`.
+  - consumidor server-side solicita a composição aplicável a um taxon;
+  - casos executáveis validam criação, lifecycle e resolução com dados de teste.
 - Entrada:
-  - taxon atendido e sua cadeia ativa;
-  - pesquisas resolvidas pela E10.8;
-  - raiz efetiva da E18.4;
-  - catálogo oficial da E18.5;
-  - catálogo resolvido da E20.2 para os quatro planos;
-  - versão ativa anterior, quando existir.
+  - taxon atendido e cadeia taxonômica normalizada;
+  - política mínima do taxon;
+  - composições persistidas;
+  - catálogo oficial da E18.5.
 - Processamento:
-  - resolver as fontes determinísticas;
-  - solicitar proposta estruturada à IA quando o administrador pedir;
-  - separar composição candidata e gaps;
-  - normalizar a resposta;
-  - validar deterministicamente;
-  - permitir revisão humana;
-  - persistir `draft`;
-  - ativar somente versão válida e sem gap impeditivo;
-  - resolver composição própria ou herdada;
-  - avaliar prontidão por plano;
-  - autorizar ou revogar combinações específicas.
+  - localizar composição própria ativa;
+  - na ausência, verificar bloqueio de herança;
+  - localizar o ancestral elegível mais próximo;
+  - validar estrutura, estado, versão e identidades;
+  - devolver resultado tipado e determinístico.
 - Validação:
-  - validar taxonomia, fontes, identidades, versões, ordem, unicidade, obrigatoriedade, opções permitidas, interação de formulário, lifecycle, gaps, herança e prontidão;
-  - revalidar no servidor antes de toda persistência ou ativação;
-  - nunca confiar apenas no estado enviado pelo client ou na saída da IA.
+  - taxon proprietário e cadeia válidos;
+  - versão inteira positiva;
+  - lifecycle válido;
+  - ordem inteira, única e contínua;
+  - módulo e variante existentes e compatíveis na E18.5;
+  - política de herança respeitada.
 - Persistência:
-  - composição e snapshots de suas referências;
-  - decisão de herança;
-  - gaps e decisão humana;
-  - resultado de prontidão;
-  - autorização e revogação.
+  - política mínima necessária à herança e à excepcionalidade do ultranicho;
+  - composição versionada e seus itens estruturais.
 - Consumo:
-  - Admin Dashboard lê e opera a E20.3;
-  - E19.4 consumirá futuramente a composição resolvida, a prontidão atual e a autorização efetiva.
+  - boundary server-side da própria E20.3;
+  - futura E12.4;
+  - futuros consumidores somente após seus planos próprios.
 - Fallback:
-  - falha da IA não cria nem altera `draft`;
-  - saída inválida da IA é rejeitada com código seguro e nova tentativa manual possível;
-  - ausência de composição própria tenta o ancestral elegível mais próximo;
-  - fonte inválida, composição inválida, gap impeditivo ou herança bloqueada falha fechado;
-  - não criar composição genérica silenciosa.
+  - composição própria ativa;
+  - composição ativa do ancestral elegível mais próximo;
+  - ausência tipada;
+  - falha fechada diante de estrutura ou identidade inválida.
 
-### 2.2. Identidade, ownership e lifecycle
-
-- `servedTaxon` é o taxon para o qual a prontidão ou autorização é avaliada.
-- `ownerTaxon` é o taxon proprietário da composição efetivamente resolvida.
-- Segmento e nicho podem possuir composição própria.
-- Composição própria de ultranicho exige autorização humana explícita registrada na política do taxon.
-- Deve existir no máximo uma composição `active` por `ownerTaxon`.
-- Versão deve ser inteira positiva e única dentro do `ownerTaxon`.
-- A versão `active` é imutável.
-- Alteração de versão ativa cria novo `draft` com nova versão.
-- Ativar um novo `draft` arquiva atomicamente a versão ativa anterior do mesmo `ownerTaxon`.
-- `archived` não retorna a `draft` nem a `active`; recuperação exige nova versão.
-
-### 2.3. Contrato mínimo da composição
+### 2.2. Contrato mínimo da composição
 
 - Identidade:
-  - ID da composição;
-  - `ownerTaxon`;
+  - ID;
+  - taxon proprietário;
   - versão;
   - status.
-- Referências congeladas:
-  - versão da raiz e preset efetivo da E18.4;
-  - versão do catálogo E18.5;
-  - versões dos módulos e variantes utilizados;
-  - versão e proveniência das pesquisas E10.8;
-  - versão do catálogo E20.2 usada como contexto.
 - Itens ordenados:
-  - identidade e versão do módulo;
-  - identidade e versão da variante;
-  - ordem inteira contínua e sem duplicidade;
-  - obrigatoriedade;
-  - opções permitidas pela ocorrência, quando existirem.
-- Gaps:
-  - tipo `module` ou `variant`;
-  - função estrutural ausente;
-  - justificativa baseada nas fontes;
-  - impacto;
-  - caráter impeditivo;
-  - decisão humana `blocking` ou `deferred`;
-  - justificativa do adiamento e condição de retomada quando `deferred`.
-- Proveniência:
-  - origem `ai_proposal`, `human_created` ou `human_adjusted`;
-  - versão do schema da proposta;
-  - modelo usado quando houver IA;
-  - `request_id` seguro;
-  - ator e datas de criação, última alteração e ativação.
+  - ID e versão do módulo;
+  - ID e versão da variante;
+  - posição;
+  - obrigatoriedade quando aplicável.
+- Metadados mínimos:
+  - criação;
+  - última atualização;
+  - ativação quando aplicável.
 - A composição não armazena:
   - copy;
-  - valores operacionais da conta;
-  - LP gerada;
-  - taxon atendido quando ele apenas herda a composição.
+  - pesquisas;
+  - parâmetros da E18.4;
+  - catálogo ou valores da E20.2;
+  - gaps;
+  - prontidão;
+  - autorização;
+  - revogação;
+  - dados da conta;
+  - LP gerada.
 
-### 2.4. Proposta síncrona por IA
+### 2.3. Persistência mínima
 
-- A proposta ocorre somente após ação explícita do administrador.
-- Provider:
-  - OpenAI Responses API;
-  - Structured Outputs com JSON Schema estrito;
-  - chamada server-side por `fetch`, reutilizando o padrão vigente sem adicionar SDK;
-  - modelo definido por env server-side própria;
-  - `store: false`;
-  - limite de saída e timeout explícitos.
-- Entradas permitidas:
-  - taxon atendido e cadeia;
-  - pesquisas E10.8 já resolvidas;
-  - raiz E18.4 resolvida;
-  - catálogo E18.5 oficial;
-  - E20.2 como contexto declarativo, sem valores concretos;
-  - composição ativa anterior, somente como referência quando existir.
-- Saída:
-  - itens que utilizem apenas identidades oficiais;
-  - ordem, obrigatoriedade e opções permitidas;
-  - gaps separados;
-  - justificativa curta por item e por gap.
-- A resposta da IA:
-  - não grava diretamente;
-  - não ativa;
-  - não cria identidade;
-  - não altera E10.8, E18.4, E18.5 ou E20.2;
-  - passa por parse, schema local e validação determinística antes de ser exibida como proposta editável.
-- Observability:
-  - registrar evento, `request_id`, status, latência, modelo, quantidade de itens, quantidade de gaps e código seguro de erro;
-  - não registrar prompt completo, pesquisas completas, payload bruto, valores operacionais, secret ou resposta bruta.
+- Criar somente as estruturas necessárias para:
+  - política de herança e permissão excepcional de composição própria;
+  - composição versionada com payload estrutural validado.
+- Usar uma representação compacta para os itens ordenados, sem normalizar prematuramente cada item em tabela própria.
+- Proteger no banco:
+  - referências ao taxon;
+  - versão positiva e única por taxon proprietário;
+  - status fechado;
+  - no máximo uma versão ativa por taxon proprietário;
+  - payload estrutural presente;
+  - imutabilidade da versão ativa.
+- Proteger no runtime:
+  - validação estrita do payload;
+  - compatibilidade módulo-variante;
+  - existência das versões na E18.5;
+  - transições de lifecycle permitidas.
+- Implementar adapter server-side no boundary da E20.3.
+- Não criar rota, API, Server Action ou UI.
+- Migration:
+  - incremental e forward-only;
+  - criada e revisada no PR da implementação;
+  - aplicada remotamente somente após merge na `main`;
+  - acompanhada da atualização de `docs/schema.md`.
+- A migration deve terminar sem registros oficiais:
+  - sem seed;
+  - sem insert de composição;
+  - sem composição ativa criada automaticamente.
 
-### 2.5. Validação determinística e ativação
+### 2.4. Lifecycle e versionamento
 
-- Rejeitar:
-  - taxon inativo ou cadeia inválida;
-  - referência desconhecida, versão inexistente ou lifecycle incompatível;
-  - módulo repetido;
-  - variante não vinculada ao módulo;
-  - ordem vazia, duplicada ou descontínua;
-  - mais de uma interação `form`;
-  - opção não permitida pela raiz, módulo ou variante;
-  - ampliação de limite da raiz;
-  - gap impeditivo;
-  - composição vazia;
-  - snapshot de fonte ausente ou incompatível.
-- Ativação:
-  - guard obrigatório `requirePlatformAdmin`;
-  - revalidação integral no servidor;
-  - transação atômica para arquivar a ativa anterior e ativar o novo `draft`;
-  - evento de auditoria com ator e IDs, sem payload sensível;
-  - nenhuma ativação por insert direto, fixture, seed ou migration atende ao fluxo funcional.
+- `draft`:
+  - pode ser validado e substituído antes da ativação;
+  - não participa da resolução.
+- `active`:
+  - é imutável;
+  - participa da resolução;
+  - existe no máximo uma por taxon proprietário.
+- `archived`:
+  - preserva a versão histórica;
+  - não participa da resolução;
+  - não retorna a `draft` nem a `active`.
+- A ativação de nova versão:
+  - revalida o payload no servidor;
+  - arquiva atomicamente a versão ativa anterior;
+  - ativa a nova versão.
+- Nesta etapa, as operações existem apenas como contrato e boundary interno para testes e futuro consumo da E12.4.
+
+### 2.5. Validação contra a E18.5
+
+- Cada item deve referenciar:
+  - módulo existente na versão informada;
+  - variante existente na versão informada;
+  - variante vinculada ao módulo informado.
+- A ordem deve ser:
+  - inteira;
+  - única;
+  - contínua;
+  - determinística.
+- Não impor nesta etapa:
+  - módulo único por composição;
+  - formulário único;
+  - limite nominal por módulo ou variante;
+  - escolhas livres não previstas pelo contrato estrutural.
+- Identidade desconhecida ou incompatível falha fechado.
+- A validação não altera o catálogo E18.5 nem cria identidades.
 
 ### 2.6. Herança e resolução
 
 - Precedência:
-  - composição ativa própria;
-  - composição ativa do ancestral elegível mais próximo;
-  - ausência de resultado.
-- Para ultranicho sem composição própria:
-  - nicho direto antes do segmento.
-- Para nicho sem composição própria:
+  - composição própria `active`;
+  - composição `active` do ancestral elegível mais próximo;
+  - ausência de composição.
+- Para ultranicho sem composição própria ativa:
+  - nicho direto;
+  - depois segmento.
+- Para nicho sem composição própria ativa:
   - segmento direto.
-- Não existe composição universal implícita.
-- Política explícita pode bloquear herança no taxon atendido.
-- Composição própria de ultranicho só participa quando autorizada.
-- Se o ancestral mais próximo possuir composição ativa inválida, a resolução falha e não procura ancestral mais distante.
-- O resultado discriminado preserva:
-  - `servedTaxon`;
-  - `ownerTaxon`;
+- O bloqueio explícito no taxon atendido impede herança.
+- Uma composição inválida não é corrigida, ignorada ou substituída silenciosamente.
+- O resultado preserva:
+  - taxon atendido;
+  - taxon proprietário;
   - ID e versão da composição;
   - relação `own` ou `inherited`;
-  - ancestral utilizado;
-  - snapshots das fontes;
+  - itens ordenados;
   - validade ou código fechado de falha.
 
-### 2.7. Prontidão por plano
+### 2.7. Casos executáveis mínimos
 
-- A prontidão é uma avaliação determinística para:
-  - `servedTaxon`;
-  - plano `starter`, `lite`, `pro` ou `ultra`;
-  - composição resolvida e sua versão.
-- Checklist obrigatório:
-  - taxon e cadeia ativos;
-  - E10.8 válida para os dois `audienceScope`;
-  - raiz E18.4 válida;
-  - catálogo E18.5 válido;
-  - E20.2 válido para o plano;
-  - composição própria ou herdada válida;
-  - ausência de gap impeditivo;
-  - compatibilidade das versões congeladas.
-- Resultado:
-  - `ready` ou `blocked`;
-  - códigos determinísticos por check;
-  - IDs e versões avaliados;
-  - data da avaliação.
-- A prontidão persistida é evidência da última avaliação, não cache autorizativo.
-- Todo consumo efetivo deve revalidar o estado atual; mudança em fonte, versão, lifecycle, herança ou composição invalida o efeito da prontidão anterior.
-- A mesma composição pode ficar pronta em um plano e bloqueada em outro.
-
-### 2.8. Autorização e revogação
-
-- Somente `platform_admin`, incluindo `super_admin` pelo guard vigente, pode autorizar ou revogar.
-- A autorização exige prontidão atual `ready`.
-- Identidade da decisão:
-  - conta;
-  - `servedTaxon`;
-  - plano.
-- Estados:
-  - `active`;
-  - `revoked`.
-- A autorização registra ator, data e referência da prontidão verificada no momento da decisão.
-- A autorização anterior permanece registrada, mas não produz efeito enquanto a prontidão atual estiver bloqueada.
-- Revalidar a prontidão pode restaurar o efeito de uma autorização ainda `active`; não criar autorização automática nova.
-- Revogação é explícita, preserva histórico e impede uso mesmo quando a prontidão estiver válida.
-- Autorização não substitui:
-  - conta ativa;
-  - membership e papel válidos;
-  - entitlement comercial da E9;
-  - futuros gates próprios da E19.4.
-
-### 2.9. Persistência mínima
-
-- Criar persistência dedicada à família `landing_page`; não reutilizar diretamente:
-  - `content_templates`;
-  - `content_template_taxons`;
-  - `content_template_compositions`;
-  - `content_artifacts`;
-  - estruturas de `commercial_activation`.
-- O modelo mínimo deve cobrir quatro responsabilidades sem criar engine genérica:
-  - política de herança e autorização de composição própria do taxon;
-  - versões de composição com payload e gaps validados;
-  - última avaliação de prontidão por taxon atendido, plano e composição;
-  - autorização e revogação por conta, taxon atendido e plano.
-- Preferir snapshot JSONB estrito e validado para itens, gaps, fontes e checks, em vez de normalização prematura de cada propriedade.
-- O banco deve proteger:
-  - FKs;
-  - enums/checks fechados;
-  - versão positiva e única por taxon proprietário;
-  - no máximo uma versão ativa por taxon proprietário;
-  - unicidade da decisão corrente de autorização;
-  - timestamps e atores aplicáveis.
-- Segurança:
-  - RLS ativo;
-  - sem acesso para `anon` ou `authenticated`;
-  - leitura e escrita somente server-side pelo fluxo administrativo autorizado;
-  - grants explícitos para `service_role`;
-  - Trigger Hub: não;
-  - eventos materiais de ativação, autorização e revogação usam `audit_context_event`.
-- Implementação de banco:
-  - migration incremental forward-only;
-  - rollback por nova migration, sem editar migration aplicada;
-  - `docs/schema.md` atualizado na fase que criar os objetos;
-  - runtime só entra após migration aplicada e verificada no ambiente alvo.
-
-### 2.10. Superfície administrativa mínima
-
-- Lista em `/admin/templates/landing-page`:
-  - taxon;
-  - nível;
-  - situação das pesquisas;
-  - composição própria ou herdada;
-  - versão ativa;
-  - prontidão resumida por plano;
-  - ação para abrir o detalhe.
-- Detalhe em `/admin/templates/landing-page/[taxonSlug]`:
-  - resumo dos três critérios do taxon;
-  - fontes e versões resolvidas;
-  - ação “Gerar proposta com IA”;
-  - editor estrutural por linhas, sem canvas e sem drag-and-drop obrigatório;
-  - controles simples para módulo, variante, obrigatoriedade, opções permitidas e mover para cima ou para baixo;
-  - painel separado de gaps;
-  - ações salvar `draft`, revalidar e ativar;
-  - prontidão por plano;
-  - autorização e revogação por conta e plano.
-- Estados visuais obrigatórios:
-  - carregando;
-  - vazio;
-  - proposta pronta para revisão;
-  - `draft` válido;
-  - `draft` bloqueado;
-  - ativo;
-  - herdado;
-  - erro seguro da IA;
-  - operação não autorizada.
-- Critérios visuais:
-  - reutilizar shell, `AdminPageHeader`, `AdminStatusBadge`, componentes do design system e tokens vigentes;
-  - layout responsivo empilhado no mobile;
-  - tabelas com overflow horizontal quando necessário;
-  - foco visível, labels associados, mensagens de erro acessíveis e botões desabilitados durante submissão;
-  - não criar redesign do Admin, preview de LP ou editor visual.
-
-### 2.11. Handoff de gaps para a E18.5
-
-- Quando um gap exigir extensão do catálogo, o registro deve fornecer ao fluxo de `docs/prompt-catalogo-lp.md`:
-  - evidência de `lp_sections` para função e anatomia;
-  - papéis semânticos e limites relevantes da E18.4;
-  - itens estruturados da E10.8 para sources de copy;
-  - evidência E20.2 somente quando houver necessidade de dado factual;
-  - critério de parada quando as fontes forem insuficientes.
-- O handoff é humano e documental; não cria PR, módulo ou variante automaticamente.
-- A necessidade de ajustar `docs/prompt-catalogo-lp.md` será decidida somente após o primeiro gap real validar esse handoff.
+- Contrato:
+  - composição válida;
+  - status inválido;
+  - versão inválida;
+  - ordem duplicada ou descontínua;
+  - módulo desconhecido;
+  - variante desconhecida ou incompatível.
+- Lifecycle:
+  - criação de `draft`;
+  - ativação sem versão anterior;
+  - ativação com arquivamento da anterior;
+  - tentativa de editar versão ativa;
+  - tentativa de manter duas versões ativas.
+- Resolução:
+  - composição própria;
+  - herança de nicho;
+  - herança de segmento;
+  - herança bloqueada;
+  - ausência de composição;
+  - composição encontrada, porém inválida.
+- Os casos usam fixtures e não criam composição oficial.
 
 ## 3. Fases e próxima ação
 
-### 3.1. E20.3.3 — Contrato persistente de composição, versões e gaps
+### 3.1. E20.3.3 — Contrato e persistência mínima da composição
 
 - Automação: não.
 - Objetivo:
-  - implementar o boundary server-side e a persistência mínima para política de herança, composição versionada e gaps.
+  - implementar o contrato estrutural, lifecycle, versionamento e persistência mínima da composição.
 - Entregas:
-  - definir o path canônico dentro de `lib/conversion-content/landing-page/composition/`;
+  - criar o boundary canônico em `lib/conversion-content/landing-page/composition/`;
   - criar contratos TypeScript e schemas Zod estritos;
-  - criar migration incremental com as estruturas mínimas da seção 2.9;
-  - implementar adapters por caso de uso, sem Supabase na UI;
-  - implementar criação, edição e validação de `draft`;
-  - implementar ativação transacional e arquivamento da versão anterior;
-  - implementar política de herança e autorização de composição própria de ultranicho;
-  - registrar auditoria material;
-  - atualizar `docs/schema.md` e, somente quando houver contrato técnico durável material, `docs/base-tecnica.md`.
+  - criar a migration mínima da seção 2.3;
+  - implementar adapter server-side;
+  - implementar operações internas de `draft`, validação e ativação;
+  - atualizar `docs/schema.md`;
+  - adicionar casos executáveis de contrato e lifecycle.
 - Critérios de aceite:
-  - lifecycle e constraints protegidos no banco e no runtime;
+  - somente as duas responsabilidades persistentes da seção 2.3;
+  - uma única versão ativa por taxon proprietário;
   - versão ativa imutável;
-  - uma única ativa por taxon proprietário;
-  - payload inválido ou gap impeditivo não ativa;
-  - sem reutilização de `commercial_activation`;
-  - RLS, policies, grants e migration validados;
-  - casos positivos e negativos executáveis;
-  - `npm run check` e `git diff --check` aprovados.
+  - payload inválido não ativa;
+  - migration sem seed ou registro oficial;
+  - nenhuma rota, API, Server Action ou UI;
+  - `npm run check` e `git diff --check` aprovados;
+  - apply remoto somente após merge na `main`.
 
-### 3.2. E20.3.4 — Resolução própria ou herdada e prontidão por plano
+### 3.2. E20.3.4 — Validação E18.5 e resolução própria ou herdada
 
 - Automação: não.
 - Objetivo:
-  - resolver a composição aplicável e avaliar prontidão fail-closed por taxon atendido e plano.
+  - validar a composição contra o catálogo vigente e resolver a versão aplicável de forma determinística e fail-closed.
 - Entregas:
-  - implementar resolver puro e adapter server-side de entrada;
-  - preservar `servedTaxon`, `ownerTaxon`, relação e versões;
-  - implementar precedência própria e ancestral mais próximo;
+  - implementar resolver puro;
+  - integrar leitura pelo adapter server-side;
+  - validar módulo, variante, versões, vínculo e ordem contra a E18.5;
+  - implementar precedência própria e ancestral elegível mais próximo;
   - implementar bloqueio explícito de herança;
-  - bloquear fallback distante quando a composição mais próxima estiver inválida;
-  - consumir sinais de E10.8, E18.4, E18.5 e E20.2 sem duplicar seus resolvers;
-  - persistir a última evidência de prontidão;
-  - expor contrato mínimo de prontidão para E12.4 e futura E19.4;
-  - adicionar script de validação executável da E20.3.
+  - preservar proveniência mínima no resultado tipado;
+  - exportar API pública mínima pelo namespace vigente;
+  - adicionar casos executáveis de validação e resolução.
 - Critérios de aceite:
-  - casos próprios, herdados, bloqueados e inválidos cobertos;
-  - os quatro planos avaliados separadamente;
-  - prontidão anterior não autoriza consumo quando a validação atual falha;
-  - nenhuma composição universal ou correção silenciosa;
-  - imutabilidade e ordenação determinística;
-  - validações E10.8, E18.4, E18.5 e E20.2 permanecem verdes;
+  - casos próprios, herdados, bloqueados, ausentes e inválidos cobertos;
+  - nenhuma composição universal implícita;
+  - nenhuma identidade criada ou corrigida silenciosamente;
+  - nenhuma dependência de E10.8, E18.4 ou E20.2 para resolver a estrutura;
+  - nenhuma prontidão, autorização ou revogação;
   - `npm run check` e `git diff --check` aprovados.
 
-### 3.3. E12.4.3 — Proposta por IA, revisão, ativação e prontidão no Admin
+### 3.3. Próxima ação
 
-- Automação: não.
-- Objetivo:
-  - implementar a cooperação humano + IA para criar e ativar a composition do taxon no Admin Dashboard.
-- Entregas:
-  - criar as rotas da seção 2.10 como extensão da área existente `/admin/templates`;
-  - criar leitura administrativa por adapters;
-  - criar Server Actions protegidas por `requirePlatformAdmin`;
-  - implementar chamada síncrona à Responses API com Structured Outputs;
-  - definir env server-side exclusiva do modelo e registrar seu nome em `docs/platform-config.md`;
-  - normalizar e revalidar a proposta antes de exibi-la;
-  - implementar editor estrutural mínimo, gaps, salvamento, revalidação e ativação;
-  - exibir os três critérios do taxon e a prontidão dos quatro planos;
-  - aplicar observability segura com `request_id` e `latency_ms`;
-  - preservar estados visuais e acessibilidade da seção 2.10.
-- Critérios de aceite:
-  - IA só roda por ação humana;
-  - falha da IA não persiste nem altera composição;
-  - identidade inventada aparece apenas como gap e nunca como item válido;
-  - saída válida continua dependendo de revisão e ativação humanas;
-  - no máximo um módulo por ocorrência e uma interação `form`;
-  - comportamento responsivo e estados de loading, erro, vazio, bloqueio, draft, ativo e herdado verificados;
-  - teste humano em Preview confirma o fluxo do primeiro taxon real;
-  - `npm run check` e `git diff --check` aprovados.
-
-### 3.4. E12.4.4 — Autorização e revogação por conta, taxon e plano
-
-- Automação: não.
-- Objetivo:
-  - permitir que o administrador controle quais contas podem usar um taxon e plano já prontos na futura E19.4.
-- Entregas:
-  - implementar contrato e persistência da autorização da seção 2.8;
-  - criar leitura e mutações administrativas protegidas;
-  - listar somente contas elegíveis pela operação administrativa vigente;
-  - exigir prontidão atual antes de autorizar;
-  - permitir revogação explícita;
-  - exibir autorização registrada e efeito atual separadamente;
-  - expor resolver server-side fail-closed para futura E19.4;
-  - registrar auditoria segura.
-- Critérios de aceite:
-  - combinação exata `conta + servedTaxon + plano`;
-  - outro plano ou taxon não é liberado implicitamente;
-  - prontidão bloqueada suspende o efeito sem apagar a autorização;
-  - revogação impede efeito mesmo com prontidão válida;
-  - entitlement E9, conta e membership não são duplicados nem contornados;
-  - teste humano em Preview confirma autorizar, bloquear por prontidão e revogar;
-  - `npm run check` e `git diff --check` aprovados.
-
-### 3.5. Próxima ação
-
-- Submeter esta v1 à avaliação única:
-  - Analista;
-  - Gestor Estrutural;
-  - Gestor de Updates.
-- Gestor de Automação: N/A, pois todas as fases têm `Automação: não`.
-- Após os pareceres:
-  - consolidar a v2 no mesmo PR pelo processo escolhido pelo humano;
-  - orientar a atualização de `docs/roadmap.md` no mesmo PR, criando somente:
+- Submeter esta v1 à avaliação única do Analista.
+- Após o parecer:
+  - consolidar a v2 no mesmo PR;
+  - orientar o Executor a atualizar `docs/roadmap.md` no PR da implementação com:
     - `20.3`;
     - `20.3.1`;
     - `20.3.3`;
     - `20.3.4`;
-    - `12.4`;
-    - `12.4.1`;
-    - `12.4.3`;
-    - `12.4.4`;
-  - omitir `20.3.2` e `12.4.2` enquanto não houver registros materiais, conforme `docs/template-roadmap.md`.
-- Não iniciar implementação material antes da aprovação, consolidação e merge humano do plano-base v2.
+  - omitir `20.3.2` enquanto não houver registro material.
+- Não iniciar implementação antes da aprovação, consolidação e merge humano do plano-base.
+- Debater a E12.4 somente após a conclusão da E20.3.
 
 ## 4. Escopo negativo e critérios de parada
 
 ### 4.1. Escopo negativo
 
-- Geração de copy ou LP.
-- Coleta e persistência de valores E20.2.
-- Snapshot da futura geração.
-- Renderer, preview visual da LP, publicação ou tracking.
-- E19.4.
-- E20.4.
-- E12.4.5–E12.4.6.
-- Alteração dos contratos da E10.8, E18.4, E18.5 ou E20.2.
-- Criação automática de módulo, variante, taxon ou pesquisa.
-- Editor visual, canvas, drag-and-drop obrigatório ou LP Builder.
-- Composição universal implícita.
-- Diferença artificial de composição por plano.
-- Reutilização direta das tabelas de `commercial_activation`.
-- Consulta direta a Stripe dentro do resolver da E20.3.
-- Duplicação de entitlement, conta ou membership.
-- Agente, Agents SDK, tool calling, automação, job, fila, cron, webhook, cache ou serviço separado.
-- SDK OpenAI novo quando o `fetch` server-side vigente for suficiente.
+- E12.4.
+- Admin Dashboard.
+- Integração com IA.
+- Proposta, revisão ou aprovação por usuário.
+- Gap persistido ou governança de gaps.
+- Prontidão.
+- Autorização ou revogação por conta, taxon ou plano.
+- Copy, geração, renderização, preview, publicação ou tracking de LP.
+- E19.4, E20.4 e E12.4.3–E12.4.6.
+- Snapshot das pesquisas E10.8, da raiz E18.4 ou das entradas E20.2.
+- Dados operacionais de conta, oferta, campanha ou LP.
+- Normalização de cada item da composição em tabela própria.
+- Tabela de avaliações, autorizações, gaps ou histórico operacional separado.
+- Rota, API, Server Action ou UI.
+- Editor visual, canvas ou drag-and-drop.
+- Agente, automação, job, fila, cron, webhook, cache ou serviço separado.
 - Nova infraestrutura.
-- Multiple approvers, aprovação em cadeia ou workflow genérico.
+- Composição oficial criada por migration, seed, fixture, script ou insert direto.
+- Reaproveitamento automático do código ou dos objetos abandonados no PR #631.
 
 ### 4.2. Critérios de parada imediata
 
 - Parar e devolver ao Estrategista se:
-  - as fontes reais exigirem responsabilidade diferente para E10.8, E18.4, E18.5, E20.2, E19.4 ou E20.4;
-  - a persistência mínima não puder preservar versão ativa imutável, herança, prontidão e revogação sem engine genérica;
-  - a UI exigir editor visual ou geração de LP;
-  - a IA precisar criar identidade não registrada;
-  - surgir necessidade de agente, tool calling, job, fila ou serviço separado;
-  - autorização exigir substituir ou alterar o entitlement da E9;
-  - composição própria de ultranicho for necessária sem autorização humana registrada;
-  - uma nova rota, tabela, policy, grant, env ou integração não puder ser justificada pelas fontes deste plano;
-  - o primeiro teste real demonstrar que o handoff de gaps não fornece evidência suficiente à E18.5.
+  - a implementação exigir prontidão, autorização, revogação, gaps persistidos ou Admin;
+  - a E18.5 não oferecer contrato público suficiente para validar módulo e variante;
+  - a política de ultranicho ou herança exigir decisão funcional adicional;
+  - a persistência mínima exigir responsabilidade além das duas previstas na seção 2.3;
+  - surgir necessidade de nova rota, UI, serviço, automação ou infraestrutura;
+  - qualquer migration precisar ser aplicada remotamente antes do merge;
+  - o estado real do repositório divergir das fontes deste plano.
 
 ### 4.3. Validação deste trabalho documental
 
-- Confirmar que o diff da v1 contém somente `docs/lousa-plano-base-e20-3.md`.
-- Confirmar as quatro seções principais obrigatórias.
-- Confirmar quatro fases executáveis:
+- Confirmar que o diff contém somente `docs/lousa-plano-base-e20-3.md`.
+- Confirmar as quatro seções obrigatórias.
+- Confirmar duas fases executáveis:
   - E20.3.3;
-  - E20.3.4;
-  - E12.4.3;
-  - E12.4.4.
-- Confirmar `Automação: não` em todas as fases.
-- Confirmar que `commercial_activation` aparece somente como fronteira negativa ou comparação rejeitada.
-- Confirmar que E19.4, E20.4 e E12.4.5–E12.4.6 permanecem fora.
+  - E20.3.4.
+- Confirmar `Automação: não` nas duas fases.
+- Confirmar que E12.4, IA, gaps persistidos, prontidão, autorização e revogação permanecem fora.
+- Confirmar ausência de composição oficial nesta etapa.
 - Executar `git diff --check`.
 - Registrar como N/A nesta v1 documental:
   - `npm ci`;
@@ -566,10 +390,10 @@
 
 ### 4.4. Critérios de encerramento do plano
 
-- O plano só encerra após:
-  - implementação das quatro fases na ordem aprovada;
+- O plano encerra após:
+  - implementação das duas fases na ordem aprovada;
   - avaliação do Analista após cada entrega material;
-  - testes humanos previstos em E12.4.3 e E12.4.4;
-  - merge humano do PR final;
+  - merge humano da implementação;
+  - confirmação do estado final do banco;
   - relatório final ao Gestor de Docs.
-- Uma composição ativa não encerra sozinha o plano enquanto a prontidão e a autorização administrativa mínima não estiverem implementadas e aprovadas.
+- A conclusão da E20.3 libera o debate conceitual da E12.4, mas não autoriza sua implementação automática.

--- a/docs/lousa-plano-base-e20-3.md
+++ b/docs/lousa-plano-base-e20-3.md
@@ -1,11 +1,11 @@
-# Plano-base — E20.3 — Composição estrutural mínima
+# Plano-base — E20.3 — Perfil de orientação para geração
 
-- Data: 25/07/2026.
-- Versão: v1 substitutiva após o PR #635.
+- Data: 26/07/2026.
+- Versão: v1.
 - Status: plano-base v1 para avaliação única do Analista.
-- Recorte previsto para o roadmap: `20.3 — Composição estrutural mínima de landing_page`.
+- Recorte previsto para o roadmap: `20.3 — Perfil de orientação para geração de landing_page`.
 - Path canônico: `docs/lousa-plano-base-e20-3.md`.
-- Plano conceitual: `docs/lp-planejamento.md`.
+- Plano conceitual: `docs/lp-planejamento.md`, após o merge do PR #642.
 
 ## 1. Estado e decisões fixas
 
@@ -16,18 +16,16 @@
   - parametrização raiz versionada da E18.4;
   - catálogo executável de módulos e variantes da E18.5;
   - catálogo declarativo de entradas da E20.2.
-- Ainda não existe a composição estrutural canônica que determine, por taxon proprietário e versão:
-  - módulos;
-  - variantes;
-  - ordem;
-  - obrigatoriedade quando aplicável.
-- O resultado esperado da E20.3 é:
-  - representar e persistir minimamente essa composição;
-  - preservar estados e versões;
-  - validar as identidades contra a E18.5;
-  - resolver composição própria ou herdada.
-- A E20.3 não cria composição oficial nesta etapa.
-- A futura E12.4 operará proposta, revisão, aprovação e ativação da primeira composição oficial.
+- Ainda não existe o perfil canônico que oriente a geração inicial de `landing_page` para um taxon.
+- A E20.3 deve:
+  - representar e persistir minimamente um perfil versionado por taxon proprietário;
+  - reunir orientação geral e recomendações por módulo;
+  - validar referências de módulo e variante contra a E18.5;
+  - resolver perfil próprio ou herdado;
+  - entregar o perfil por um único boundary server-side.
+- O perfil orienta escolhas futuras. Ele não define uma composição obrigatória, não fixa a LP final e não gera conteúdo.
+- A E20.3 atual não cadastra nem ativa perfil oficial.
+- O primeiro cadastro e a primeira ativação serão operados pela futura E12.4.
 
 ### 1.2. Fontes usadas
 
@@ -35,267 +33,212 @@
 - `docs/prompt-estrategista.md`.
 - `docs/template-roadmap.md`.
 - `docs/roadmap.md`.
-- `docs/lp-planejamento.md`, após o merge do PR #635.
+- `docs/lp-planejamento.md`, após o merge do PR #642.
 - `docs/base-tecnica.md`.
 - `docs/schema.md`.
 - `docs/lousa-plano-base-e18-5.md`.
 - `docs/lousa-plano-base-e20-2.md`.
-- Implementação vigente em:
+- Implementação vigente:
   - `lib/conversion-content/landing-page/module-catalog/`;
   - `lib/conversion-content/landing-page/input-catalog/`;
   - `lib/conversion-content/index.ts`.
 - Estado pós-reconciliação do PR #636:
-  - as migrations antecipadas permanecem no histórico;
-  - os objetos abandonados foram removidos;
-  - nenhuma estrutura da implementação superdimensionada permanece vigente.
+  - migrations antecipadas preservadas no histórico;
+  - objetos abandonados removidos;
+  - nenhuma estrutura superdimensionada vigente.
 
 ### 1.3. Decisões funcionais fixas
 
-- Existe uma composição canônica por `taxon proprietário + versão`.
-- A composição é reutilizada entre planos.
-- Cada item da composição referencia:
-  - módulo e versão;
-  - variante e versão;
-  - posição ordenada;
-  - obrigatoriedade quando aplicável.
+- Existe um perfil versionado por `taxon proprietário + versão`, reutilizado entre planos.
+- O perfil pode pertencer a segmento ou nicho; perfil próprio de ultranicho é excepcional e depende de decisão humana explícita no fluxo futuro responsável.
+- O perfil reúne:
+  - orientação geral;
+  - módulo recomendado;
+  - variante preferencial, quando aplicável;
+  - prioridade;
+  - ordem recomendada;
+  - orientação específica;
+  - justificativa, quando aplicável.
+- Prioridade orientará a seleção futura; ordem recomendada indicará a posição relativa entre os módulos selecionados.
+- Nenhuma recomendação torna módulo obrigatório ou redefine a E18.4 ou a E18.5.
 - Somente identidades oficialmente registradas na E18.5 são válidas.
-- O lifecycle mínimo distingue:
-  - `draft`;
-  - `active`;
-  - `archived`.
-- Uma versão `active` não é editada diretamente.
-- Uma mudança aprovada cria nova versão e preserva as anteriores.
-- No máximo uma versão pode estar `active` por taxon proprietário.
-- Na ausência de composição própria ativa, a resolução usa o ancestral elegível mais próximo, salvo bloqueio explícito de herança.
-- Não existe composição universal implícita.
-- A composição própria de ultranicho permanece excepcional e depende de permissão explícita no contrato mínimo de política do taxon.
+- Estados do perfil: `draft`, `active` e `archived`.
+- Uma versão `active` não é editada diretamente; mudança aprovada cria nova versão e preserva as anteriores.
+- Existe no máximo uma versão `active` por taxon proprietário.
+- Sem perfil próprio ativo, a resolução usa o ancestral elegível mais próximo.
+- Não existe perfil universal implícito.
+- A LP futuramente materializada é independente e não muda com novas versões do perfil.
 - Automação: não.
 
 ### 1.4. Fronteiras de responsabilidade
 
-- A E18.5 define módulos e variantes; a E20.3 apenas referencia e valida suas identidades versionadas.
-- A E20.2 permanece responsável pelo catálogo de entradas e não integra o payload da composição.
-- A E20.3 fornece:
-  - contrato estrutural;
-  - persistência mínima;
-  - lifecycle e versões;
-  - validação;
-  - resolução própria ou herdada.
-- A futura E12.4 operará:
-  - proposta;
-  - revisão;
-  - aprovação;
-  - ativação;
-  - primeiro cadastro oficial.
-- Planos posteriores tratarão:
-  - IA;
-  - gaps persistidos;
-  - prontidão;
-  - autorização;
-  - revogação;
-  - geração e publicação de LP.
+- E18.4 define a parametrização raiz.
+- E18.5 define módulos, variantes e contratos; E20.3 apenas referencia e valida suas identidades versionadas.
+- E20.2 define entradas; seus valores não integram o perfil.
+- E20.3 fornece contrato, persistência mínima, estados, versões, validação, leitura e resolução.
+- A futura E12.4 opera proposta por IA, revisão humana, primeiro cadastro, aprovação e ativação.
+- Planos posteriores tratam seleção efetiva por prioridade, geração, gaps persistidos, prontidão, autorização, revogação, aprendizado, publicação e evolução da LP.
 
 ## 2. Contrato do caso
 
 ### 2.1. Fluxo operacional
 
 - Gatilho:
-  - consumidor server-side solicita a composição aplicável a um taxon;
-  - casos executáveis validam criação, lifecycle e resolução com dados de teste.
+  - consumidor server-side solicita o perfil aplicável a um taxon;
+  - casos executáveis validam contrato e resolução com fixtures.
 - Entrada:
   - taxon atendido e cadeia taxonômica normalizada;
-  - política mínima do taxon;
-  - composições persistidas;
+  - perfis persistidos;
   - catálogo oficial da E18.5.
 - Processamento:
-  - localizar composição própria ativa;
-  - na ausência, verificar bloqueio de herança;
-  - localizar o ancestral elegível mais próximo;
-  - validar estrutura, estado, versão e identidades;
-  - devolver resultado tipado e determinístico.
-- Validação:
-  - taxon proprietário e cadeia válidos;
-  - versão inteira positiva;
-  - lifecycle válido;
-  - ordem inteira, única e contínua;
-  - módulo e variante existentes e compatíveis na E18.5;
-  - política de herança respeitada.
+  - localizar perfil próprio `active` ou, na ausência, o ancestral elegível mais próximo;
+  - validar versão, estado, orientação e recomendações;
+  - validar identidades contra a E18.5;
+  - devolver resultado tipado e com proveniência.
 - Persistência:
-  - política mínima necessária à herança e à excepcionalidade do ultranicho;
-  - composição versionada e seus itens estruturais.
-- Consumo:
-  - boundary server-side da própria E20.3;
-  - futura E12.4;
-  - futuros consumidores somente após seus planos próprios.
+  - somente perfil versionado e payload de orientação.
 - Fallback:
-  - composição própria ativa;
-  - composição ativa do ancestral elegível mais próximo;
+  - perfil próprio;
+  - perfil herdado;
   - ausência tipada;
-  - falha fechada diante de estrutura ou identidade inválida.
+  - falha fechada para perfil ou referência inválida.
 
-### 2.2. Contrato mínimo da composição
+### 2.2. Contrato mínimo do perfil
 
 - Identidade:
   - ID;
   - taxon proprietário;
-  - versão;
-  - status.
-- Itens ordenados:
-  - ID e versão do módulo;
-  - ID e versão da variante;
-  - posição;
-  - obrigatoriedade quando aplicável.
-- Metadados mínimos:
-  - criação;
-  - última atualização;
-  - ativação quando aplicável.
-- A composição não armazena:
+  - versão inteira positiva;
+  - estado.
+- Orientação geral:
+  - texto não vazio.
+- Cada recomendação contém:
+  - módulo e versão;
+  - variante preferencial e versão, quando aplicável;
+  - prioridade inteira positiva;
+  - ordem recomendada inteira positiva;
+  - orientação específica, quando aplicável;
+  - justificativa, quando aplicável.
+- Regras:
+  - menor prioridade numérica representa maior prioridade;
+  - ordem recomendada é única entre as recomendações, mas não precisa ser contínua;
+  - existe no máximo uma recomendação por módulo;
+  - não existe campo de obrigatoriedade.
+- O perfil não armazena:
+  - composição final;
   - copy;
   - pesquisas;
   - parâmetros da E18.4;
   - catálogo ou valores da E20.2;
-  - gaps;
-  - prontidão;
-  - autorização;
-  - revogação;
+  - gaps, prontidão, autorização ou revogação;
   - dados da conta;
-  - LP gerada.
+  - LP ou snapshot.
 
 ### 2.3. Persistência mínima
 
-- Criar somente as estruturas necessárias para:
-  - política de herança e permissão excepcional de composição própria;
-  - composição versionada com payload estrutural validado.
-- Usar uma representação compacta para os itens ordenados, sem normalizar prematuramente cada item em tabela própria.
+- Criar uma única tabela para o perfil versionado.
+- Manter orientação e recomendações em payload compacto, sem tabela própria por recomendação.
 - Proteger no banco:
-  - referências ao taxon;
+  - FK para o taxon proprietário;
   - versão positiva e única por taxon proprietário;
-  - status fechado;
-  - no máximo uma versão ativa por taxon proprietário;
-  - payload estrutural presente;
-  - imutabilidade da versão ativa.
+  - estado fechado;
+  - uma única versão `active` por taxon proprietário;
+  - payload presente;
+  - RLS habilitado e ausência de acesso direto por `anon` e `authenticated`.
 - Proteger no runtime:
-  - validação estrita do payload;
-  - compatibilidade módulo-variante;
-  - existência das versões na E18.5;
-  - transições de lifecycle permitidas.
-- Implementar adapter server-side no boundary da E20.3.
-- Não criar rota, API, Server Action ou UI.
-- Migration:
-  - incremental e forward-only;
-  - criada e revisada no PR da implementação;
-  - aplicada remotamente somente após merge na `main`;
-  - acompanhada da atualização de `docs/schema.md`.
-- A migration deve terminar sem registros oficiais:
-  - sem seed;
-  - sem insert de composição;
-  - sem composição ativa criada automaticamente.
+  - shape estrito do payload;
+  - regras de prioridade e ordem;
+  - ausência de obrigatoriedade;
+  - existência e compatibilidade de módulo e variante na E18.5;
+  - imutabilidade do resultado entregue.
+- Implementar somente leitura server-side.
+- Não criar operação de escrita, RPC, trigger de lifecycle, rota, API, Server Action, UI ou tabela de política do taxon.
+- A migration deve:
+  - ser incremental e forward-only;
+  - ser aplicada remotamente somente após merge na `main`;
+  - atualizar `docs/schema.md`;
+  - terminar sem seed, insert ou perfil oficial.
 
-### 2.4. Lifecycle e versionamento
+### 2.4. Estados e versionamento
 
 - `draft`:
-  - pode ser validado e substituído antes da ativação;
+  - versão ainda não aprovada;
   - não participa da resolução.
 - `active`:
-  - é imutável;
+  - versão aprovada;
   - participa da resolução;
-  - existe no máximo uma por taxon proprietário.
+  - não é editada diretamente.
 - `archived`:
-  - preserva a versão histórica;
-  - não participa da resolução;
-  - não retorna a `draft` nem a `active`.
-- A ativação de nova versão:
-  - revalida o payload no servidor;
-  - arquiva atomicamente a versão ativa anterior;
-  - ativa a nova versão.
-- Nesta etapa, as operações existem apenas como contrato e boundary interno para testes e futuro consumo da E12.4.
+  - versão histórica;
+  - não participa da resolução.
+- Nesta etapa:
+  - estados e invariantes pertencem ao contrato da E20.3;
+  - transições não são implementadas;
+  - fixtures podem representar os três estados sem criar perfil oficial.
+- A futura E12.4 implementará as mutações e a atomicidade necessárias sem alterar o significado dos estados.
 
 ### 2.5. Validação contra a E18.5
 
-- Cada item deve referenciar:
-  - módulo existente na versão informada;
-  - variante existente na versão informada;
-  - variante vinculada ao módulo informado.
-- A ordem deve ser:
-  - inteira;
-  - única;
-  - contínua;
-  - determinística.
-- Não impor nesta etapa:
-  - módulo único por composição;
-  - formulário único;
-  - limite nominal por módulo ou variante;
-  - escolhas livres não previstas pelo contrato estrutural.
+- Módulo deve existir na versão informada.
+- Variante preferencial, quando presente, deve existir na versão informada e pertencer ao módulo.
+- A recomendação não pode redefinir fields, capabilities ou interactions.
+- Prioridade não significa obrigação; ordem recomendada não significa composição fixa.
 - Identidade desconhecida ou incompatível falha fechado.
-- A validação não altera o catálogo E18.5 nem cria identidades.
+- A validação não altera a E18.5 nem cria identidades.
 
 ### 2.6. Herança e resolução
 
 - Precedência:
-  - composição própria `active`;
-  - composição `active` do ancestral elegível mais próximo;
-  - ausência de composição.
-- Para ultranicho sem composição própria ativa:
-  - nicho direto;
-  - depois segmento.
-- Para nicho sem composição própria ativa:
-  - segmento direto.
-- O bloqueio explícito no taxon atendido impede herança.
-- Uma composição inválida não é corrigida, ignorada ou substituída silenciosamente.
-- O resultado preserva:
-  - taxon atendido;
-  - taxon proprietário;
-  - ID e versão da composição;
-  - relação `own` ou `inherited`;
-  - itens ordenados;
-  - validade ou código fechado de falha.
+  - perfil próprio `active`;
+  - perfil `active` do ancestral elegível mais próximo;
+  - ausência de perfil.
+- Ultranicho sem perfil próprio ativo consulta nicho direto e depois segmento.
+- Nicho sem perfil próprio ativo consulta segmento direto.
+- A excepcionalidade de perfil próprio de ultranicho será controlada pelo fluxo futuro de cadastro, sem política persistente paralela nesta etapa.
+- Perfil inválido não é corrigido, ignorado ou substituído silenciosamente.
+- Resultado preserva taxon atendido, taxon proprietário, ID, versão, relação `own` ou `inherited`, orientação e recomendações.
 
 ### 2.7. Casos executáveis mínimos
 
 - Contrato:
-  - composição válida;
-  - status inválido;
-  - versão inválida;
-  - ordem duplicada ou descontínua;
-  - módulo desconhecido;
-  - variante desconhecida ou incompatível.
-- Lifecycle:
-  - criação de `draft`;
-  - ativação sem versão anterior;
-  - ativação com arquivamento da anterior;
-  - tentativa de editar versão ativa;
-  - tentativa de manter duas versões ativas.
+  - perfil válido;
+  - estado ou versão inválidos;
+  - orientação inválida;
+  - prioridade ou ordem inválidas;
+  - recomendação duplicada;
+  - tentativa de declarar obrigatoriedade;
+  - módulo ou variante inválidos.
+- Estados:
+  - somente `active` participa da resolução;
+  - unicidade da versão ativa protegida pela persistência.
 - Resolução:
-  - composição própria;
+  - perfil próprio;
   - herança de nicho;
   - herança de segmento;
-  - herança bloqueada;
-  - ausência de composição;
-  - composição encontrada, porém inválida.
-- Os casos usam fixtures e não criam composição oficial.
+  - ausência;
+  - perfil inválido.
+- Casos usam fixtures e não cadastram nem ativam perfil oficial.
 
 ## 3. Fases e próxima ação
 
-### 3.1. E20.3.3 — Contrato e persistência mínima da composição
+### 3.1. E20.3.3 — Contrato e persistência mínima do perfil
 
 - Automação: não.
 - Objetivo:
-  - implementar o contrato estrutural, lifecycle, versionamento e persistência mínima da composição.
+  - implementar contrato versionado e persistência mínima do perfil de orientação.
 - Entregas:
-  - criar o boundary canônico em `lib/conversion-content/landing-page/composition/`;
+  - criar boundary em `lib/conversion-content/landing-page/generation-profile/`;
   - criar contratos TypeScript e schemas Zod estritos;
   - criar a migration mínima da seção 2.3;
-  - implementar adapter server-side;
-  - implementar operações internas de `draft`, validação e ativação;
+  - implementar leitura server-side;
   - atualizar `docs/schema.md`;
-  - adicionar casos executáveis de contrato e lifecycle.
+  - adicionar casos de contrato e estados.
 - Critérios de aceite:
-  - somente as duas responsabilidades persistentes da seção 2.3;
-  - uma única versão ativa por taxon proprietário;
-  - versão ativa imutável;
-  - payload inválido não ativa;
-  - migration sem seed ou registro oficial;
-  - nenhuma rota, API, Server Action ou UI;
+  - uma única tabela do perfil;
+  - uma única versão `active` por taxon proprietário;
+  - nenhum módulo obrigatório ou composição final;
+  - nenhuma mutação, RPC, trigger, rota, API, Server Action ou UI;
+  - nenhum registro oficial;
   - `npm run check` e `git diff --check` aprovados;
   - apply remoto somente após merge na `main`.
 
@@ -303,97 +246,85 @@
 
 - Automação: não.
 - Objetivo:
-  - validar a composição contra o catálogo vigente e resolver a versão aplicável de forma determinística e fail-closed.
+  - validar recomendações e resolver o perfil aplicável de forma determinística e fail-closed.
 - Entregas:
-  - implementar resolver puro;
-  - integrar leitura pelo adapter server-side;
-  - validar módulo, variante, versões, vínculo e ordem contra a E18.5;
-  - implementar precedência própria e ancestral elegível mais próximo;
-  - implementar bloqueio explícito de herança;
-  - preservar proveniência mínima no resultado tipado;
-  - exportar API pública mínima pelo namespace vigente;
-  - adicionar casos executáveis de validação e resolução.
+  - implementar resolver puro e integrar a leitura server-side;
+  - validar módulo, variante, versões e vínculo contra a E18.5;
+  - preservar prioridade e ordem como orientação;
+  - implementar precedência própria e ancestral;
+  - preservar proveniência;
+  - exportar API pública mínima;
+  - adicionar casos de validação e resolução.
 - Critérios de aceite:
-  - casos próprios, herdados, bloqueados, ausentes e inválidos cobertos;
-  - nenhuma composição universal implícita;
-  - nenhuma identidade criada ou corrigida silenciosamente;
-  - nenhuma dependência de E10.8, E18.4 ou E20.2 para resolver a estrutura;
-  - nenhuma prontidão, autorização ou revogação;
+  - casos próprios, herdados, ausentes e inválidos cobertos;
+  - nenhum perfil universal implícito;
+  - nenhuma identidade criada ou corrigida;
+  - nenhuma seleção por plano ou prioridade;
+  - nenhuma prontidão, autorização, revogação ou geração;
   - `npm run check` e `git diff --check` aprovados.
 
 ### 3.3. Próxima ação
 
 - Submeter esta v1 à avaliação única do Analista.
-- Após o parecer:
-  - consolidar a v2 no mesmo PR;
-  - orientar o Executor a atualizar `docs/roadmap.md` no PR da implementação com:
-    - `20.3`;
-    - `20.3.1`;
-    - `20.3.3`;
-    - `20.3.4`;
-  - omitir `20.3.2` enquanto não houver registro material.
-- Não iniciar implementação antes da aprovação, consolidação e merge humano do plano-base.
+- Se necessário, ajustar a própria v1 no mesmo PR.
+- Após aprovação e merge humano, orientar o Executor a:
+  - implementar E20.3.3 e E20.3.4 na ordem;
+  - atualizar `docs/roadmap.md` no PR material;
+  - não iniciar E12.4.
 - Debater a E12.4 somente após a conclusão da E20.3.
 
 ## 4. Escopo negativo e critérios de parada
 
 ### 4.1. Escopo negativo
 
-- E12.4.
-- Admin Dashboard.
-- Integração com IA.
-- Proposta, revisão ou aprovação por usuário.
-- Gap persistido ou governança de gaps.
-- Prontidão.
-- Autorização ou revogação por conta, taxon ou plano.
-- Copy, geração, renderização, preview, publicação ou tracking de LP.
+- Composição obrigatória, estrutura final ou módulo obrigatório.
+- Seleção efetiva por prioridade ou diferenciação por plano.
+- E12.4, Admin Dashboard, IA e aprendizado automático.
+- Cadastro, edição, aprovação, ativação ou arquivamento de perfil.
+- Gaps persistidos, prontidão, autorização ou revogação.
+- Copy, geração, renderização, preview, publicação, tracking ou snapshot.
 - E19.4, E20.4 e E12.4.3–E12.4.6.
-- Snapshot das pesquisas E10.8, da raiz E18.4 ou das entradas E20.2.
 - Dados operacionais de conta, oferta, campanha ou LP.
-- Normalização de cada item da composição em tabela própria.
-- Tabela de avaliações, autorizações, gaps ou histórico operacional separado.
-- Rota, API, Server Action ou UI.
-- Editor visual, canvas ou drag-and-drop.
-- Agente, automação, job, fila, cron, webhook, cache ou serviço separado.
-- Nova infraestrutura.
-- Composição oficial criada por migration, seed, fixture, script ou insert direto.
-- Reaproveitamento automático do código ou dos objetos abandonados no PR #631.
+- Tabela por recomendação, tabela de política ou estrutura operacional paralela.
+- RPC, trigger de lifecycle, rota, API, Server Action ou UI.
+- Editor visual, agente, automação, job, fila, cron, webhook, cache, serviço ou nova infraestrutura.
+- Perfil oficial criado por migration, seed, fixture, script ou insert direto.
+- Reaproveitamento automático dos objetos abandonados no PR #631.
 
 ### 4.2. Critérios de parada imediata
 
 - Parar e devolver ao Estrategista se:
-  - a implementação exigir prontidão, autorização, revogação, gaps persistidos ou Admin;
-  - a E18.5 não oferecer contrato público suficiente para validar módulo e variante;
-  - a política de ultranicho ou herança exigir decisão funcional adicional;
-  - a persistência mínima exigir responsabilidade além das duas previstas na seção 2.3;
-  - surgir necessidade de nova rota, UI, serviço, automação ou infraestrutura;
-  - qualquer migration precisar ser aplicada remotamente antes do merge;
-  - o estado real do repositório divergir das fontes deste plano.
+  - surgir composição obrigatória, seleção efetiva, geração ou diferença por plano;
+  - for exigida qualquer mutação do perfil;
+  - a E18.5 não oferecer contrato público suficiente;
+  - surgir caso real de perfil próprio de ultranicho antes da definição de sua autorização;
+  - a persistência exigir mais de uma tabela de domínio;
+  - surgir rota, UI, serviço, automação ou infraestrutura;
+  - uma migration precisar ser aplicada antes do merge;
+  - o repositório divergir das fontes do plano.
 
 ### 4.3. Validação deste trabalho documental
 
-- Confirmar que o diff contém somente `docs/lousa-plano-base-e20-3.md`.
-- Confirmar as quatro seções obrigatórias.
-- Confirmar duas fases executáveis:
-  - E20.3.3;
-  - E20.3.4.
-- Confirmar `Automação: não` nas duas fases.
-- Confirmar que E12.4, IA, gaps persistidos, prontidão, autorização e revogação permanecem fora.
-- Confirmar ausência de composição oficial nesta etapa.
+- Confirmar:
+  - somente `docs/lousa-plano-base-e20-3.md` alterado;
+  - quatro seções preservadas;
+  - duas fases com `Automação: não`;
+  - documento mantido como v1;
+  - ausência de composição obrigatória, cadastro oficial, E12.4, IA, gaps, prontidão, autorização, revogação e geração.
 - Executar `git diff --check`.
-- Registrar como N/A nesta v1 documental:
+- Registrar como N/A:
   - `npm ci`;
   - `npm run check`;
-  - validações materiais;
+  - validação material;
   - teste humano;
   - smoke visual.
 
 ### 4.4. Critérios de encerramento do plano
 
 - O plano encerra após:
-  - implementação das duas fases na ordem aprovada;
-  - avaliação do Analista após cada entrega material;
-  - merge humano da implementação;
+  - implementação das duas fases na ordem;
+  - avaliação do Analista após cada entrega;
+  - merge humano;
   - confirmação do estado final do banco;
   - relatório final ao Gestor de Docs.
-- A conclusão da E20.3 libera o debate conceitual da E12.4, mas não autoriza sua implementação automática.
+- A conclusão da E20.3 libera o debate da E12.4, mas não autoriza sua implementação.

--- a/docs/lousa-plano-base-e20-3.md
+++ b/docs/lousa-plano-base-e20-3.md
@@ -52,13 +52,13 @@
 - Existe um perfil versionado por `taxon proprietário + versão`, reutilizado entre planos.
 - O perfil pode pertencer a segmento ou nicho; perfil próprio de ultranicho é excepcional e depende de decisão humana explícita no fluxo futuro responsável.
 - O perfil reúne:
-  - orientação geral;
-  - módulo recomendado;
+  - orientação geral em `generation_guidance`;
+  - recomendações próprias por módulo;
   - variante preferencial, quando aplicável;
   - prioridade;
   - ordem recomendada;
-  - orientação específica;
-  - justificativa, quando aplicável.
+  - `item_guidance`, quando aplicável.
+- A prioridade usa enum fechado `P1`, `P2` e `P3`, em ordem decrescente de importância.
 - Prioridade orientará a seleção futura; ordem recomendada indicará a posição relativa entre os módulos selecionados.
 - Nenhuma recomendação torna módulo obrigatório ou redefine a E18.4 ou a E18.5.
 - Somente identidades oficialmente registradas na E18.5 são válidas.
@@ -96,7 +96,8 @@
   - validar identidades contra a E18.5;
   - devolver resultado tipado e com proveniência.
 - Persistência:
-  - somente perfil versionado e payload de orientação.
+  - exatamente duas tabelas de domínio: perfil versionado e itens recomendados;
+  - os itens pertencem à versão do perfil e não possuem versão ou lifecycle próprios.
 - Fallback:
   - perfil próprio;
   - perfil herdado;
@@ -112,18 +113,20 @@
   - estado.
 - Orientação geral:
   - texto não vazio.
-- Cada recomendação contém:
+- Cada item recomendado contém:
   - módulo e versão;
   - variante preferencial e versão, quando aplicável;
-  - prioridade inteira positiva;
+  - prioridade `P1`, `P2` ou `P3`;
   - ordem recomendada inteira positiva;
-  - orientação específica, quando aplicável;
-  - justificativa, quando aplicável.
+  - `item_guidance`, quando aplicável.
 - Regras:
-  - menor prioridade numérica representa maior prioridade;
-  - ordem recomendada é única entre as recomendações, mas não precisa ser contínua;
-  - existe no máximo uma recomendação por módulo;
+  - `P1` representa maior prioridade, seguida por `P2` e `P3`;
+  - não são aceitos `P4`, `P5` ou valores numéricos arbitrários;
+  - ordem recomendada é única entre os itens do perfil, mas não precisa ser contínua;
+  - existe no máximo um item por módulo no perfil;
+  - `item_guidance` pode reunir a orientação específica e sua razão;
   - não existe campo de obrigatoriedade.
+- Perfil e itens formam um único agregado de domínio entregue aos consumidores.
 - O perfil não armazena:
   - composição final;
   - copy;
@@ -136,24 +139,48 @@
 
 ### 2.3. Persistência mínima
 
-- Criar uma única tabela para o perfil versionado.
-- Manter orientação e recomendações em payload compacto, sem tabela própria por recomendação.
+- Criar exatamente duas tabelas de domínio:
+  - `landing_page_generation_profiles`:
+    - ID;
+    - taxon proprietário;
+    - versão;
+    - status;
+    - `generation_guidance`;
+    - metadados mínimos;
+  - `landing_page_generation_profile_items`:
+    - ID;
+    - `profile_id`;
+    - módulo e versão;
+    - variante preferencial e versão, quando houver;
+    - prioridade;
+    - ordem recomendada;
+    - `item_guidance`, quando houver.
+- A tabela de itens possui FK para `landing_page_generation_profiles`.
+- Os itens pertencem à versão do perfil e não possuem versão, status ou lifecycle próprios.
 - Proteger no banco:
-  - FK para o taxon proprietário;
+  - FK do perfil para o taxon proprietário;
+  - FK de cada item para o perfil;
   - versão positiva e única por taxon proprietário;
-  - estado fechado;
+  - status fechado;
   - uma única versão `active` por taxon proprietário;
-  - payload presente;
-  - RLS habilitado e ausência de acesso direto por `anon` e `authenticated`.
+  - `generation_guidance` presente;
+  - prioridade fechada em `P1`, `P2` e `P3`;
+  - integridade entre perfil e itens;
+  - RLS habilitado nas duas tabelas e ausência de acesso direto por `anon` e `authenticated`.
 - Proteger no runtime:
-  - shape estrito do payload;
+  - contratos próprios do perfil e dos itens;
+  - schema estrito do agregado;
   - regras de prioridade e ordem;
   - ausência de obrigatoriedade;
   - existência e compatibilidade de módulo e variante na E18.5;
   - imutabilidade do resultado entregue.
+- Implementar adapter server-side que leia as duas tabelas.
+- Expor um único boundary que entregue perfil e itens juntos.
+- Consumidores não consultam as duas tabelas separadamente.
 - Implementar somente leitura server-side.
 - Não criar operação de escrita, RPC, trigger de lifecycle, rota, API, Server Action, UI ou tabela de política do taxon.
 - A migration deve:
+  - criar exatamente as duas tabelas;
   - ser incremental e forward-only;
   - ser aplicada remotamente somente após merge na `main`;
   - atualizar `docs/schema.md`;
@@ -203,11 +230,18 @@
 - Contrato:
   - perfil válido;
   - estado ou versão inválidos;
-  - orientação inválida;
-  - prioridade ou ordem inválidas;
-  - recomendação duplicada;
+  - `generation_guidance` inválida;
+  - prioridade fora de `P1`, `P2` e `P3`;
+  - ordem recomendada inválida;
+  - item duplicado;
+  - `item_guidance` inválida, quando presente;
   - tentativa de declarar obrigatoriedade;
   - módulo ou variante inválidos.
+- Integridade:
+  - item vinculado ao perfil por FK;
+  - item sem perfil rejeitado;
+  - item sem versão ou lifecycle próprio;
+  - agregado entregue sempre com perfil e itens juntos.
 - Estados:
   - somente `active` participa da resolução;
   - unicidade da versão ativa protegida pela persistência.
@@ -225,17 +259,24 @@
 
 - Automação: não.
 - Objetivo:
-  - implementar contrato versionado e persistência mínima do perfil de orientação.
+  - implementar o agregado versionado e a persistência mínima do perfil de orientação.
 - Entregas:
   - criar boundary em `lib/conversion-content/landing-page/generation-profile/`;
-  - criar contratos TypeScript e schemas Zod estritos;
-  - criar a migration mínima da seção 2.3;
-  - implementar leitura server-side;
+  - criar contratos TypeScript próprios do perfil e dos itens;
+  - criar schema Zod estrito do agregado;
+  - criar migration com `landing_page_generation_profiles` e `landing_page_generation_profile_items`;
+  - implementar adapter server-side que leia as duas tabelas;
+  - expor boundary único que entregue perfil e itens juntos;
   - atualizar `docs/schema.md`;
-  - adicionar casos de contrato e estados.
+  - adicionar casos de contrato, estados e integridade entre perfil e itens.
 - Critérios de aceite:
-  - uma única tabela do perfil;
+  - exatamente duas tabelas de domínio;
+  - FK dos itens para o perfil;
+  - itens sem versão ou lifecycle próprios;
+  - prioridade limitada a `P1`, `P2` e `P3`;
+  - um único `item_guidance` textual por item;
   - uma única versão `active` por taxon proprietário;
+  - consumidores sem consulta separada às tabelas;
   - nenhum módulo obrigatório ou composição final;
   - nenhuma mutação, RPC, trigger, rota, API, Server Action ou UI;
   - nenhum registro oficial;
@@ -285,7 +326,8 @@
 - Copy, geração, renderização, preview, publicação, tracking ou snapshot.
 - E19.4, E20.4 e E12.4.3–E12.4.6.
 - Dados operacionais de conta, oferta, campanha ou LP.
-- Tabela por recomendação, tabela de política ou estrutura operacional paralela.
+- Terceira tabela de domínio.
+- Tabelas de políticas, gaps, avaliações, aprendizado ou autorização.
 - RPC, trigger de lifecycle, rota, API, Server Action ou UI.
 - Editor visual, agente, automação, job, fila, cron, webhook, cache, serviço ou nova infraestrutura.
 - Perfil oficial criado por migration, seed, fixture, script ou insert direto.
@@ -298,7 +340,7 @@
   - for exigida qualquer mutação do perfil;
   - a E18.5 não oferecer contrato público suficiente;
   - surgir caso real de perfil próprio de ultranicho antes da definição de sua autorização;
-  - a persistência exigir mais de uma tabela de domínio;
+  - surgir necessidade de uma terceira tabela de domínio nesta etapa;
   - surgir rota, UI, serviço, automação ou infraestrutura;
   - uma migration precisar ser aplicada antes do merge;
   - o repositório divergir das fontes do plano.
@@ -310,6 +352,10 @@
   - quatro seções preservadas;
   - duas fases com `Automação: não`;
   - documento mantido como v1;
+  - exatamente duas tabelas de domínio;
+  - prioridade fechada em `P1`, `P2` e `P3`;
+  - um único `item_guidance` por item;
+  - boundary único para perfil e itens;
   - ausência de composição obrigatória, cadastro oficial, E12.4, IA, gaps, prontidão, autorização, revogação e geração.
 - Executar `git diff --check`.
 - Registrar como N/A:


### PR DESCRIPTION
## 1. Objetivo

Substituir o plano-base superdimensionado da E20.3 por uma v1 aderente à definição conceitual mergeada no PR #642: perfil versionado de orientação para geração por taxon.

## 2. Fontes

- `README.md`;
- `docs/lp-planejamento.md`, após o PR #642;
- `docs/roadmap.md`;
- `docs/base-tecnica.md`;
- `docs/schema.md`;
- planos-base vigentes da E18.5 e E20.2;
- estado reconciliado pelo PR #636;
- avaliação do Analista que determinou a normalização do perfil e de seus itens.

## 3. Alterações

- mantém o documento como plano-base v1;
- substitui composição obrigatória por perfil de orientação;
- define orientação geral em `generation_guidance`;
- normaliza recomendações em `landing_page_generation_profile_items`;
- cria exatamente duas tabelas de domínio, com FK dos itens para o perfil;
- mantém os itens dentro da versão e do lifecycle do perfil;
- fecha prioridade em `P1`, `P2` e `P3`;
- mantém apenas `item_guidance` como campo textual próprio do item;
- separa prioridade de ordem recomendada;
- impede que recomendação torne módulo obrigatório;
- exige adapter para as duas tabelas e boundary único do agregado;
- implementa somente leitura nesta etapa;
- mantém duas fases: E20.3.3 e E20.3.4;
- exclui cadastro e ativação oficial, E12.4, Admin, IA, geração, gaps persistidos, prontidão, autorização, revogação e aprendizado automático;
- interrompe a etapa se surgir necessidade de uma terceira tabela de domínio.

## 4. Impacto

A E20.3 passa a fornecer contrato, persistência mínima normalizada e resolução do perfil de orientação como um único agregado. O primeiro cadastro, a aprovação e a ativação do perfil oficial permanecem para o futuro plano da E12.4.

## 5. Causa do ajuste

A versão anterior da v1 concentrava perfil e recomendações em uma tabela e aceitava prioridade numérica aberta. O ajuste preserva a identidade conceitual do PR #642, mas representa separadamente o perfil e seus itens, sem criar lifecycle próprio para as recomendações.

## 6. Validação

- somente `docs/lousa-plano-base-e20-3.md` alterado;
- quatro seções obrigatórias preservadas;
- duas fases executáveis;
- `Automação: não` nas duas fases;
- documento mantido como v1, sem referência a v2;
- exatamente duas tabelas de domínio;
- prioridade fechada em `P1`, `P2` e `P3`;
- um único `item_guidance` por item;
- consumidores recebem perfil e itens por boundary único;
- `npm ci`: N/A, alteração exclusivamente documental;
- `npm run check`: N/A, alteração exclusivamente documental.

## 7. Próxima decisão

Submeter a v1 ajustada à reavaliação do Analista. Não iniciar implementação antes da consolidação e do merge humano do plano-base.