### PR TITLE
fix: bloqueia migrations remotas antes do merge

### DIFF
--- a/.agents/skills/lp-factory-executar-plano/SKILL.md
+++ b/.agents/skills/lp-factory-executar-plano/SKILL.md
@@ -38,6 +38,14 @@ Quando invocada por `$lp-factory-orquestrar-plano`:
 4. No handoff interno, reutilizar a branch e o PR existentes. Na execução independente, criar ou selecionar uma única branch `codex-app/<caso>-implementacao` a partir da `main` e um único PR draft contra `main`. Recusar base diferente de `main` e nunca criar branch ou PR por subseção.
 5. Registrar o SHA do plano como contrato imutável. Se houver execução anterior, identificar o último checkpoint pelo trailer de commit `LP-Factory-Phase: <identificador>`; se não for possível determinar unicamente a próxima subseção, parar e pedir o identificador.
 
+## Gate Supabase pré-merge
+
+Quando a subseção alterar schema ou migrations:
+
+1. Criar e versionar a migration em `supabase/migrations/` e validá-la somente em ambiente local ou isolado. Antes do merge, permitir no projeto remoto apenas inspeção read-only, `supabase migration list --linked` e `supabase db push --linked --dry-run`.
+2. Não executar alteração remota de schema ou do histórico de migrations, inclusive por `apply_migration`, SQL mutável via `execute_sql`, SQL Editor, Table Editor, `supabase db push --linked` sem `--dry-run` ou ferramenta equivalente. O merge na `main` dispara o workflow canônico de aplicação.
+3. Se o plano exigir aplicação remota pré-merge ou se ela já tiver ocorrido, parar em modo fail-closed, registrar a operação e o estado encontrados e informar o humano. Não aplicar rollback, `migration repair`, nova migration corretiva ou outra mutação remota por inferência.
+
 ## Executar uma subseção
 
 Para a próxima subseção ainda não aprovada:


### PR DESCRIPTION
## Objetivo

Impedir que o Executor da automação altere remotamente schema ou histórico de migrations antes do merge humano.

## Regra

- migrations são criadas e validadas localmente ou em ambiente isolado;
- no remoto, antes do merge, somente inspeção read-only, migration list e db push com dry-run;
- apply_migration, SQL mutável, SQL Editor, Table Editor e db push sem dry-run ficam proibidos;
- conflito no plano ou aplicação prematura interrompem o fluxo em modo fail-closed, sem reparo por inferência.

## Validação

- git diff --check aprovado;
- alteração exclusivamente documental; npm ci e npm run check não aplicáveis.