### PR TITLE
fix: filtra bloqueios indevidos na orquestração

### DIFF
--- a/.agents/skills/lp-factory-avaliar-plano-analista/SKILL.md
+++ b/.agents/skills/lp-factory-avaliar-plano-analista/SKILL.md
@@ -48,7 +48,8 @@ Matriz incompleta ou sem correspondência verificável impede o handoff.
 1. Continuar no mesmo thread no modo `auditoria_consolidacao`.
 2. Entregar pareceres integrais e matriz, sem reescrever achados.
 3. Exigir auditoria linha a linha contra os pareceres e a v2, preservando a Passagem 1.
-4. Aguardar a conclusão formal definida no contrato runtime de `.codex/agents/analista.toml`.
+4. Antes da conclusão, exigir o filtro de bloqueio definido no contrato runtime: conflito resolvido por fonte ou invariante vira correção objetiva; validação exclusivamente pós-merge vira pendência; precedência de banco exige prova de inevitabilidade.
+5. Aguardar a conclusão formal definida no contrato runtime de `.codex/agents/analista.toml`.
 
 ## Devolver
 
@@ -58,7 +59,7 @@ Conferir o estado Git. Se faltar passagem ou conclusão, devolver o conteúdo e 
 
 ## Revisar correções
 
-Usar `revisao_delta` no mesmo Analista, entregando versões ou diff e correções solicitadas. Retornar ao especialista somente diante de questão material nova ou conclusão especializada alterada. Liberar o gate apenas após `aprovado para merge do plano-base v2`.
+Usar `revisao_delta` no mesmo Analista, entregando versões ou diff e correções solicitadas. Retornar ao especialista somente diante de questão material nova ou conclusão especializada alterada. Não encaminhar bloqueio humano sem o filtro obrigatório do contrato runtime. Liberar o gate apenas após `aprovado para merge do plano-base v2`.
 
 ## Revisar o roadmap final
 

--- a/.agents/skills/lp-factory-orquestrar-plano/SKILL.md
+++ b/.agents/skills/lp-factory-orquestrar-plano/SKILL.md
@@ -73,7 +73,7 @@ Parar somente diante de handoff incompleto, investigação necessária ou decis�
 1. Executar a Passagem 1 com v1, v2, plano conceitual quando existente ou `N/A`, decisões e fontes do caso, sem pareceres ou matriz.
 2. Preservar a resposta, gravar e versionar `docs/matriz-consolidacao-<caso>.md` e continuar no mesmo Analista.
 3. Executar a Passagem 2 com os pareceres integrais e a matriz.
-4. Em correções objetivas, atualizar v2 e matriz e pedir `revisao_delta` ao mesmo Analista. Retornar a especialista somente por questão material nova; decisão humana permanece humana.
+4. Em correções objetivas, inclusive conflito resolvido por fonte ou invariante e validação exclusivamente pós-merge, atualizar v2 e matriz e pedir `revisao_delta` ao mesmo Analista. Antes de parar por decisão humana, exigir ausência de fonte determinante e, para precedência de banco, prova de que migration compatível, feature flag ou expand/contract não evita PR precursor. Retornar a especialista somente por questão material nova.
 5. Avançar apenas com `aprovado para merge do plano-base v2`.
 
 ## 5. Reconciliar roadmap e abrir o PR

--- a/.codex/agents/analista.toml
+++ b/.codex/agents/analista.toml
@@ -6,7 +6,7 @@ sandbox_mode = "read-only"
 developer_instructions = """
 Atue exclusivamente como Analista read-only do LP Factory 10. Avalie planos-base v2 ou implementações contra um plano aprovado; não consolide, corrija nem implemente. Seja o gate de integridade de escopo e rastreabilidade entre planejamento conceitual quando existente, v1, v2, pareceres e implementação.
 
-Confirme o modo (`passagem_independente`, `auditoria_consolidacao`, `revisao_delta`, `revisao_implementacao`, `revisao_delta_implementacao` ou `revisao_final_implementacao`), worktree, branch, repositório, caso, paths e referências imutáveis aplicáveis. Leia integralmente os artefatos permitidos no modo atual. Consulte somente fontes competentes necessárias e liste apenas as efetivamente usadas. Em conflito, prevalece a fonte competente pelo assunto; parecer não substitui fonte canônica, decisão humana ou evidência do repositório.
+Confirme o modo (`passagem_independente`, `auditoria_consolidacao`, `revisao_delta`, `revisao_implementacao`, `revisao_delta_implementacao` ou `revisao_final_implementacao`), worktree, branch, repositório, caso, paths e referências imutáveis aplicáveis. Leia integralmente os artefatos permitidos no modo atual. Consulte somente fontes competentes necessárias e liste apenas as efetivamente usadas. Em conflito, prevalece a fonte competente pelo assunto; parecer não substitui fonte canônica, decisão humana ou evidência do repositório. Antes de usar `bloqueado por decisão humana`, confirme que nenhuma fonte ou invariante resolve a questão e que não existe correção objetiva dentro do escopo. Validação exclusivamente pós-merge ou indisponibilidade ambiental é pendência, não escolha humana. Precedência real de banco só bloqueia quando houver evidência de que migration compatível, feature flag ou estratégia expand/contract não preserva o runtime atual e um PR precursor com merge intermediário é inevitável.
 
 Classifique todo acréscimo da v2 ou implementação em relação à v1 como `preservação do escopo`, `extensão adjacente necessária e proporcional` ou `expansão de escopo`. Extensão adjacente é somente o menor delta indispensável para o resultado da v1 funcionar corretamente, com segurança ou sem regressão, rastreável a requisito, dependência comprovada ou fonte competente e sem criar capacidade, domínio, infraestrutura ou frente independente. Se puder ser adiada sem prejudicar o recorte, não é necessária; expansão exige exclusão, novo recorte ou decisão humana.
 
@@ -68,13 +68,13 @@ Use exatamente uma conclusão de plano:
 - `aprovado para merge do plano-base v2`: nenhuma pendência permanece;
 - `aprovado com correções obrigatórias`: há correções objetivas dentro do escopo;
 - `requer nova rodada especializada`: surgiu questão material nova ou conclusão especializada alterada;
-- `bloqueado por decisão humana`: existe escolha material de produto, escopo ou arquitetura que as fontes não resolvem.
+- `bloqueado por decisão humana`: existe escolha material de produto, escopo, arquitetura ou precedência inevitável que as fontes e invariantes não resolvem.
 
 Em modos de implementação, use exatamente uma conclusão:
 - `aprovado para avançar`: a subseção atual pode receber checkpoint; não autoriza merge;
 - `aprovado com correções obrigatórias`: há correções objetivas no delta;
 - `requer teste humano`: é necessária evidência humana identificada;
-- `bloqueado por decisão humana`: existe escolha material sem fonte determinante;
+- `bloqueado por decisão humana`: existe escolha material sem fonte ou invariante determinante;
 - `aprovado para merge da implementação`: somente em `revisao_final_implementacao`, sem pendências.
 
 Somente a conclusão própria do modo libera o gate. Finalize com `## Próximo passo mínimo e seguro`.


### PR DESCRIPTION
## Objetivo

Impedir gates humanos quando fontes ou invariantes já resolvem o conflito, preservando o bloqueio legítimo para precedência inevitável de banco.

## Alterações

- restringe loqueado por decisão humana no contrato do Analista;
- trata validação exclusivamente pós-merge como pendência;
- exige prova de inevitabilidade antes de propor PR precursor;
- orienta o orquestrador a corrigir v2/matriz e usar evisao_delta quando houver solução objetiva.

## Validação

- TOML válido;
- frontmatter das skills válido;
- git diff --check aprovado;
- 
pm ci e 
pm run check: não aplicáveis (contratos textuais).