### PR TITLE
fix: evita bloqueio por confirmação externa

### DIFF
--- a/.agents/skills/lp-factory-executar-plano/SKILL.md
+++ b/.agents/skills/lp-factory-executar-plano/SKILL.md
@@ -45,7 +45,7 @@ Quando a subseção alterar schema ou migrations:
 1. Criar e versionar a migration em `supabase/migrations/` e, quando disponível, validá-la em ambiente local ou isolado. Antes do merge, permitir no projeto remoto apenas inspeção read-only, `supabase migration list --linked` e `supabase db push --linked --dry-run`.
 2. Não executar alteração remota de schema ou do histórico de migrations, inclusive por `apply_migration`, SQL mutável via `execute_sql`, SQL Editor, Table Editor, `supabase db push --linked` sem `--dry-run` ou ferramenta equivalente. O merge na `main` dispara o workflow canônico de aplicação.
 3. Se o plano exigir aplicação remota pré-merge ou se ela já tiver ocorrido, parar em modo fail-closed, registrar a operação e o estado encontrados e informar o humano. Não aplicar rollback, `migration repair`, nova migration corretiva ou outra mutação remota por inferência.
-4. Tratar ausência de Docker, PostgreSQL, Supabase CLI, vínculo ou credenciais locais como validação pendente, não como bloqueio de implementação, commit, push ou trabalho comprovadamente independente. Executar as validações disponíveis, registrar a pendência e não declarar essa validação aprovada nem o PR pronto para merge. Parar somente se faltar informação necessária para escrever a migration com segurança ou existir dependência não resolvida.
+4. Tratar ausência de ambiente ou confirmação externa como pendência de validação ou aplicação: manter o feature flag desligado, produzir os artefatos candidatos e continuar o trabalho independente. Parar somente se a lacuna impedir definir com segurança a implementação; a pendência final impede apenas declarar o PR pronto para merge.
 
 ## Executar uma subseção
 


### PR DESCRIPTION
## Objetivo

Distinguir pendência externa de impedimento real de implementação no fluxo do Executor.

## Alteração

- substitui uma única regra existente na skill;
- mantém feature flags desligados quando aplicável;
- permite produzir artefatos candidatos e continuar trabalho independente;
- reserva a parada para lacunas que impeçam definir a implementação com segurança;
- impede apenas declarar o PR pronto para merge enquanto a pendência final existir.

## Validação

- git diff --check: aprovado;
- estrutura do SKILL.md: válida;
- npm ci e npm run check: não aplicáveis (alteração textual).