### PR TITLE
Alinhar Estrategista ao ABC e preservar template de relatório

### DIFF
--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -1,6 +1,6 @@
 27/07/2026 — Fluxo do Estrategista
 
-Versão: v24
+Versão: v25
 
 0. Papel do Estrategista
 Você é o Estrategista do LP Factory 10. Sua função é transformar casos em plano-base, coordenar análises, orientar execução por fase e consolidar a decisão final, preservando o escopo aprovado, a simplicidade proporcional e os diferenciais estratégicos condicionais.
@@ -49,7 +49,7 @@ Regra:
 • criar somente fases executáveis e necessárias ao recorte aprovado;
 • quando a fase corresponder a conteúdo específico do roadmap, usar o identificador previsto da subseção, ex.: 3.1 E9.5.3 — [entrega];
 • não usar X.Y.1 e X.Y.2 como fases; entregas implementáveis usam X.Y.3 até X.Y.n, conforme docs/template-roadmap.md;
-• não criar fase administrativa, de governança, handoff, revisão, fechamento ou documentação final;
+• não criar fase administrativa, de governança, handoff, revisão ou fechamento; validação e fechamento documental pelo Prompt ABC integram a fase implementável correspondente;
 • validação entra como critério de aceite da fase, salvo risco técnico próprio;
 • após concluir a v1, orientar o Executor a ajustar `docs/roadmap.md` no mesmo PR, conforme `docs/prompt-abc.md` e `docs/template-roadmap.md`, registrando somente seções, subseções, títulos, objetivos e status planejado, sem registros de implementação;
 • não antecipar na v1 o detalhamento técnico da automação nem criar fase administrativa apenas para essa decisão.
@@ -70,8 +70,8 @@ Regra:
 • a escolha do processo depende de decisão humana explícita;
 • por decisão humana, os processos podem ser desenvolvidos paralelamente, como já ocorreu para testes;
 • qualquer mutação do processo automatizado depende de o plano-base v1 já estar incorporado à main;
-• na opção 2, não seguir manualmente aos itens 5 a 8; a skill de orquestração executa internamente a avaliação dos especialistas, a criação e aprovação da v2, a reconciliação do roadmap e a implementação;
-• na opção 2, a v2, o roadmap e a implementação seguem na mesma branch e no mesmo PR, sem merge intermediário da v2.
+• na opção 2, não seguir manualmente aos itens 5 a 8; a skill de orquestração executa internamente a avaliação dos especialistas, a criação e aprovação da v2, a reconciliação do roadmap, a implementação e o fechamento documental pelo Prompt ABC;
+• na opção 2, a v2, o roadmap, a implementação e os documentos canônicos afetados seguem na mesma branch e no mesmo PR, sem merge intermediário da v2.
 
 5. Avaliação única do plano-base v1 por especialistas
    Solicitar uma avaliação do plano completo no PR antes da execução.
@@ -110,7 +110,7 @@ Regra: entregar somente as mensagens aplicáveis, substituindo apenas o path e a
 Regra:
 • consolidar todos os retornos em uma única análise;
 • classificar os pontos como aceito, rejeitado, pendente, já coberto ou preservado como oportunidade estratégica condicional; esta última não autoriza implementação no recorte atual;
-• fora da atualização prevista do roadmap, alterar somente o plano-base do caso;
+• durante a consolidação da v2, fora da atualização prevista do roadmap, alterar somente o plano-base do caso; os demais documentos canônicos serão avaliados e atualizados pelo Executor durante a implementação, exclusivamente conforme `docs/prompt-abc.md`;
 • no processo atual, após consolidar a v2, repetir com o Executor a atualização de `docs/roadmap.md` no mesmo PR, conforme `docs/prompt-abc.md` e `docs/template-roadmap.md`, usando a v2 como fonte;
 • não abrir novo escopo sem decisão humana explícita;
 • detalhar na v2 a automação dentro da categoria aprovada na v1;
@@ -125,7 +125,7 @@ Regra:
 • executar uma fase por vez, na ordem do plano;
 • avançar somente após aprovação do Analista e decisão do Estrategista;
 • devolver ao Estrategista qualquer conflito, dependência ou mudança de escopo;
-• o Executor pode ajustar somente o plano-base do caso.
+• o Executor pode ajustar o plano-base do caso conforme o fluxo e os documentos canônicos materialmente afetados pela implementação somente por meio do Prompt ABC; não editar documento canônico diretamente nem ampliar o escopo aprovado.
 
 8. Avaliação do Analista — processo atual
    Exclusivamente na Opção 1, após a entrega de cada fase ou do recorte, o Analista avalia aderência ao plano, diff, riscos e evidências.
@@ -151,35 +151,9 @@ Regra:
 • não registrar senhas, tokens ou secrets em documentos versionados;
 • se o teste reprovar, voltar ao item 7.
 
-10. Relatório final ao Gestor de Docs
-   Emitir o relatório somente após o PR final da execução estar mergeado e o plano encerrado por aprovação da última fase ou decisão explícita de encerramento.
+10. Conclusão da fase
+   Registrar no PR e, quando previsto pelo plano-base, no próprio plano, a decisão e a próxima ação: avançar, ajustar, bloquear ou encerrar.
 
-Registrar apenas o que ocorreu, informar a decisão documental do roadmap e marcar N/A quando não se aplicar.
-
-Roadmap / decisão documental
-• Seção afetada: [E[n].[x] — nome]
-• Subseções a criar ou atualizar: [lista exata] | N/A
-• Não criar fora das subseções listadas sem decisão humana explícita.
-
-Updates aplicados
-• [tag, ex.: supa#5] — aplicado | avaliado | N/A — [efeito curto]
-
-BD / schema
-• Estruturas de BD: [tabela/view/RPC/policy/grant] — criada | ajustada | N/A — [função curta]
-• SQL de inspeção: sim | não | N/A
-• SQL de implementação: sim | não | N/A
-• Migration: [path] | N/A
-• Rollback: [path] | N/A
-
-Observability
-• aplicada | não aplicada | N/A — [sinal observado + evidência curta]
-
-Artefatos
-• Arquivos criados: [paths sem docs/] | N/A
-• Arquivos ajustados: [paths sem docs/] | N/A
-• Arquivos excluídos: [paths sem docs/] | N/A
-
-Regra: não incluir pendências nem instruções ao Gestor de Docs.
-
-11. Conclusão da fase
-   Registrar no plano-base a decisão e a próxima ação: avançar, ajustar, bloquear ou encerrar o plano.
+Regra:
+• o fechamento documental ocorre durante a implementação pelo Prompt ABC e integra a entrega da fase ou do recorte;
+• não emitir relatório posterior ao Gestor de Docs nem reconstruir em outro fluxo o que já foi atualizado e registrado no PR.

--- a/docs/template-relatorio-plano-implementacao.md
+++ b/docs/template-relatorio-plano-implementacao.md
@@ -1,0 +1,108 @@
+# Template — Relatório de Implementação de Plano
+
+## 1. Uso e limites
+
+- Uso opcional, somente por instrução humana ou workflow futuro aprovado.
+- Não integra automaticamente o fluxo do Estrategista, do Executor, do Analista ou da orquestração.
+- Não substitui PR, plano-base, checkpoints, documentos canônicos ou resultados do Prompt ABC.
+- Não aciona atualização documental; usa somente estado já implementado, validado e registrado.
+- Não registrar secrets, credenciais, PII, hipóteses, propostas não aprovadas ou histórico operacional superado.
+- Usar `N/A` quando uma seção não se aplicar.
+
+## 2. Identificação
+
+- Projeto: LP Factory 10
+- Caso ou recorte: [identificador e título]
+- Plano-base: [path e versão]
+- PR: [número ou URL]
+- Branch ou referência: [branch, commit ou tag]
+- Período ou data de referência: [data ou intervalo]
+- Responsável pela emissão: [humano, agente ou workflow]
+
+## 3. Resultado da implementação
+
+- Objetivo do recorte: [resultado esperado]
+- Estado final: [concluído | concluído com limitações | bloqueado | encerrado por decisão]
+- Decisão de encerramento: [avançar | ajustar | bloquear | encerrar]
+- Resumo factual: [síntese curta do que foi materialmente entregue]
+
+## 4. Fechamento documental
+
+### 4.1 Documentos avaliados pelo Prompt ABC
+
+Para cada documento canônico:
+
+- `DOC_ALVO`: [path]
+- Resultado: [delta aplicado | `SEM ALTERAÇÕES NECESSÁRIAS`]
+- Operações aplicadas: [IDs das operações ou `N/A`]
+- Referência final: [commit, PR ou path]
+
+### 4.2 Observação
+
+- Este relatório não cria nem corrige delta documental.
+- Divergência entre o relatório, o ABC e o diff deve ser resolvida no PR ou fluxo competente antes do uso deste documento.
+
+## 5. Roadmap
+
+- Seção afetada: [identificador e título] | `N/A`
+- Subseções atualizadas: [lista exata] | `N/A`
+- Estado registrado: [planejado | definido | implementado | bloqueado | encerrado]
+- Referência da atualização: [PR, commit ou path] | `N/A`
+
+## 6. Updates
+
+Para cada update relevante:
+
+- Identificador: [tag ou nome]
+- Tratamento: [aplicado | usado como referência, validação ou trava | preservado como oportunidade estratégica condicional | não aplicável]
+- Efeito no recorte: [descrição curta]
+- Referência: [path, PR ou fonte] | `N/A`
+
+## 7. Banco e Schema
+
+- Estruturas criadas ou ajustadas: [tabelas, views, functions, RPCs, policies, grants ou `N/A`]
+- SQL de inspeção: [sim | não | `N/A`]
+- SQL de implementação: [sim | não | `N/A`]
+- Migration: [path] | `N/A`
+- Estado da migration: [não aplicada | aplicada | validada | bloqueada | `N/A`]
+- Correção ou reversão incremental: [path] | `N/A`
+- Evidência de verificação: [descrição curta ou referência] | `N/A`
+
+## 8. Observabilidade e validações
+
+- Observabilidade aplicada: [descrição curta] | `N/A`
+- Validações técnicas: [comandos, checks ou referências]
+- Smoke ou QA funcional: [resultado e evidência] | `N/A`
+- Teste humano: [realizado | requerido | não aplicável]
+- Limitações do ambiente: [descrição curta] | `N/A`
+
+## 9. Artefatos
+
+### 9.1 Criados
+
+- [path] | `N/A`
+
+### 9.2 Ajustados
+
+- [path] | `N/A`
+
+### 9.3 Excluídos
+
+- [path] | `N/A`
+
+## 10. Pendências e riscos
+
+- Incluir somente quando o relatório solicitado exigir estado aberto.
+- Pendência: [descrição] | `N/A`
+- Responsável: [papel ou pessoa] | `N/A`
+- Próximo gate ou decisão: [descrição] | `N/A`
+- Risco residual: [descrição] | `N/A`
+
+## 11. Referências
+
+- Plano-base: [path]
+- Roadmap: `docs/roadmap.md`
+- Prompt ABC: `docs/prompt-abc.md`
+- Prompt do Executor: `docs/prompt-executor.md`
+- PR e commits: [referências]
+- Outras fontes utilizadas: [paths ou URLs autorizadas] | `N/A`


### PR DESCRIPTION
## 1. Objetivo

Alinhar `docs/prompt-estrategista.md` ao fechamento documental integrado à implementação pelo Prompt ABC, sem remover nenhuma das duas reconciliações legítimas do Roadmap, e preservar como template opcional a estrutura do antigo relatório final.

## 2. Ajustes no Prompt Estrategista

- preserva a atualização do Roadmap após a v1;
- preserva a reconciliação do Roadmap após a v2;
- esclarece que validação e fechamento documental integram a fase implementável, sem fase administrativa separada;
- registra que o processo automatizado inclui fechamento documental pelo ABC no mesmo PR;
- limita a restrição ao plano-base somente ao momento de consolidação da v2;
- permite ao Executor atualizar documentos canônicos materialmente afetados exclusivamente pelo Prompt ABC;
- remove integralmente o relatório posterior ao Gestor de Docs;
- substitui o fechamento antigo por registro no PR e, quando previsto, no plano-base.

## 3. Template opcional preservado

Foi criado `docs/template-relatorio-plano-implementacao.md` com base na seção removida do Prompt Estrategista.

O template:

- é opcional e só pode ser usado por instrução humana ou workflow futuro aprovado;
- não integra automaticamente o fluxo do Estrategista, Executor, Analista ou orquestração;
- não substitui PR, plano-base, checkpoints, documentos canônicos ou resultados do ABC;
- não aciona atualização documental;
- preserva blocos para identificação, resultado, fechamento documental, Roadmap, updates, banco/Schema, observabilidade, validações, artefatos, pendências, riscos e referências;
- proíbe secrets, credenciais, PII, hipóteses e histórico superado.

## 4. Documentação usada

- `docs/prompt-estrategista.md`;
- `docs/prompt-executor.md`;
- `docs/prompt-abc.md`;
- `.agents/skills/lp-factory-orquestrar-plano/SKILL.md`;
- `.agents/skills/lp-factory-executar-plano/SKILL.md`.

## 5. Escopo

- `docs/prompt-estrategista.md`;
- `docs/template-relatorio-plano-implementacao.md`;
- versão do Estrategista `v24` → `v25`;
- nenhuma alteração em código, banco, workflow, skill ou infraestrutura.

## 6. Validação

- branch criada da `main` atual;
- `npm ci`: não aplicável;
- `npm run check`: não aplicável;
- merge permanece humano.