### PR TITLE
docs: reorganiza E11 do roadmap

### DIFF
--- a/docs/lousa-plano-base-e11.md
+++ b/docs/lousa-plano-base-e11.md
@@ -1,9 +1,9 @@
 # Plano-base E11 — Gestão de Usuários e Convites
 
-- Versão: v2
-- Data: 27/07/2026
-- Status: consolidado pelos pareceres especializados; aguardando gate do Analista.
-- Recorte previsto para roadmap: `11.1 — Gestão de membros e convites`
+- Versão: v3
+- Data: 28/07/2026
+- Status: fases `11.1.3` a `11.1.6` implementadas; `11.1.7` em validação para ativação controlada.
+- Recorte no roadmap: `11.1 — Gestão de membros e convites`
 - Path canônico: `docs/lousa-plano-base-e11.md`
 - Plano conceitual: N/A — debate realizado entre Estrategista, Analista e humano antes da v1.
 - Fontes obrigatórias: `README.md`, `AGENTS.md`, `docs/prompt-estrategista.md`, `docs/template-roadmap.md`, `docs/prompt-executor.md`, `docs/prompt-abc.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/schema.md`, `docs/platform-config.md`, `docs/design-system.md`, `docs/lp-planejamento.md`, `docs/supa-up.md`, `app/auth/confirm/route.ts`, `app/auth/update-password/page.tsx`, `app/a/home/page.tsx`, `app/a/[account]/actions.ts`, `lib/admin/adapters/adminAccountsAdapter.ts`, `supabase/migrations/20260611172930_remote_public_baseline.sql` e documentação oficial vigente do Supabase para `listUsers()`, `createUser()`, `updateUserById()`, `inviteUserByEmail()`, templates de Auth e redirects.
@@ -12,7 +12,7 @@
 
 ### 1.1. Problema e resultado esperado
 
-- O banco já representa vínculos entre contas e usuários, mas o produto ainda não possui gestão funcional de membros e convites.
+- A gestão funcional de membros e convites está implementada, mas permanece desabilitada até a conclusão da fase `11.1.7`.
 - A E11 deve permitir que owner e admin administrem membros não-owner da conta pelo Account Dashboard.
 - O fluxo deve atender tanto um e-mail ainda inexistente no Supabase Auth quanto um usuário já cadastrado.
 - O aceite deve ativar somente o vínculo selecionado e nunca todos os vínculos pendentes do usuário.
@@ -33,11 +33,10 @@
 - `/a/home` redireciona imediatamente o usuário logado para a última ou primeira conta ativa e não apresenta convites pendentes.
 - O projeto já possui `createServiceClient()` server-only e consulta `user_id → e-mail` por `auth.admin.getUserById()`.
 - Supabase Auth, SMTP via Resend, redirects e o template nativo `Invite user` pertencem à stack atual.
-- O estado remoto é volátil e deve ser inspecionado antes da primeira migration e dos testes, sem assumir como contrato da E11 qualquer inventário anterior de contas ou usuários.
+- A migration `20260727155312_e11_account_members_security.sql` foi aplicada e o estado pós-apply foi verificado; a prova hospedada deve partir do estado remoto atual, sem assumir inventários anteriores de contas ou usuários.
 
 ### 1.3. Decisões humanas encerradas
 
-- Automação: não.
 - Usuário já cadastrado e confirmado não recebe novo e-mail.
 - Ao entrar no produto, esse usuário vê o convite pendente e pode aceitar ou recusar.
 - Owner e admin acessam a gestão de membros.
@@ -45,7 +44,6 @@
 - O owner não é transferido, rebaixado, desativado ou revogado na E11.
 - Não haverá e-mail customizado pelo Core.
 - Não haverá tabela, serviço, fila, job, agente ou engine de convite.
-- A E11 preserva uma única branch e um único PR para v2 e implementação; não haverá `workflow_dispatch` pré-merge nem PR precursor. Apply da migration, configuração externa, redeploy, habilitação do gate e prova hospedada ocorrerão somente após o merge humano.
 
 ### 1.4. Decisões funcionais consolidadas
 
@@ -103,11 +101,11 @@
 - Reenvio do usuário ainda não confirmado usa nova chamada a `inviteUserByEmail()`; `auth.resend()` não será usado como convite.
 - O hook amplo existente não será adotado.
 - O runtime não dependerá da função legada de aceite enquanto ela não garantir linha específica, autorização e confirmação de linha alterada.
-- A migration incremental da E11 é obrigatória após confirmar que o Auth Hook amplo não está configurado. Ela preserva `account_users` com RLS habilitada e mantém a policy de SELECT própria/owner-admin; revoga `INSERT`, `UPDATE` e `DELETE` de `authenticated`; concede explicitamente `SELECT`, `INSERT` e `UPDATE` a `service_role`, sem `DELETE`; revoga `EXECUTE` de `PUBLIC`, `anon`, `authenticated` e `ai_readonly` nas funções `accept_account_invite(uuid, integer)`, `revoke_account_invite(uuid, uuid)`, `invitation_expires_at(uuid, integer)` e `invitation_is_expired(uuid, integer)`; e, após confirmação operacional de ausência do hook, revoga `EXECUTE` de `PUBLIC`, `anon`, `authenticated`, `ai_readonly` e `supabase_auth_admin` em `activate_user_from_auth_hook(jsonb)`.
+- A migration incremental da E11 está aplicada e verificada. O contrato final de grants, RLS, policies e funções reside em `docs/schema.md`; o snippet canônico de verificação é `supabase/snippets/e11_account_members_verify.sql`.
 - A migration não cria tabela, coluna, view, RPC ou `SECURITY DEFINER` e preserva o Trigger Hub e a proteção do último owner.
 - O gate server-only `E11_MEMBERS_ENABLED` é obrigatório, com ausência ou valor diferente de `true` interpretado como desabilitado. Enquanto desabilitado, a navegação não aparece e `/a/[account]/members`, Server Actions e o fluxo específico de convite falham fechados sem chamar Auth Admin nem realizar writes.
 - O booleano do gate pode ser passado explicitamente pelo layout server ao Header, mas não integra a decisão de autorização do `AccessProvider`.
-- Antes do merge, o PR entrega implementação, migration versionada, documentação e todas as validações locais, estáticas, contratuais e de Preview disponíveis com o gate fechado. A prova hospedada real não bloqueia commit, push ou merge; após o merge, a prova em Preview ou ambiente hospedado autorizado bloqueia a habilitação do gate em Production.
+- As fases `11.1.3` a `11.1.6` estão implementadas. A configuração remanescente do Supabase Auth e a prova hospedada da fase `11.1.7` bloqueiam a habilitação do gate em Production.
 
 ## 2. Contrato do caso
 
@@ -314,22 +312,18 @@
 - `/auth/confirm`, sua mitigação anti-scanner e `/auth/update-password` como base da conclusão do cadastro.
 - `/a/home` e sua precedência atual de redirect.
 - Supabase Auth Admin, template nativo `Invite user`, SMTP via Resend e Redirect URL allowlist.
-- Vercel Preview e Production para `INVITE_STATE_SECRET`, com redeploy após configuração.
-- `E11_MEMBERS_ENABLED`, ausente ou falso por padrão durante todo o PR e no primeiro deployment posterior ao merge.
-- Pré-merge: implementar no PR único, executar `npm ci`, validações próprias, `npm run check`, testes contratuais, revisão de migration e QA disponível com o gate fechado; commitar e publicar normalmente, sem apply remoto, configuração externa ou prova hospedada.
-- Pós-merge: manter `E11_MEMBERS_ENABLED=false` em Production; aguardar o workflow aprovado aplicar a migration da `main`; executar `supabase/snippets/e11_account_members_verify.sql`; configurar `INVITE_STATE_SECRET`, template, Email OTP Expiration e redirects; habilitar o gate somente no escopo Preview ou em ambiente hospedado autorizado; redeployar esse ambiente e executar a matriz hospedada.
-- Somente após aprovação da prova hospedada habilitar `E11_MEMBERS_ENABLED=true` em Production e redeployar. A prova hospedada é gate de ativação de Production, não de commit, push ou merge. Falha preserva Production com o gate desabilitado e exige correção incremental pelo fluxo normal, sem fallback de e-mail próprio nem ativação parcial.
-- Após a ativação de Production, executar smoke mínimo pós-ativação. Esse smoke confirma o fechamento operacional; se falhar, desabilitar novamente o gate e corrigir pelo fluxo normal, sem tratá-lo como condição retroativa do merge ou da habilitação já executada.
+- Vercel Preview e Production para o gate e o secret server-only já configurados.
+- `docs/platform-config.md` como fonte única do estado e das regras de configuração externa.
+- Fase `11.1.7` para a ordem vigente de configuração do Supabase Auth, prova hospedada, ativação e smoke.
 - Não há dependência de E12, limite por plano, Stripe, automações ou agentes.
 
 ## 3. Fases e próxima ação
 
 ### 3.1. 11.1.3 — Domínio server-side e ciclo seguro de vínculos
 
-- Status: planejada.
+- Status: implementada e verificada.
 - Objetivo: implementar contratos, autorização, resolução de identidade e transições seguras de `account_users`.
-- Automação: não.
-- Escopo executável:
+- Escopo implementado:
   - criar o boundary `lib/access/account-members/`;
   - implementar contratos tipados e normalização de e-mail;
   - estender `lib/access/guards.ts` com o guard canônico owner/admin e reutilizá-lo em todos os consumidores administrativos;
@@ -338,13 +332,12 @@
   - implementar classificação de active, pending, inactive e revoked;
   - implementar convite, aceite interno, recusa, alteração de papel, revogação e desativação como operações idempotentes por `account_user_id`;
   - criar migration obrigatória com o contrato exato de grants, RLS preservada e revogações de funções legadas definido na seção 1.5;
-  - manter a migration somente versionada e revisada no PR; não aplicar antes do merge;
-  - confirmar no Supabase que o hook amplo não está configurado antes de removê-lo ou restringi-lo;
+  - aplicar a migration após confirmar no Supabase que o hook amplo não estava configurado;
   - atualizar `docs/schema.md` na mesma alteração da migration, registrando grants finais de `account_users`, RLS/policies preservadas, funções legadas retiradas do caminho operacional e migration relacionada;
   - criar `supabase/snippets/e11_account_members_verify.sql` para verificar ACL de tabela, RLS/policies e ACL das funções separadamente;
   - impedir expiração automática local do membership e uso de `created_at` como validade do link;
   - criar casos executáveis da matriz aplicável.
-- Artefatos previstos:
+- Artefatos implementados:
   - `lib/access/account-members/contracts.ts`;
   - `lib/access/account-members/policy.ts`;
   - `lib/access/account-members/adapters/accountMembersAdapter.ts`;
@@ -352,7 +345,7 @@
   - `lib/access/account-members/validation-cases.ts`;
   - `lib/access/account-members/index.ts`;
   - ajuste em `lib/access/guards.ts`;
-  - migration incremental obrigatória da E11 após confirmação de ausência do hook;
+  - `supabase/migrations/20260727155312_e11_account_members_security.sql`;
   - `supabase/snippets/e11_account_members_verify.sql`;
   - ajuste em `docs/schema.md`;
   - script de validação em `package.json`.
@@ -367,15 +360,14 @@
   - `service_role` possui somente `SELECT`, `INSERT` e `UPDATE` em `account_users`, e os papéis revogados não executam as funções legadas;
   - nenhum client importa módulo privilegiado;
   - nenhuma tabela ou coluna nova é criada sem retorno ao Estrategista.
-- Decisão da fase: executar após aprovação da v2.
+- Decisão da fase: concluída.
 - Próxima ação: 11.1.4.
 
 ### 3.2. 11.1.4 — Convite de novo usuário, conclusão do cadastro e confirmação específica
 
-- Status: planejada.
+- Status: implementada no repositório; validação hospedada pendente na `11.1.7`.
 - Objetivo: entregar o convite nativo por e-mail, a definição de senha e o aceite seguro de uma única linha.
-- Automação: não.
-- Escopo executável:
+- Escopo implementado:
   - implementar criação prévia do usuário não confirmado e membership;
   - implementar HMAC versionado com `INVITE_STATE_SECRET`;
   - gravar o estado opaco em metadata somente para transporte;
@@ -387,19 +379,14 @@
   - validar assinatura, linha, usuário, conta e estado antes da ativação;
   - implementar retry idempotente da mesma linha se a ativação falhar após a senha;
   - implementar reenvio por `inviteUserByEmail()`;
-  - validar Email OTP Expiration e Redirect URL vigentes em Preview e Production, sem duplicar prazo local na aplicação;
-  - atualizar `docs/platform-config.md` com `INVITE_STATE_SECRET`, `E11_MEMBERS_ENABLED`, finalidade e escopos server-only, proibição de versionar valores, necessidade de redeploy, template `Invite user`, Redirect URLs e Email OTP Expiration verificados;
-  - preparar os casos do teste hospedado de envio, reenvio, senha, aceite, logout e novo login; executá-los somente no gate pós-merge descrito na seção 2.9.
-- Artefatos previstos:
+  - definir a matriz hospedada de envio, reenvio, senha, aceite, logout e novo login para execução na `11.1.7`.
+- Artefatos implementados:
   - `lib/access/account-members/invite-state.ts`;
   - ajustes em `lib/access/account-members/adapters/accountMembersAdapter.ts` e `lib/access/account-members/adapters/authAdminAdapter.ts`;
   - ajuste em `app/auth/confirm/route.ts`;
   - ajuste em `app/auth/update-password/page.tsx`;
-  - configuração externa do template `Invite user`;
-  - variável server-only `INVITE_STATE_SECRET` na Vercel;
-  - gate server-only `E11_MEMBERS_ENABLED` na Vercel;
-  - ajuste em `docs/platform-config.md`;
-  - casos executáveis e evidência hospedada.
+  - gate server-only `E11_MEMBERS_ENABLED`;
+  - casos executáveis da matriz hospedada.
 - Critérios de aceite:
   - o e-mail é enviado somente pelo Supabase Auth;
   - o template não expõe secret nem usa metadata como autorização;
@@ -414,15 +401,14 @@
   - logout e novo login por e-mail e senha funcionam;
   - reenvio real entrega o segundo e-mail e possui comportamento documentado para ambos os links;
   - falha de envio deixa retry recuperável sem duplicidade.
-- Decisão da fase: antes do merge, avançar após as validações disponíveis com `E11_MEMBERS_ENABLED` fechado; após o merge, a prova hospedada em Preview ou ambiente autorizado deve ser aprovada antes de habilitar o gate em Production.
+- Decisão da fase: implementação concluída; critérios hospedados transferidos para a `11.1.7`.
 - Próxima ação: 11.1.5.
 
 ### 3.3. 11.1.5 — Gestão de membros no Account Dashboard
 
-- Status: planejada.
+- Status: implementada.
 - Objetivo: permitir que owner/admin listem e administrem membros e convites não-owner.
-- Automação: não.
-- Escopo executável:
+- Escopo implementado:
   - criar `/a/[account]/members`;
   - criar Server Actions próprias da rota;
   - adicionar navegação condicionada a owner/admin;
@@ -432,7 +418,7 @@
   - implementar reenvio, revogação, alteração de papel e desativação;
   - aplicar estados visuais e responsividade da seção 2.7;
   - manter bloqueio server-side para editor/viewer.
-- Artefatos previstos:
+- Artefatos implementados:
   - `app/a/[account]/members/page.tsx`;
   - `app/a/[account]/members/actions.ts`;
   - componentes locais mínimos quando necessários;
@@ -445,15 +431,14 @@
   - estados vazio, carregando, erro, sucesso e em andamento estão presentes;
   - desktop e mobile permanecem utilizáveis;
   - nenhuma regra de negócio fica somente no client.
-- Decisão da fase: avançar após validação funcional e visual.
+- Decisão da fase: concluída.
 - Próxima ação: 11.1.6.
 
 ### 3.4. 11.1.6 — Pendências do usuário já cadastrado
 
-- Status: planejada.
+- Status: implementada.
 - Objetivo: permitir que usuário confirmado veja, aceite ou recuse seus convites sem receber e-mail.
-- Automação: não.
-- Escopo executável:
+- Escopo implementado:
   - ajustar `/a/home` para verificar pendências próprias antes do redirect automático;
   - preservar o redirect atual e não realizar writes enquanto `E11_MEMBERS_ENABLED` não for exatamente `true`;
   - exibir conta e papel proposto;
@@ -461,7 +446,7 @@
   - preservar o redirect atual quando não houver pendência;
   - após aceite, permitir entrada na conta ativada;
   - após recusa, remover a pendência da superfície.
-- Artefatos previstos:
+- Artefatos implementados:
   - ajuste em `app/a/home/page.tsx`;
   - action ou boundary server-side mínimo para aceite e recusa;
   - componentes locais mínimos quando necessários.
@@ -473,8 +458,40 @@
   - a pendência não expira automaticamente e só concede acesso após aceite;
   - sem pendências, o comportamento atual de `/a/home` é preservado;
   - falha de leitura ou escrita não cria acesso parcial.
-- Decisão da fase: concluir a implementação e as validações pré-merge disponíveis; após o merge, aprovar a prova hospedada fora de Production, habilitar Production e executar o smoke pós-ativação para fechar operacionalmente o recorte.
-- Próxima ação: N/A — plano implementado.
+- Decisão da fase: concluída.
+- Próxima ação: 11.1.7.
+
+### 3.5. 11.1.7 — Ativação controlada e validação hospedada
+
+- Status: em validação.
+- Objetivo: concluir a configuração externa remanescente, comprovar os fluxos hospedados e ativar a funcionalidade em Production de forma reversível.
+- Estado de entrada:
+  - migration aplicada e estado pós-apply verificado;
+  - `INVITE_STATE_SECRET` configurada com valores independentes em Production e Preview;
+  - `E11_MEMBERS_ENABLED=false` em Production e Preview;
+  - redeploys dos dois ambientes concluídos;
+  - fases `11.1.3` a `11.1.6` implementadas.
+- Execução:
+  - configurar no Supabase Auth o template nativo `Invite user`, os redirects estritamente necessários e a Email OTP Expiration compatível com o fluxo;
+  - manter Production com o gate desabilitado;
+  - habilitar `E11_MEMBERS_ENABLED=true` somente no Preview autorizado e executar novo redeploy;
+  - executar a matriz da seção 2.8, incluindo convite novo, reenvio, adulteração do link, senha antes da ativação, isolamento entre memberships, aceite e recusa do usuário já cadastrado, autorização por papel e idempotência;
+  - se a prova falhar, desabilitar novamente o gate do Preview, redeployar e limitar a correção à falha comprovada;
+  - se a prova for aprovada, habilitar o gate em Production, redeployar e executar o smoke mínimo do fluxo;
+  - se o smoke de Production falhar, desabilitar novamente o gate, redeployar e corrigir pelo fluxo normal;
+  - reconciliar `docs/roadmap.md` e `docs/platform-config.md` com o estado final comprovado, sem duplicar detalhes técnicos ou valores de configuração.
+- Critérios de aceite:
+  - configuração do Supabase Auth confirmada sem exposição de secrets;
+  - matriz hospedada aprovada no Preview antes da ativação de Production;
+  - Production mantida desabilitada até a aprovação da prova;
+  - smoke de Production aprovado após a ativação;
+  - nenhuma tabela, coluna, rota, envio próprio de e-mail ou infraestrutura nova;
+  - evidências sem token, secret, senha ou e-mail pessoal integral.
+- Autonomia do Executor:
+  - executar esta fase diretamente com este plano-base;
+  - corrigir falhas localizadas que não ampliem o escopo nem alterem contratos;
+  - parar e retornar ao Estrategista somente quando algum critério da seção 4.2 ocorrer.
+- Próxima ação: configurar o Supabase Auth e iniciar a prova controlada em Preview.
 
 ## 4. Escopo negativo e critérios de parada
 
@@ -515,7 +532,6 @@
 
 ### 4.3. Decisão atual e próxima ação
 
-- Decisão: plano-base v2 consolidado a partir da v1 imutável e dos pareceres especializados; o recorte não exige novo papel, permissão ou infraestrutura na E11.1.
-- Processo selecionado: Opção 2 — processo automatizado.
-- Gestor de Automação: não se aplica, pois todas as fases estão marcadas como `Automação: não`.
-- Próxima ação: submeter esta v2 ao gate do Analista e reconciliar `docs/roadmap.md` somente após sua aprovação.
+- Decisão: plano-base v3 reconciliado com o estado pós-merge; nenhuma nova passagem por especialistas é exigida para executar a `11.1.7`.
+- Processo selecionado: execução direta pelo Executor, sem automação.
+- Próxima ação: configurar o Supabase Auth e executar a prova controlada em Preview conforme a seção 3.5.

--- a/docs/lousa-plano-base-e11.md
+++ b/docs/lousa-plano-base-e11.md
@@ -20,20 +20,14 @@
 
 ### 1.2. Estado real confirmado
 
-- `account_users` possui:
-  - unicidade por `(account_id, user_id)`;
-  - papéis `owner`, `admin`, `editor` e `viewer`;
-  - estados `pending`, `active`, `inactive` e `revoked`;
-  - `created_at` como registro da criação da linha, sem representar a validade de cada link do Supabase Auth;
-  - proteção do último owner.
-- As policies atuais permitem leitura do próprio vínculo ou por owner/admin e reservam mutações diretas a owner/admin ou platform admin.
-- `accept_account_invite(account_id, ttl_days)` é invoker, identifica o vínculo por conta e usuário e depende de uma policy de update que o convidado não satisfaz.
-- `activate_user_from_auth_hook(event)` ativa todos os vínculos pendentes do usuário e não pode ser usado pela E11.
-- `/auth/confirm` confirma tokens no POST, com mitigação anti-scanner, mas atualmente não preserva contexto específico de convite nem ativa membership.
-- `/a/home` redireciona imediatamente o usuário logado para a última ou primeira conta ativa e não apresenta convites pendentes.
-- O projeto já possui `createServiceClient()` server-only e consulta `user_id → e-mail` por `auth.admin.getUserById()`.
-- Supabase Auth, SMTP via Resend, redirects e o template nativo `Invite user` pertencem à stack atual.
-- A migration `20260727155312_e11_account_members_security.sql` foi aplicada e o estado pós-apply foi verificado; a prova hospedada deve partir do estado remoto atual, sem assumir inventários anteriores de contas ou usuários.
+- `account_users` preserva unicidade por `(account_id, user_id)`, papéis `owner`, `admin`, `editor` e `viewer`, estados `pending`, `active`, `inactive` e `revoked` e proteção do último owner.
+- O boundary server-only, os adapters separados de Data API e Auth Admin, o guard owner/admin e as transições por membership específico estão implementados.
+- As mutações da E11 usam contexto autorizado e escrita privilegiada; funções legadas amplas estão fora do caminho operacional e indisponíveis aos papéis revogados.
+- `/auth/confirm` preserva a mitigação anti-scanner e transporta contexto assinado de um convite específico até a conclusão do cadastro.
+- `/a/home` apresenta as pendências do usuário autenticado antes do redirect para conta ativa quando o gate está habilitado.
+- A migration `20260727155312_e11_account_members_security.sql` foi aplicada e o estado pós-apply foi verificado.
+- `INVITE_STATE_SECRET` e `E11_MEMBERS_ENABLED=false` estão configuradas em Production e Preview, com os redeploys concluídos.
+- Template `Invite user`, redirects, Email OTP Expiration e prova hospedada permanecem na fase `11.1.7`; o estado operacional detalhado reside em `docs/platform-config.md`.
 
 ### 1.3. Decisões humanas encerradas
 
@@ -73,8 +67,8 @@
 - `contracts.ts` importa `MemberRole` e `MemberStatus` de `lib/types/status.ts`, sem redefini-los.
 - `index.ts` não exporta clients, rows de banco nem tipos do SDK Supabase.
 - Toda mutação 1-a-1 usa filtros de conta, membership, usuário e estado esperado, aplica `.maxAffected(1)` e só retorna sucesso após confirmar exatamente uma linha ou o estado idempotente permitido.
-- `e-mail → user_id` será resolvido por `adapters/authAdminAdapter.ts` com `auth.admin.listUsers()` paginado, depois da autorização do owner/admin.
-- `lib/access/guards.ts` será estendido com um guard server-only de gestão de membros que resolve sessão e Access Context, exige conta permitida, membership `active` e papel `owner` ou `admin`, e devolve contexto autoritativo com `accountId`, `accountSubdomain`, `actorUserId` e `actorRole`.
+- `e-mail → user_id` é resolvido por `adapters/authAdminAdapter.ts` com `auth.admin.listUsers()` paginado, depois da autorização do owner/admin.
+- `lib/access/guards.ts` contém o guard server-only de gestão de membros que resolve sessão e Access Context, exige conta permitida, membership `active` e papel `owner` ou `admin`, e devolve contexto autoritativo com `accountId`, `accountSubdomain`, `actorUserId` e `actorRole`.
 - A página administrativa, suas Server Actions e os fluxos administrativos de convite usam esse guard antes de consultar Auth Admin ou chamar adapters privilegiados. A navegação pode usar o papel sanitizado do `AccessProvider` apenas para visibilidade; a URL e todas as actions administrativas repetem o guard server-side.
 - O autoatendimento em `/a/home` não usa o guard owner/admin. Ele exige sessão autenticada, deriva `actorUserId` exclusivamente de `auth.getUser()`, seleciona a linha por `account_user_id` e confirma `account_users.user_id = actorUserId` e status `pending` antes de aceitar ou recusar.
 - A UI nunca recebe resultado que revele a existência global de um e-mail no Auth.
@@ -98,9 +92,9 @@
 - Aceite repetido da mesma linha já `active` retorna sucesso idempotente; divergência, `inactive`, `revoked` ou ausência falha fechada.
 - Se a senha for definida e a ativação falhar, o mesmo vínculo pode ser retomado por retry idempotente; enquanto permanecer `pending`, não concede acesso à conta.
 - Usuário confirmado aceita ou recusa pela sessão autenticada e pelo `account_user_id` escolhido, sem `invite_state`.
-- Reenvio do usuário ainda não confirmado usa nova chamada a `inviteUserByEmail()`; `auth.resend()` não será usado como convite.
-- O hook amplo existente não será adotado.
-- O runtime não dependerá da função legada de aceite enquanto ela não garantir linha específica, autorização e confirmação de linha alterada.
+- Reenvio do usuário ainda não confirmado usa nova chamada a `inviteUserByEmail()`; `auth.resend()` não é usado como convite.
+- O hook amplo existente não é adotado.
+- O runtime não depende da função legada de aceite.
 - A migration incremental da E11 está aplicada e verificada. O contrato final de grants, RLS, policies e funções reside em `docs/schema.md`; o snippet canônico de verificação é `supabase/snippets/e11_account_members_verify.sql`.
 - A migration não cria tabela, coluna, view, RPC ou `SECURITY DEFINER` e preserva o Trigger Hub e a proteção do último owner.
 - O gate server-only `E11_MEMBERS_ENABLED` é obrigatório, com ausência ou valor diferente de `true` interpretado como desabilitado. Enquanto desabilitado, a navegação não aparece e `/a/[account]/members`, Server Actions e o fluxo específico de convite falham fechados sem chamar Auth Admin nem realizar writes.

--- a/docs/platform-config.md
+++ b/docs/platform-config.md
@@ -130,7 +130,7 @@
 • Finalidade: gate operacional da gestão de membros e convites.
 • Escopo: Production e Preview.
 • Estado atual: `false`, configurada em Production e Preview.
-• Regra operacional: manter `false` até a configuração remanescente do Supabase Auth e a prova hospedada terem sido concluídas; a liberação exige validação primeiro em Preview.
+• Regra operacional: manter Production em `false` até a aprovação da prova hospedada; o Preview pode ser habilitado temporariamente somente após a configuração remanescente do Supabase Auth, com redeploy próprio e finalidade exclusiva de validação.
 
 • `INVITE_STATE_SECRET`
 • Finalidade: assinar o estado opaco transportado pelo convite nativo do Supabase Auth.
@@ -236,7 +236,7 @@
 • Redirect de Preview: cadastrar somente o domínio/path do deployment usado na validação; quando wildcard for necessário, restringir a Preview e usar `/**`.
 • Email OTP Expiration: confirmar no Dashboard que a validade hospedada é compatível com a janela operacional do convite; o Core não adiciona validade local paralela.
 • Estado: template, redirects, expiração e envio real permanecem pendentes de configuração e validação hospedada pós-merge.
-• Ordem operacional remanescente: configurar e revisar template, redirects e expiração, validar o fluxo hospedado em Preview com `E11_MEMBERS_ENABLED=false` e só então avaliar a habilitação do gate.
+• Ordem operacional remanescente: configurar e revisar template, redirects e expiração; habilitar o gate somente no Preview autorizado; redeployar e validar o fluxo hospedado; manter Production desabilitada até a aprovação da prova.
 • Evidência hospedada exigida antes da habilitação: convite novo, reenvio idempotente, link adulterado rejeitado, link legítimo concluído com definição de senha antes da ativação e isolamento entre memberships.
 
 4.7 Acesso operacional read-only para automações

--- a/docs/platform-config.md
+++ b/docs/platform-config.md
@@ -2,8 +2,8 @@
 
 0.1 Cabeçalho
 • Documento: LP Factory 10 — Platform Config
-• Versão: v0.1.9
-• Data: 27/07/2026
+• Versão: v0.1.10
+• Data: 28/07/2026
 
 0.2 Contrato do documento
 • O QUE É: snapshot operacional e fonte única das configurações de plataformas externas do LP Factory 10, refletindo o estado conhecido/cadastrado nas plataformas conforme indicado.
@@ -129,14 +129,15 @@
 • `E11_MEMBERS_ENABLED`
 • Finalidade: gate operacional da gestão de membros e convites.
 • Escopo: Production e Preview.
-• Estado aprovado antes do merge, apply da migration e validação hospedada: `false`.
-• Regra operacional: manter `false` até a migration ter sido aplicada pelo workflow pós-merge e as configurações externas desta entrega terem sido concluídas; a liberação exige redeploy e validação primeiro em Preview.
+• Estado atual: `false`, configurada em Production e Preview.
+• Regra operacional: manter `false` até a configuração remanescente do Supabase Auth e a prova hospedada terem sido concluídas; a liberação exige validação primeiro em Preview.
 
 • `INVITE_STATE_SECRET`
 • Finalidade: assinar o estado opaco transportado pelo convite nativo do Supabase Auth.
 • Escopo: Production e Preview.
-• Estado: pendente de configuração pós-merge; usar valores independentes por ambiente, com no mínimo 32 caracteres, sem versionar o conteúdo.
-• Regra operacional: configurar antes de habilitar `E11_MEMBERS_ENABLED` e executar redeploy do deployment alvo.
+• Estado atual: configurada em Production e Preview, com valores independentes por ambiente e sem versionar o conteúdo.
+• Estado operacional conjunto: redeploys de Production e Preview concluídos após a configuração das variáveis da E11.
+• Regra operacional: manter configurada antes de habilitar `E11_MEMBERS_ENABLED`.
 
 • `SUPABASE_SECRET_KEY`
 • Finalidade: chave server-side Supabase para operações autorizadas do runtime.
@@ -235,7 +236,7 @@
 • Redirect de Preview: cadastrar somente o domínio/path do deployment usado na validação; quando wildcard for necessário, restringir a Preview e usar `/**`.
 • Email OTP Expiration: confirmar no Dashboard que a validade hospedada é compatível com a janela operacional do convite; o Core não adiciona validade local paralela.
 • Estado: template, redirects, expiração e envio real permanecem pendentes de configuração e validação hospedada pós-merge.
-• Ordem operacional pós-merge: aguardar o workflow aplicar a migration, configurar e revisar os itens externos, configurar as envs no ambiente alvo, redeployar com `E11_MEMBERS_ENABLED=false`, validar em Preview e só então avaliar a habilitação do gate.
+• Ordem operacional remanescente: configurar e revisar template, redirects e expiração, validar o fluxo hospedado em Preview com `E11_MEMBERS_ENABLED=false` e só então avaliar a habilitação do gate.
 • Evidência hospedada exigida antes da habilitação: convite novo, reenvio idempotente, link adulterado rejeitado, link legítimo concluído com definição de senha antes da ativação e isolamento entre memberships.
 
 4.7 Acesso operacional read-only para automações
@@ -439,6 +440,8 @@ Regra:
 • Configurações de plataformas, secrets por nome, workflows, ambientes e endpoints usados por automações devem ser registrados neste documento.
 
 99. Changelog
+v0.1.10 — 28/07/2026 — Registradas as variáveis da E11 configuradas em Production e Preview, os redeploys concluídos e a configuração remanescente do Supabase Auth.
+
 v0.1.8 — 02/07/2026 — Configuração Stripe atualizada com uso de webhook produtivo, endpoint `/api/stripe/webhook`, lookup de subscriptions e secret `STRIPE_WEBHOOK_SECRET`.
 
 v0.1.7 — 25/06/2026 — Atualizado `OPENAI_COMMERCIAL_ACTIVATION_MODEL` para escopo Production e Preview, com referência `gpt-5.4-mini` e regra operacional de não prender configuração a branch no MVP.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 0.1 Cabeçalho
 • Data: 28/07/2026
-• Versão: v1.5.106
+• Versão: v1.5.107
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -1150,13 +1150,13 @@ Repositório — Ajustados
 
 11. E11 — Gestão de Usuários e Convites
 - Objetivo: permitir gestão segura de membros não-owner e convites por conta, usando Supabase Auth e o Account Dashboard.
-- Status: implementação concluída com a funcionalidade desabilitada em Production; ativação pendente de verificação do banco, configuração externa e prova hospedada.
+- Status: implementação concluída com a funcionalidade desabilitada em Production; ativação pendente da configuração remanescente do Supabase Auth e da prova hospedada.
 
 11.1 Gestão de membros e convites
 
 11.1.1 Objetivo e status
 - Objetivo: permitir que owner e admin convidem, acompanhem e administrem membros com papéis admin, editor e viewer, preservando o owner e o isolamento multi-tenant.
-- Status: implementado; migration aplicada; ativação controlada pendente.
+- Status: implementado; migration aplicada e estado pós-apply verificado; ativação controlada pendente.
 
 11.1.2 Registros do recorte
 - Banco:
@@ -1220,10 +1220,10 @@ Repositório — Ajustados
 11.1.7 Ativação controlada e validação hospedada
 - Status: em validação.
 - Conteúdo:
-  - migration aplicada, com verificação pós-apply do banco pendente;
-  - gate da funcionalidade mantido desabilitado;
-  - configuração externa e prova funcional hospedada pendentes;
-  - ativação em Production e smoke final condicionados à aprovação das verificações.
+  - migration aplicada e estado pós-apply verificado;
+  - gate da funcionalidade mantido desabilitado em Production e Preview;
+  - configuração remanescente do Supabase Auth e prova funcional hospedada pendentes;
+  - ativação em Production e smoke final condicionados à aprovação da prova.
 
 12. E12 — Admin Dashboard
 - Objetivo: Consolidar o Admin Dashboard como seção administrativa protegida, separada do Account Dashboard, com navegação própria e leitura operacional read-only.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 0.1 Cabeçalho
 • Data: 28/07/2026
-• Versão: v1.5.105
+• Versão: v1.5.106
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -1150,79 +1150,80 @@ Repositório — Ajustados
 
 11. E11 — Gestão de Usuários e Convites
 - Objetivo: permitir gestão segura de membros não-owner e convites por conta, usando Supabase Auth e o Account Dashboard.
-- Status: validações pré-merge concluídas; PR liberado para merge humano. A ativação de Production permanece condicionada aos gates pós-merge, com `E11_MEMBERS_ENABLED=false` até sua conclusão.
+- Status: implementação concluída com a funcionalidade desabilitada em Production; ativação pendente de verificação do banco, configuração externa e prova hospedada.
 
 11.1 Gestão de membros e convites
 
 11.1.1 Objetivo e status
 - Objetivo: permitir que owner e admin convidem, acompanhem e administrem membros com papéis admin, editor e viewer, preservando o owner e o isolamento multi-tenant.
-- Status: implementado no repositório com `E11_MEMBERS_ENABLED=false`; migration versionada e não aplicada.
-- Gate confirmado: ausência de Auth Hook configurado no Supabase, verificada operacionalmente em 27/07/2026.
-- Validações pré-merge: `npm ci`, `npm run check` com zero erros, `npm run validate:account-members` com 13 casos aprovados e `git diff --check`.
-- Gates externos pendentes após o merge: apply e verificação da migration pelo fluxo aprovado, configuração de secret/template/redirects/expiração, redeploy com gate desabilitado, prova hospedada em Preview, habilitação controlada em Production, novo redeploy e smoke pós-ativação.
+- Status: implementado; migration aplicada; ativação controlada pendente.
 
 11.1.2 Registros do recorte
-- Banco — versionados, sem apply manual:
-  - `supabase/migrations/20260727155312_e11_account_members_security.sql`;
-  - `supabase/snippets/e11_account_members_verify.sql`.
-- Repositório — criados:
-  - `lib/access/account-members/`;
-  - `app/a/[account]/members/`;
-  - `app/a/home/PendingInviteActionButton.tsx`;
-  - `app/a/home/member-invite-actions.ts`.
-- Repositório — ajustados:
-  - `app/a/[account]/layout.tsx`;
-  - `app/a/home/page.tsx`;
-  - `app/auth/confirm/route.ts`;
-  - `app/auth/update-password/page.tsx`;
-  - `components/layout/Header.tsx`;
-  - `lib/access/guards.ts`;
-  - `lib/supabase/service.ts`;
-  - `package.json`.
+- Banco:
+  - Ajustados:
+    - `public.account_users`;
+    - `public.accept_account_invite(uuid, integer)`;
+    - `public.revoke_account_invite(uuid, uuid)`;
+    - `public.invitation_expires_at(uuid, integer)`;
+    - `public.invitation_is_expired(uuid, integer)`;
+    - `public.activate_user_from_auth_hook(jsonb)`.
+- Repositório:
+  - Criados:
+    - `supabase/migrations/20260727155312_e11_account_members_security.sql`;
+    - `supabase/snippets/e11_account_members_verify.sql`;
+    - `lib/access/account-members/`;
+    - `app/a/[account]/members/`;
+    - `app/a/home/PendingInviteActionButton.tsx`;
+    - `app/a/home/member-invite-actions.ts`.
+  - Ajustados:
+    - `app/a/[account]/layout.tsx`;
+    - `app/a/home/page.tsx`;
+    - `app/auth/confirm/route.ts`;
+    - `app/auth/update-password/page.tsx`;
+    - `components/layout/Header.tsx`;
+    - `lib/access/guards.ts`;
+    - `lib/supabase/service.ts`;
+    - `package.json`.
 
 11.1.3 Domínio server-side e ciclo seguro de vínculos
-- Status: implementado e aprovado no gate de implementação pré-merge.
+- Status: implementado.
 - Conteúdo:
-  - boundary server-only com adapters separados para Data API e Supabase Auth Admin;
-  - guard canônico owner/admin para os fluxos administrativos, sem reutilizá-lo no autoatendimento do convidado;
-  - busca paginada de usuário por e-mail no Supabase Auth após autorização;
-  - aceite, recusa, alteração de papel, revogação e desativação por membership específico;
-  - tratamento idempotente de duplicidade e reuso de vínculo, sem expiração automática local do membership;
-  - correção ou retirada do caminho operacional das funções legadas incompatíveis, sem tabela ou coluna nova por padrão.
+  - boundary server-only para operações de membros e Supabase Auth Admin;
+  - autorização administrativa por owner ou admin e autoatendimento do convidado vinculado à sessão autenticada;
+  - transições idempotentes por membership específico, com proteção do owner e do próprio ator;
+  - escrita direta restrita e funções legadas amplas indisponíveis aos papéis de runtime.
 
-11.1.4 Convite de novo usuário, conclusão do cadastro e confirmação específica
-- Status: implementado e aprovado no gate de implementação pré-merge; configuração e prova hospedada permanecem pós-merge.
+11.1.4 Convite de novo usuário e conclusão do cadastro
+- Status: implementado.
 - Conteúdo:
-  - usuário novo ou ainda não confirmado recebe o template nativo `Invite user`;
-  - contexto versionado e assinado identifica um único `account_user_id`;
-  - `/auth/confirm` preserva a mitigação anti-scanner, confirma o Auth e cria a sessão;
-  - `/auth/update-password` é reutilizada ou adaptada para definir senha antes da ativação do vínculo;
-  - estado de convite, metadata, query string e cookie servem somente como transporte; a autorização exige sessão autenticada e validação da linha específica;
-  - a conclusão ativa somente o vínculo validado e admite retry idempotente da mesma linha;
-  - o happy path inclui logout e novo login por e-mail e senha;
-  - validade e reenvio do link pertencem ao Supabase Auth, sem prazo local do membership;
-  - nenhum e-mail próprio, hook amplo, job ou automação;
-  - o gate permanece desabilitado em Production durante o PR e até a prova hospedada pós-merge em Preview ou ambiente autorizado; somente após a aprovação dessa prova ocorre a ativação em Production e o redeploy, seguidos de smoke pós-ativação.
+  - template nativo `Invite user` para usuário novo ou ainda não confirmado;
+  - contexto versionado e assinado vinculado a um único `account_user_id`;
+  - confirmação anti-scanner, definição de senha e ativação apenas do vínculo validado, com retry idempotente;
+  - validade e reenvio sob responsabilidade do Supabase Auth, sem expiração local, e-mail próprio, hook amplo, job ou automação.
 
 11.1.5 Gestão de membros no Account Dashboard
-- Status: implementado e aprovado no gate de implementação pré-merge; validação hospedada permanece pós-merge.
+- Status: implementado.
 - Conteúdo:
-  - rota `/a/[account]/members` acessível somente a owner e admin;
+  - rota `/a/[account]/members` restrita a owner e admin;
   - lista de membros ativos e convites pendentes;
-  - convite para admin, editor ou viewer;
-  - reenvio e revogação de pendente, alteração de papel e desativação de membro ativo;
-  - owner e vínculo do próprio ator protegidos;
-  - navegação, rota e ações falham fechadas enquanto o gate da E11 não estiver habilitado.
+  - convite, reenvio, revogação, alteração de papel e desativação, com proteção do owner e do próprio ator;
+  - navegação, rota e ações fechadas enquanto o gate da E11 estiver desabilitado.
 
 11.1.6 Pendências do usuário já cadastrado
-- Status: implementado e aprovado no gate de implementação pré-merge; validação hospedada permanece pós-merge.
+- Status: implementado.
 - Conteúdo:
-  - usuário confirmado não recebe novo e-mail;
-  - `/a/home` apresenta os próprios convites pendentes antes do redirect para conta ativa;
-  - usuário pode aceitar ou recusar uma pendência por vez, com identidade derivada da sessão e validação de que a linha pendente pertence ao próprio usuário;
-  - o canal do convite é registrado em evento append-only e vinculado ao `hub_dispatch` que abriu o ciclo `pending` atual; eventos de ciclos anteriores são ignorados e ausência de canal corrente falha fechada;
-  - membership permanece `pending` sem expiração automática local até aceite, recusa ou revogação;
-  - sem pendências, permanece o comportamento atual de redirect.
+  - usuário confirmado recebe o convite na própria `/a/home`, sem novo e-mail;
+  - aceite ou recusa de uma pendência por vez, com identidade derivada da sessão;
+  - canal correlacionado ao ciclo `pending` atual, com falha fechada para evento ausente ou anterior;
+  - membership permanece `pending` até aceite, recusa ou revogação, sem expiração local.
+
+11.1.7 Ativação controlada e validação hospedada
+- Status: em validação.
+- Conteúdo:
+  - migration aplicada, com verificação pós-apply do banco pendente;
+  - gate da funcionalidade mantido desabilitado;
+  - configuração externa e prova funcional hospedada pendentes;
+  - ativação em Production e smoke final condicionados à aprovação das verificações.
 
 12. E12 — Admin Dashboard
 - Objetivo: Consolidar o Admin Dashboard como seção administrativa protegida, separada do Account Dashboard, com navegação própria e leitura operacional read-only.


### PR DESCRIPTION
## 1. Objetivo

Reorganizar a E11 conforme o `docs/template-roadmap.md`, aplicar o gate anti-inflação do `docs/prompt-abc.md` e deixar o plano-base pronto para a execução direta da fase `11.1.7`.

## 2. Alterações

- normaliza objetivo, status e registros da E11 no roadmap;
- remove narrativa pré-merge e passos operacionais já superados;
- preserva os contratos implementados nas subseções `11.1.3` a `11.1.6`;
- adiciona `11.1.7 — Ativação controlada e validação hospedada` ao roadmap e ao plano-base;
- atualiza o plano-base para v3, marcando as fases anteriores como implementadas e delimitando execução, critérios de aceite, rollback e autonomia do Executor;
- registra o estado real: PR 648 mergeado, migration aplicada e estado pós-apply verificado;
- registra no `docs/platform-config.md` as variáveis configuradas, os redeploys concluídos e a ordem controlada de ativação;
- mantém Production desabilitada até a prova hospedada aprovada e permite habilitação temporária somente no Preview autorizado;
- mantém como pendentes apenas a configuração remanescente do Supabase Auth, a prova hospedada, a ativação e o smoke final;
- remove redundâncias entre plano-base, roadmap e `platform-config`;
- não cria `11.1.8`, não move tarefas da E16 e não registra refatoração preventiva.

## 3. Fontes usadas

- `README.md`;
- `docs/roadmap.md`;
- `docs/lousa-plano-base-e11.md`;
- `docs/template-roadmap.md`;
- `docs/prompt-abc.md`;
- `docs/platform-config.md`;
- `docs/schema.md`;
- PR 648;
- migration e snippet de verificação da E11.

## 4. Validação

- diff limitado a `docs/roadmap.md`, `docs/platform-config.md` e `docs/lousa-plano-base-e11.md`;
- hierarquia `11.1.1` a `11.1.7` validada no roadmap;
- fase `11.1.7` reconciliada entre roadmap, plano-base e configuração externa;
- estados planejados, instruções pré-merge e passos superados removidos do plano-base;
- Production preservada com o gate desabilitado até a prova;
- ausência de blocos vazios e whitespace final;
- `npm ci`: não aplicável;
- `npm run check`: não aplicável.

## 5. Impacto

- alteração exclusivamente documental;
- o Executor pode prosseguir diretamente com a `11.1.7` após o merge;
- sem mudança de runtime, banco, rota, workflow ou configuração nas plataformas.