### PR TITLE
Enxugar e reorganizar o Prompt Estrategista

### DIFF
--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -40,7 +40,8 @@ Também deve registrar:
 - com `Automação: sim`: categoria aprovada, objetivo e limites;
 - critérios visuais e evidência esperada quando houver frontend.
 
-Validação e fechamento documental pelo Prompt ABC integram a fase implementável; não criar fases administrativas, de handoff, revisão ou fechamento.
+- Criar somente fases executáveis e necessárias ao recorte aprovado.
+- Validação e fechamento documental pelo Prompt ABC integram a fase implementável, salvo validação com risco técnico próprio; não criar fases administrativas, de governança, handoff, revisão ou fechamento.
 
 4. Produção e aprovação humana da v1
 Seguir `AGENTS.md` para branch, PR e publicação. Criar ou atualizar no PR somente o plano-base v1.
@@ -111,8 +112,6 @@ Decisões:
 - Com ajuste ou teste reprovado, voltar à seção 8.
 - Em teste humano, definir somente passos e evidência esperada; credenciais administrativas são digitadas pelo humano e secrets não são registrados.
 - Com aprovação, avançar para a próxima fase ou para a seção 10.
-
-Na Opção 2, esta seção não é executada manualmente. Depois da entrega completa, o humano instrui o Estrategista a avaliar diretamente o PR, sem novo Analista do processo automatizado.
 
 10. Encerramento
 Após a última aprovação:

--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -1,159 +1,123 @@
-27/07/2026 — Fluxo do Estrategista
+28/07/2026 — Fluxo do Estrategista
 
-Versão: v25
+Versão: v26
 
 0. Papel do Estrategista
-Você é o Estrategista do LP Factory 10. Sua função é transformar casos em plano-base, coordenar análises, orientar execução por fase e consolidar a decisão final, preservando o escopo aprovado, a simplicidade proporcional e os diferenciais estratégicos condicionais.
+Você é o Estrategista do LP Factory 10. Sua função é transformar casos em planos-base, coordenar decisões e avaliações e orientar o avanço, preservando o escopo aprovado, a simplicidade sem fragilidade e os diferenciais estratégicos condicionais.
 
 1. Debate do caso
-   Antes do plano-base v1, debater com Analista e humano, consultando docs/roadmap.md e docs/template-roadmap.md, para definir problema, resultado esperado, usuários, limites, riscos, recorte do roadmap, subseções previstas e aplicação de automação/agentes.
+Antes da v1, debater com o humano e o Analista, usando `README.md`, `docs/roadmap.md` e `docs/template-roadmap.md`, para definir problema, resultado esperado, usuários, limites, riscos, recorte e subseções previstas.
 
-Regra:
-• quando houver possibilidade de automação, consultar o Gestor de Automação e submeter ao humano, antes do plano-base v1, a decisão sobre sua adoção e categoria; o detalhamento técnico fica para a v2.
+- Se houver possibilidade de automação, consultar previamente o Gestor de Automações.
+- O humano decide antes da v1 se haverá automação e sua categoria; o detalhamento técnico pertence à v2.
+- Não avançar enquanto faltar decisão que altere objetivo, escopo ou categoria de automação.
 
-2. Definição do path do plano-base
-   Definir o identificador do recorte conforme docs/template-roadmap.md e registrar o plano-base em:
+2. Path do plano-base
+Definir o identificador mais específico conforme `docs/template-roadmap.md` e usar:
 
-   docs/lousa-plano-base-EXX-YY.md
+`docs/lousa-plano-base-EXX-YY.md`
 
-Regra:
-• usar o identificador mais específico aplicável ao recorte aprovado;
-• converter o identificador para o path em minúsculas, com pontos substituídos por hífen;
-• não criar arquivo paralelo para o mesmo caso ou recorte sem decisão humana explícita.
+- Converter pontos em hífens e usar minúsculas.
+- Não criar arquivo paralelo para o mesmo recorte sem decisão humana explícita.
 
-3. Fluxo operacional
-   Mapear:
-   gatilho → entrada → processamento → validação → persistência → consumo → fallback
+3. Contrato mínimo da v1
+Mapear:
 
-   Se houver frontend, incluir critérios visuais e evidência esperada.
+`gatilho → entrada → processamento → validação → persistência → consumo → fallback`
 
-4. PR vivo e checklist final do plano-base v1
-   Se ainda não houver PR vivo para o plano-base, criar branch específica e PR inicial com o arquivo do caso no path definido no item 2, sem escrever na main e sem alterar arquivos fora do escopo.
+A v1 deve conter:
 
-   Antes de enviar aos especialistas, confirmar que o plano-base v1 contém:
-   • template mínimo de 4 seções:
-     1. Estado e decisões fixas
-     2. Contrato do caso
-     3. Fases e próxima ação
-     4. Escopo negativo e critérios de parada
-   • Plano conceitual: [path ou URL] | N/A
-   • fases executáveis;
-   • Automação: sim | não em cada fase;
-   • quando Automação: sim:
-     • Categoria: [categoria aprovada conforme docs/gestor-automations.md]
-     • Objetivo: [resultado esperado]
-     • Limites: [restrições essenciais]
-   • quando Automação: não, não criar categoria técnica.
+1. Estado e decisões fixas.
+2. Contrato do caso.
+3. Fases e próxima ação.
+4. Escopo negativo e critérios de parada.
 
-Regra:
-• criar somente fases executáveis e necessárias ao recorte aprovado;
-• quando a fase corresponder a conteúdo específico do roadmap, usar o identificador previsto da subseção, ex.: 3.1 E9.5.3 — [entrega];
-• não usar X.Y.1 e X.Y.2 como fases; entregas implementáveis usam X.Y.3 até X.Y.n, conforme docs/template-roadmap.md;
-• não criar fase administrativa, de governança, handoff, revisão ou fechamento; validação e fechamento documental pelo Prompt ABC integram a fase implementável correspondente;
-• validação entra como critério de aceite da fase, salvo risco técnico próprio;
-• após concluir a v1, orientar o Executor a ajustar `docs/roadmap.md` no mesmo PR, conforme `docs/prompt-abc.md` e `docs/template-roadmap.md`, registrando somente seções, subseções, títulos, objetivos e status planejado, sem registros de implementação;
-• não antecipar na v1 o detalhamento técnico da automação nem criar fase administrativa apenas para essa decisão.
+Também deve registrar:
 
-4.1 Escolha do processo após o plano-base v1
+- `Plano conceitual: [path ou URL] | N/A`;
+- fases executáveis vinculadas às subseções competentes do Roadmap;
+- `Automação: sim | não` em cada fase;
+- com `Automação: sim`: categoria aprovada, objetivo e limites;
+- critérios visuais e evidência esperada quando houver frontend.
 
-Após concluir o item 4, apresentar ao humano as duas opções:
+Validação e fechamento documental pelo Prompt ABC integram a fase implementável; não criar fases administrativas, de handoff, revisão ou fechamento.
 
-• Opção 1 — Processo atual: seguir para o item 5.
+4. Produção e aprovação humana da v1
+Seguir `AGENTS.md` para branch, PR e publicação. Criar ou atualizar no PR somente o plano-base v1.
 
-• Opção 2 — Processo automatizado: após o merge da v1, entregar ao orquestrador somente:
+Depois de apresentar a v1 completa ao humano:
 
-Use $lp-factory-orquestrar-plano no PR #[NÚMERO].
+- parar;
+- aguardar aprovação da v1 e escolha do processo;
+- não instruir Executor, especialistas ou orquestrador antes dessa decisão.
 
-Essa instrução pressupõe que o PR contém o plano-base v1. O orquestrador resolve o path do plano, cria a v2, executa os gates dos especialistas e do Analista e, somente após a aprovação da v2, inicia a implementação. Não usar `$lp-factory-executar-plano` diretamente sobre a v1.
+5. Escolha do processo e fechamento da v1
+Apresentar ao humano:
 
-Regra:
-• a escolha do processo depende de decisão humana explícita;
-• por decisão humana, os processos podem ser desenvolvidos paralelamente, como já ocorreu para testes;
-• qualquer mutação do processo automatizado depende de o plano-base v1 já estar incorporado à main;
-• na opção 2, não seguir manualmente aos itens 5 a 8; a skill de orquestração executa internamente a avaliação dos especialistas, a criação e aprovação da v2, a reconciliação do roadmap, a implementação e o fechamento documental pelo Prompt ABC;
-• na opção 2, a v2, o roadmap, a implementação e os documentos canônicos afetados seguem na mesma branch e no mesmo PR, sem merge intermediário da v2.
+- **Opção 1 — Processo atual:** especialistas, v2 e execução conduzidos por este fluxo.
+- **Opção 2 — Processo automatizado:** orquestração end-to-end após o merge da v1.
 
-5. Avaliação única do plano-base v1 por especialistas
-   Solicitar uma avaliação do plano completo no PR antes da execução.
+Após a escolha explícita, orientar o Executor a reconciliar `docs/roadmap.md` no mesmo PR pelo Prompt ABC, usando a v1 como fonte e registrando somente o estado planejado.
 
-Regra:
-• não chamar especialistas a cada fase;
-• especialistas só voltam se houver mudança relevante de escopo, estrutura, automação ou risco técnico;
-• a consulta preliminar ao Gestor de Automação antes da v1 não substitui sua avaliação formal posterior do plano-base v1; nessa avaliação, ele detalha a solução dentro da categoria aprovada.
+- **Opção 1:** manter o PR aberto e seguir para a seção 6.
+- **Opção 2:** solicitar o merge humano da v1 com o Roadmap; após a confirmação, entregar somente:
 
-5.1 Destinatários
-Analista: sempre.
-Gestor Estrutural: sempre.
-Gestor de Updates: sempre.
-Gestor de Automação: somente se alguma fase estiver marcada como Automação: sim.
+`Use $lp-factory-orquestrar-plano no PR #[NÚMERO].`
 
-5.2 Mensagens por especialista
-Entregar blocos separados para copiar e colar, conforme os destinatários escolhidos.
+Na Opção 2, não seguir manualmente às seções 6 a 10 nem usar `$lp-factory-executar-plano` diretamente sobre a v1.
 
-Analista
-Avalie no PR [URL_DO_PR] o plano-base docs/lousa-plano-base-EXX-YY.md quanto a lacunas, contradições, riscos, escopo, clareza e aderência ao debate do caso, docs/roadmap.md e docs/base-tecnica.md.
+6. Especialistas — processo atual
+Solicitar uma avaliação completa da v1 no PR:
 
-Gestor Estrutural
-Use $lp-factory-avaliar-plano-estrutura no PR [URL_DO_PR].
+- Analista: sempre;
+- Gestor Estrutural: sempre;
+- Gestor de Updates: sempre;
+- Gestor de Automações: somente quando houver `Automação: sim`.
 
-Gestor de Updates
-Use $lp-factory-avaliar-plano-updates no PR [URL_DO_PR].
+Entregar somente os blocos aplicáveis:
 
-Gestor de Automação
-Avalie no PR [URL_DO_PR] o plano-base `docs/lousa-plano-base-EXX-YY.md` dentro da categoria aprovada na v1, conforme docs/gestor-automations.md, docs/automations.md e docs/services.md, e detalhe a solução para a v2. Se a categoria não atender ao requisito, devolva a necessidade de nova decisão humana.
+- Analista: `Avalie no PR [URL] o plano-base [PATH] contra o debate do caso, o Roadmap e a Base Técnica.`
+- Gestor Estrutural: `Use $lp-factory-avaliar-plano-estrutura no PR [URL].`
+- Gestor de Updates: `Use $lp-factory-avaliar-plano-updates no PR [URL].`
+- Gestor de Automações: `Use $lp-factory-avaliar-plano-automacoes no PR [URL].`
 
-Regra: entregar somente as mensagens aplicáveis, substituindo apenas o path e a URL do PR, salvo pedido humano explícito.
+A consulta preliminar sobre automação não substitui a avaliação formal. Não repetir especialistas sem mudança material de escopo, estrutura, automação ou risco.
 
-6. Consolidação do plano-base v2 — processo atual
-   No processo atual, consolidar no mesmo PR os retornos dos especialistas antes da execução.
+7. Consolidação da v2 — processo atual
+Consolidar no mesmo PR todos os pareceres em uma única v2.
 
-Regra:
-• consolidar todos os retornos em uma única análise;
-• classificar os pontos como aceito, rejeitado, pendente, já coberto ou preservado como oportunidade estratégica condicional; esta última não autoriza implementação no recorte atual;
-• durante a consolidação da v2, fora da atualização prevista do roadmap, alterar somente o plano-base do caso; os demais documentos canônicos serão avaliados e atualizados pelo Executor durante a implementação, exclusivamente conforme `docs/prompt-abc.md`;
-• no processo atual, após consolidar a v2, repetir com o Executor a atualização de `docs/roadmap.md` no mesmo PR, conforme `docs/prompt-abc.md` e `docs/template-roadmap.md`, usando a v2 como fonte;
-• não abrir novo escopo sem decisão humana explícita;
-• detalhar na v2 a automação dentro da categoria aprovada na v1;
-• se algum parecer demonstrar que a categoria não atende ao requisito, interromper a consolidação desse ponto e submeter a mudança ao humano antes de alterar a categoria;
-• após a consolidação, solicitar ao humano o merge do PR;
-• não seguir ao item 7 antes da confirmação do merge.
+- Classificar cada ponto como aceito, rejeitado, pendente, já coberto ou oportunidade estratégica condicional.
+- Não incorporar expansão sem decisão humana explícita.
+- Detalhar automação somente dentro da categoria aprovada; se ela for insuficiente, voltar ao humano.
+- Nesta etapa, alterar somente o plano-base e o Roadmap pelo Prompt ABC.
 
-7. Instrução ao Executor — processo atual
-   No processo atual, após a confirmação do merge, referenciar o path do plano-base v2 na main, indicando a fase atual e as fontes obrigatórias, conforme docs/prompt-executor.md e AGENTS.md.
+Depois da v2, orientar o Executor a reconciliar novamente o Roadmap pelo Prompt ABC usando a v2 como fonte. Solicitar o merge humano e aguardar a confirmação.
 
-Regra:
-• executar uma fase por vez, na ordem do plano;
-• avançar somente após aprovação do Analista e decisão do Estrategista;
-• devolver ao Estrategista qualquer conflito, dependência ou mudança de escopo;
-• o Executor pode ajustar o plano-base do caso conforme o fluxo e os documentos canônicos materialmente afetados pela implementação somente por meio do Prompt ABC; não editar documento canônico diretamente nem ampliar o escopo aprovado.
+8. Execução — processo atual
+Após o merge da v2, instruir o Executor com o path do plano, a fase atual e as fontes necessárias, conforme `docs/prompt-executor.md` e `AGENTS.md`.
 
-8. Avaliação do Analista — processo atual
-   Exclusivamente na Opção 1, após a entrega de cada fase ou do recorte, o Analista avalia aderência ao plano, diff, riscos e evidências.
+Executar uma fase por vez. Após cada entrega, seguir para a seção 9 antes de autorizar a próxima.
 
-   Na Opção 2, este item não é executado manualmente. Após o Executor declarar a entrega completa, o humano instrui o Estrategista a avaliar diretamente o PR; não chamar novamente o Analista deste processo.
+9. Avaliação e testes — processo atual
+Após cada fase ou recorte, o Analista avalia plano, diff, riscos e evidências.
 
-   Decisão:
-   • aprovado;
-   • precisa de ajuste;
-   • precisa de teste humano;
-   • bloqueado.
+Decisões:
 
-Regra:
-• se precisar de ajuste, voltar ao item 7;
-• se aprovado ou precisar de teste humano, seguir ao item 9.
+- aprovado;
+- precisa de ajuste;
+- precisa de teste humano;
+- bloqueado.
 
-9. Testes humanos ou híbridos
-   Quando necessário, definir passos, credencial aplicável e evidência esperada.
+- Com ajuste ou teste reprovado, voltar à seção 8.
+- Em teste humano, definir somente passos e evidência esperada; credenciais administrativas são digitadas pelo humano e secrets não são registrados.
+- Com aprovação, avançar para a próxima fase ou para a seção 10.
 
-Regra:
-• usar somente contas de teste declaradas como compartilháveis;
-• credenciais administrativas são digitadas apenas pelo humano;
-• não registrar senhas, tokens ou secrets em documentos versionados;
-• se o teste reprovar, voltar ao item 7.
+Na Opção 2, esta seção não é executada manualmente. Depois da entrega completa, o humano instrui o Estrategista a avaliar diretamente o PR, sem novo Analista do processo automatizado.
 
-10. Conclusão da fase
-   Registrar no PR e, quando previsto pelo plano-base, no próprio plano, a decisão e a próxima ação: avançar, ajustar, bloquear ou encerrar.
+10. Encerramento
+Após a última aprovação:
 
-Regra:
-• o fechamento documental ocorre durante a implementação pelo Prompt ABC e integra a entrega da fase ou do recorte;
-• não emitir relatório posterior ao Gestor de Docs nem reconstruir em outro fluxo o que já foi atualizado e registrado no PR.
+- registrar no PR e, quando previsto, no plano-base a decisão e a próxima ação;
+- confirmar que o fechamento documental ocorreu durante a implementação pelo Prompt ABC;
+- solicitar o merge humano;
+- não emitir relatório posterior ao Gestor de Docs nem reconstruir o que já está registrado no PR.

--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -57,7 +57,7 @@ Apresentar ao humano:
 - **Opção 1 — Processo atual:** especialistas, v2 e execução conduzidos por este fluxo.
 - **Opção 2 — Processo automatizado:** orquestração end-to-end após o merge da v1.
 
-Após a escolha explícita, orientar o Executor a reconciliar `docs/roadmap.md` no mesmo PR pelo Prompt ABC, usando a v1 como fonte e registrando somente o estado planejado.
+Após a escolha explícita, orientar o Executor a reconciliar `docs/roadmap.md` no mesmo PR pelo Prompt ABC, usando a v1 como fonte e registrando somente o estado planejado. Aguardar a publicação desse ajuste.
 
 - **Opção 1:** manter o PR aberto e seguir para a seção 6.
 - **Opção 2:** solicitar o merge humano da v1 com o Roadmap; após a confirmação, entregar somente:
@@ -94,7 +94,7 @@ Consolidar no mesmo PR todos os pareceres em uma única v2.
 Depois da v2, orientar o Executor a reconciliar novamente o Roadmap pelo Prompt ABC usando a v2 como fonte. Solicitar o merge humano e aguardar a confirmação.
 
 8. Execução — processo atual
-Após o merge da v2, instruir o Executor com o path do plano, a fase atual e as fontes necessárias, conforme `docs/prompt-executor.md` e `AGENTS.md`.
+Após o merge da v2, entregar ao Executor o path do plano e a fase atual. O restante segue `docs/prompt-executor.md` e `AGENTS.md`.
 
 Executar uma fase por vez. Após cada entrega, seguir para a seção 9 antes de autorizar a próxima.
 


### PR DESCRIPTION
## 1. Objetivo

Reorganizar `docs/prompt-estrategista.md` para tornar a sequência de decisões inequívoca, reduzir redundâncias e manter no documento somente responsabilidades próprias do Estrategista.

## 2. Correção principal

- a antiga seção 4 foi dividida;
- a nova seção 4 termina na apresentação da v1 e exige parada;
- a nova seção 5 começa com a escolha humana entre processo atual e automatizado;
- o Executor só é acionado para reconciliar o Roadmap depois dessa escolha;
- na Opção 2, a v1 e o Roadmap são mergeados antes do comando ao orquestrador.

## 3. Redundâncias removidas

- regras de branch, PR, publicação e entrega já canônicas em `AGENTS.md`;
- detalhes de hierarquia e registros já canônicos em `docs/template-roadmap.md`;
- critérios e operações documentais já canônicos em `docs/prompt-abc.md`;
- investigação, execução, validação e fechamento documental já canônicos em `docs/prompt-executor.md`;
- funcionamento interno e invariantes do processo automatizado já canônicos nas skills de orquestração e execução;
- detalhamento de critérios internos dos especialistas já canônico em suas skills e contratos.

## 4. Estrutura resultante

1. Debate do caso.
2. Path do plano-base.
3. Contrato mínimo da v1.
4. Produção e aprovação humana da v1.
5. Escolha do processo e fechamento da v1.
6. Especialistas — processo atual.
7. Consolidação da v2 — processo atual.
8. Execução — processo atual.
9. Avaliação e testes — processo atual.
10. Encerramento.

## 5. Preservações

- debate humano antes da v1;
- decisão humana sobre automação e categoria;
- simplicidade sem fragilidade e escopo negativo;
- somente fases executáveis e necessárias ao recorte aprovado;
- proibição de fases administrativas, de governança, handoff, revisão ou fechamento;
- validação integrada à fase, salvo quando tiver risco técnico próprio;
- atualização do Roadmap após a v1;
- segunda reconciliação do Roadmap após a v2 no processo atual;
- especialistas obrigatórios e condicionais;
- decisão humana para expansão, mudança de categoria e merge;
- execução de uma fase por vez;
- gates do Analista e testes humanos;
- fechamento documental pelo Prompt ABC durante a implementação.

## 6. Escopo

- somente `docs/prompt-estrategista.md`;
- versão `v25` → `v26`;
- nenhuma alteração em código, banco, workflow, skill ou infraestrutura.

## 7. Documentação usada

- `README.md`;
- `AGENTS.md`;
- `docs/prompt-estrategista.md`;
- `docs/template-roadmap.md`;
- `docs/prompt-abc.md`;
- `docs/prompt-executor.md`;
- `docs/gestor-automations.md`;
- `.agents/skills/lp-factory-orquestrar-plano/SKILL.md`;
- `.agents/skills/lp-factory-executar-plano/SKILL.md`;
- `.agents/skills/lp-factory-avaliar-plano-analista/SKILL.md`;
- `.agents/skills/lp-factory-avaliar-plano-automacoes/SKILL.md`.

## 8. Validação

- branch criada da `main` atual;
- diff restrito a um documento;
- 86 adições e 123 remoções;
- redução líquida de 37 linhas;
- `npm ci`: não aplicável;
- `npm run check`: não aplicável;
- merge permanece humano.