### PR TITLE
fix: corrige provas pós-merge da E12.4.3

### DIFF
--- a/.github/workflows/pipeline-supabase-apply-migrations.yml
+++ b/.github/workflows/pipeline-supabase-apply-migrations.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Report disabled migration gate
         if: ${{ vars.SUPABASE_APPLY_MIGRATIONS_ENABLED != 'true' }}

--- a/supabase/snippets/e12_4_3_generation_profile_lifecycle_verify.sql
+++ b/supabase/snippets/e12_4_3_generation_profile_lifecycle_verify.sql
@@ -4,28 +4,15 @@ with expected(signature) as (
     ('activate_landing_page_generation_profile(uuid,timestamp with time zone)'),
     ('archive_landing_page_generation_profile(uuid,timestamp with time zone)'),
     ('get_landing_page_generation_profile_lifecycle_status()')
-), actual as (
-  select
-    p.proname || '(' || pg_get_function_identity_arguments(p.oid) || ')' as signature,
-    p.prosecdef,
-    p.proconfig
-  from pg_proc p
-  join pg_namespace n on n.oid = p.pronamespace
-  where n.nspname = 'public'
-    and p.proname in (
-      'save_landing_page_generation_profile_draft',
-      'activate_landing_page_generation_profile',
-      'archive_landing_page_generation_profile',
-      'get_landing_page_generation_profile_lifecycle_status'
-    )
 )
 select
   expected.signature,
-  actual.signature is not null as exists,
-  coalesce(actual.prosecdef, false) as security_definer,
-  coalesce(actual.proconfig @> array['search_path=public, pg_temp'], false) as fixed_search_path
+  function.oid is not null as exists,
+  coalesce(function.prosecdef, false) as security_definer,
+  coalesce(function.proconfig @> array['search_path=public, pg_temp'], false) as fixed_search_path
 from expected
-left join actual using (signature)
+left join pg_proc function
+  on function.oid = to_regprocedure('public.' || expected.signature)
 order by expected.signature;
 
 select

--- a/supabase/tests/e12_4_3_generation_profile_lifecycle.test.sql
+++ b/supabase/tests/e12_4_3_generation_profile_lifecycle.test.sql
@@ -65,7 +65,7 @@ reset role;
 set local role authenticated;
 select set_config(
   'request.jwt.claims',
-  '{"sub":"12040000-0000-4000-8000-000000000099","role":"authenticated","platform_admin":true}',
+  '{"sub":"ce899cd2-5360-478e-817e-ee3690aabecd","role":"authenticated","platform_admin":true}',
   true
 );
 
@@ -289,7 +289,7 @@ $$;
 set local role authenticated;
 select set_config(
   'request.jwt.claims',
-  '{"sub":"12040000-0000-4000-8000-000000000099","role":"authenticated","platform_admin":true}',
+  '{"sub":"ce899cd2-5360-478e-817e-ee3690aabecd","role":"authenticated","platform_admin":true}',
   true
 );
 do $$


### PR DESCRIPTION
## Objetivo

Corrige somente os três defeitos observados durante o início dos gates pós-merge da E12.4.3, sem alterar nem reaplicar a migration já aplicada pelo PR #654.

## Correções

1. **Workflow com checkout raso**
   - configura `fetch-depth: 0` no checkout;
   - permite que `git diff EVENT_BEFORE_SHA..GITHUB_SHA` encontre o commit anterior e registre corretamente as migrations alteradas;
   - elimina o `fatal: bad object` observado no run pós-merge do PR #654.

2. **Ator do teste SQL**
   - substitui o UUID fictício do fluxo privilegiado pelo `platform_admin` canônico já existente no projeto;
   - evita a violação da FK `audit_logs_user_id_fkey` durante as provas transacionais;
   - preserva o usuário comum fictício usado nas provas negativas das três RPCs e do readiness.

3. **Assinaturas do verificador read-only**
   - resolve cada assinatura esperada com `to_regprocedure`;
   - evita comparar strings sem nomes de parâmetros com `pg_get_function_identity_arguments`, que inclui esses nomes;
   - mantém as verificações de existência, `SECURITY DEFINER` e `search_path` fixo.

## Limites

- nenhuma migration nova;
- nenhuma aplicação, reversão ou reparo remoto;
- nenhuma alteração nas RPCs, ACLs, RLS, policies ou lifecycle;
- nenhuma declaração de gates concluídos neste PR;
- após o merge humano, repetir o workflow por `workflow_dispatch`, o teste SQL e o verificador read-only antes da reconciliação documental.

## Validação pré-PR

- `npm ci`: aprovado — 430 pacotes;
- `npm run check`: aprovado — zero erros e 24 warnings preexistentes;
- `git diff --check`: aprovado;
- diff restrito aos três arquivos declarados.

## Revisão

`revisao_delta_implementacao` concluída no intervalo `origin/main...d2ffee0`: **aprovado para avançar**, sem correções adicionais. O head revisado foi preservado e o PR pode seguir ao merge humano pela interface Web.