### PR TITLE
docs: reconcilia gates pós-merge da E12.4.3

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 0.1 Cabeçalho
 • Data: 28/07/2026
-• Versão: v1.5.111
+• Versão: v1.5.112
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -1389,14 +1389,14 @@ Repositório — Ajustados
 
 12.4 Gestão do perfil de orientação
 - Objetivo: Definir a operação administrativa do perfil de orientação que direciona gerações futuras de landing pages sem materializar nem alterar LPs.
-- Status: E12.4.3 implementada como candidata; migration aplicada e provas automatizadas pós-apply aprovadas. Configuração da assistência e teste humano autenticado em Preview permanecem pendentes antes da conclusão.
+- Status: E12.4.3 concluída; migration aplicada, provas automatizadas pós-apply, configuração da assistência e validação humana autenticada em Preview aprovadas.
 
 12.4.1 Objetivo e status
 - Objetivo: Entregar a operação manual completa de criação, edição, revisão, ativação e arquivamento de versões do perfil, com proposta opcional por IA no mesmo editor.
-- Status: Operação manual e assistência opcional implementadas como candidatas; validações automatizadas de banco concluídas e validações humanas em Preview pendentes.
+- Status: Operação manual e assistência opcional implementadas e validadas; provas automatizadas de banco e validações humanas autenticadas em Preview concluídas.
 
 12.4.3 Proposta, revisão, aprovação e ativação do perfil
-- Status: Implementação candidata integrada à `main`; workflow idempotente, teste SQL transacional e verificação read-only pós-apply aprovados. Configuração da OpenAI em Preview e teste humano autenticado permanecem pendentes.
+- Status: Concluída; implementação integrada à `main`, com workflow idempotente, teste SQL transacional, verificação read-only pós-apply, configuração da OpenAI em Preview e teste humano autenticado aprovados.
 - Conteúdo:
   - Perfil próprio permitido somente para segmento e nicho; ultranicho resolve o perfil ativo do ancestral elegível mais próximo.
   - Estados persistidos limitados a `draft`, `active` e `archived`; uma versão ativa é imutável e qualquer mudança exige nova versão em rascunho.
@@ -1406,14 +1406,14 @@ Repositório — Ajustados
   - Dependência técnica atendida em 28/07/2026: PR #655 mergeado, branch sincronizada com a `main` e `next`/`eslint-config-next` confirmados em `16.2.11` no lockfile antes da implementação.
   - A proposta por IA exige resolução completa da E10.8 e identidades públicas vigentes da E18.5; ausência ou indisponibilidade da assistência não bloqueia o fluxo manual.
   - E12.4.4 e subseções posteriores, autorização por conta, geração, materialização, preview, publicação e alteração de LP permanecem fora do recorte.
-- Registros de implementação candidata:
+- Registros de implementação:
   - Admin Dashboard: listagem e editor em `app/admin/(protected)/perfis-de-orientacao/`, com salvar draft, ativar e arquivar protegidos por `platform_admin`.
   - Boundary e adapters: contratos administrativos, validação estrita, correlação da proposta, acesso server-only e integração opcional com Responses API em `lib/conversion-content/`.
   - Banco: migration `20260728153500_e12_4_3_generation_profile_lifecycle.sql` aplicada; teste SQL transacional, snippet read-only, RPCs, ACLs, RLS e policies verificados pós-apply.
-  - Validação: casos executáveis do perfil, typecheck, check e checks hospedados aprovados; Preview autenticado e fluxo real com OpenAI permanecem pendentes.
+  - Validação: casos executáveis do perfil, typecheck, check, checks hospedados e fluxo autenticado em Preview aprovados; proposta inicial, refinamento e gate negativo da E10.8 validados sem salvamento ou ativação automáticos.
 
 12.4.3.1 Refinamento iterativo assistido por IA
-- Status: Implementação candidata integrada à `main`; checks hospedados automatizados aprovados. Teste humano autenticado do refinamento em Preview permanece pendente e a subfase não está concluída.
+- Status: Concluída; implementação integrada à `main`, com checks hospedados automatizados e teste humano autenticado do refinamento em Preview aprovados.
 - Conteúdo:
   - Toda proposta inicial ou revisão depende de ação explícita do `platform_admin`.
   - A IA pode sugerir alterações em `generation_guidance`, recomendações e `item_guidance` dentro do contrato fechado vigente.
@@ -2195,15 +2195,15 @@ Repositório — Ajustados
 20.3.1 Objetivo e status
 
 * Objetivo: definir e resolver um perfil versionado por taxon que oriente a geração de `landing_page` com recomendações de módulos e variantes da E18.5, sem impor composição final ou prontidão.
-* Status: Implementação concluída no PR #644; pendente apenas de merge, apply automático da migration e verificação read-only pós-apply.
+* Status: Concluída; PR #644 mergeado, migration aplicada e verificação read-only pós-apply aprovada.
 
 20.3.3 Contrato e persistência mínima do perfil
 
-* Status: Implementada no PR #644, com aplicação da migration pendente do merge.
+* Status: Concluída; implementação do PR #644 integrada à `main`, migration aplicada e estado final do banco verificado.
 * Conteúdo:
 
-  * Implementar o agregado versionado, as duas tabelas sem registros oficiais, a leitura server-side, o boundary único e as validações de contrato, estados, cadeia taxonômica, integridade e segurança.
-  * Nenhum consumidor, rota ou outro caminho runtime será ativado antes do apply da migration após merge humano e da verificação do estado final do banco.
+  * O agregado versionado, as duas tabelas sem registros oficiais, a leitura server-side, o boundary único e as validações de contrato, estados, cadeia taxonômica, integridade e segurança estão implementados.
+  * A migration foi aplicada após o merge humano e o estado final do banco foi verificado antes da ativação de consumidores, rotas ou outros caminhos runtime.
 
 20.3.4 Validação E18.5 e resolução própria ou herdada
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 0.1 Cabeçalho
 • Data: 28/07/2026
-• Versão: v1.5.110
+• Versão: v1.5.111
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -1389,14 +1389,14 @@ Repositório — Ajustados
 
 12.4 Gestão do perfil de orientação
 - Objetivo: Definir a operação administrativa do perfil de orientação que direciona gerações futuras de landing pages sem materializar nem alterar LPs.
-- Status: E12.4.3 implementada como candidata no repositório; aplicação da migration, configuração da assistência e teste humano em Preview permanecem pendentes antes da conclusão.
+- Status: E12.4.3 implementada como candidata; migration aplicada e provas automatizadas pós-apply aprovadas. Configuração da assistência e teste humano autenticado em Preview permanecem pendentes antes da conclusão.
 
 12.4.1 Objetivo e status
 - Objetivo: Entregar a operação manual completa de criação, edição, revisão, ativação e arquivamento de versões do perfil, com proposta opcional por IA no mesmo editor.
-- Status: Operação manual e assistência opcional implementadas como candidatas; validações externas pendentes.
+- Status: Operação manual e assistência opcional implementadas como candidatas; validações automatizadas de banco concluídas e validações humanas em Preview pendentes.
 
 12.4.3 Proposta, revisão, aprovação e ativação do perfil
-- Status: Implementação candidata concluída no repositório; validações externas pendentes.
+- Status: Implementação candidata integrada à `main`; workflow idempotente, teste SQL transacional e verificação read-only pós-apply aprovados. Configuração da OpenAI em Preview e teste humano autenticado permanecem pendentes.
 - Conteúdo:
   - Perfil próprio permitido somente para segmento e nicho; ultranicho resolve o perfil ativo do ancestral elegível mais próximo.
   - Estados persistidos limitados a `draft`, `active` e `archived`; uma versão ativa é imutável e qualquer mudança exige nova versão em rascunho.
@@ -1409,11 +1409,11 @@ Repositório — Ajustados
 - Registros de implementação candidata:
   - Admin Dashboard: listagem e editor em `app/admin/(protected)/perfis-de-orientacao/`, com salvar draft, ativar e arquivar protegidos por `platform_admin`.
   - Boundary e adapters: contratos administrativos, validação estrita, correlação da proposta, acesso server-only e integração opcional com Responses API em `lib/conversion-content/`.
-  - Banco versionado: migration `20260728153500_e12_4_3_generation_profile_lifecycle.sql`, teste SQL e snippet de verificação; aplicação no Supabase e reconciliação posterior de `docs/schema.md` ainda pendentes.
-  - Validação local: casos executáveis do perfil, typecheck e check aprovados; Preview autenticado e fluxo real com OpenAI/Supabase ainda não executados por ausência das configurações locais.
+  - Banco: migration `20260728153500_e12_4_3_generation_profile_lifecycle.sql` aplicada; teste SQL transacional, snippet read-only, RPCs, ACLs, RLS e policies verificados pós-apply.
+  - Validação: casos executáveis do perfil, typecheck, check e checks hospedados aprovados; Preview autenticado e fluxo real com OpenAI permanecem pendentes.
 
 12.4.3.1 Refinamento iterativo assistido por IA
-- Status: Implementação candidata no PR #654; provas hospedadas aplicáveis permanecem pendentes e a subfase não está concluída.
+- Status: Implementação candidata integrada à `main`; checks hospedados automatizados aprovados. Teste humano autenticado do refinamento em Preview permanece pendente e a subfase não está concluída.
 - Conteúdo:
   - Toda proposta inicial ou revisão depende de ação explícita do `platform_admin`.
   - A IA pode sugerir alterações em `generation_guidance`, recomendações e `item_guidance` dentro do contrato fechado vigente.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data da última atualização: 27/07/2026
-• Documento: LP Factory 10 — Schema (DB Contract) v1.0.34
+• Data da última atualização: 28/07/2026
+• Documento: LP Factory 10 — Schema (DB Contract) v1.0.35
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -749,7 +749,8 @@
 
 1.24.1 Função
 • Perfil versionado de orientação para geração pertencente a um taxon.
-• Estados permitidos: `draft`, `active` e `archived`; transições não são implementadas neste recorte.
+• Estados permitidos: `draft`, `active` e `archived`; as transições controladas são executadas somente pelas RPCs da seção 3.7.
+• Uma versão `active` é imutável; alterações exigem uma versão `draft`.
 
 1.24.2 Colunas
 • id uuid primary key default gen_random_uuid()
@@ -773,7 +774,7 @@
 • public, anon e authenticated: sem grants.
 • service_role: SELECT; sem INSERT, UPDATE ou DELETE.
 • ai_readonly: exceção explícita aos default privileges, sem grants quando a role existir.
-• Trigger Hub e auditoria: não.
+• Trigger Hub de tabela: não; as mutações pelas RPCs da seção 3.7 registram auditoria em `audit_logs` por `audit_context_event`.
 • `landing_page_generation_profiles_set_updated_at`: executa `public.tg_set_updated_at()` antes de UPDATE.
 
 1.25 landing_page_generation_profile_items
@@ -1001,6 +1002,29 @@
 • Estratégias cobertas: alias_exact, alias_normalized, taxon_name_exact, taxon_name_normalized, taxon_slug_normalized, fts, trgm
 • Consumidor previsto: camada server/adapter do app; sem consumo direto pelo client nesta etapa
 • Fora do escopo: writes, IA, fallback final, account_taxonomy, account_niche_resolutions e escolha de template
+
+3.7 Lifecycle administrativo do perfil de orientação
+• As quatro RPCs são `SECURITY DEFINER`, fixam `search_path = public, pg_temp` e concedem `EXECUTE` somente a `authenticated`; `public`, `anon`, `service_role` e `ai_readonly`, quando existir, não possuem `EXECUTE`.
+• Todas exigem `platform_admin`; as tabelas permanecem sem DML direto para papéis de runtime.
+
+3.7.1 save_landing_page_generation_profile_draft(uuid, uuid, timestamptz, text, jsonb, text, uuid, text) → table
+• Cria nova versão `draft` ou atualiza um `draft` existente com concorrência otimista por `updated_at`.
+• Valida o agregado completo, inclusive o par opcional `variant_key`/`variant_version`, e substitui atomicamente os itens do rascunho.
+• Registra `generation_profile_draft_saved`, origem `manual` ou `ai` e somente a correlação autorizada; não registra prompt, pesquisa bruta nem payload integral.
+
+3.7.2 activate_landing_page_generation_profile(uuid, timestamptz) → table
+• Ativa um `draft` com concorrência otimista e arquiva atomicamente a versão `active` anterior do mesmo taxon.
+• Registra `generation_profile_activated` sem reutilizar correlação de proposta.
+
+3.7.3 archive_landing_page_generation_profile(uuid, timestamptz) → table
+• Arquiva uma versão `draft` ou `active` com concorrência otimista.
+• Registra `generation_profile_archived`.
+
+3.7.4 get_landing_page_generation_profile_lifecycle_status() → table
+• Retorna readiness administrativo calculado a partir de tabelas, constraints, RLS e grants exigidos pelo lifecycle.
+
+• Migration aplicada: `supabase/migrations/20260728153500_e12_4_3_generation_profile_lifecycle.sql`.
+• Provas pós-apply: `supabase/tests/e12_4_3_generation_profile_lifecycle.test.sql` e `supabase/snippets/e12_4_3_generation_profile_lifecycle_verify.sql`.
 
 4. Triggers 
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -2,7 +2,7 @@
 
 0.1 Cabeçalho
 • Data da última atualização: 28/07/2026
-• Documento: LP Factory 10 — Schema (DB Contract) v1.0.35
+• Documento: LP Factory 10 — Schema (DB Contract) v1.0.36
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -1014,14 +1014,14 @@
 
 3.7.2 activate_landing_page_generation_profile(uuid, timestamptz) → table
 • Ativa um `draft` com concorrência otimista e arquiva atomicamente a versão `active` anterior do mesmo taxon.
-• Registra `generation_profile_activated` sem reutilizar correlação de proposta.
+• Registra `generation_profile_activated` reutilizando, quando disponível, o `request_id` e o `correlation_status` do último salvamento do `draft`; na ausência de correlação salva, registra `correlation_status = unavailable`.
 
 3.7.3 archive_landing_page_generation_profile(uuid, timestamptz) → table
 • Arquiva uma versão `draft` ou `active` com concorrência otimista.
 • Registra `generation_profile_archived`.
 
 3.7.4 get_landing_page_generation_profile_lifecycle_status() → table
-• Retorna readiness administrativo calculado a partir de tabelas, constraints, RLS e grants exigidos pelo lifecycle.
+• Retorna readiness administrativo calculado a partir das RPCs, grants, RLS e ausência de policies exigidos pelo lifecycle.
 
 • Migration aplicada: `supabase/migrations/20260728153500_e12_4_3_generation_profile_lifecycle.sql`.
 • Provas pós-apply: `supabase/tests/e12_4_3_generation_profile_lifecycle.test.sql` e `supabase/snippets/e12_4_3_generation_profile_lifecycle_verify.sql`.


### PR DESCRIPTION
Reconciliação documental final da E12.4.3 e E12.4.3.1 após os gates pós-merge e hospedados.

Corrige docs/schema.md para registrar que a ativação reutiliza a correlação do último salvamento do draft quando disponível e para limitar o readiness às RPCs, grants, RLS e ausência de policies realmente verificados. Reconciliam-se em docs/roadmap.md os estados concluídos da E12.4.3, E12.4.3.1 e E20.3.

Gates concluídos: workflow idempotente; migration aplicada sem reaplicação; teste SQL transacional com ROLLBACK; verificador read-only; RPCs, ACLs, RLS e policies; configuração OpenAI no Vercel Preview; fluxo humano autenticado em desktop e mobile; proposta inicial, refinamento, estado sujo, ausência de salvamento/ativação automáticos e gate negativo da E10.8.

Nenhuma migration, código, banco, configuração externa ou dado foi alterado por este PR. A validação hospedada não foi repetida, conforme o veredito. Validação documental: git diff --check aprovado; npm ci e npm run check não aplicáveis ao delta exclusivamente documental.