### PR TITLE
E12.4: planeja criação e evolução estrutural do perfil

### DIFF
--- a/docs/lousa-plano-base-e12-4.md
+++ b/docs/lousa-plano-base-e12-4.md
@@ -1,7 +1,7 @@
 # Plano-base — E12.4 — Gestão do perfil de orientação
 
 - Data: 29/07/2026.
-- Versão: v2.3.
+- Versão: v2.4.
 - Status: E12.4.3 e E12.4.3.1 implementadas, validadas e reconciliadas na `main`; E12.4.3.2 planejada como correção funcional do fluxo de proposta estrutural.
 - Recorte previsto para o roadmap: `12.4 — Gestão do perfil de orientação`.
 - Recorte executável inicial: `12.4.3 — Proposta, revisão, aprovação e ativação do perfil`.
@@ -62,12 +62,11 @@
 - O mesmo `platform_admin` pode revisar e executar `Aprovar e ativar`; a decisão é humana e auditada, sem novo status persistido.
 - Quando não houver perfil próprio, a ação inicial destacada deve ser `Criar perfil com IA`; o fluxo manual permanece alternativa completa.
 - A IA usa `lp_sections` como fonte estrutural principal e os demais blocos resolvidos da E10.8 apenas como contexto.
-- A IA propõe somente:
-  - correspondência entre cada seção pesquisada e identidades válidas do catálogo;
-  - módulo e variante disponíveis;
-  - prioridade `P1`, `P2` ou `P3`;
-  - ordem recomendada;
-  - seções atendidas parcialmente ou sem correspondência no catálogo.
+- A resposta estrutural separa obrigatoriamente:
+  - `coverage[]`, com uma avaliação para cada item de `lp_sections`;
+  - `recommendations[]`, com a lista final deduplicada por módulo.
+- Cada item de `coverage[]` preserva `item_key`, nome da seção, prioridade e ordem de origem e informa cobertura `covered`, `partial` ou `missing`, além das identidades compatíveis, motivo e impacto quando aplicáveis.
+- `recommendations[]` contém somente módulo e variante disponíveis, prioridade `P1`, `P2` ou `P3` e ordem recomendada.
 - A IA não cria módulo, variante ou identidade e não preenche nem modifica `generation_guidance` ou `item_guidance`.
 - `generation_guidance`, no perfil-pai, e `item_guidance`, no item-filho, são exceções opcionais preenchidas somente pelo humano.
 - O refinamento por IA atua apenas sobre a estrutura proposta e preserva integralmente as exceções humanas existentes.
@@ -83,7 +82,7 @@
 
 - E10.8 fornece a pesquisa resolvida e versionada; dentro dela, `lp_sections` é a fonte estrutural principal da proposta.
 - E18.4 e E18.5 fornecem limites e identidades vigentes para a geração inicial; a E12.4.3.2 não os redefine nem cria módulos.
-- E20.3 continua responsável pelo contrato, persistência e resolução do perfil; a E12.4.3.2 aplica somente o delta mínimo para tornar `generation_guidance` opcional.
+- Tornar `generation_guidance` opcional altera o contrato de domínio da E20.3; a evolução é formalizada na E20.3.5 e implementada no mesmo PR técnico da E12.4.3.2.
 - E12.4.3.2 corrige a criação e o refinamento estrutural do perfil no Admin Dashboard.
 - E12.4.4 deverá, obrigatoriamente:
   - recalcular ou recuperar os gaps antes de autorizar geração;
@@ -91,11 +90,11 @@
   - classificar se o gap é impeditivo;
   - bloquear autorização enquanto houver gap impeditivo;
   - verificar incompatibilidades entre exceções humanas e os contratos usados na geração inicial.
-- E19.4 deverá formalizar:
-  - geração e materialização com snapshot das fontes usadas;
-  - independência da LP materializada;
-  - liberdade posterior de edição pelo cliente dentro das capacidades técnicas, de funcionamento e de segurança do editor;
-  - proteção contra regeneração que apague silenciosamente alterações humanas.
+- O snapshot das fontes e a independência da LP materializada permanecem decisões consolidadas para consumo futuro pela E19.4.
+- O futuro plano-base da E19.4 deverá decidir, sem antecipação neste plano:
+  - quais edições o cliente poderá fazer após a materialização;
+  - quais limites permanentes pertencem ao editor;
+  - se haverá regeneração e como ela tratará alterações humanas.
 
 ## 2. Contrato do caso
 
@@ -123,17 +122,23 @@
   - exigir ação explícita do `platform_admin` e resolução completa da E10.8;
   - usar todos os itens de `lp_sections` como esqueleto;
   - fazer correspondência semântica somente com identidades válidas da E18.5;
-  - propor módulo, variante, prioridade e ordem;
+  - produzir `coverage[]` para avaliar cada seção e `recommendations[]` como lista final única por módulo;
+  - permitir que várias seções apontem para o mesmo módulo e que uma seção aponte para mais de um módulo;
+  - converter a prioridade de origem explicitamente em `3 → P1`, `2 → P2` e `1 → P3`;
+  - ao deduplicar um módulo, preservar a prioridade mais alta entre as seções cobertas;
+  - ordenar recomendações pela menor ordem de origem; em empate, usar a primeira ocorrência em `coverage[]` e depois `module_key`, atribuindo ordens finais positivas e únicas em intervalos de 10;
   - separar seções atendidas, parcialmente atendidas e sem correspondência;
   - não inventar identidade nem preencher ou modificar exceções humanas;
   - realizar no máximo uma chamada por acionamento, sem retry ou encadeamento;
-  - validar deterministicamente cobertura, identidades, duplicidades e ordem;
+  - validar deterministicamente cobertura, identidades, duplicidades, conversão de prioridade e ordem final;
   - preencher o editor sem persistência automática.
 - Tratamento do delta:
   - apresentar seção pesquisada, prioridade, ordem, motivo da ausência e impacto de prosseguir;
-  - `Aguardar criação dos módulos` mantém o perfil sem conclusão estrutural e não cria nada automaticamente na E18.5;
-  - `Prosseguir com os disponíveis` usa somente recomendações válidas e mantém aviso visível;
-  - gaps e decisão permanecem transitórios neste recorte; registro e reavaliação pertencem à E12.4.4.
+  - `Aguardar criação dos módulos` mantém o perfil em `draft`, bloqueia `Aprovar e ativar` e não cria nada automaticamente na E18.5;
+  - `Prosseguir com os disponíveis` usa somente recomendações válidas e mantém aviso visível na sessão corrente;
+  - nenhuma nova tabela é criada e os gaps não integram as tabelas do perfil;
+  - ao salvar o rascunho, registrar no evento de auditoria vigente a decisão `wait_for_modules` ou `proceed_with_available`, os `item_key` afetados, quantidade de gaps, impacto resumido e versões das fontes usadas;
+  - a auditoria preserva a decisão, mas não substitui o recálculo obrigatório dos gaps pela E12.4.4 antes da prontidão.
 - Validação:
   - validar taxon, agregado, identidades e versões antes de salvar, ativar ou arquivar;
   - rejeitar saída ou mutação incompatível sem alterar o `draft` nem o `active`.
@@ -200,6 +205,7 @@
   - usar `Salvar rascunho` tanto após proposta da IA quanto após edição humana.
 - Aprovar e ativar:
   - revalidar o agregado;
+  - bloquear quando a última decisão auditada para o rascunho for `wait_for_modules`;
   - registrar a decisão humana;
   - arquivar o `active` anterior, quando existir;
   - ativar o novo `draft`;
@@ -212,6 +218,7 @@
   - reutilizar o mecanismo vigente, sem nova tabela;
   - registrar somente mutações confirmadas;
   - distinguir criação ou salvamento de `draft` com origem manual ou IA;
+  - incluir no `changes_json` do salvamento a decisão humana sobre gaps e seu resumo auditável, quando houver;
   - registrar `Aprovar e ativar` como uma operação;
   - registrar arquivamento explícito.
 
@@ -223,7 +230,7 @@
 - A RPC de arquivamento deve bloquear e revalidar o perfil, receber e conferir `expected_updated_at`, aceitar apenas `draft` ou `active`, registrar arquivamento explícito na mesma transação e não criar fallback intermediário.
 - Cada RPC deve reutilizar explicitamente `public.audit_context_event(...)` dentro da mesma transação da mutação confirmada, incluindo `request_id` e resultado humano em `changes_json` quando aplicáveis. É proibido substituir esse vínculo por auditoria paralela ou operação posterior best-effort.
 - Antes de salvar e novamente antes de ativar, o boundary puro deve validar o agregado pelo schema vigente e cada identidade exclusivamente por `validateLandingPageModuleIdentity`. O adapter não aceita DTO não validado nem importa o registry da E18.5.
-- A E12.4.3.2 deve criar migration incremental própria para permitir `generation_guidance` nulo, sem alterar migrations históricas, preservando invariantes e atualizando RPCs, DTOs, schemas, testes e verificador read-only.
+- A evolução E20.3.5 deve ser materializada por migration incremental própria no PR técnico da E12.4.3.2 para permitir `generation_guidance` nulo, sem alterar migrations históricas, preservando invariantes e atualizando RPCs, DTOs, schemas, testes e verificador read-only.
 
 ### 2.4. Contrato da assistência por IA
 
@@ -237,10 +244,11 @@
   - delta de cobertura parcial ou ausente, com motivo e impacto.
 - A saída não contém `generation_guidance` nem `item_guidance`.
 - A resposta estruturada separa:
-  - recomendações válidas vinculadas ao `item_key` de origem;
-  - gaps vinculados ao `item_key`, com cobertura `partial` ou `missing`, prioridade, ordem, motivo e impacto.
-- O vínculo de origem e os gaps são transitórios e não integram as tabelas do perfil.
-- A validação determinística comprova que todos os itens de `lp_sections` foram avaliados, que identidades existem, que a variante pertence ao módulo e que não há módulo ou ordem duplicados.
+  - `coverage[]`, com exatamente uma avaliação por `item_key`, podendo referenciar zero, uma ou várias identidades válidas;
+  - `recommendations[]`, deduplicado por módulo e sem obrigação de relação um para um com as seções.
+- Várias seções podem convergir para uma recomendação; uma seção pode originar várias recomendações quando funções estruturais distintas forem necessárias.
+- `coverage[]` e os gaps não integram as tabelas do perfil; a decisão humana é registrada no evento de auditoria existente.
+- A validação determinística comprova cobertura de todos os itens, conversão `3 → P1`, `2 → P2`, `1 → P3`, identidades existentes, vínculo da variante, deduplicação por módulo e ordens finais positivas e únicas.
 - No refinamento, o provider recebe somente a estrutura atual e feedback estrutural; o merge local preserva integralmente as exceções humanas.
 - Cada clique em `Criar perfil com IA` ou `Refinar estrutura com IA` autoriza uma chamada, sem conversa, histórico, memória, `previous_response_id`, retry ou encadeamento.
 - A proposta válida substitui somente a estrutura visível; salvar, ativar, arquivar e decidir sobre gaps permanecem ações humanas.
@@ -263,7 +271,7 @@
 - Quando houver gaps, mostrar seção, prioridade, ordem, motivo e impacto, com:
   - `Aguardar criação dos módulos`;
   - `Prosseguir com os disponíveis`.
-- O aviso permanece visível durante a criação e revisão quando o humano prosseguir.
+- O aviso permanece visível na sessão corrente quando o humano prosseguir; após recarga, a E12.4.3.2 não promete reconstruí-lo pelas tabelas do perfil, e a E12.4.4 deverá recalcular os gaps.
 - Ações visuais:
   - criar nova versão;
   - criar perfil com IA;
@@ -373,19 +381,22 @@
 - Entregas:
   - destacar `Criar perfil com IA` antes do editor manual;
   - usar todos os itens de `lp_sections` como esqueleto;
-  - retornar somente recomendações estruturais e gaps;
+  - retornar `coverage[]`, recomendações estruturais deduplicadas e gaps;
+  - aplicar as regras explícitas de cardinalidade, prioridade e ordem;
   - perguntar se o humano aguarda módulos ou prossegue com os disponíveis;
-  - manter aviso transitório quando houver pendência;
+  - auditar a decisão no evento vigente e manter aviso na sessão corrente;
   - tornar `generation_guidance` opcional por migration incremental;
   - preservar `item_guidance` opcional;
   - impedir alteração de exceções humanas pela IA;
   - registrar em E12.4.4 a obrigação de recuperar gaps e decidir prontidão;
   - registrar em E19.4 a independência da LP materializada.
 - Critérios de aceite:
-  - cada item de `lp_sections` aparece como atendido, parcialmente atendido ou faltante;
+  - `coverage[]` avalia exatamente cada item de `lp_sections` como atendido, parcialmente atendido ou faltante;
+  - `recommendations[]` aceita um-para-muitos e muitos-para-um, mas termina único por módulo;
   - somente identidades válidas entram nas recomendações;
-  - prioridade e ordem são propostas para todas as seções;
+  - a prioridade de origem é convertida por `3 → P1`, `2 → P2`, `1 → P3` e a ordem final é determinística, positiva e única;
   - gaps exibem seção, motivo, impacto e decisão humana;
+  - a decisão é auditada no salvamento, `wait_for_modules` bloqueia ativação e a E12.4.4 recalcula gaps;
   - IA não produz nem altera `generation_guidance` ou `item_guidance`;
   - prosseguir não oculta a pendência e aguardar não cria módulo automaticamente;
   - lifecycle, auditoria e resolver active-only permanecem funcionais;
@@ -446,7 +457,7 @@
 
 - Confirmar:
   - quatro seções principais, numeração e ordem preservadas;
-  - E12.4.3.2 registrada como sub-recorte corretivo, sem reabrir E20.3;
+  - E12.4.3.2 registrada como sub-recorte corretivo e E20.3.5 como evolução do contrato de domínio;
   - `lp_sections` como fonte estrutural principal;
   - IA limitada a módulos, variantes, prioridade, ordem e gaps;
   - `generation_guidance` e `item_guidance` como exceções opcionais humanas;
@@ -463,7 +474,7 @@
   - implementação da E12.4.3.2;
   - migration incremental aplicada e verificada;
   - validações técnicas e visuais aprovadas;
-  - pendências da E12.4.4 e E19.4 registradas nos documentos próprios;
+  - pendência da E12.4.4 e questões ainda não decididas da E19.4 registradas nos documentos próprios;
   - reconciliação documental pelo Prompt ABC;
   - merge humano;
   - confirmação do estado final no ambiente alvo.

--- a/docs/lousa-plano-base-e12-4.md
+++ b/docs/lousa-plano-base-e12-4.md
@@ -1,11 +1,11 @@
 # Plano-base — E12.4 — Gestão do perfil de orientação
 
-- Data: 29/07/2026.
-- Versão: v2.4.
+- Data: 30/07/2026.
+- Versão: v2.5.
 - Status: E12.4.3 e E12.4.3.1 implementadas, validadas e reconciliadas na `main`; E12.4.3.2 planejada como correção funcional do fluxo de proposta estrutural.
 - Recorte previsto para o roadmap: `12.4 — Gestão do perfil de orientação`.
 - Recorte executável inicial: `12.4.3 — Proposta, revisão, aprovação e ativação do perfil`.
-- Recorte corretivo planejado: `12.4.3.2 — Proposta estrutural baseada em lp_sections e delta do catálogo`.
+- Recorte corretivo planejado: `12.4.3.2 — Criação e evolução estrutural baseada em lp_sections, catálogo vigente e debate humano–IA`.
 - Path canônico: `docs/lousa-plano-base-e12-4.md`.
 - Plano conceitual: `docs/lp-planejamento.md`.
 
@@ -17,10 +17,13 @@
 - A E12.4.3 e a E12.4.3.1 já entregaram a operação oficial do lifecycle e a assistência por IA no editor.
 - O teste do primeiro perfil revelou um desvio funcional: a tela começa pelo preenchimento manual e a IA também propõe textos de orientação, quando a ação principal deveria criar a estrutura a partir de `lp_sections`.
 - A E12.4.3.2 deve corrigir o fluxo para que:
-  - a primeira ação humana destacada seja `Criar perfil com IA`;
+  - sem perfil próprio, a ação destacada seja `Criar perfil com IA`;
+  - com perfil `active` próprio, a nova versão use `Evoluir perfil com IA` e inicialize o editor com a estrutura completa ativa como baseline;
   - `lp_sections` seja o esqueleto obrigatório da análise;
-  - a IA proponha somente módulos e variantes válidos, prioridade e ordem;
+  - a IA reavalie cada recomendação contra as pesquisas e o catálogo vigentes, propondo somente módulos e variantes válidos, prioridade e ordem;
+  - o debate ocorra sobre a nova versão em `draft`, com proposta candidata e diff transitórios antes de qualquer aplicação ao editor;
   - a IA informe o delta de seções sem módulo ou variante compatível;
+  - a pesquisa bruta arquivada seja usada apenas como contexto complementar quando existir e couber integralmente na requisição, sem novo gate;
   - `generation_guidance` e `item_guidance` sejam exceções opcionais e exclusivamente humanas;
   - o humano escolha entre aguardar a criação dos módulos faltantes ou prosseguir com os disponíveis, mantendo aviso explícito.
 - O resultado continua sendo um perfil orientativo. Não é composição final, LP, autorização de geração nem criação automática de módulo.
@@ -36,6 +39,7 @@
 - `docs/base-tecnica.md`.
 - `docs/schema.md`.
 - `docs/lousa-plano-base-e20-3.md`.
+- PR #662 e convenção opcional `docs/pesquisas-brutas/<taxon_slug>/<audience_scope>/v<research_version>.md`.
 - PR #644 e implementação vigente da E20.3:
   - `lib/conversion-content/landing-page/generation-profile/`;
   - `lib/conversion-content/adapters/landingPageGenerationProfileAdapter.ts`;
@@ -58,19 +62,26 @@
 - Ultranicho usa o perfil `active` do ancestral elegível mais próximo.
 - Os estados persistidos permanecem somente `draft`, `active` e `archived`.
 - Uma versão `active` é imutável; mudança exige nova versão em `draft`.
+- Ao iniciar a evolução, o editor copia integralmente a estrutura do `active` como baseline transitório; a cópia não persiste e nenhuma recomendação herdada continua válida sem reavaliação.
 - Existe no máximo uma versão `active` por taxon proprietário e a versão é única nesse taxon.
 - O mesmo `platform_admin` pode revisar e executar `Aprovar e ativar`; a decisão é humana e auditada, sem novo status persistido.
-- Quando não houver perfil próprio, a ação inicial destacada deve ser `Criar perfil com IA`; o fluxo manual permanece alternativa completa.
-- A IA usa `lp_sections` como fonte estrutural principal e os demais blocos resolvidos da E10.8 apenas como contexto.
+- Quando não houver perfil próprio, a ação inicial destacada deve ser `Criar perfil com IA`; quando houver perfil `active` próprio, a ação contextual deve ser `Evoluir perfil com IA`.
+- O fluxo manual permanece alternativa completa nos dois contextos.
+- A hierarquia das fontes é: E10.8 estruturada, aprovada e obrigatória como fonte operacional; E18.5 como fonte canônica das identidades executáveis; pesquisa bruta como contexto complementar opcional; feedback humano como hipótese ou orientação a avaliar.
+- A IA usa `lp_sections` como esqueleto estrutural e os demais blocos resolvidos da E10.8 como contexto obrigatório.
+- Quando existir pesquisa bruta correspondente à proveniência efetivamente resolvida pela E10.8, ela pode complementar a análise sem substituir, ampliar ou contrariar a fonte estruturada; divergências devem ser apresentadas ao humano e a E10.8 continua governando o perfil.
 - A resposta estrutural separa obrigatoriamente:
   - `coverage[]`, com uma avaliação para cada item de `lp_sections`;
   - `recommendations[]`, com a lista final deduplicada por módulo.
 - Cada item de `coverage[]` preserva `item_key`, nome da seção, prioridade e ordem de origem e informa cobertura `covered`, `partial` ou `missing`, além das identidades compatíveis, motivo e impacto quando aplicáveis.
 - `recommendations[]` contém somente módulo e variante disponíveis, prioridade `P1`, `P2` ou `P3` e ordem recomendada.
+- `coverage[]`, referências entre seções e módulos, gaps e estados do diff são derivados e transitórios; somente `recommendations[]`, depois de aplicada ao editor e persistida por `Salvar rascunho`, integra o perfil.
 - A IA não cria módulo, variante ou identidade e não preenche nem modifica `generation_guidance` ou `item_guidance`.
 - `generation_guidance`, no perfil-pai, e `item_guidance`, no item-filho, são exceções opcionais preenchidas somente pelo humano.
-- O refinamento por IA atua apenas sobre a estrutura proposta e preserva integralmente as exceções humanas existentes.
-- Cada acionamento humano autoriza somente uma chamada, sem conversa persistente, memória, retry ou continuidade automática.
+- A criação e a evolução por IA atuam somente sobre a estrutura da nova versão em `draft` e preservam integralmente as exceções humanas existentes.
+- Em cada rodada, a proposta candidata permanece apenas no estado transitório da interface; nova rodada recebe o draft original, a candidata exibida e o feedback humano mais recente.
+- `Aplicar proposta` altera somente o editor não salvo; `Refinar novamente` mantém o editor original intacto; `Descartar proposta` remove a candidata e preserva o editor original.
+- Cada acionamento humano autoriza somente uma chamada, sem chat persistente, memória própria, retry ou continuidade automática; a candidata transitória é reenviada explicitamente como entrada quando houver nova rodada.
 - Quando houver faltantes, o humano escolhe:
   - aguardar a criação dos módulos, sem concluir o perfil como estruturalmente completo;
   - prosseguir com os disponíveis, mantendo aviso explícito da pendência.
@@ -103,23 +114,28 @@
 - Gatilho:
   - `platform_admin` acessa a gestão de perfis no Admin Dashboard;
   - seleciona um segmento ou nicho;
-  - inicia manualmente uma nova versão ou solicita a proposta opcional por IA.
+  - sem perfil próprio, inicia manualmente ou usa `Criar perfil com IA`;
+  - com perfil `active` próprio, inicia a nova versão e usa `Evoluir perfil com IA` quando desejar assistência.
 - Entrada comum:
   - taxon proprietário e cadeia ativa;
   - perfil `active` atual, quando existir;
   - identidades públicas vigentes da E18.4 e E18.5.
 - Entrada adicional da IA:
-  - resultado completo e resolvido da E10.8, com versões e proveniência;
-  - última versão anteriormente ativa do perfil, quando houver;
-  - conteúdo atual do editor, quando o acionamento for um refinamento;
-  - feedback humano mais recente do `platform_admin`, quando informado.
+  - resultado completo e resolvido da E10.8, com `sourceTaxonId`, `audienceScope`, versões e proveniência;
+  - estrutura completa do perfil `active` próprio como baseline, quando houver;
+  - conteúdo original atual do editor da nova versão em `draft`;
+  - proposta candidata transitória, quando houver nova rodada antes da aplicação;
+  - feedback humano mais recente do `platform_admin`, quando informado;
+  - pesquisa bruta opcional correspondente a cada fonte resolvida, localizada pelo slug canônico server-side do `sourceTaxonId`, `audienceScope` e `version`, somente quando existir e couber integralmente na requisição.
 - Processamento manual:
-  - iniciar a próxima versão no editor;
+  - iniciar a próxima versão no editor; quando houver `active` próprio, copiar integralmente sua estrutura como baseline não persistido;
   - preencher recomendações e, excepcionalmente, `generation_guidance` e `item_guidance`;
   - persistir somente após `Salvar rascunho`;
   - permitir alteração somente enquanto a versão estiver em `draft`.
 - Processamento com IA:
   - exigir ação explícita do `platform_admin` e resolução completa da E10.8;
+  - comparar as versões e proveniências vigentes da E10.8 e as identidades e contratos vigentes da E18.5 com o baseline ativo;
+  - copiar apenas o que continua válido e reavaliar semanticamente o que mudou, sem manter recomendação apenas por herança;
   - usar todos os itens de `lp_sections` como esqueleto;
   - fazer correspondência semântica somente com identidades válidas da E18.5;
   - produzir `coverage[]` para avaliar cada seção e `recommendations[]` como lista final única por módulo;
@@ -131,13 +147,17 @@
   - não inventar identidade nem preencher ou modificar exceções humanas;
   - realizar no máximo uma chamada por acionamento, sem retry ou encadeamento;
   - validar deterministicamente cobertura, identidades, duplicidades, conversão de prioridade e ordem final;
-  - preencher o editor sem persistência automática.
+    - apresentar a proposta candidata e o diff antes de alterar o editor;
+  - permitir `Aplicar proposta`, `Refinar novamente` ou `Descartar proposta`;
+  - aplicar somente ao editor e nunca persistir automaticamente.
 - Tratamento do delta:
+  - comparar candidata e editor original e mostrar módulos mantidos, adicionados, removidos e substituídos, além de variantes, prioridades e ordens alteradas e gaps novos ou resolvidos;
+  - usar `mantido`, `adicionado`, `alterado` e `removido` somente como estados derivados de apresentação, sem persistência no perfil;
   - apresentar seção pesquisada, prioridade, ordem, motivo da ausência e impacto de prosseguir;
   - `Aguardar criação dos módulos` mantém o perfil em `draft`, bloqueia `Aprovar e ativar` e não cria nada automaticamente na E18.5;
   - `Prosseguir com os disponíveis` usa somente recomendações válidas e mantém aviso visível na sessão corrente;
   - nenhuma nova tabela é criada e os gaps não integram as tabelas do perfil;
-  - ao salvar o rascunho, registrar no evento de auditoria vigente a decisão `wait_for_modules` ou `proceed_with_available`, os `item_key` afetados, quantidade de gaps, impacto resumido e versões das fontes usadas;
+  - ao salvar o rascunho, registrar no evento de auditoria vigente a decisão `wait_for_modules` ou `proceed_with_available`, os `item_key` afetados, quantidade de gaps, impacto resumido, versões das fontes usadas e, quando utilizada, referência segura da pesquisa bruta com path, versão declarada, commit ou blob, público e taxon de origem;
   - a auditoria preserva a decisão, mas não substitui o recálculo obrigatório dos gaps pela E12.4.4 antes da prontidão.
 - Validação:
   - validar taxon, agregado, identidades e versões antes de salvar, ativar ou arquivar;
@@ -199,7 +219,9 @@
 
 - Criar nova versão:
   - calcular a próxima versão sem sobrescrever histórico;
-  - persistir como `draft` somente após confirmação humana.
+  - quando houver `active` próprio, inicializar o editor com sua estrutura completa como baseline não persistido;
+  - reavaliar todas as recomendações contra E10.8 e E18.5 vigentes antes da aprovação;
+  - persistir como `draft` somente após `Salvar rascunho`.
 - Salvar:
   - permitir apenas sobre `draft`;
   - usar `Salvar rascunho` tanto após proposta da IA quanto após edição humana.
@@ -247,12 +269,14 @@
   - `coverage[]`, com exatamente uma avaliação por `item_key`, podendo referenciar zero, uma ou várias identidades válidas;
   - `recommendations[]`, deduplicado por módulo e sem obrigação de relação um para um com as seções.
 - Várias seções podem convergir para uma recomendação; uma seção pode originar várias recomendações quando funções estruturais distintas forem necessárias.
-- `coverage[]` e os gaps não integram as tabelas do perfil; a decisão humana é registrada no evento de auditoria existente.
+- `coverage[]`, referências seção–módulo, estados do diff e gaps não integram as tabelas do perfil; somente `recommendations[]` aplicadas e salvas integram o agregado, e a decisão humana sobre gaps é registrada no evento de auditoria existente.
 - A validação determinística comprova cobertura de todos os itens, conversão `3 → P1`, `2 → P2`, `1 → P3`, identidades existentes, vínculo da variante, deduplicação por módulo e ordens finais positivas e únicas.
-- No refinamento, o provider recebe somente a estrutura atual e feedback estrutural; o merge local preserva integralmente as exceções humanas.
-- Cada clique em `Criar perfil com IA` ou `Refinar estrutura com IA` autoriza uma chamada, sem conversa, histórico, memória, `previous_response_id`, retry ou encadeamento.
-- A proposta válida substitui somente a estrutura visível; salvar, ativar, arquivar e decidir sobre gaps permanecem ações humanas.
-- A implementação reutiliza `OPENAI_API_KEY` e `OPENAI_LANDING_PAGE_GENERATION_PROFILE_MODEL`, Responses API, JSON Schema estrito, `store = false`, limite de 96 KiB e timeout de 30 segundos.
+- Em cada rodada, o provider recebe o editor original, a proposta candidata transitória quando existir e o feedback estrutural mais recente; o merge local preserva integralmente as exceções humanas.
+- Cada clique em `Criar perfil com IA`, `Evoluir perfil com IA` ou `Refinar novamente` autoriza uma chamada, sem chat persistente, histórico próprio, memória, `previous_response_id`, retry ou encadeamento.
+- A proposta válida é exibida como candidata com diff; somente `Aplicar proposta` substitui a estrutura visível do editor, e salvar, ativar, arquivar e decidir sobre gaps permanecem ações humanas separadas.
+- A implementação reutiliza `OPENAI_API_KEY` e `OPENAI_LANDING_PAGE_GENERATION_PROFILE_MODEL`, Responses API, JSON Schema estrito, `store = false`, limite integral de 96 KiB por requisição e timeout de 30 segundos.
+- O carregamento da pesquisa bruta é server-side e determinístico no path `docs/pesquisas-brutas/<taxon_slug>/<audience_scope>/v<research_version>.md`; ausência não bloqueia o fluxo.
+- A pesquisa bruta só é incluída integralmente quando couber junto às fontes obrigatórias; se não couber, é omitida sem truncamento silencioso, a proposta continua com E10.8 e E18.5 e a interface informa transitoriamente a omissão por limite.
 - Limite de saída ou custo só muda após fixtures comprovarem cobertura, qualidade e custo; truncamento é `technical_failure` e preserva o editor.
 - A função de IA não recebe cliente de banco e não salva, ativa, arquiva, cria módulo ou corrige dados.
 - O mapeamento de falhas permanece fechado entre `missing_information`, `invalid_data` e `technical_failure`.
@@ -265,8 +289,10 @@
 - Exibição clara do perfil atual como próprio, herdado ou ausente.
 - Versão e status sempre visíveis.
 - Editor único para recomendações e exceções humanas opcionais.
-- Na ausência de perfil próprio, `Criar perfil com IA` aparece antes do editor técnico como ação principal; o preenchimento manual permanece alternativa.
-- Após proposta válida, o editor mostra módulos, variantes, prioridade e ordem para revisão.
+- Na ausência de perfil próprio, `Criar perfil com IA` aparece antes do editor técnico como ação principal; com perfil `active` próprio, a ação contextual é `Evoluir perfil com IA`; o preenchimento manual permanece alternativa.
+- A evolução inicializa o editor da nova versão com a estrutura ativa completa, sem salvar automaticamente.
+- Antes da aplicação, a interface mostra candidata, diff e as ações `Aplicar proposta`, `Refinar novamente` e `Descartar proposta`, preservando o editor original.
+- Após `Aplicar proposta`, o editor mostra ordem, módulo, variante preferencial opcional e prioridade; módulo presente na lista está recomendado e não existe estado ativado/desativado por item.
 - `generation_guidance` e `item_guidance` aparecem como exceções humanas opcionais, visualmente secundárias e sem sugestão automática.
 - Quando houver gaps, mostrar seção, prioridade, ordem, motivo e impacto, com:
   - `Aguardar criação dos módulos`;
@@ -274,8 +300,8 @@
 - O aviso permanece visível na sessão corrente quando o humano prosseguir; após recarga, a E12.4.3.2 não promete reconstruí-lo pelas tabelas do perfil, e a E12.4.4 deverá recalcular os gaps.
 - Ações visuais:
   - criar nova versão;
-  - criar perfil com IA;
-  - refinar estrutura com IA;
+  - `Criar perfil com IA` ou `Evoluir perfil com IA`, conforme o contexto;
+  - `Aplicar proposta`, `Refinar novamente` e `Descartar proposta` durante o debate transitório;
   - `Salvar rascunho`;
   - `Aprovar e ativar`;
   - arquivar.
@@ -289,7 +315,7 @@
 
 - Toda leitura e mutação operacional permanece server-side.
 - Toda mutação exige `platform_admin` confirmado pelo guard vigente.
-- A IA não recebe dados de conta, oferta, campanha, LP, copy produzida, tabelas brutas de pesquisa ou registry interno da E18.5.
+- A IA não recebe dados de conta, oferta, campanha, LP, copy produzida, tabelas brutas do banco ou registry interno da E18.5; pode receber somente o Markdown opcional autorizado e resolvido pelas regras deste plano.
 - Registrar o mínimo necessário para diagnóstico e auditoria:
   - `platform_admin` solicitante;
   - taxon e versões das fontes utilizadas;
@@ -298,7 +324,7 @@
   - latência, consumo e custo da chamada quando houver;
   - resultado da revisão humana.
 - Logs não devem expor segredo, credencial ou conteúdo não autorizado.
-- Cada solicitação de proposta deve registrar evento estruturado com `request_id`, identificador do `platform_admin`, taxon, versões e relações de proveniência da E10.8, versão das identidades públicas da E18.5, modelo configurado, OpenAI response ID quando disponível, latência, `input_tokens`, `output_tokens`, custo calculado pelas tarifas operacionais vigentes, resultado (`success`, `missing_information`, `invalid_data` ou `technical_failure`) e, posteriormente, resultado da revisão humana. Logs não podem conter API key, prompt integral, orientação livre do admin, pesquisas brutas, payload completo nem resposta integral. Falha de logging não altera o resultado funcional.
+- Cada solicitação de proposta deve registrar evento estruturado com `request_id`, identificador do `platform_admin`, taxon, versões e relações de proveniência da E10.8, versão das identidades públicas da E18.5, referência segura da pesquisa bruta quando utilizada ou motivo transitório de omissão, modelo configurado, OpenAI response ID quando disponível, latência, `input_tokens`, `output_tokens`, custo calculado pelas tarifas operacionais vigentes, resultado (`success`, `missing_information`, `invalid_data` ou `technical_failure`) e, posteriormente, resultado da revisão humana. Logs não podem conter API key, prompt integral, orientação livre do admin, pesquisas brutas, payload completo nem resposta integral. Falha de logging não altera o resultado funcional.
 - O provider retorna ao editor um `request_id` opaco e um fingerprint da proposta, usados somente para correlação e nunca para autorização. Ao salvar, a Server Action recomputa o fingerprint: igualdade registra revisão `aceita`; diferença registra `ajustada`. A RPC inclui `request_id` e resultado da revisão no `changes_json` do evento de auditoria da mutação confirmada. A ativação recupera a correlação do último evento auditado do `draft` e registra o mesmo `request_id` como `ativada`. Substituir ou limpar uma proposta ainda não salva registra apenas evento estruturado `descartada`, sem linha de domínio ou nova tabela. Valores ausentes ou inválidos de correlação não impedem o fluxo funcional e são registrados como correlação indisponível.
 - A chamada deve usar `store:false`. Isso evita estado de aplicação da resposta, mas não elimina por si só os logs de monitoramento de abuso da OpenAI, que podem ser retidos por até 30 dias no regime padrão; portanto somente a allowlist de dados já aprovada pode sair do LP Factory. Não se exige Moderation API no MVP porque a saída é interna, estruturada, sem ação autônoma e obrigatoriamente revisada por `platform_admin`; essa decisão deve ser reavaliada se o conteúdo passar a ser publicado ou enviado externamente sem revisão equivalente.
 
@@ -363,12 +389,12 @@
 
 - Status: implementada e validada; seu escopo será restringido pela E12.4.3.2.
 - Objetivo final:
-  - refinar módulos, variantes, prioridade, ordem e gaps, preservando exceções humanas.
+  - sustentar rodadas explícitas de debate sobre a nova versão em `draft`, refinando módulos, variantes, prioridade, ordem e gaps e preservando exceções humanas.
 - Critérios finais:
   - cada refinamento exige novo acionamento explícito;
-  - não existe conversa, memória ou continuidade automática;
+  - não existe chat persistente, memória própria ou continuidade automática; a proposta candidata é somente estado transitório explícito da interface;
   - falha preserva editor, `draft` e `active`;
-  - proposta refinada mantém alterações não salvas e bloqueia ativação até novo salvamento;
+  - proposta refinada permanece candidata até aplicação; depois de aplicada, mantém alterações não salvas e bloqueia ativação até novo salvamento;
   - `generation_guidance` e `item_guidance` nunca são enviados para alteração pela IA.
 - Escopo negativo:
   - sem tabela, rota estrutural, chat, histórico, memória, agente, `previous_response_id`, provider adicional, E12.4.4 ou geração de LP.
@@ -377,11 +403,15 @@
 
 - Status: planejada; implementação pendente após aprovação deste plano.
 - Objetivo:
-  - corrigir a ação inicial, o contrato da IA e a opcionalidade das exceções humanas sem refazer o lifecycle entregue.
+  - corrigir a criação e a evolução estrutural, o debate humano–IA, o contrato da proposta e a opcionalidade das exceções humanas sem refazer o lifecycle entregue.
 - Entregas:
-  - destacar `Criar perfil com IA` antes do editor manual;
+  - destacar `Criar perfil com IA` sem perfil próprio e `Evoluir perfil com IA` quando existir perfil `active` próprio;
+- inicializar a nova versão com a estrutura ativa completa como baseline não persistido e revalidar cada recomendação contra as fontes vigentes;
   - usar todos os itens de `lp_sections` como esqueleto;
   - retornar `coverage[]`, recomendações estruturais deduplicadas e gaps;
+- manter `coverage[]`, relações seção–módulo, gaps e estados do diff como resultados transitórios;
+- mostrar candidata e diff antes da aplicação e permitir aplicar, refinar novamente ou descartar sem alterar o editor original;
+- carregar opcionalmente a pesquisa bruta pela proveniência resolvida da E10.8, sem novo gate, truncamento silencioso ou bloqueio por ausência;
   - aplicar as regras explícitas de cardinalidade, prioridade e ordem;
   - perguntar se o humano aguarda módulos ou prossegue com os disponíveis;
   - auditar a decisão no evento vigente e manter aviso na sessão corrente;
@@ -391,7 +421,9 @@
   - registrar em E12.4.4 a obrigação de recuperar gaps e decidir prontidão;
   - registrar em E19.4 a independência da LP materializada.
 - Critérios de aceite:
-  - `coverage[]` avalia exatamente cada item de `lp_sections` como atendido, parcialmente atendido ou faltante;
+  - `coverage[]` avalia exatamente cada item de `lp_sections` como atendido, parcialmente atendido ou faltante e não é persistido;
+- evolução parte da estrutura ativa completa, mas só mantém recomendações revalidadas contra as versões vigentes da E10.8 e da E18.5;
+- rodadas adicionais recebem draft original, candidata atual e novo feedback; descartar preserva o editor original;
   - `recommendations[]` aceita um-para-muitos e muitos-para-um, mas termina único por módulo;
   - somente identidades válidas entram nas recomendações;
   - a prioridade de origem é convertida por `3 → P1`, `2 → P2`, `1 → P3` e a ordem final é determinística, positiva e única;
@@ -402,13 +434,13 @@
   - lifecycle, auditoria e resolver active-only permanecem funcionais;
   - migration e contratos aceitam `generation_guidance` ausente ou não vazio;
   - testes cobrem cobertura, gaps, identidade inventada, preservação de exceções, env ausente, timeout e truncamento;
-  - Preview desktop e mobile comprovam ação inicial, editor preenchido, decisão de gaps e ausência de salvamento ou ativação automática.
+  - Preview desktop e mobile comprovam ações contextuais, baseline ativo, candidata com diff, aplicar/refinar/descartar, editor não salvo, decisão de gaps e ausência de salvamento ou ativação automática.
 - Escopo negativo:
   - sem tabela de gaps, criação automática de módulos, diálogo com IA para exceções, E12.4.4, E19.4, geração, job, fila, agente ou nova infraestrutura.
 
 ### 3.2. Próxima ação
 
-- Aprovar e mergear a v2.3 documental.
+- Aprovar e mergear a v2.5 documental.
 - Implementar a E12.4.3.2 em PR técnico próprio criado a partir da `main` atual.
 - Não usar o PR #656, que permanece restrito à correção e ao reteste da E11.1.7.
 - No PR técnico, aplicar o menor delta em UI, contrato da proposta, normalização, migration incremental, testes e documentos canônicos materialmente afetados.
@@ -432,7 +464,7 @@
 - Quarto status, estado `approved`, terceira tabela de domínio ou tabela própria de auditoria.
 - Escrita direta por `public`, `anon`, `authenticated`, cliente ou `ai_readonly`.
 - Ativação, salvamento, repetição ou correção automática pela IA.
-- Chat, histórico de mensagens, memória persistente, `previous_response_id`, diálogo com IA para exceções humanas, refinamento automático, retry automático, comparação de versões ou otimização baseada em métricas.
+- Chat persistente, histórico de mensagens, memória própria, `previous_response_id`, diálogo com IA para exceções humanas, refinamento automático, retry automático ou otimização baseada em métricas.
 - Agente, comportamento agentic, job, fila, cron, webhook, workflow ou nova infraestrutura.
 - Implementação além do menor delta necessário para cumprir as entregas e os critérios de aceite da E12.4.3.
 - Refatoração, limpeza ou reorganização de áreas não indispensáveis à E12.4.3.
@@ -469,7 +501,7 @@
 
 ### 4.4. Critérios de encerramento do plano
 
-- O plano v2.3 será encerrado somente após:
+- O plano v2.5 será encerrado somente após:
   - decisão conceitual aprovada;
   - implementação da E12.4.3.2;
   - migration incremental aplicada e verificada;

--- a/docs/lousa-plano-base-e12-4.md
+++ b/docs/lousa-plano-base-e12-4.md
@@ -1,10 +1,11 @@
 # Plano-base — E12.4 — Gestão do perfil de orientação
 
-- Data: 28/07/2026.
-- Versão: v2.2.
-- Status: plano-base v2 vigente com a E12.4.3.1 como implementação candidata no PR draft #654; revisão delta aprovada e provas hospedadas e gates pós-merge ainda pendentes.
+- Data: 29/07/2026.
+- Versão: v2.3.
+- Status: E12.4.3 e E12.4.3.1 implementadas, validadas e reconciliadas na `main`; E12.4.3.2 planejada como correção funcional do fluxo de proposta estrutural.
 - Recorte previsto para o roadmap: `12.4 — Gestão do perfil de orientação`.
 - Recorte executável inicial: `12.4.3 — Proposta, revisão, aprovação e ativação do perfil`.
+- Recorte corretivo planejado: `12.4.3.2 — Proposta estrutural baseada em lp_sections e delta do catálogo`.
 - Path canônico: `docs/lousa-plano-base-e12-4.md`.
 - Plano conceitual: `docs/lp-planejamento.md`.
 
@@ -12,14 +13,17 @@
 
 ### 1.1. Problema e resultado esperado
 
-- A E20.3 já fornece o contrato versionado, a persistência mínima e a resolução server-side, read-only e fail-closed do perfil `active` próprio ou herdado.
-- Ainda não existe operação oficial para o `platform_admin` criar, revisar, ativar ou arquivar versões do perfil.
-- A E12.4.3 deve entregar no Admin Dashboard:
-  - fluxo manual completo;
-  - assistência opcional por IA para propor uma nova versão;
-  - lifecycle humano e controlado entre `draft`, `active` e `archived`;
-  - primeiro cadastro e primeira ativação oficiais do perfil.
-- O resultado é uma nova versão do perfil orientativo. Não é uma composição final, uma LP ou uma autorização de geração.
+- A E20.3 fornece o contrato versionado, a persistência mínima e a resolução server-side, read-only e fail-closed do perfil `active` próprio ou herdado.
+- A E12.4.3 e a E12.4.3.1 já entregaram a operação oficial do lifecycle e a assistência por IA no editor.
+- O teste do primeiro perfil revelou um desvio funcional: a tela começa pelo preenchimento manual e a IA também propõe textos de orientação, quando a ação principal deveria criar a estrutura a partir de `lp_sections`.
+- A E12.4.3.2 deve corrigir o fluxo para que:
+  - a primeira ação humana destacada seja `Criar perfil com IA`;
+  - `lp_sections` seja o esqueleto obrigatório da análise;
+  - a IA proponha somente módulos e variantes válidos, prioridade e ordem;
+  - a IA informe o delta de seções sem módulo ou variante compatível;
+  - `generation_guidance` e `item_guidance` sejam exceções opcionais e exclusivamente humanas;
+  - o humano escolha entre aguardar a criação dos módulos faltantes ou prosseguir com os disponíveis, mantendo aviso explícito.
+- O resultado continua sendo um perfil orientativo. Não é composição final, LP, autorização de geração nem criação automática de módulo.
 
 ### 1.2. Fontes usadas
 
@@ -36,39 +40,62 @@
   - `lib/conversion-content/landing-page/generation-profile/`;
   - `lib/conversion-content/adapters/landingPageGenerationProfileAdapter.ts`;
   - migration `20260726144651_e20_3_generation_profile.sql`.
-- Parecer do Gestor de Automações e decisão humana de 28/07/2026:
+- Parecer do Gestor de Automações e decisões humanas de 28 e 29/07/2026:
   - automação opcional;
   - categoria `Automação com IA em fluxo controlado`;
   - ambiente `Runtime do LP Factory`;
   - OpenAI condicional;
   - acionamento exclusivo pelo `platform_admin`;
-  - validação determinística, revisão e ativação humanas e fallback manual completo.
+  - validação determinística, revisão e ativação humanas e fallback manual completo;
+  - `lp_sections` como fonte estrutural principal da proposta;
+  - IA limitada a módulos, variantes, prioridade, ordem e delta do catálogo;
+  - `generation_guidance` e `item_guidance` como exceções opcionais exclusivamente humanas;
+  - independência da LP materializada em relação às fontes usadas na geração inicial.
 
 ### 1.3. Decisões funcionais fixas
 
 - Perfil próprio é permitido somente para segmento e nicho no MVP.
 - Ultranicho usa o perfil `active` do ancestral elegível mais próximo.
 - Os estados persistidos permanecem somente `draft`, `active` e `archived`.
-- Uma versão `active` é imutável.
-- Mudança de orientação exige nova versão em `draft`.
-- Existe no máximo uma versão `active` por taxon proprietário.
-- A versão é única por taxon proprietário.
-- O mesmo `platform_admin` pode revisar e executar `Aprovar e ativar`.
-- A aprovação é decisão humana e evento auditado dentro de `Aprovar e ativar`; não é status persistido nem resultado estável separado.
-- A IA apenas propõe conteúdo para o editor. Não salva, aprova, ativa, arquiva nem gera LP.
-- A proposta pode iniciar ou refinar o conteúdo do editor; cada acionamento humano autoriza somente uma chamada, sem conversa persistente, memória própria ou continuidade automática.
-- A operação manual permanece completa quando a IA não for usada, falhar ou estiver indisponível.
-- A LP materializada permanece independente e não muda quando o perfil evolui.
-- A E12.4.4 e as subseções posteriores permanecem fora deste plano.
+- Uma versão `active` é imutável; mudança exige nova versão em `draft`.
+- Existe no máximo uma versão `active` por taxon proprietário e a versão é única nesse taxon.
+- O mesmo `platform_admin` pode revisar e executar `Aprovar e ativar`; a decisão é humana e auditada, sem novo status persistido.
+- Quando não houver perfil próprio, a ação inicial destacada deve ser `Criar perfil com IA`; o fluxo manual permanece alternativa completa.
+- A IA usa `lp_sections` como fonte estrutural principal e os demais blocos resolvidos da E10.8 apenas como contexto.
+- A IA propõe somente:
+  - correspondência entre cada seção pesquisada e identidades válidas do catálogo;
+  - módulo e variante disponíveis;
+  - prioridade `P1`, `P2` ou `P3`;
+  - ordem recomendada;
+  - seções atendidas parcialmente ou sem correspondência no catálogo.
+- A IA não cria módulo, variante ou identidade e não preenche nem modifica `generation_guidance` ou `item_guidance`.
+- `generation_guidance`, no perfil-pai, e `item_guidance`, no item-filho, são exceções opcionais preenchidas somente pelo humano.
+- O refinamento por IA atua apenas sobre a estrutura proposta e preserva integralmente as exceções humanas existentes.
+- Cada acionamento humano autoriza somente uma chamada, sem conversa persistente, memória, retry ou continuidade automática.
+- Quando houver faltantes, o humano escolhe:
+  - aguardar a criação dos módulos, sem concluir o perfil como estruturalmente completo;
+  - prosseguir com os disponíveis, mantendo aviso explícito da pendência.
+- E18.4, E18.5, E10.8 e o perfil orientam somente a geração inicial.
+- Depois de materializada, a LP pertence à conta e permanece independente dessas fontes; mudanças nelas não alteram nem governam automaticamente a LP existente.
+- A E12.4.4 e a E19.4 permanecem fora da implementação deste plano, com pendências explícitas registradas em 1.4.
 
 ### 1.4. Fronteiras de responsabilidade
 
-- E10.8 fornece a pesquisa estruturada resolvida e versionada usada pela proposta por IA.
-- E18.4 e E18.5 mantêm seus contratos vigentes; a E12.4.3 não os redefine.
-- E20.3 continua responsável pelo contrato, validação, persistência e resolução do perfil.
-- E12.4.3 opera criação, edição, revisão, ativação e arquivamento por `platform_admin`.
-- E12.4.4 tratará autorização e revogação por conta, taxon e plano.
-- E19.4 e planos posteriores tratarão geração e materialização da LP.
+- E10.8 fornece a pesquisa resolvida e versionada; dentro dela, `lp_sections` é a fonte estrutural principal da proposta.
+- E18.4 e E18.5 fornecem limites e identidades vigentes para a geração inicial; a E12.4.3.2 não os redefine nem cria módulos.
+- E20.3 continua responsável pelo contrato, persistência e resolução do perfil; a E12.4.3.2 aplica somente o delta mínimo para tornar `generation_guidance` opcional.
+- E12.4.3.2 corrige a criação e o refinamento estrutural do perfil no Admin Dashboard.
+- E12.4.4 deverá, obrigatoriamente:
+  - recalcular ou recuperar os gaps antes de autorizar geração;
+  - registrar adiamento com justificativa, impacto, responsável e condição de retomada;
+  - classificar se o gap é impeditivo;
+  - bloquear autorização enquanto houver gap impeditivo;
+  - verificar incompatibilidades entre exceções humanas e os contratos usados na geração inicial.
+- E19.4 deverá formalizar:
+  - geração e materialização com snapshot das fontes usadas;
+  - independência da LP materializada;
+  - liberdade posterior de edição pelo cliente dentro das capacidades técnicas, de funcionamento e de segurança do editor;
+  - proteção contra regeneração que apague silenciosamente alterações humanas.
 
 ## 2. Contrato do caso
 
@@ -89,18 +116,24 @@
   - feedback humano mais recente do `platform_admin`, quando informado.
 - Processamento manual:
   - iniciar a próxima versão no editor;
-  - preencher orientação geral e recomendações;
+  - preencher recomendações e, excepcionalmente, `generation_guidance` e `item_guidance`;
   - persistir somente após `Salvar rascunho`;
   - permitir alteração somente enquanto a versão estiver em `draft`.
 - Processamento com IA:
-  - exigir ação explícita do `platform_admin`;
-  - verificar a resolução completa da E10.8 antes da chamada;
-  - fornecer somente as entradas autorizadas;
-  - distinguir a primeira proposta, sem conteúdo anterior, do refinamento que recebe o estado atual do editor e o feedback humano mais recente;
-  - realizar no máximo uma chamada por acionamento, sem retry ou encadeamento automático;
-  - receber proposta limitada aos campos do perfil;
-  - validar a saída deterministicamente;
+  - exigir ação explícita do `platform_admin` e resolução completa da E10.8;
+  - usar todos os itens de `lp_sections` como esqueleto;
+  - fazer correspondência semântica somente com identidades válidas da E18.5;
+  - propor módulo, variante, prioridade e ordem;
+  - separar seções atendidas, parcialmente atendidas e sem correspondência;
+  - não inventar identidade nem preencher ou modificar exceções humanas;
+  - realizar no máximo uma chamada por acionamento, sem retry ou encadeamento;
+  - validar deterministicamente cobertura, identidades, duplicidades e ordem;
   - preencher o editor sem persistência automática.
+- Tratamento do delta:
+  - apresentar seção pesquisada, prioridade, ordem, motivo da ausência e impacto de prosseguir;
+  - `Aguardar criação dos módulos` mantém o perfil sem conclusão estrutural e não cria nada automaticamente na E18.5;
+  - `Prosseguir com os disponíveis` usa somente recomendações válidas e mantém aviso visível;
+  - gaps e decisão permanecem transitórios neste recorte; registro e reavaliação pertencem à E12.4.4.
 - Validação:
   - validar taxon, agregado, identidades e versões antes de salvar, ativar ou arquivar;
   - rejeitar saída ou mutação incompatível sem alterar o `draft` nem o `active`.
@@ -110,6 +143,7 @@
   - manter `public`, `anon`, `authenticated`, cliente e `ai_readonly` sem escrita direta;
   - usar uma única ação visual `Salvar rascunho`;
   - executar `Aprovar e ativar` atomicamente, arquivando a versão `active` anterior quando existir;
+  - tornar `generation_guidance` opcional por migration incremental e atualizar contrato, schemas, DTOs e RPCs pelo menor delta;
   - implementar a superfície em `app/admin/(protected)/perfis-de-orientacao/`, com listagem em `page.tsx`, edição por taxon em `[taxonId]/page.tsx`, Server Actions route-local em `actions.ts` e componentes com estado próprio somente em `_components/`;
   - ajustar `components/admin/adminNavigation.ts` para expor a área;
   - exigir que toda Server Action execute `requirePlatformAdmin` antes de ler entradas operacionais, chamar IA ou mutar estado;
@@ -121,7 +155,8 @@
 - Consumo:
   - Admin Dashboard apresenta versões e o perfil resolvido atual;
   - o boundary vigente da E20.3 continua entregando somente o perfil `active` próprio ou herdado;
-  - somente gerações futuras poderão consumir a nova versão ativa.
+  - somente a futura geração inicial poderá consumir a nova versão ativa;
+  - a LP materializada não recebe atualização automática quando catálogo, pesquisa ou perfil evoluem.
 - Fallback:
   - manter o editor manual disponível sem IA;
   - preservar o `active` atual em qualquer falha de proposta, salvamento ou ativação;
@@ -131,21 +166,29 @@
 ### 2.2. Contrato do perfil e validações
 
 - O taxon proprietário deve ser segmento ou nicho ativo.
-- `generation_guidance` deve ser texto não vazio.
+- `generation_guidance`:
+  - opcional no banco, contrato e interface;
+  - texto não vazio quando informado;
+  - preenchimento e alteração exclusivamente humanos.
 - Cada recomendação deve conter:
   - módulo e versão existentes;
   - `variant_key` e `variant_version` ambas presentes ou ambas ausentes;
   - variante existente e pertencente ao módulo, quando informada;
   - prioridade `P1`, `P2` ou `P3`;
   - ordem recomendada inteira positiva;
-  - orientação específica não vazia, quando presente.
+  - `item_guidance` opcional, não vazio quando presente e exclusivamente humano.
+- Exemplos de exceção humana:
+  - `generation_guidance`: usar somente duas cores nas LPs do nicho;
+  - `item_guidance`: impor uma faixa específica ao título do módulo hero.
 - No mesmo perfil:
   - módulo não pode se repetir;
   - ordem recomendada não pode se repetir;
   - a versão não pode se repetir para o mesmo taxon proprietário.
-- Prioridade e ordem permanecem orientativas.
-- Nenhum campo pode transformar módulo em obrigatório.
+- Prioridade e ordem permanecem orientativas e nenhum campo transforma módulo em obrigatório.
 - Identidade ausente ou incompatível falha fechado e não é criada ou corrigida automaticamente.
+- A E12.4.3.2 não interpreta semanticamente as exceções humanas nem permite que alterem E18.4 ou E18.5.
+- Exceção humana incompatível pode permanecer no perfil, mas não autoriza geração: a E12.4.4 deve classificá-la como não pronta e a futura geração deve falhar fechado.
+- Os gaps da proposta não são persistidos nas tabelas do perfil neste recorte.
 
 ### 2.3. Lifecycle, atomicidade e auditoria
 
@@ -180,16 +223,32 @@
 - A RPC de arquivamento deve bloquear e revalidar o perfil, receber e conferir `expected_updated_at`, aceitar apenas `draft` ou `active`, registrar arquivamento explícito na mesma transação e não criar fallback intermediário.
 - Cada RPC deve reutilizar explicitamente `public.audit_context_event(...)` dentro da mesma transação da mutação confirmada, incluindo `request_id` e resultado humano em `changes_json` quando aplicáveis. É proibido substituir esse vínculo por auditoria paralela ou operação posterior best-effort.
 - Antes de salvar e novamente antes de ativar, o boundary puro deve validar o agregado pelo schema vigente e cada identidade exclusivamente por `validateLandingPageModuleIdentity`. O adapter não aceita DTO não validado nem importa o registry da E18.5.
+- A E12.4.3.2 deve criar migration incremental própria para permitir `generation_guidance` nulo, sem alterar migrations históricas, preservando invariantes e atualizando RPCs, DTOs, schemas, testes e verificador read-only.
 
 ### 2.4. Contrato da assistência por IA
 
-- A assistência por IA é opcional e exclusivamente server-side. Uma Server Action protegida por `requirePlatformAdmin()` deve chamar uma função server-only local ao boundary `lib/conversion-content/landing-page/generation-profile/`. Antes da chamada, a função deve resolver a E10.8 pela API pública `resolveLandingPageResearchForTaxon`, exigir resultado completo e obter módulos e variantes somente pelas APIs públicas da E18.5.
-- A implementação deve reutilizar `OPENAI_API_KEY` e usar a variável dedicada `OPENAI_LANDING_PAGE_GENERATION_PROFILE_MODEL`, sem fallback hardcoded; o valor inicial de referência é `gpt-5.4-mini`. A chamada deve usar `POST https://api.openai.com/v1/responses`, `text.format.type = json_schema`, `strict = true`, `store = false`, `max_output_tokens = 2000` e timeout de 30 segundos. O request não deve fornecer `tools`, `previous_response_id`, background mode ou qualquer mecanismo agentic. O corpo JSON integral da requisição, já serializado e incluindo schema e instruções, não pode exceder 96 KiB. Não existe retry automático.
-- Com os limites e tarifas vigentes na consolidação da v2, o teto operacional de referência deve permanecer inferior a aproximadamente US$ 0,09 por chamada. Antes de habilitar qualquer troca do modelo configurado ou mudança material de tarifa, repetir as fixtures de contrato, qualidade e custo e atualizar a referência operacional; configuração alterada sem essa evidência mantém a assistência indisponível e não afeta o fluxo manual.
-- A saída permitida contém somente `generation_guidance` e `recommendations[]`, cada recomendação limitada a `module_key`, `module_version`, `variant_key`, `variant_version`, `priority`, `recommended_order` e `item_guidance`. Todos os objetos do JSON Schema devem usar `additionalProperties: false`. A proposta deve passar por schema Zod próprio e pela validação pública de identidade da E18.5 antes de preencher o editor. A função de IA não recebe cliente de banco e não salva, ativa, arquiva ou corrige dados.
-- O primeiro clique humano em `Solicitar proposta por IA` e cada clique posterior em `Refinar com IA` autorizam, cada um, uma única chamada paga. No refinamento, o DTO autorizado inclui o conteúdo atual do editor e o feedback humano mais recente; não usa `previous_response_id`, conversa, histórico persistente ou memória própria. A proposta válida apenas substitui o conteúdo visível do editor após validação; `Salvar rascunho`, `Aprovar e ativar` e arquivamento permanecem ações humanas independentes. Env ausente ou indisponibilidade da OpenAI tornam somente a assistência indisponível, preservando o fluxo manual completo.
-- O contrato e a validação puros permanecem em `lib/conversion-content/landing-page/generation-profile/`, e o provider fica em adapter server-only separado. A Server Action protegida monta somente o DTO autorizado usando `resolveLandingPageResearchForTaxon`, a última versão anteriormente ativa própria do taxon quando houver, o estado atual validado do editor no refinamento, o feedback humano mais recente e APIs públicas da E18.5; perfil herdado ou ausência atual não substituem silenciosamente essa entrada histórica. O provider não importa Supabase, tabelas, registry interno nem adapter de mutação. Sua saída completa retorna ao boundary puro, é validada e somente então preenche o editor. O caminho de proposta ou refinamento não chama RPC de salvamento, ativação ou arquivamento.
-- O mapeamento de falhas é fechado e preserva os códigos reais da E10.8: ausência, incompletude ou inelegibilidade legítima retornam `missing_information`; `READ_FAILED` e `SOURCE_NOT_NORMALIZABLE` retornam `technical_failure`; `RESEARCH_INVALID` e `RESEARCH_AMBIGUOUS` retornam `invalid_data`, sem mascaramento como ausência. Schema de proposta inválido, identidade inexistente, variante incompatível, módulo ou ordem duplicados, corpo autorizado acima de 96 KiB e demais violações do agregado retornam `invalid_data` antes de qualquer chamada quando aplicável. Configuração ausente, timeout, erro HTTP, recusa, conteúdo filtrado, resposta incompleta, ausência de output ou falha de parsing retornam `technical_failure`, com motivo técnico seguro apenas nos logs. Qualquer falha preserva integralmente os valores atuais do editor, o `draft` e o `active`. Nova tentativa exige nova ação explícita do `platform_admin`.
+- A assistência permanece opcional, exclusivamente server-side e protegida por `requirePlatformAdmin()`.
+- Antes da chamada, o boundary resolve a E10.8, exige resultado completo, separa `lp_sections` e obtém módulos e variantes somente pelas APIs públicas da E18.5.
+- `lp_sections` é o esqueleto obrigatório; `strategic_core`, `lp_overview` e `seo` apenas contextualizam prioridade, ordem e escolha entre identidades válidas.
+- A saída da IA contém somente:
+  - correspondências entre itens de `lp_sections` e módulos ou variantes válidos;
+  - prioridade `P1`, `P2` ou `P3`;
+  - ordem recomendada;
+  - delta de cobertura parcial ou ausente, com motivo e impacto.
+- A saída não contém `generation_guidance` nem `item_guidance`.
+- A resposta estruturada separa:
+  - recomendações válidas vinculadas ao `item_key` de origem;
+  - gaps vinculados ao `item_key`, com cobertura `partial` ou `missing`, prioridade, ordem, motivo e impacto.
+- O vínculo de origem e os gaps são transitórios e não integram as tabelas do perfil.
+- A validação determinística comprova que todos os itens de `lp_sections` foram avaliados, que identidades existem, que a variante pertence ao módulo e que não há módulo ou ordem duplicados.
+- No refinamento, o provider recebe somente a estrutura atual e feedback estrutural; o merge local preserva integralmente as exceções humanas.
+- Cada clique em `Criar perfil com IA` ou `Refinar estrutura com IA` autoriza uma chamada, sem conversa, histórico, memória, `previous_response_id`, retry ou encadeamento.
+- A proposta válida substitui somente a estrutura visível; salvar, ativar, arquivar e decidir sobre gaps permanecem ações humanas.
+- A implementação reutiliza `OPENAI_API_KEY` e `OPENAI_LANDING_PAGE_GENERATION_PROFILE_MODEL`, Responses API, JSON Schema estrito, `store = false`, limite de 96 KiB e timeout de 30 segundos.
+- Limite de saída ou custo só muda após fixtures comprovarem cobertura, qualidade e custo; truncamento é `technical_failure` e preserva o editor.
+- A função de IA não recebe cliente de banco e não salva, ativa, arquiva, cria módulo ou corrige dados.
+- O mapeamento de falhas permanece fechado entre `missing_information`, `invalid_data` e `technical_failure`.
+- Qualquer falha preserva editor, exceções humanas, `draft` e `active`; nova tentativa exige nova ação explícita.
 
 ### 2.5. Critérios visuais
 
@@ -197,11 +256,18 @@
 - Seleção somente de segmento e nicho.
 - Exibição clara do perfil atual como próprio, herdado ou ausente.
 - Versão e status sempre visíveis.
-- Editor único para orientação geral e recomendações.
+- Editor único para recomendações e exceções humanas opcionais.
+- Na ausência de perfil próprio, `Criar perfil com IA` aparece antes do editor técnico como ação principal; o preenchimento manual permanece alternativa.
+- Após proposta válida, o editor mostra módulos, variantes, prioridade e ordem para revisão.
+- `generation_guidance` e `item_guidance` aparecem como exceções humanas opcionais, visualmente secundárias e sem sugestão automática.
+- Quando houver gaps, mostrar seção, prioridade, ordem, motivo e impacto, com:
+  - `Aguardar criação dos módulos`;
+  - `Prosseguir com os disponíveis`.
+- O aviso permanece visível durante a criação e revisão quando o humano prosseguir.
 - Ações visuais:
   - criar nova versão;
-  - solicitar proposta por IA;
-  - refinar com IA quando houver conteúdo no editor;
+  - criar perfil com IA;
+  - refinar estrutura com IA;
   - `Salvar rascunho`;
   - `Aprovar e ativar`;
   - arquivar.
@@ -287,36 +353,67 @@
 
 #### 3.1.1. E12.4.3.1 — Refinamento iterativo assistido por IA
 
-- Objetivo:
-  - permitir que o `platform_admin` refine a proposta no editor com o conteúdo corrente e seu feedback humano mais recente, sem transformar o refinamento em frente, conversa ou automação independente.
-- Entregas:
-  - manter `Solicitar proposta por IA` para o editor sem conteúdo anterior e apresentar `Refinar com IA` quando houver conteúdo;
-  - enviar E10.8 completa, identidades públicas da E18.5, referências vigentes, conteúdo atual validado do editor e feedback humano mais recente;
-  - receber e validar uma proposta completa antes de substituir somente o conteúdo visível do editor;
-  - reutilizar modelo, tarifa, limites, gates, correlação e observabilidade da E12.4.3.
-- Critérios de aceite:
-  - primeira proposta funciona sem conteúdo anterior;
-  - refinamento usa o conteúdo atual e o feedback humano mais recente;
-  - falha ou resposta inválida preserva integralmente editor, `draft` e `active`;
-  - proposta refinada mantém o editor com alterações não salvas e bloqueia a ativação;
-  - nenhuma chamada salva ou ativa, e cada refinamento exige novo acionamento explícito.
+- Status: implementada e validada; seu escopo será restringido pela E12.4.3.2.
+- Objetivo final:
+  - refinar módulos, variantes, prioridade, ordem e gaps, preservando exceções humanas.
+- Critérios finais:
+  - cada refinamento exige novo acionamento explícito;
+  - não existe conversa, memória ou continuidade automática;
+  - falha preserva editor, `draft` e `active`;
+  - proposta refinada mantém alterações não salvas e bloqueia ativação até novo salvamento;
+  - `generation_guidance` e `item_guidance` nunca são enviados para alteração pela IA.
 - Escopo negativo:
-  - sem tabela, migration, RPC, rota estrutural, chat, histórico de mensagens, memória persistente, agente, autonomia, `previous_response_id`, provider adicional, abstração genérica, comparação automática, métricas de desempenho, E12.4.4 ou geração de LP.
+  - sem tabela, rota estrutural, chat, histórico, memória, agente, `previous_response_id`, provider adicional, E12.4.4 ou geração de LP.
+
+#### 3.1.2. E12.4.3.2 — Proposta estrutural baseada em `lp_sections` e delta do catálogo
+
+- Status: planejada; implementação pendente após aprovação deste plano.
+- Objetivo:
+  - corrigir a ação inicial, o contrato da IA e a opcionalidade das exceções humanas sem refazer o lifecycle entregue.
+- Entregas:
+  - destacar `Criar perfil com IA` antes do editor manual;
+  - usar todos os itens de `lp_sections` como esqueleto;
+  - retornar somente recomendações estruturais e gaps;
+  - perguntar se o humano aguarda módulos ou prossegue com os disponíveis;
+  - manter aviso transitório quando houver pendência;
+  - tornar `generation_guidance` opcional por migration incremental;
+  - preservar `item_guidance` opcional;
+  - impedir alteração de exceções humanas pela IA;
+  - registrar em E12.4.4 a obrigação de recuperar gaps e decidir prontidão;
+  - registrar em E19.4 a independência da LP materializada.
+- Critérios de aceite:
+  - cada item de `lp_sections` aparece como atendido, parcialmente atendido ou faltante;
+  - somente identidades válidas entram nas recomendações;
+  - prioridade e ordem são propostas para todas as seções;
+  - gaps exibem seção, motivo, impacto e decisão humana;
+  - IA não produz nem altera `generation_guidance` ou `item_guidance`;
+  - prosseguir não oculta a pendência e aguardar não cria módulo automaticamente;
+  - lifecycle, auditoria e resolver active-only permanecem funcionais;
+  - migration e contratos aceitam `generation_guidance` ausente ou não vazio;
+  - testes cobrem cobertura, gaps, identidade inventada, preservação de exceções, env ausente, timeout e truncamento;
+  - Preview desktop e mobile comprovam ação inicial, editor preenchido, decisão de gaps e ausência de salvamento ou ativação automática.
+- Escopo negativo:
+  - sem tabela de gaps, criação automática de módulos, diálogo com IA para exceções, E12.4.4, E19.4, geração, job, fila, agente ou nova infraestrutura.
 
 ### 3.2. Próxima ação
 
-- Submeter o PR draft #654 à autorização final de merge humano, preservando a E12.4.3.1 como implementação candidata.
-- Não marcar a E12.4.3.1 como concluída antes das provas hospedadas aplicáveis e da execução dos gates pós-merge previstos neste plano.
-- Preservar `vercel#1 — AI Gateway` e `supa#63 — rlsautotest` apenas como oportunidades estratégicas condicionais, sem implementação neste recorte.
+- Aprovar e mergear a v2.3 documental.
+- Implementar a E12.4.3.2 em PR técnico próprio criado a partir da `main` atual.
+- Não usar o PR #656, que permanece restrito à correção e ao reteste da E11.1.7.
+- No PR técnico, aplicar o menor delta em UI, contrato da proposta, normalização, migration incremental, testes e documentos canônicos materialmente afetados.
+- Não marcar a E12.4.3.2 como concluída antes de migration aplicada, verificador read-only aprovado, checks e validação humana hospedada em desktop e mobile.
+- Preservar `vercel#1 — AI Gateway` e `supa#63 — rlsautotest` apenas como oportunidades estratégicas condicionais.
 
 ## 4. Escopo negativo e critérios de parada
 
 ### 4.1. Escopo negativo
 
-- E12.4.4, autorização ou revogação por conta, taxon e plano.
-- E12.4.5, E12.4.6, E19.4, geração, materialização, preview, publicação ou alteração de LP.
+- Implementação da E12.4.4; somente o registro explícito de suas pendências integra este plano.
+- Autorização ou revogação por conta, taxon e plano.
+- E12.4.5, E12.4.6 e implementação da E19.4; somente o registro da independência da LP integra este plano.
+- Geração, materialização, preview, publicação ou alteração de LP.
 - Perfil próprio de ultranicho.
-- Gaps persistidos, prontidão, aprendizado automático ou evolução automática do catálogo.
+- Tabela ou persistência de gaps na E12.4.3.2, prontidão, aprendizado automático ou evolução automática do catálogo.
 - Criação ou alteração de módulo, variante, E18.4 ou E18.5.
 - Dados de conta, oferta, campanha, LP ou copy produzida.
 - Acesso a tabelas brutas de pesquisa ou ao registry interno da E18.5.
@@ -324,7 +421,7 @@
 - Quarto status, estado `approved`, terceira tabela de domínio ou tabela própria de auditoria.
 - Escrita direta por `public`, `anon`, `authenticated`, cliente ou `ai_readonly`.
 - Ativação, salvamento, repetição ou correção automática pela IA.
-- Chat, histórico de mensagens, memória persistente, `previous_response_id`, refinamento automático, retry automático, comparação de versões ou otimização baseada em métricas.
+- Chat, histórico de mensagens, memória persistente, `previous_response_id`, diálogo com IA para exceções humanas, refinamento automático, retry automático, comparação de versões ou otimização baseada em métricas.
 - Agente, comportamento agentic, job, fila, cron, webhook, workflow ou nova infraestrutura.
 - Implementação além do menor delta necessário para cumprir as entregas e os critérios de aceite da E12.4.3.
 - Refatoração, limpeza ou reorganização de áreas não indispensáveis à E12.4.3.
@@ -348,20 +445,25 @@
 ### 4.3. Validação deste trabalho documental
 
 - Confirmar:
-  - `docs/lousa-plano-base-e12-4.md` e `docs/roadmap.md` ajustados pelo menor delta; `docs/base-tecnica.md` sem alteração por não registrar o payload detalhado da assistência;
-  - quatro seções principais preservadas;
-  - uma única fase executável, `E12.4.3`, com a subfase interna `E12.4.3.1` sem frente independente;
-  - `Automação: sim` com categoria, ambiente, objetivo e limites;
-  - E12.4.4 e subseções posteriores fora do recorte;
-  - ausência de tabela, migration, RPC, rota estrutural, agente, memória ou provider novo.
-- Executar a validação específica, typecheck, check e verificação de whitespace; manter Preview autenticado e teste humano como provas hospedadas pendentes.
+  - quatro seções principais, numeração e ordem preservadas;
+  - E12.4.3.2 registrada como sub-recorte corretivo, sem reabrir E20.3;
+  - `lp_sections` como fonte estrutural principal;
+  - IA limitada a módulos, variantes, prioridade, ordem e gaps;
+  - `generation_guidance` e `item_guidance` como exceções opcionais humanas;
+  - decisão entre aguardar ou prosseguir com aviso;
+  - pendências explícitas da E12.4.4 e E19.4;
+  - PR #656 preservado fora do escopo;
+  - ausência de nova tabela, agente, job, fila, service ou infraestrutura.
+- Para este delta documental, executar revisão do diff e verificação de whitespace; checks de runtime, typecheck e banco pertencem ao futuro PR técnico.
 
 ### 4.4. Critérios de encerramento do plano
 
-- O plano será encerrado somente após:
-  - v2 aprovada;
-  - implementação da E12.4.3;
+- O plano v2.3 será encerrado somente após:
+  - decisão conceitual aprovada;
+  - implementação da E12.4.3.2;
+  - migration incremental aplicada e verificada;
   - validações técnicas e visuais aprovadas;
+  - pendências da E12.4.4 e E19.4 registradas nos documentos próprios;
   - reconciliação documental pelo Prompt ABC;
   - merge humano;
   - confirmação do estado final no ambiente alvo.

--- a/docs/lousa-plano-base-e20-3.md
+++ b/docs/lousa-plano-base-e20-3.md
@@ -1,8 +1,8 @@
 # Plano-base — E20.3 — Perfil de orientação para geração
 
-- Data: 26/07/2026.
-- Versão: v2.
-- Status: plano-base v2 consolidado para o gate do Analista na orquestração end-to-end.
+- Data: 29/07/2026.
+- Versão: v2.1.
+- Status: E20.3.3 e E20.3.4 concluídas; E20.3.5 planejada como evolução mínima do contrato para tornar `generation_guidance` opcional.
 - Recorte previsto para o roadmap: `20.3 — Perfil de orientação para geração de landing_page`.
 - Path canônico: `docs/lousa-plano-base-e20-3.md`.
 - Plano conceitual: `docs/lp-planejamento.md`, após o merge do PR #642.
@@ -19,7 +19,7 @@
 - Ainda não existe o perfil canônico que oriente a geração inicial de `landing_page` para um taxon.
 - A E20.3 deve:
   - representar e persistir minimamente um perfil versionado por taxon proprietário;
-  - reunir orientação geral e recomendações por módulo;
+  - reunir recomendações por módulo e, excepcionalmente, orientação geral humana;
   - validar referências de módulo e variante contra a E18.5;
   - resolver perfil próprio ou herdado;
   - entregar o perfil por um único boundary server-side.
@@ -53,8 +53,8 @@
 - Existe um perfil versionado por `taxon proprietário + versão`, reutilizado entre planos.
 - O perfil pode pertencer a segmento ou nicho; perfil próprio de ultranicho é excepcional e depende de decisão humana explícita no fluxo futuro responsável.
 - O perfil reúne:
-  - orientação geral em `generation_guidance`;
   - recomendações próprias por módulo;
+  - `generation_guidance` opcional, exclusivamente humano e excepcional;
   - variante preferencial, quando aplicável;
   - prioridade;
   - ordem recomendada;
@@ -79,7 +79,7 @@
 - E18.5 define módulos, variantes e contratos; E20.3 apenas referencia suas identidades versionadas e consome a validação pública mínima autorizada, sem acessar registry ou schema internos.
 - E20.2 define entradas; seus valores não integram o perfil.
 - E20.3 fornece contrato, persistência mínima, estados, versões, validação, leitura e resolução.
-- A futura E12.4 opera proposta por IA, revisão humana, primeiro cadastro, aprovação e ativação.
+- A E12.4 opera proposta estrutural por IA, revisão humana, cadastro, aprovação e ativação; a E12.4.3.2 implementará a evolução de domínio E20.3.5 no mesmo PR técnico.
 - Planos posteriores tratam seleção efetiva por prioridade, geração, gaps persistidos, prontidão, autorização, revogação, aprendizado, publicação e evolução da LP.
 
 ## 2. Contrato do caso
@@ -177,7 +177,8 @@
   - FK de cada item para o perfil com `ON UPDATE CASCADE` e `ON DELETE CASCADE`, pois os itens integram o agregado;
   - versão do perfil positiva e única por taxon proprietário;
   - status fechado e índice único parcial de uma versão `active` por taxon proprietário;
-  - `generation_guidance` não vazia após `trim`;
+  - no contrato vigente, `generation_guidance` é obrigatória e não vazia após `trim`;
+  - após a E20.3.5, `generation_guidance` será anulável e, quando presente, continuará não vazia após `trim`;
   - prioridade fechada em `P1`, `P2` e `P3`;
   - ordem recomendada positiva e única por perfil;
   - módulo textual não vazio e único por perfil;
@@ -266,7 +267,8 @@
 - Contrato:
   - perfil válido;
   - estado ou versão inválidos;
-  - `generation_guidance` inválida;
+  - no contrato vigente, `generation_guidance` ausente ou inválida;
+  - após a E20.3.5, ausência aceita e valor presente vazio ou inválido rejeitado;
   - prioridade fora de `P1`, `P2` e `P3`;
   - ordem recomendada inválida;
   - item duplicado;
@@ -370,12 +372,31 @@
   - nenhuma prontidão, autorização, revogação ou geração;
   - `npm run validate:landing-page-module-catalog`, `npm run validate:landing-page-generation-profile`, `npm run check` e `git diff --check` aprovados.
 
-### 3.3. Próxima ação
+### 3.3. E20.3.5 — Opcionalidade da orientação geral
 
-- Submeter esta v2 ao gate do Analista em duas passagens, preservando a independência da Passagem 1 e auditando pareceres e matriz somente na Passagem 2.
-- Após aprovação da v2, reconciliar `docs/roadmap.md` pelo fluxo ABC e submeter o delta ao mesmo Analista.
-- Depois do checkpoint `LP-Factory-Stage: plan-v2-approved`, implementar E20.3.3 e E20.3.4 na ordem, na mesma branch e no mesmo PR draft contra `main`, sem iniciar E12.4.
-- Debater a E12.4 somente após a conclusão da E20.3.
+- Automação: não.
+- Status: planejada; implementação vinculada ao PR técnico da E12.4.3.2.
+- Objetivo:
+  - evoluir o agregado para que `generation_guidance` seja exceção humana opcional, sem alterar estados, herança, resolução active-only ou recomendações.
+- Entregas:
+  - migration incremental forward-only, sem editar a migration histórica da E20.3;
+  - coluna anulável com validação de texto não vazio quando presente;
+  - atualização coordenada de contratos, schemas, DTOs, RPCs, normalização, testes e verificador read-only;
+  - preservação integral de `item_guidance` como campo opcional do item-filho.
+- Critérios de aceite:
+  - perfil válido sem `generation_guidance`;
+  - valor presente vazio ou inválido rejeitado;
+  - perfis históricos preservados;
+  - resolver público mantém o mesmo comportamento próprio, herdado e fail-closed;
+  - nenhuma IA produz ou modifica `generation_guidance` ou `item_guidance`.
+- Escopo negativo:
+  - sem novo estado, tabela, resolver, herança, módulo, variante, gap, prontidão, UI ou infraestrutura própria da E20.3.5.
+
+### 3.4. Próxima ação
+
+- Preservar E20.3.3 e E20.3.4 como concluídas.
+- Aprovar conceitualmente a E20.3.5 junto da E12.4.3.2.
+- Implementar a E20.3.5 no mesmo PR técnico da E12.4.3.2, com migration e reconciliação documental, sem reabrir os demais contratos da E20.3.
 
 ## 4. Escopo negativo e critérios de parada
 
@@ -383,7 +404,7 @@
 
 - Composição obrigatória, estrutura final ou módulo obrigatório.
 - Seleção efetiva por prioridade ou diferenciação por plano.
-- E12.4, Admin Dashboard, IA e aprendizado automático.
+- E12.4, Admin Dashboard, IA e aprendizado automático, exceto a evolução de domínio E20.3.5 executada pelo PR técnico da E12.4.3.2.
 - Cadastro, edição, aprovação, ativação ou arquivamento de perfil.
 - Gaps persistidos, prontidão, autorização ou revogação.
 - Copy, geração, renderização, preview, publicação, tracking ou snapshot.
@@ -432,10 +453,6 @@
 
 ### 4.4. Critérios de encerramento do plano
 
-- O plano encerra após:
-  - implementação das duas fases na ordem;
-  - avaliação do Analista após cada entrega;
-  - merge humano;
-  - confirmação do estado final do banco;
-  - relatório final ao Gestor de Docs.
-- A conclusão da E20.3 libera o debate da E12.4, mas não autoriza sua implementação.
+- E20.3.3 e E20.3.4 estão encerradas após implementação, merge humano e confirmação do banco.
+- A E20.3.5 encerra somente após migration incremental, contratos, testes, verificação do banco, reconciliação documental e merge humano.
+- A E20.3.5 não reabre as fases concluídas nem autoriza ampliar E12.4.3.2.

--- a/docs/lousa-plano-base-e20-3.md
+++ b/docs/lousa-plano-base-e20-3.md
@@ -1,7 +1,7 @@
 # Plano-base — E20.3 — Perfil de orientação para geração
 
-- Data: 29/07/2026.
-- Versão: v2.1.
+- Data: 30/07/2026.
+- Versão: v2.2.
 - Status: E20.3.3 e E20.3.4 concluídas; E20.3.5 planejada como evolução mínima do contrato para tornar `generation_guidance` opcional.
 - Recorte previsto para o roadmap: `20.3 — Perfil de orientação para geração de landing_page`.
 - Path canônico: `docs/lousa-plano-base-e20-3.md`.
@@ -58,7 +58,7 @@
   - variante preferencial, quando aplicável;
   - prioridade;
   - ordem recomendada;
-  - `item_guidance`, quando aplicável.
+  - `item_guidance` opcional e exclusivamente humano, quando aplicável.
 - A prioridade usa enum fechado `P1`, `P2` e `P3`, em ordem decrescente de importância.
 - Prioridade orientará a seleção futura; ordem recomendada indicará a posição relativa entre os módulos selecionados.
 - Nenhuma recomendação torna módulo obrigatório ou redefine a E18.4 ou a E18.5.
@@ -126,13 +126,15 @@
   - versão inteira positiva;
   - estado.
 - Orientação geral:
-  - texto não vazio.
+  - `generation_guidance` opcional;
+  - quando informada, texto não vazio após `trim`;
+  - preenchimento e alteração exclusivamente humanos.
 - Cada item recomendado contém:
   - módulo e versão;
   - variante preferencial e versão, quando aplicável;
   - prioridade `P1`, `P2` ou `P3`;
   - ordem recomendada inteira positiva;
-  - `item_guidance`, quando aplicável.
+  - `item_guidance` opcional e exclusivamente humano, quando aplicável.
 - Regras:
   - `P1` representa maior prioridade, seguida por `P2` e `P3`;
   - não são aceitos `P4`, `P5` ou valores numéricos arbitrários;

--- a/docs/lp-planejamento.md
+++ b/docs/lp-planejamento.md
@@ -57,10 +57,12 @@ Fontes de referência: `README.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `
 - Existe um perfil versionado e evolutivo por taxon proprietário, reutilizado entre planos para orientar a geração inicial da LP.
 - No MVP, o perfil próprio pertence somente a segmento ou nicho; ultranicho usa o perfil `active` do ancestral elegível mais próximo.
 - Os estados persistidos são `draft`, `active` e `archived`.
-- O perfil reúne orientação geral, módulos recomendados, variantes preferenciais, prioridades, ordem recomendada e orientações específicas por módulo.
+- O perfil reúne módulos recomendados, variantes preferenciais, prioridades e ordem recomendada; `generation_guidance` e `item_guidance` são exceções humanas opcionais.
 - Prioridade orienta a seleção futura; ordem recomendada indica a posição relativa entre os módulos selecionados; nenhuma delas torna um módulo obrigatório.
 - A E12.4.3 estabelece o Admin Dashboard como fluxo oficial para o `platform_admin` criar, revisar, salvar, ativar e arquivar versões do perfil.
-- A IA pode propor uma versão inicial ou refinar o conteúdo atual somente após ação explícita; cada acionamento autoriza uma chamada e nenhuma proposta salva, aprova, ativa ou arquiva automaticamente.
+- A E12.4.3.2 usa `lp_sections` como esqueleto: `coverage[]` avalia cada seção e `recommendations[]` entrega a lista final deduplicada por módulo.
+- Várias seções podem convergir para um módulo e uma seção pode exigir vários módulos; a prioridade é convertida por `3 → P1`, `2 → P2`, `1 → P3` e a ordem final é determinística, positiva e única.
+- A IA propõe ou refina somente módulos, variantes, prioridade, ordem e gaps após ação explícita; cada acionamento autoriza uma chamada e nenhuma proposta salva, aprova, ativa ou arquiva automaticamente.
 - O fluxo manual permanece completo quando a IA não é usada, falha ou está indisponível.
 - A orientação pode guiar escolhas dentro dos contratos vigentes, mas não redefinir, ampliar ou contrariar a E18.4 ou a E18.5; módulos e variantes referenciados devem existir na E18.5.
 - Migration, seed, fixture, script ou insert direto podem apoiar testes, mas não substituem o fluxo oficial de gestão do perfil.
@@ -73,10 +75,12 @@ Fontes de referência: `README.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `
 - Identidade inexistente não pode entrar nas recomendações oficiais e deve permanecer como gap para decisão humana.
 - A IA não cria novos contratos automaticamente.
 - O administrador decide se o gap:
-  - bloqueia o perfil ou a prontidão atual e deve retornar à E18.5;
-  - pode ser adiado, com justificativa, impacto, responsável e condição de retomada registrados.
+  - exige `wait_for_modules`, mantém o perfil em `draft` e bloqueia sua ativação;
+  - permite `proceed_with_available`, com aviso na sessão corrente.
+- A decisão e o resumo dos gaps são registrados no evento de auditoria vigente ao salvar o rascunho, sem nova tabela.
+- A E12.4.4 deve recalcular os gaps antes da prontidão e, se houver adiamento, registrar justificativa, impacto, responsável e condição de retomada.
 - Gap de função estrutural aponta para novo módulo; diferença reutilizável de execução aponta para nova variante.
-- Quando o gap for impeditivo, o perfil permanece `draft`, a prontidão não é aprovada e a extensão segue por plano e PR próprios da E18.5.
+- Quando o gap for impeditivo, a prontidão não é aprovada e a extensão segue por plano e PR próprios da E18.5.
 - Depois do merge da nova identidade versionada, a IA deve refazer ou revalidar o perfil antes da aprovação humana.
 - A ampliação da E18.5 deve permanecer simples. Se uma extensão comum voltar a exigir alterações distribuídas, a arquitetura deve ser otimizada antes de prosseguir, sem remover proteções comprovadas.
 
@@ -133,8 +137,8 @@ Fontes de referência: `README.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `
 
 ### 2.5. E20.3 — Perfil de orientação para geração
 
-- Preservar o contrato, a persistência mínima e os três estados do perfil versionado por taxon.
-- Manter orientação geral e recomendações por módulo, com variante preferencial, prioridade, ordem recomendada e orientação específica quando aplicável.
+- Preservar a persistência mínima e os três estados do perfil versionado por taxon.
+- Evoluir o contrato pela E20.3.5 para manter recomendações por módulo e tornar `generation_guidance` exceção humana opcional; `item_guidance` permanece opcional por item.
 - Validar todas as referências contra a E18.5.
 - Resolver perfil próprio ou herdado e entregá-lo por um único boundary server-side.
 - O perfil orienta gerações futuras sem governar ou alterar a LP materializada.
@@ -143,7 +147,8 @@ Fontes de referência: `README.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `
 
 - Operar criação, edição, salvamento, ativação e arquivamento por decisão humana no Admin Dashboard.
 - Manter `Salvar rascunho`, `Aprovar e ativar` e arquivamento como ações explícitas do `platform_admin`.
-- Permitir proposta inicial e refinamento opcional por IA dentro do contrato fechado, sem persistência ou ativação automática.
+- Pela E12.4.3.2, permitir proposta inicial e refinamento estrutural por IA com `coverage[]`, recomendações deduplicadas e gaps, sem persistência ou ativação automática.
+- Não permitir que a IA preencha ou modifique `generation_guidance` ou `item_guidance`.
 - Exigir uma nova ação humana para cada chamada, sem conversa persistente, memória própria, retry ou continuidade automática.
 - Preservar validação determinística, fallback manual completo e independência das LPs já materializadas.
 
@@ -168,6 +173,7 @@ Fontes de referência: `README.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `
 ## 3. Ordem dos próximos planos-base
 
 - Base consolidada para a jornada: E10.8, E18.4, E18.5, E20.2, E20.3 e E12.4.3.
+- Correção anterior à prontidão — implementar E12.4.3.2 e a evolução E20.3.5 no mesmo PR técnico.
 - 1º — implementar E12.4.4 para prontidão, autorização e revogação por conta, taxon e plano.
 - 2º — implementar E19.4 como fluxo real e único de geração, revisão, materialização e publicação por conta.
 - 3º — implementar a avaliação e liberação por E20.4 e E12.4.5–12.4.6.
@@ -184,8 +190,9 @@ Fontes de referência: `README.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `
 ### 4.2. E12
 
 - `12.4.3` opera proposta por IA, revisão, salvamento, aprovação, ativação e arquivamento do perfil.
-- `12.4.3.1` permite refinamento assistido do conteúdo atual do editor, sempre por ação explícita e sem persistência automática.
-- `12.4.4` tratará prontidão, autorização e revogação por conta, taxon e plano.
+- `12.4.3.1` mantém refinamento por ação explícita; após a E12.4.3.2, ele atua somente sobre a estrutura.
+- `12.4.3.2` separa `coverage[]` de `recommendations[]`, restringe a IA à estrutura, audita a decisão sobre gaps e implementa a opcionalidade da orientação geral definida pela E20.3.5.
+- `12.4.4` recalculará gaps e tratará prontidão, autorização e revogação por conta, taxon e plano.
 - `12.4.5` e `12.4.6` avaliam a LP real e registram a liberação.
 - A E12 opera decisões humanas; os contratos, estados e resolução pertencem à E20.
 
@@ -200,6 +207,7 @@ Fontes de referência: `README.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `
 
 - E20.2 permanece responsável pelo catálogo de entradas.
 - E20.3 mantém contrato, persistência, estados, validação e resolução própria ou herdada do perfil de orientação.
+- A E20.3.5 torna `generation_guidance` opcional sem alterar os demais contratos.
 - A operação humana do lifecycle pertence à E12.4.3.
 - Identidades inexistentes não entram nas recomendações oficiais e poderão ser tratadas posteriormente como gaps.
 - E20.4 define critérios de liberação por evidência da LP real.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data: 28/07/2026
-• Versão: v1.5.112
+• Data: 29/07/2026
+• Versão: v1.5.113
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -1389,7 +1389,7 @@ Repositório — Ajustados
 
 12.4 Gestão do perfil de orientação
 - Objetivo: Definir a operação administrativa do perfil de orientação que direciona gerações futuras de landing pages sem materializar nem alterar LPs.
-- Status: E12.4.3 concluída; migration aplicada, provas automatizadas pós-apply, configuração da assistência e validação humana autenticada em Preview aprovadas.
+- Status: E12.4.3 e E12.4.3.1 concluídas; E12.4.3.2 planejada como correção funcional da proposta estrutural.
 
 12.4.1 Objetivo e status
 - Objetivo: Entregar a operação manual completa de criação, edição, revisão, ativação e arquivamento de versões do perfil, com proposta opcional por IA no mesmo editor.
@@ -1416,11 +1416,24 @@ Repositório — Ajustados
 - Status: Concluída; implementação integrada à `main`, com checks hospedados automatizados e teste humano autenticado do refinamento em Preview aprovados.
 - Conteúdo:
   - Toda proposta inicial ou revisão depende de ação explícita do `platform_admin`.
-  - A IA pode sugerir alterações em `generation_guidance`, recomendações e `item_guidance` dentro do contrato fechado vigente.
+  - No estado implementado, a IA ainda pode sugerir `generation_guidance`, recomendações e `item_guidance`; a E12.4.3.2 restringirá o refinamento a módulos, variantes, prioridade, ordem e gaps.
   - O refinamento recebe o conteúdo atual do editor e o feedback humano mais recente, além das fontes já autorizadas pela E12.4.3.
   - Cada acionamento autoriza somente uma chamada; não há refinamento nem retry automático.
   - Nenhuma proposta salva, aprova ou ativa automaticamente; o `platform_admin` continua responsável por revisar, editar, salvar e ativar.
   - Não existe conversa persistente, histórico de mensagens, agente ou memória própria.
+
+12.4.3.2 Proposta estrutural baseada em `lp_sections` e delta do catálogo
+- Status: Planejada; correção conceitual definida no plano-base E12.4 v2.4 e implementação técnica pendente.
+- Conteúdo:
+  - `Criar perfil com IA` será a ação inicial destacada; o fluxo manual permanece completo.
+  - `coverage[]` avaliará cada item de `lp_sections`; `recommendations[]` será a lista final única por módulo.
+  - Várias seções poderão convergir para um módulo e uma seção poderá exigir vários módulos.
+  - A prioridade será convertida por `3 → P1`, `2 → P2`, `1 → P3`; a ordem final será determinística, positiva e única.
+  - A IA não preencherá nem modificará `generation_guidance` ou `item_guidance`, que serão exceções humanas opcionais.
+  - A decisão `wait_for_modules` ou `proceed_with_available` será registrada no evento de auditoria do rascunho; aguardar bloqueará ativação.
+  - A E12.4.4 recalculará os gaps antes da prontidão, sem nova tabela neste recorte.
+  - A evolução E20.3.5 tornará `generation_guidance` opcional no mesmo PR técnico.
+  - Snapshot e independência da LP permanecem consolidados; liberdade de edição e comportamento de regeneração serão decididos apenas no futuro plano-base da E19.4.
 
 13. E13 — Partner Dashboard
 
@@ -2220,14 +2233,25 @@ Repositório — Ajustados
 * Status: Definido.
 * Conteúdo:
 
-  * O perfil pertence a um taxon, possui versão, estado e orientação geral e reúne itens com módulo e versão, variante e versão opcionais, prioridade `P1`, `P2` ou `P3`, ordem recomendada positiva e orientação específica opcional.
+  * O perfil pertence a um taxon, possui versão e estado e reúne itens com módulo e versão, variante e versão opcionais, prioridade `P1`, `P2` ou `P3`, ordem recomendada positiva e orientação específica opcional; `generation_guidance` permanece obrigatória no contrato vigente até a E20.3.5.
   * Prioridade e ordem são orientação; não criam módulo obrigatório, composição final, seleção por plano, prontidão, autorização, revogação ou geração.
   * Perfil e itens formam um agregado único, somente leitura server-side, persistido em exatamente duas tabelas e entregue por um único boundary, sem perfil oficial neste recorte.
   * A resolução usa perfil `active` próprio ou do ancestral elegível mais próximo, preserva proveniência e falha fechado para cadeia, leitura, identidade ou perfil inválido; ausência legítima permanece distinta de erro.
   * A E20.3 depende da taxonomia vigente e da identidade pública da E18.5, mas permanece independente do catálogo e dos valores da E20.2.
   * Permanecem fora do recorte mutações e lifecycle operacional do perfil, terceira tabela de domínio, rota, API HTTP, Server Action, UI, composição, copy, geração, IA, automação, job, serviço e nova infraestrutura.
 
+20.3.5 Opcionalidade da orientação geral
+
+* Status: Planejada; evolução de domínio vinculada à implementação técnica da E12.4.3.2.
+* Conteúdo:
+
+  * Tornar `generation_guidance` anulável, mas não vazio quando presente, por migration incremental forward-only.
+  * Atualizar contratos, schemas, DTOs, RPCs, normalização, testes e verificador read-only sem alterar estados, herança, resolução active-only ou recomendações.
+  * Preservar `item_guidance` opcional e exclusivamente humano.
+
 99. Changelog
+v1.5.113 — 29/07/2026 — Planejada a E12.4.3.2 com cobertura por `lp_sections`, recomendações deduplicadas, prioridade e ordem determinísticas, auditoria da decisão sobre gaps e evolução E20.3.5; decisões de edição e regeneração permanecem para o futuro plano-base da E19.4.
+
 v1.5.102 — 26/07/2026 — E20.3 implementada no PR #644: E20.3.3 concluída com migration versionada e aplicação pendente do merge; E20.3.4 implementada e validada; fechamento da fase pendente apenas de merge, apply automático e verificação read-only pós-apply.
 
 v1.5.101 — 25/07/2026 — Promovidos `comparison@v1`, `comparison.standard@v1`, `lead_capture@v1` e `lead_capture.form@v1` ao catálogo canônico da E18.5, totalizando doze módulos, quatorze variantes e 34 casos executáveis, com Form reutilizado e mecanismos centrais preservados.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data: 29/07/2026
-• Versão: v1.5.113
+• Data: 30/07/2026
+• Versão: v1.5.114
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -1389,7 +1389,7 @@ Repositório — Ajustados
 
 12.4 Gestão do perfil de orientação
 - Objetivo: Definir a operação administrativa do perfil de orientação que direciona gerações futuras de landing pages sem materializar nem alterar LPs.
-- Status: E12.4.3 e E12.4.3.1 concluídas; E12.4.3.2 planejada como correção funcional da proposta estrutural.
+- Status: E12.4.3 e E12.4.3.1 concluídas; E12.4.3.2 planejada como correção funcional da criação e evolução estrutural do perfil.
 
 12.4.1 Objetivo e status
 - Objetivo: Entregar a operação manual completa de criação, edição, revisão, ativação e arquivamento de versões do perfil, com proposta opcional por IA no mesmo editor.
@@ -1422,17 +1422,22 @@ Repositório — Ajustados
   - Nenhuma proposta salva, aprova ou ativa automaticamente; o `platform_admin` continua responsável por revisar, editar, salvar e ativar.
   - Não existe conversa persistente, histórico de mensagens, agente ou memória própria.
 
-12.4.3.2 Proposta estrutural baseada em `lp_sections` e delta do catálogo
-- Status: Planejada; correção conceitual definida no plano-base E12.4 v2.4 e implementação técnica pendente.
+12.4.3.2 Criação e evolução estrutural baseada em `lp_sections`, catálogo vigente e debate humano–IA
+- Status: Planejada; correção conceitual definida no plano-base E12.4 v2.5 e implementação técnica pendente.
 - Conteúdo:
-  - `Criar perfil com IA` será a ação inicial destacada; o fluxo manual permanece completo.
+  - Sem perfil próprio, a ação será `Criar perfil com IA`; com perfil `active` próprio, será `Evoluir perfil com IA`; o fluxo manual permanece completo.
+  - A evolução inicializará o editor da nova versão com a estrutura ativa completa como baseline não persistido e revalidará cada recomendação contra as versões vigentes da E10.8 e da E18.5.
   - `coverage[]` avaliará cada item de `lp_sections`; `recommendations[]` será a lista final única por módulo.
+  - `coverage[]`, relações seção–módulo, gaps e estados do diff serão resultados derivados e transitórios; somente recomendações aplicadas e salvas integrarão o perfil.
   - Várias seções poderão convergir para um módulo e uma seção poderá exigir vários módulos.
   - A prioridade será convertida por `3 → P1`, `2 → P2`, `1 → P3`; a ordem final será determinística, positiva e única.
+  - Cada rodada explícita ocorrerá sobre a nova versão em `draft`, usando editor original, candidata atual e feedback humano; a candidata e o diff aparecerão antes de aplicar, refinar novamente ou descartar.
+  - Aplicar alterará somente o editor; `Salvar rascunho`, aprovação, ativação e arquivamento continuarão separados e humanos.
+  - A pesquisa bruta será contexto complementar opcional, resolvido pela proveniência efetiva da E10.8 e incluído apenas quando existir e couber integralmente no limite da requisição; ausência ou omissão não criarão gate.
   - A IA não preencherá nem modificará `generation_guidance` ou `item_guidance`, que serão exceções humanas opcionais.
   - A decisão `wait_for_modules` ou `proceed_with_available` será registrada no evento de auditoria do rascunho; aguardar bloqueará ativação.
   - A E12.4.4 recalculará os gaps antes da prontidão, sem nova tabela neste recorte.
-  - A evolução E20.3.5 tornará `generation_guidance` opcional no mesmo PR técnico.
+  - A evolução E20.3.5 tornará `generation_guidance` opcional no mesmo PR técnico, sem reabrir E20.3.3 ou E20.3.4.
   - Snapshot e independência da LP permanecem consolidados; liberdade de edição e comportamento de regeneração serão decididos apenas no futuro plano-base da E19.4.
 
 13. E13 — Partner Dashboard
@@ -2245,11 +2250,14 @@ Repositório — Ajustados
 * Status: Planejada; evolução de domínio vinculada à implementação técnica da E12.4.3.2.
 * Conteúdo:
 
-  * Tornar `generation_guidance` anulável, mas não vazio quando presente, por migration incremental forward-only.
+  * Tornar `generation_guidance` anulável, exclusivamente humano e não vazio quando presente, por migration incremental forward-only.
   * Atualizar contratos, schemas, DTOs, RPCs, normalização, testes e verificador read-only sem alterar estados, herança, resolução active-only ou recomendações.
   * Preservar `item_guidance` opcional e exclusivamente humano.
+  * Não criar novo campo, estado, tabela, resolver ou infraestrutura e não reabrir E20.3.3 ou E20.3.4.
 
 99. Changelog
+v1.5.114 — 30/07/2026 — Reconciliada a E12.4.3.2 para criação e evolução do perfil em `draft`, baseline ativo revalidado, ações contextuais, candidata e diff transitórios, aplicação separada do salvamento e pesquisa bruta complementar opcional; E20.3.5 mantida como evolução mínima.
+
 v1.5.113 — 29/07/2026 — Planejada a E12.4.3.2 com cobertura por `lp_sections`, recomendações deduplicadas, prioridade e ordem determinísticas, auditoria da decisão sobre gaps e evolução E20.3.5; decisões de edição e regeneração permanecem para o futuro plano-base da E19.4.
 
 v1.5.102 — 26/07/2026 — E20.3 implementada no PR #644: E20.3.3 concluída com migration versionada e aplicação pendente do merge; E20.3.4 implementada e validada; fechamento da fase pendente apenas de merge, apply automático e verificação read-only pós-apply.


### PR DESCRIPTION
## 1. Objetivo

Reconciliar documentalmente a E12.4.3.2 como correção da criação e da evolução estrutural do perfil de orientação, incluindo o microajuste de domínio E20.3.5, sem alterar código, banco ou ambiente.

## 2. Abordagem consolidada

- Sem perfil próprio, a ação contextual é `Criar perfil com IA`.
- Com perfil `active` próprio, a ação contextual é `Evoluir perfil com IA`.
- A nova versão ocorre em `draft` e o editor é inicializado com a estrutura ativa completa como baseline não persistido.
- Nenhuma recomendação é mantida apenas por herança: E10.8 e E18.5 vigentes são reavaliadas.
- Cada rodada explícita recebe editor original, proposta candidata transitória e feedback humano mais recente.
- Candidata e diff aparecem antes de `Aplicar proposta`, `Refinar novamente` ou `Descartar proposta`.
- Aplicar altera somente o editor; `Salvar rascunho`, aprovação, ativação e arquivamento continuam separados e humanos.
- `coverage[]`, relações seção–módulo, gaps e estados do diff são derivados e não integram o perfil.
- Somente `recommendations[]`, após aplicação e salvamento, integra o agregado.
- `generation_guidance` e `item_guidance` permanecem opcionais, exclusivamente humanos e preservados pela IA.
- `wait_for_modules` bloqueia ativação; `proceed_with_available` permite prosseguir sob decisão auditada.

## 3. Pesquisa bruta opcional

- A E10.8 estruturada permanece fonte operacional obrigatória e a E18.5 permanece fonte canônica das identidades executáveis.
- A pesquisa bruta é apenas contexto complementar quando existir.
- O path é resolvido server-side pela proveniência efetiva da E10.8: `sourceTaxonId` convertido em slug canônico, `audienceScope` e `version`.
- Convenção: `docs/pesquisas-brutas/<taxon_slug>/<audience_scope>/v<research_version>.md`.
- Ausência, erro 404 ou omissão por tamanho não cria gate nem impede a proposta.
- O arquivo só é enviado integralmente quando couber junto às fontes obrigatórias no limite total de 96 KiB; não há truncamento silencioso.
- Quando utilizado, path, versão, commit ou blob, público e taxon de origem acompanham a rastreabilidade já existente.
- Divergência deve ser apresentada ao humano; a E10.8 aprovada continua governando o perfil.
- Pesquisa externa nova permanece fora do escopo.

## 4. E20.3.5

- `generation_guidance` torna-se anulável, exclusivamente humano e não vazio quando presente.
- `item_guidance` permanece opcional e exclusivamente humano.
- Contratos, schemas, DTOs, RPCs, normalização, testes e verificador read-only serão atualizados no futuro PR técnico.
- E20.3.3 e E20.3.4 permanecem concluídas.
- Nenhum campo, estado, tabela, resolver ou infraestrutura nova é criado.

## 5. Documentos reconciliados

- `docs/lousa-plano-base-e12-4.md` — v2.5.
- `docs/lousa-plano-base-e20-3.md` — v2.2.
- `docs/roadmap.md` — v1.5.114.
- `docs/lp-planejamento.md` — permanece no diff anterior do PR; a pesquisa bruta opcional não vira nova etapa da jornada.

## 6. Escopo negativo

- Sem implementação técnica neste PR.
- Sem migration, RPC, rota, componente, configuração ou alteração de ambiente.
- Sem chat persistente, agente, memória própria, retry automático, job, fila ou nova infraestrutura.
- Sem persistência de `coverage[]`, diff ou gaps nas tabelas do perfil.
- Sem criação automática de módulo ou variante.
- Sem E12.4.4, E19.4 ou pesquisa externa nova.

## 7. Validação documental

- Estrutura, numeração e ordem dos documentos preservadas.
- E12.4.3.2 e E20.3.5 reutilizadas; nenhuma nova fase criada.
- Regras de baseline, revalidação, debate transitório, diff, aplicação e salvamento separadas.
- Hierarquia, proveniência, rastreabilidade e limite da pesquisa bruta registrados.
- Inconsistência da seção 2.2 da E20.3 corrigida.
- Revisão de conteúdo e ausência de formulações contraditórias concluídas.
- Checks de runtime, typecheck e banco pertencem ao futuro PR técnico.

## 8. Próximo passo após aprovação

Implementar E12.4.3.2 e E20.3.5 em PR técnico próprio, seguindo integralmente os planos-base reconciliados e a instrução operacional do Estrategista.