### PR TITLE
docs: registrar E11 ativa em Production

### DIFF
--- a/docs/platform-config.md
+++ b/docs/platform-config.md
@@ -2,7 +2,7 @@
 
 0.1 Cabeçalho
 • Documento: LP Factory 10 — Platform Config
-• Versão: v0.1.14
+• Versão: v0.1.15
 • Data: 30/07/2026
 
 0.2 Contrato do documento
@@ -129,14 +129,14 @@
 • `E11_MEMBERS_ENABLED`
 • Finalidade: gate operacional da gestão de membros e convites.
 • Escopo: Production e Preview.
-• Estado atual: `false` em Production e `true` somente no Preview da branch `codex-app/e11-11-1-7`.
-• Regra operacional: os testes humanos da correção do transporte concorrente foram aprovados no Preview da branch `codex-app/e11-11-1-7`; manter Production em `false` até o merge humano do PR #656 e o fluxo pós-merge.
+• Estado atual: `true` em Production e Preview.
+• Estado operacional: PR #656 mergeado, redeploy de Production concluído e smoke final aprovado em 30/07/2026.
 
 • `INVITE_STATE_SECRET`
 • Finalidade: assinar o estado opaco transportado pelo convite nativo do Supabase Auth.
 • Escopo: Production e Preview.
 • Estado atual: configurada em Production e Preview, com valores independentes por ambiente e sem versionar o conteúdo.
-• Estado operacional conjunto: Preview da branch `codex-app/e11-11-1-7` configurado e aprovado nos testes humanos corretivos com o gate habilitado; Production permanece com o gate desabilitado.
+• Estado operacional conjunto: configurado em Production e Preview; fluxo corretivo aprovado no Preview e operação final aprovada em Production.
 • Regra operacional: manter configurada antes de habilitar `E11_MEMBERS_ENABLED`.
 
 • `SUPABASE_SECRET_KEY`
@@ -245,7 +245,7 @@
 • Redirect de Preview: wildcard restrito a `https://*-alcino-afonsos-projects.vercel.app/**` confirmado na allowlist; a prova deve usar somente o deployment autorizado.
 • Email OTP Expiration: `3600` segundos confirmados no Dashboard em 28/07/2026; o Core não adiciona validade local paralela.
 • Estado: template, redirects e expiração configurados; correção do transporte concorrente implementada e testes humanos hospedados aprovados no Preview autorizado da fase `11.1.7`.
-• Ordem operacional remanescente: manter Production desabilitada até o merge humano do PR #656; após o merge, habilitar o gate em Production, redeployar e executar o smoke final.
+• Estado final: PR #656 mergeado; gate habilitado em Production; redeploy concluído; smoke final aprovado na página de membros e convites.
 • Evidência hospedada aprovada: convite novo, reenvio idempotente, link adulterado rejeitado, link legítimo concluído com definição de senha antes da ativação, dois convites concorrentes para contas diferentes e isolamento entre memberships por `account_user_id`.
 
 4.7 Acesso operacional read-only para automações
@@ -459,6 +459,8 @@ Regra:
 • Configurações de plataformas, secrets por nome, workflows, ambientes e endpoints usados por automações devem ser registrados neste documento.
 
 99. Changelog
+v0.1.15 — 30/07/2026 — Registrados o merge do PR #656, a habilitação do gate, o redeploy e o smoke final aprovado em Production.
+
 v0.1.14 — 30/07/2026 — Registrada a aprovação dos testes humanos da correção do transporte concorrente no Preview autorizado, removida a pendência de reteste e mantida Production desabilitada até o merge humano do PR #656.
 
 v0.1.13 — 28/07/2026 — Corrigido o transporte do estado assinado por emissão no `RedirectTo` do convite nativo, removida a dependência de metadata compartilhado e preparado o reteste hospedado restrito, com Production desabilitada.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 0.1 Cabeçalho
 • Data: 30/07/2026
-• Versão: v1.5.115
+• Versão: v1.5.116
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -1150,13 +1150,13 @@ Repositório — Ajustados
 
 11. E11 — Gestão de Usuários e Convites
 - Objetivo: permitir gestão segura de membros não-owner e convites por conta, usando Supabase Auth e o Account Dashboard.
-- Status: implementação e validação hospedada concluídas, incluindo os testes humanos da correção do transporte concorrente; funcionalidade mantida desabilitada em Production até o merge humano do PR #656.
+- Status: implementação e validação hospedada concluídas; PR #656 mergeado, funcionalidade habilitada e smoke final aprovado em Production.
 
 11.1 Gestão de membros e convites
 
 11.1.1 Objetivo e status
 - Objetivo: permitir que owner e admin convidem, acompanhem e administrem membros com papéis admin, editor e viewer, preservando o owner e o isolamento multi-tenant.
-- Status: implementado; migration aplicada e estado pós-apply verificado; ativação controlada pendente.
+- Status: concluído; migration aplicada, estado pós-apply verificado e ativação controlada aprovada em Production.
 
 11.1.2 Registros do recorte
 - Banco:
@@ -1218,16 +1218,16 @@ Repositório — Ajustados
   - membership permanece `pending` até aceite, recusa ou revogação, sem expiração local.
 
 11.1.7 Ativação controlada e validação hospedada
-- Status: correção do transporte concorrente implementada e testes humanos corretivos aprovados no Preview; Production permanece desabilitada até o merge humano do PR #656.
+- Status: concluído; correção do transporte concorrente aprovada no Preview e smoke final aprovado em Production após o merge do PR #656.
 - Conteúdo:
   - migration aplicada e estado pós-apply verificado;
   - configuração remanescente do Supabase Auth concluída, com o template `Invite user` usando `RedirectTo`, `TokenHash` e `type=invite`;
-  - gate habilitado somente no Preview da branch `codex-app/e11-11-1-7`, com redeploy próprio;
+  - gate habilitado em Production após o merge do PR #656, com redeploy concluído;
   - matriz hospedada anterior aprovada para convite de usuário novo e existente, aceite, recusa, reativação, troca de papel, desativação, proteções de owner e do próprio vínculo, isolamento de acesso, logout, navegação por teclado, responsividade e retorno da gestão de membros à página principal;
   - transporte do estado assinado corrigido para ser codificado no `redirectTo` específico de cada emissão, sem gravação ou leitura por `data` ou `user_metadata` compartilhado;
   - testes humanos corretivos aprovados para convite novo e reenvio, senha e ativação, dois convites do mesmo usuário não confirmado para contas diferentes, ativação exclusiva do respectivo `account_user_id` e adulteração do estado bloqueada;
-  - gate mantido desabilitado em Production até o merge humano do PR #656;
-  - após o merge, habilitar Production, redeployar e executar o smoke final antes de concluir a fase.
+  - smoke final em Production aprovado na página de membros e convites, com dados e ações de gestão carregados;
+  - fase concluída sem teste manual remanescente.
 
 12. E12 — Admin Dashboard
 - Objetivo: Consolidar o Admin Dashboard como seção administrativa protegida, separada do Account Dashboard, com navegação própria e leitura operacional read-only.
@@ -2260,6 +2260,8 @@ Repositório — Ajustados
   * Não criar novo campo, estado, tabela, resolver ou infraestrutura e não reabrir E20.3.3 ou E20.3.4.
 
 99. Changelog
+v1.5.116 — 30/07/2026 — Registrados o merge do PR #656, a habilitação da E11, o redeploy e o smoke final aprovado em Production.
+
 v1.5.115 — 30/07/2026 — Registrada a aprovação dos testes humanos da correção concorrente da E11.1.7 no Preview autorizado, removida a pendência de reteste e mantida Production desabilitada até o merge humano do PR #656.
 
 v1.5.114 — 30/07/2026 — Reconciliada a E12.4.3.2 para criação e evolução do perfil em `draft`, baseline ativo revalidado, ações contextuais, candidata e diff transitórios, aplicação separada do salvamento e pesquisa bruta complementar opcional; E20.3.5 mantida como evolução mínima.


### PR DESCRIPTION
## 1. Ajustes

- Atualiza `docs/platform-config.md` para registrar `E11_MEMBERS_ENABLED=true` em Production, redeploy concluído e smoke final aprovado.
- Atualiza `docs/roadmap.md` para concluir a ativação controlada da E11 e remover instruções pós-merge já superadas.
- Incrementa as versões documentais e adiciona uma entrada curta em cada changelog.

## 2. Motivo

O PR #656 foi mergeado, a E11 foi habilitada em Production, o deployment ficou `Ready` e o smoke final da página de membros e convites foi aprovado. Os documentos ainda refletiam o estado anterior ao merge.

## 3. Impacto

- Documentação apenas.
- Nenhuma alteração em código, banco, rota, job, agente, automação ou infraestrutura.
- Nenhum teste manual remanescente para a ativação da E11.

## 4. Validação

- Branch criada a partir da `main`, sem commits atrasados no momento da abertura.
- Comparação com `main`: somente `docs/platform-config.md` e `docs/roadmap.md`.
- Referências defasadas à Production desabilitada removidas do estado vigente da E11.
- Testes de código não aplicáveis ao delta exclusivamente documental.