### PR TITLE
docs: planejar E11.2 autoridade comercial e membros

### DIFF
--- a/docs/lousa-plano-base-e11-2.md
+++ b/docs/lousa-plano-base-e11-2.md
@@ -2,7 +2,7 @@
 
 - Versão: v1
 - Data: 30/07/2026
-- Status: planejado; v1 aguardando aprovação humana.
+- Status: planejado; v1 aprovada; Processo automatizado escolhido; aguardando merge humano.
 - Recorte no roadmap: `11.2 — Autoridade comercial e elegibilidade para gestão de membros`
 - Path canônico: `docs/lousa-plano-base-e11-2.md`
 - Plano conceitual: N/A — debate realizado entre humano, Analista e Estrategista antes da v1.
@@ -218,51 +218,95 @@
 
 ## 3. Fases e próxima ação
 
-### 3.1. Fase única — 11.2.3 a 11.2.7
+### 3.1. E11.2.3 — Autoridade para o checkout
 
-- Status: planejada; execução bloqueada até aprovação da v1 e escolha do processo.
+- Status: planejada; execução pelo Processo automatizado somente após o merge humano da v1.
 - Automação: não.
-- Objetivo: aplicar a política consolidada de autoridade comercial e elegibilidade para convites nos fluxos existentes, com validação técnica, visual e humana no mesmo recorte.
-- Subseções do Roadmap atendidas:
-  - `11.2.3` Autoridade para o checkout;
-  - `11.2.4` Elegibilidade para criação e reenvio de convites;
-  - `11.2.5` Experiência da conta sem entitlement;
-  - `11.2.6` Preservação dos vínculos e ações existentes;
-  - `11.2.7` Validação técnica, visual e humana.
+- Objetivo: restringir o checkout existente ao owner sem entitlement comercial válido e impedir nova compra pela mesma action quando a conta já estiver elegível.
 - Execução:
-  - usar o sinal canônico já carregado em `/a/[account]` para separar a experiência por papel e entitlement;
-  - restringir a action de checkout a owner sem entitlement;
-  - bloquear checkout quando já houver entitlement válido;
-  - exigir entitlement no boundary existente de criação e reenvio de convites;
-  - ajustar a página de membros para comunicar e refletir o bloqueio somente nas ações dependentes de entitlement;
-  - preservar as demais operações da E11.1;
-  - criar ou ajustar testes no padrão já existente, sem inventar infraestrutura de testes paralela;
-  - validar Preview em desktop e mobile;
-  - reconciliar o Roadmap e somente os documentos que apresentarem delta real pelo Prompt ABC.
+  - revalidar conta, membership, papel e sinal canônico na Server Action antes de `createStripeTestCheckoutSession()`;
+  - permitir o fluxo apenas para owner ativo de conta ativa com `isCommerciallyEligible=false`;
+  - bloquear admin, editor, viewer e owner com entitlement válido;
+  - preservar preço, recorrência, URLs, webhook e confirmação comercial existentes.
+- Artefatos esperados:
+  - ajuste em `app/a/[account]/_components/commercial-page/checkout-actions.ts`;
+  - testes no padrão já existente para papel e entitlement, conforme a estrutura confirmada durante a execução.
+- Critérios de aceite:
+  - owner sem entitlement inicia o checkout existente;
+  - owner com entitlement e todos os papéis não-owner falham server-side;
+  - nenhum bloqueio cria Checkout Session;
+  - `isCommerciallyEligible` permanece a única decisão comercial consumida;
+  - nenhuma regra de billing inexistente é antecipada;
+  - validações automatizadas aplicáveis são aprovadas.
+- Evidência esperada:
+  - resultados dos casos autorizados e bloqueados;
+  - prova de ausência de Checkout Session nos bloqueios;
+  - diff restrito ao checkout existente.
+
+### 3.2. E11.2.4 — Elegibilidade para criação e reenvio de convites
+
+- Status: planejada; sucede a E11.2.3 no Processo automatizado.
+- Automação: não.
+- Objetivo: exigir entitlement comercial válido somente para criar e reenviar convites, preservando as ações de manutenção dos vínculos existentes.
+- Execução:
+  - aplicar o guard no boundary server-side existente com o `accountId` autoritativo;
+  - permitir criação e reenvio somente a owner/admin com `isCommerciallyEligible=true`;
+  - bloquear antes de criação no Auth, preparação do membership, gravação do canal ou envio;
+  - refletir o bloqueio no formulário de novo convite e na ação de reenvio;
+  - preservar listagem, aceite, recusa, revogação, desativação e alteração de papel conforme a E11.1.
+- Artefatos esperados:
+  - ajuste no boundary existente `lib/access/account-members/`;
+  - ajuste em `app/a/[account]/members/page.tsx` e nos componentes/actions já responsáveis pelo fluxo;
+  - testes no padrão já existente, conforme a estrutura confirmada durante a execução.
+- Critérios de aceite:
+  - owner/admin com entitlement criam e reenviam convites;
+  - owner/admin sem entitlement não produzem efeito;
+  - editor/viewer continuam bloqueados pela autorização da E11.1;
+  - ações preservadas continuam disponíveis sem entitlement;
+  - convites pendentes e memberships existentes permanecem inalterados;
+  - isolamento multi-tenant e proteções do owner continuam aprovados.
+- Evidência esperada:
+  - matriz de owner/admin com e sem entitlement;
+  - prova de ausência de efeitos externos e persistência nos bloqueios;
+  - smoke das ações preservadas.
+
+### 3.3. E11.2.5 — Experiência da conta sem entitlement
+
+- Status: planejada; sucede a E11.2.4 no Processo automatizado.
+- Automação: não.
+- Objetivo: separar a experiência comercial do owner do estado de espera dos demais papéis, sem criar novo dashboard produtivo.
+- Execução:
+  - usar o sinal já carregado em `/a/[account]` e o papel do Access Context;
+  - manter a página comercial e os CTAs existentes para owner sem entitlement;
+  - remover cards e CTAs financeiros de admin, editor e viewer;
+  - apresentar a não-owner sem entitlement a mensagem `Esta conta aguarda ativação comercial pelo proprietário.`;
+  - manter o comportamento pós-entitlement vigente, sem antecipar a E10.5.1;
+  - validar desktop e mobile e executar o fechamento documental material pelo Prompt ABC.
 - Artefatos esperados:
   - ajuste em `app/a/[account]/page.tsx`;
-  - ajuste em `app/a/[account]/_components/commercial-page/GenericCommercialPage.tsx`;
-  - ajuste em `app/a/[account]/_components/commercial-page/checkout-actions.ts`;
-  - ajuste no boundary existente `lib/access/account-members/`;
-  - ajuste em `app/a/[account]/members/page.tsx`;
-  - testes ou casos de validação nos artefatos canônicos já existentes, conforme a estrutura confirmada pelo Executor.
+  - ajuste nos componentes existentes de `app/a/[account]/_components/commercial-page/`;
+  - testes ou casos de validação nos artefatos canônicos existentes.
 - Critérios de aceite:
-  - todos os casos da seção 2.6 aprovados;
-  - nenhuma sessão Stripe criada por ator não-owner ou conta já elegível;
-  - nenhum novo convite ou reenvio produz efeito sem entitlement;
-  - ações preservadas continuam funcionando sem entitlement;
-  - não-owner sem entitlement recebe estado de espera sem CTA financeiro;
-  - Preview aprovado em desktop e mobile;
-  - `npm ci`, `npm run check` e validações específicas aplicáveis aprovados;
-  - diff restrito ao recorte, sem banco, rota ou infraestrutura nova;
-  - fechamento documental executado na própria implementação pelo Prompt ABC.
+  - owner sem entitlement recebe página comercial e CTA funcional;
+  - admin, editor e viewer sem entitlement recebem estado de espera sem escolha de plano ou checkout;
+  - nenhum não-owner recebe CTA financeiro, inclusive com chamada direta já bloqueada pela E11.2.3;
+  - memberships, papéis e ações preservadas não sofrem alteração retroativa;
+  - estado visual aprovado em desktop e mobile quanto a hierarquia, contraste, foco e legibilidade;
+  - `npm ci`, `npm run check` e validações específicas aplicáveis são aprovados;
+  - diff não cria banco, rota, boundary ou infraestrutura;
+  - Roadmap e documentos materialmente afetados são reconciliados pelo Prompt ABC.
 - Evidência esperada:
-  - resultados automatizados para a matriz de papéis e entitlement;
-  - prova de ausência de efeito nos bloqueios de checkout e convite;
-  - capturas do owner sem entitlement, do não-owner sem entitlement e da gestão de membros com convite bloqueado;
-  - capturas em desktop e mobile sem dado sensível;
-  - smoke do fluxo autorizado e das ações preservadas.
-- Próxima ação: após aprovação humana da v1, escolher entre Processo atual e Processo automatizado antes de instruir Executor ou especialistas.
+  - capturas do owner e de pelo menos um papel não-owner sem entitlement;
+  - capturas em desktop e mobile sem dados sensíveis;
+  - smoke do fluxo autorizado e das ações preservadas;
+  - checks e fechamento documental registrados no PR.
+
+### 3.4. Próxima ação
+
+- A v1 está aprovada e o Processo automatizado foi escolhido.
+- Após o merge humano do PR #666, acionar exclusivamente o orquestrador com:
+  - `Use $lp-factory-orquestrar-plano no PR #666.`
+- Não executar manualmente as fases, não chamar especialistas fora da orquestração e não usar `$lp-factory-executar-plano` diretamente sobre a v1.
 
 ## 4. Escopo negativo e critérios de parada
 
@@ -296,5 +340,7 @@
 
 ### 4.3. Decisão atual
 
-- Decisão: debate concluído e v1 produzida com uma única fase executável, sem automação.
-- Execução: não autorizada antes da aprovação humana da v1 e da escolha explícita do processo.
+- Decisão: debate concluído, v1 aprovada e Processo automatizado escolhido.
+- Fases executáveis: E11.2.3, E11.2.4 e E11.2.5, todas sem automação.
+- Preservação dos vínculos e validação das subseções 11.2.6 e 11.2.7 integram os critérios de aceite das fases correspondentes.
+- Execução: não autorizada antes do merge humano; após o merge, cabe exclusivamente ao orquestrador previsto no item 3.4.

--- a/docs/lousa-plano-base-e11-2.md
+++ b/docs/lousa-plano-base-e11-2.md
@@ -1,0 +1,300 @@
+# Plano-base E11.2 — Autoridade comercial e elegibilidade para gestão de membros
+
+- Versão: v1
+- Data: 30/07/2026
+- Status: planejado; v1 aguardando aprovação humana.
+- Recorte no roadmap: `11.2 — Autoridade comercial e elegibilidade para gestão de membros`
+- Path canônico: `docs/lousa-plano-base-e11-2.md`
+- Plano conceitual: N/A — debate realizado entre humano, Analista e Estrategista antes da v1.
+- Automação: não.
+- Fontes obrigatórias: `README.md`, `AGENTS.md`, `docs/prompt-estrategista.md`, `docs/template-roadmap.md`, `docs/prompt-abc.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/design-system.md`, `docs/lousa-plano-base-e9.md`, `docs/lousa-plano-base-e11.md`, `lib/commercial-entitlements/contracts.ts`, `lib/commercial-entitlements/adapters/commercialEntitlementAdapter.ts`, `lib/access/getAccessContext.ts`, `lib/access/guards.ts`, `lib/access/account-members/index.ts`, `app/a/[account]/page.tsx`, `app/a/[account]/_components/commercial-page/GenericCommercialPage.tsx`, `app/a/[account]/_components/commercial-page/checkout-actions.ts`, `app/a/[account]/members/page.tsx` e `app/a/[account]/members/actions.ts`.
+
+## 1. Estado e decisões fixas
+
+### 1.1. Problema e resultado esperado
+
+- A conta pode estar operacionalmente `active` sem possuir entitlement comercial válido.
+- Hoje, qualquer membership ativo autorizado pelo Access Context recebe a página comercial e pode acionar o checkout existente, pois a Server Action não restringe o papel.
+- Owner e admin também podem criar ou reenviar convites sem entitlement comercial válido.
+- O resultado esperado é separar autoridade financeira de colaboração:
+  - somente owner pode visualizar a ação de contratação e iniciar o checkout existente;
+  - owner e admin só podem criar ou reenviar convites quando a conta for comercialmente elegível;
+  - admin, editor e viewer sem entitlement recebem um estado simples de espera;
+  - ações necessárias para reduzir ou organizar acessos existentes permanecem disponíveis conforme a E11.1.
+
+### 1.2. Estado real confirmado
+
+- `getCommercialEntitlementSignal({ accountId })` é a leitura canônica da E9 e falha fechado para `NO_COMMERCIAL_ENTITLEMENT_SIGNAL`.
+- `CommercialEntitlementSignal.isCommerciallyEligible` é o único campo usado pela E11.2 para decidir elegibilidade; origem, status efetivo e plano não são reinterpretados neste recorte.
+- `/a/[account]` já carrega o sinal comercial server-side, mas descarta o resultado e apresenta a mesma página a todos os papéis ativos.
+- A página comercial genérica expõe os cards que chamam `startStripeCheckoutAction()`.
+- `startStripeCheckoutAction()` valida conta e contexto de acesso, mas não exige papel owner e não bloqueia nova sessão quando já existe entitlement válido.
+- O boundary `lib/access/account-members/` e a rota `/a/[account]/members` já protegem a gestão por owner/admin, porém criação e reenvio de convite ainda não dependem de entitlement.
+- Trial permanece previsto e não implementado; a E11.2 não cria nem antecipa seu contrato.
+
+### 1.3. Decisões funcionais encerradas
+
+- Autoridade financeira durável pertence ao owner.
+- A implementação atual limita essa autoridade ao fluxo existente:
+  - visualizar CTAs de contratação;
+  - iniciar o checkout Stripe atual.
+- Owner ativo, conta ativa e sem entitlement pode visualizar a página comercial e iniciar checkout.
+- Owner com `isCommerciallyEligible=true` não inicia outro checkout pela action atual.
+- Admin, editor e viewer não iniciam checkout, independentemente da UI.
+- Owner e admin com `isCommerciallyEligible=true` podem criar e reenviar convites.
+- Owner e admin sem entitlement não podem criar nem reenviar convites.
+- Aceite, recusa, revogação, desativação e alteração de papel permanecem regidos pela E11.1 e independentes de entitlement.
+- Memberships existentes não são apagados, desativados ou alterados retroativamente pela E11.2.
+
+### 1.4. Experiência por papel e elegibilidade
+
+- Owner sem entitlement:
+  - recebe a página comercial vigente;
+  - visualiza os CTAs de contratação;
+  - pode iniciar um checkout;
+  - não pode criar nem reenviar convites.
+- Owner com entitlement:
+  - não recebe CTA capaz de iniciar nova assinatura pela action atual;
+  - mantém o comportamento pós-entitlement já existente até a evolução da E10.5.1;
+  - pode criar e reenviar convites.
+- Admin, editor e viewer sem entitlement:
+  - não recebem cards ou CTA de contratação;
+  - recebem a mensagem: `Esta conta aguarda ativação comercial pelo proprietário.`
+- Admin, editor e viewer com entitlement:
+  - mantêm a experiência vigente compatível com seu papel;
+  - não recebem CTA financeiro;
+  - somente admin mantém acesso à gestão de membros e pode criar ou reenviar convites.
+
+### 1.5. Decisões técnicas consolidadas
+
+- A E11.2 consome exclusivamente `commercialEntitlement.isCommerciallyEligible`; não consulta origem comercial, provedor, plano ou tabela diretamente.
+- Autorização, papel e entitlement são revalidados server-side nas operações protegidas; ocultar controles na UI não substitui os guards.
+- O checkout usa o Access Context existente, exige conta e membership ativos, exige papel owner e exige `isCommerciallyEligible=false` antes de criar a Checkout Session.
+- Erro ou ausência do sinal equivale a não elegível:
+  - no checkout, preserva a possibilidade do owner iniciar a contratação;
+  - em criação e reenvio de convite, bloqueia a operação;
+  - nunca concede permissão financeira a não-owner.
+- A assimetria é intencional: ausência de entitlement habilita a contratação somente para o owner, mas bloqueia a expansão de membros.
+- A criação e o reenvio de convites aplicam o guard comercial no boundary server-side existente antes de criar usuário, preparar membership, consultar Auth Admin para entrega ou enviar e-mail.
+- Revogação, desativação e alteração de papel não recebem dependência comercial.
+- A página `/a/[account]` usa o sinal já carregado e o papel do contexto server-side para escolher entre página comercial, estado de espera e experiência vigente.
+- Não são criados novo boundary, rota, tabela, coluna, RPC, policy, migration, variável, webhook, job, fila, agente ou automação.
+
+## 2. Contrato do caso
+
+### 2.1. Contrato mínimo ponta a ponta
+
+- Gatilho:
+  - abertura de `/a/[account]`;
+  - acionamento de `startStripeCheckoutAction()`;
+  - criação ou reenvio de convite em `/a/[account]/members`.
+- Entrada:
+  - sessão autenticada;
+  - conta e membership resolvidos pelo Access Context;
+  - papel efetivo do ator;
+  - `accountId` canônico;
+  - `CommercialEntitlementSignal` da conta;
+  - dados já aceitos pelos fluxos de checkout ou convite.
+- Processamento:
+  - resolver conta, membership e papel server-side;
+  - obter o sinal canônico por `accountId`;
+  - aplicar a política específica de checkout, convite ou renderização;
+  - chamar o fluxo existente apenas quando a combinação de papel e elegibilidade for permitida.
+- Validação:
+  - checkout exige owner ativo, conta ativa e `isCommerciallyEligible=false`;
+  - criação e reenvio exigem owner/admin ativos, conta ativa e `isCommerciallyEligible=true`;
+  - nenhum papel não-owner recebe autoridade financeira;
+  - nenhuma ação usa origem, plano ou status comercial como regra paralela.
+- Persistência:
+  - não há persistência nova;
+  - checkout e convites preservam as persistências já pertencentes à E9 e à E11.1;
+  - bloqueios não criam Checkout Session, usuário Auth, membership ou envio.
+- Consumo:
+  - owner elegível para compra segue ao checkout existente;
+  - owner/admin elegíveis para colaboração usam a gestão de membros existente;
+  - não-owner sem entitlement recebe estado de espera;
+  - operações preservadas continuam disponíveis conforme o papel.
+- Fallback:
+  - papel insuficiente falha fechado sem criar checkout;
+  - conta já elegível falha fechado sem criar checkout duplicado;
+  - ausência ou erro no sinal bloqueia criação e reenvio de convite;
+  - falha na leitura para renderização não expõe CTA financeiro a não-owner;
+  - nenhum bloqueio comercial desativa membership existente.
+
+### 2.2. Autoridade para o checkout
+
+- O guard server-side ocorre antes de `createStripeTestCheckoutSession()`.
+- O fluxo autorizado exige simultaneamente:
+  - conta `active`;
+  - membership `active`;
+  - papel `owner`;
+  - `isCommerciallyEligible=false`.
+- O fluxo rejeita de forma determinística:
+  - admin, editor ou viewer;
+  - owner com entitlement válido;
+  - conta ou membership não ativos;
+  - contexto ausente ou inconsistente.
+- O retorno de bloqueio não revela dados comerciais além do necessário para a UX segura.
+- A E11.2 não altera preço, recorrência, mapeamento Stripe, success URL, cancel URL, webhook ou confirmação de entitlement.
+
+### 2.3. Elegibilidade para criação e reenvio de convites
+
+- `inviteAccountMember()` e `resendAccountMemberInvite()` exigem `isCommerciallyEligible=true` antes de efeitos externos ou persistência.
+- O guard reutiliza o `accountId` autoritativo do `AccountMembersManagerContext`.
+- Quando bloqueado:
+  - não cria usuário no Supabase Auth;
+  - não cria nem reabre ciclo `pending`;
+  - não grava canal de convite;
+  - não envia nem reenvia e-mail.
+- A listagem de membros e as operações de alteração de papel, revogação e desativação permanecem disponíveis para owner/admin sem entitlement.
+- A UI de membros:
+  - bloqueia ou omite apenas o formulário de novo convite e o reenvio;
+  - explica que novos convites dependem da ativação comercial;
+  - preserva as ações independentes de entitlement.
+
+### 2.4. Experiência da conta sem entitlement
+
+- Owner recebe a página comercial vigente e seus CTAs de contratação.
+- Admin, editor e viewer recebem um estado enxuto com:
+  - título ou mensagem clara de indisponibilidade comercial;
+  - texto `Esta conta aguarda ativação comercial pelo proprietário.`;
+  - nenhuma escolha de plano;
+  - nenhum botão de checkout.
+- O estado reutiliza componentes e tokens do `docs/design-system.md`, sem novo padrão visual.
+- A experiência funciona em desktop e mobile, com leitura clara, foco previsível e sem controle acessível somente por hover.
+- A E11.2 não cria dashboard produtivo, LP Builder navegável nem gestão de assinatura.
+
+### 2.5. Preservação dos vínculos e ações existentes
+
+- Permanecem sem dependência de entitlement:
+  - listar membros e convites;
+  - aceitar ou recusar convite próprio;
+  - revogar convite;
+  - desativar membro;
+  - alterar papel entre admin, editor e viewer;
+  - proteções do owner e do próprio ator;
+  - troca de conta e isolamento multi-tenant.
+- Convites já pendentes continuam aceitos ou recusados conforme a E11.1.
+- A mudança de elegibilidade comercial não altera automaticamente membership, papel ou status.
+- A liberação manual existente produz efeito somente por meio do sinal canônico da E9.
+
+### 2.6. Matriz mínima de validação
+
+- Checkout:
+  - owner sem entitlement visualiza CTA e consegue iniciar checkout;
+  - owner com entitlement não visualiza CTA capaz de nova compra e a chamada direta falha;
+  - admin, editor e viewer não visualizam CTA financeiro e a chamada direta falha;
+  - bloqueio ocorre antes da criação de Checkout Session.
+- Convites:
+  - owner e admin com entitlement criam e reenviam convites;
+  - owner e admin sem entitlement não criam nem reenviam;
+  - editor e viewer continuam bloqueados pela autorização da E11.1;
+  - bloqueio ocorre antes de criação de Auth user, membership, canal ou envio.
+- Operações preservadas:
+  - owner/admin sem entitlement ainda listam membros;
+  - alteração de papel, revogação e desativação permitidas continuam funcionando;
+  - convidado ainda aceita ou recusa convite pendente próprio;
+  - memberships existentes permanecem inalterados pela mudança comercial.
+- Renderização:
+  - owner sem entitlement recebe página comercial;
+  - não-owner sem entitlement recebe estado de espera;
+  - nenhum não-owner recebe botão ou cards acionáveis de checkout;
+  - desktop e mobile mantêm hierarquia, contraste, foco e legibilidade.
+- Anti-regressão:
+  - `isCommerciallyEligible` é a única decisão comercial consumida;
+  - entitlement por liberação manual produz o mesmo comportamento que outro entitlement efetivo;
+  - conta com entitlement não inicia checkout duplicado;
+  - isolamento entre contas e papéis permanece intacto.
+
+### 2.7. Dependências reais
+
+- E9.1 — sinal canônico de entitlement comercial.
+- E9.4 — checkout Stripe existente.
+- E10.5.1 — matriz de preparação versus produtivo, sem antecipar sua UX principal.
+- E10.6 e E10.7 — páginas comerciais existentes.
+- E11.1 — papéis, guards e gestão de membros.
+- `docs/design-system.md` — componentes, tokens, estados e acessibilidade visual.
+- Não há dependência de trial operacional, plano gratuito, billing admin, upgrade, downgrade, cancelamento ou automação.
+
+## 3. Fases e próxima ação
+
+### 3.1. Fase única — 11.2.3 a 11.2.7
+
+- Status: planejada; execução bloqueada até aprovação da v1 e escolha do processo.
+- Automação: não.
+- Objetivo: aplicar a política consolidada de autoridade comercial e elegibilidade para convites nos fluxos existentes, com validação técnica, visual e humana no mesmo recorte.
+- Subseções do Roadmap atendidas:
+  - `11.2.3` Autoridade para o checkout;
+  - `11.2.4` Elegibilidade para criação e reenvio de convites;
+  - `11.2.5` Experiência da conta sem entitlement;
+  - `11.2.6` Preservação dos vínculos e ações existentes;
+  - `11.2.7` Validação técnica, visual e humana.
+- Execução:
+  - usar o sinal canônico já carregado em `/a/[account]` para separar a experiência por papel e entitlement;
+  - restringir a action de checkout a owner sem entitlement;
+  - bloquear checkout quando já houver entitlement válido;
+  - exigir entitlement no boundary existente de criação e reenvio de convites;
+  - ajustar a página de membros para comunicar e refletir o bloqueio somente nas ações dependentes de entitlement;
+  - preservar as demais operações da E11.1;
+  - criar ou ajustar testes no padrão já existente, sem inventar infraestrutura de testes paralela;
+  - validar Preview em desktop e mobile;
+  - reconciliar o Roadmap e somente os documentos que apresentarem delta real pelo Prompt ABC.
+- Artefatos esperados:
+  - ajuste em `app/a/[account]/page.tsx`;
+  - ajuste em `app/a/[account]/_components/commercial-page/GenericCommercialPage.tsx`;
+  - ajuste em `app/a/[account]/_components/commercial-page/checkout-actions.ts`;
+  - ajuste no boundary existente `lib/access/account-members/`;
+  - ajuste em `app/a/[account]/members/page.tsx`;
+  - testes ou casos de validação nos artefatos canônicos já existentes, conforme a estrutura confirmada pelo Executor.
+- Critérios de aceite:
+  - todos os casos da seção 2.6 aprovados;
+  - nenhuma sessão Stripe criada por ator não-owner ou conta já elegível;
+  - nenhum novo convite ou reenvio produz efeito sem entitlement;
+  - ações preservadas continuam funcionando sem entitlement;
+  - não-owner sem entitlement recebe estado de espera sem CTA financeiro;
+  - Preview aprovado em desktop e mobile;
+  - `npm ci`, `npm run check` e validações específicas aplicáveis aprovados;
+  - diff restrito ao recorte, sem banco, rota ou infraestrutura nova;
+  - fechamento documental executado na própria implementação pelo Prompt ABC.
+- Evidência esperada:
+  - resultados automatizados para a matriz de papéis e entitlement;
+  - prova de ausência de efeito nos bloqueios de checkout e convite;
+  - capturas do owner sem entitlement, do não-owner sem entitlement e da gestão de membros com convite bloqueado;
+  - capturas em desktop e mobile sem dado sensível;
+  - smoke do fluxo autorizado e das ações preservadas.
+- Próxima ação: após aprovação humana da v1, escolher entre Processo atual e Processo automatizado antes de instruir Executor ou especialistas.
+
+## 4. Escopo negativo e critérios de parada
+
+### 4.1. Escopo negativo
+
+- Nova tabela, coluna, view, RPC, policy, grant ou migration.
+- Nova rota, página comercial, dashboard produtivo ou LP Builder navegável.
+- Novo boundary, Billing Engine, billing admin ou papel comercial.
+- Trial operacional, plano gratuito ou concessão automática de trial.
+- Upgrade, downgrade, renovação, cancelamento ou portal de assinatura.
+- Mudança de preço, recorrência, Product/Price Stripe, webhook ou confirmação de pagamento.
+- Limite de usuários por plano.
+- Solicitação ou aprovação de compra por não-owner.
+- Alteração retroativa, exclusão ou desativação automática de memberships.
+- Bloqueio de aceite, recusa, revogação, desativação ou alteração de papel por falta de entitlement.
+- Consulta direta a origem comercial, plano, provedor ou tabela como substituto de `isCommerciallyEligible`.
+- Nova variável, serviço, fila, job, cron, agente, automação ou engine.
+- Redesign amplo da página comercial ou da gestão de membros.
+
+### 4.2. Critérios de parada
+
+- Parar se a regra exigir redefinir o contrato de `CommercialEntitlementSignal`.
+- Parar se trial, plano gratuito ou nova origem comercial se tornar necessário para concluir o recorte.
+- Parar se a autoridade financeira exigir novo papel ou billing admin.
+- Parar se o bloqueio de checkout depender de gestão de assinatura ainda inexistente.
+- Parar se o guard de convite não puder ocorrer antes de qualquer criação no Auth, membership ou envio.
+- Parar se a implementação exigir tabela, coluna, migration, rota, boundary ou infraestrutura nova.
+- Parar se a experiência pós-entitlement exigir construir a E10.5.1 ou novo dashboard.
+- Parar se testes exigirem pagamento real, credencial humana principal ou exposição de secret.
+- Parar se a preservação das ações existentes entrar em conflito com proteção do owner, isolamento multi-tenant ou regra da E11.1.
+
+### 4.3. Decisão atual
+
+- Decisão: debate concluído e v1 produzida com uma única fase executável, sem automação.
+- Execução: não autorizada antes da aprovação humana da v1 e da escolha explícita do processo.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1233,7 +1233,7 @@ Repositório — Ajustados
 
 11.2.1 Objetivo e status
 - Objetivo: conectar os papéis da E11 ao sinal canônico de entitlement da E9, separando autoridade financeira, elegibilidade para novos convites e ações de manutenção dos vínculos existentes.
-- Status: planejado; plano-base v1 aguardando aprovação humana.
+- Status: planejado; plano-base v1 aprovado; Processo automatizado escolhido; aguardando merge humano.
 - Plano-base: `docs/lousa-plano-base-e11-2.md`.
 - Automação: não.
 
@@ -2309,6 +2309,8 @@ Repositório — Ajustados
   * Não criar novo campo, estado, tabela, resolver ou infraestrutura e não reabrir E20.3.3 ou E20.3.4.
 
 99. Changelog
+v1.5.117 — 30/07/2026 — Planejada a E11.2 com fases executáveis E11.2.3, E11.2.4 e E11.2.5; v1 aprovada e Processo automatizado escolhido, aguardando merge humano.
+
 v1.5.116 — 30/07/2026 — Registrados o merge do PR #656, a habilitação da E11, o redeploy e o smoke final aprovado em Production.
 
 v1.5.115 — 30/07/2026 — Registrada a aprovação dos testes humanos da correção concorrente da E11.1.7 no Preview autorizado, removida a pendência de reteste e mantida Production desabilitada até o merge humano do PR #656.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 0.1 Cabeçalho
 • Data: 30/07/2026
-• Versão: v1.5.116
+• Versão: v1.5.117
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -1228,6 +1228,55 @@ Repositório — Ajustados
   - testes humanos corretivos aprovados para convite novo e reenvio, senha e ativação, dois convites do mesmo usuário não confirmado para contas diferentes, ativação exclusiva do respectivo `account_user_id` e adulteração do estado bloqueada;
   - smoke final em Production aprovado na página de membros e convites, com dados e ações de gestão carregados;
   - fase concluída sem teste manual remanescente.
+
+11.2 Autoridade comercial e elegibilidade para gestão de membros
+
+11.2.1 Objetivo e status
+- Objetivo: conectar os papéis da E11 ao sinal canônico de entitlement da E9, separando autoridade financeira, elegibilidade para novos convites e ações de manutenção dos vínculos existentes.
+- Status: planejado; plano-base v1 aguardando aprovação humana.
+- Plano-base: `docs/lousa-plano-base-e11-2.md`.
+- Automação: não.
+
+11.2.3 Autoridade para o checkout
+- Status: planejado.
+- Conteúdo:
+  - somente owner ativo de conta ativa e sem entitlement comercial válido pode visualizar a ação de contratação e iniciar o checkout existente;
+  - admin, editor e viewer não iniciam checkout, com bloqueio server-side independente da UI;
+  - owner com `isCommerciallyEligible=true` não cria nova assinatura pela action atual;
+  - preço, recorrência, webhook, gestão de assinatura e outros fluxos de billing permanecem fora do recorte.
+
+11.2.4 Elegibilidade para criação e reenvio de convites
+- Status: planejado.
+- Conteúdo:
+  - owner e admin só criam ou reenviam convites quando `isCommerciallyEligible=true`;
+  - o guard ocorre no boundary server-side existente antes de criação no Auth, preparação do membership ou envio;
+  - ausência ou erro do sinal bloqueia criação e reenvio;
+  - editor e viewer permanecem sem gestão de membros.
+
+11.2.5 Experiência da conta sem entitlement
+- Status: planejado.
+- Conteúdo:
+  - owner sem entitlement mantém a página comercial e os CTAs do checkout existente;
+  - admin, editor e viewer sem entitlement recebem estado simples de espera pela ativação comercial do proprietário;
+  - nenhum não-owner recebe cards ou CTA financeiro;
+  - a E11.2 não cria novo dashboard produtivo nem antecipa a E10.5.1.
+
+11.2.6 Preservação dos vínculos e ações existentes
+- Status: planejado.
+- Conteúdo:
+  - listagem, aceite, recusa, revogação, desativação e alteração de papel permanecem regidos pela E11.1 e independentes de entitlement;
+  - memberships existentes não são apagados, desativados ou alterados retroativamente;
+  - a decisão comercial consome exclusivamente `CommercialEntitlementSignal.isCommerciallyEligible`, sem reinterpretar origem, plano ou provedor.
+
+11.2.7 Validação técnica, visual e humana
+- Status: planejado.
+- Conteúdo:
+  - validar owner, admin, editor e viewer com e sem entitlement nos fluxos de página, checkout e membros;
+  - comprovar que bloqueios de checkout e convite ocorrem antes de efeitos externos ou persistência;
+  - confirmar que as ações preservadas continuam funcionando sem entitlement;
+  - validar o estado de espera em desktop e mobile, sem CTA financeiro para não-owner;
+  - concluir no mesmo recorte os checks aplicáveis, a prova em Preview e o fechamento documental pelo Prompt ABC.
+
 
 12. E12 — Admin Dashboard
 - Objetivo: Consolidar o Admin Dashboard como seção administrativa protegida, separada do Account Dashboard, com navegação própria e leitura operacional read-only.


### PR DESCRIPTION
## 1. Objetivo

Registrar a v1 aprovada do plano-base E11.2 — Autoridade comercial e elegibilidade para gestão de membros — adequada ao Fluxo do Estrategista v27 e reconciliar o Roadmap com o Processo automatizado escolhido.

## 2. Alterações

- cria `docs/lousa-plano-base-e11-2.md`;
- divide a execução em fases com identificador único: `E11.2.3`, `E11.2.4` e `E11.2.5`;
- mantém preservação dos vínculos e validação (`11.2.6` e `11.2.7`) nos critérios de aceite das fases correspondentes;
- atualiza `docs/roadmap.md` com o recorte planejado, a aprovação da v1 e a escolha do Processo automatizado;
- restringe o plano ao checkout existente, à elegibilidade de criação/reenvio de convites e à experiência sem entitlement;
- preserva as ações e memberships existentes da E11.1;
- mantém trial, billing completo, banco, rotas e nova infraestrutura fora do escopo.

## 3. Decisões principais

- somente owner pode iniciar o checkout existente;
- owner com entitlement válido não inicia novo checkout pela action atual;
- owner/admin só criam ou reenviam convites com `isCommerciallyEligible=true`;
- não-owner sem entitlement recebe estado de espera sem CTA financeiro;
- a implementação consome exclusivamente o sinal canônico da E9;
- automação: não em todas as fases;
- processo escolhido: Opção 2 — Processo automatizado.

## 4. Validação e próxima ação

- alteração exclusivamente documental;
- execução não autorizada antes do merge humano;
- PR mantido como rascunho;
- após o merge, a única instrução prevista é: `Use $lp-factory-orquestrar-plano no PR #666.`
