### PR TITLE
fix(admin): correções pós-merge da E12.4.3.2

### DIFF
--- a/app/admin/(protected)/perfis-de-orientacao/_components/GenerationProfileEditor.tsx
+++ b/app/admin/(protected)/perfis-de-orientacao/_components/GenerationProfileEditor.tsx
@@ -71,6 +71,7 @@ export function GenerationProfileEditor({ taxon, profiles, aiConfigured, researc
     ? "Assistencia indisponivel: use exclusivamente o modelo aprovado gpt-5.4-mini e configure a OpenAI. O fluxo manual continua completo."
     : researchAvailability.reason;
   const activationBlockedByGaps = (appliedProposalContext?.decision ?? persistedGapDecision) === "wait_for_modules";
+  const editorLockedByCandidate = candidate !== null;
 
   function announce(next: Feedback) {
     setFeedback(next);
@@ -135,6 +136,7 @@ export function GenerationProfileEditor({ taxon, profiles, aiConfigured, researc
   }
 
   function saveDraft() {
+    if (editorLockedByCandidate) return;
     startTransition(async () => {
       const result = await saveGenerationProfileAction({
         ownerTaxonId: taxon.id,
@@ -221,6 +223,9 @@ export function GenerationProfileEditor({ taxon, profiles, aiConfigured, researc
       <div ref={feedbackRef} tabIndex={-1} aria-live="polite" className={feedback ? `rounded-md border p-3 text-sm ${feedback.tone === "error" ? "border-red-200 bg-red-50 text-red-700" : feedback.tone === "warning" ? "border-amber-200 bg-amber-50 text-amber-700" : "border-green-200 bg-green-50 text-green-700"}` : "sr-only"}>{feedback?.message ?? "Sem feedback."}</div>
 
       {manualEditorVisible && <>
+      {editorLockedByCandidate && <p id="editor-candidate-lock" className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-800">O editor esta temporariamente bloqueado enquanto a proposta candidata e o diff estao em revisao. Aplique ou descarte a proposta para voltar a editar.</p>}
+      <fieldset disabled={editorLockedByCandidate} aria-describedby={editorLockedByCandidate ? "editor-candidate-lock" : undefined} className="min-w-0 space-y-5 border-0 p-0">
+      <legend className="sr-only">Editor do perfil</legend>
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <h2 className="font-semibold">Editor do perfil</h2>
@@ -264,6 +269,7 @@ export function GenerationProfileEditor({ taxon, profiles, aiConfigured, researc
         {activationBlockedByGaps && <p className="text-sm text-red-700">Ativacao bloqueada: a decisao atual e aguardar a criacao dos modulos faltantes.</p>}
         {!draftMeta && <p className="text-sm text-muted-foreground">Aprovar e ativar indisponivel: salve primeiro uma versao draft.</p>}
       </div>
+      </fieldset>
       </>}
     </section>
 
@@ -291,11 +297,11 @@ function CandidateReview({ candidate, diff, replacements, gapDiff, gapDecision, 
 }) {
   return <section className="space-y-4 rounded-md border border-blue-200 bg-blue-50/50 p-4" aria-label="Proposta candidata">
     <div><h3 className="font-semibold">Proposta candidata</h3><p className="text-sm text-muted-foreground">A candidata e o diff sao transitórios; o editor ainda nao foi alterado.</p></div>
-    <div><h4 className="text-sm font-semibold">Cobertura de lp_sections</h4><ul className="mt-2 space-y-1 text-sm">{candidate.coverage.map((item) => <li key={`${item.audienceScope}:${item.itemKey}`}><strong>{item.sectionName}</strong> — {item.status} — {item.compatibleIdentities.map((identity) => identity.variantKey ?? identity.moduleKey).join(", ") || "sem identidade compatível"}</li>)}</ul></div>
+    <div><h4 className="text-sm font-semibold">Cobertura de lp_sections</h4><ul className="mt-2 space-y-1 text-sm">{candidate.coverage.map((item) => <li key={item.coverageId}><strong>{item.sectionName}</strong> — {item.status} — {item.compatibleIdentities.map((identity) => identity.variantKey ?? identity.moduleKey).join(", ") || "sem identidade compatível"}</li>)}</ul></div>
     <div><h4 className="text-sm font-semibold">Diff estrutural</h4><ul className="mt-2 flex flex-wrap gap-2">{diff.map((item) => <li key={item.moduleKey}><AdminStatusBadge tone={item.status === "removed" ? "danger" : item.status === "added" ? "success" : "neutral"}>{item.moduleKey}: {item.status}{item.changes.length > 0 ? ` (${item.changes.join(", ")})` : ""}</AdminStatusBadge></li>)}</ul><p className="mt-2 text-xs text-muted-foreground">Substituições: {replacements.map((item) => `${item.fromModuleKey} → ${item.toModuleKey} (ordem ${item.recommendedOrder})`).join(", ") || "nenhuma"}. Gaps novos: {gapDiff.added.map((gap) => gap.sectionName).join(", ") || "nenhum"}. Gaps resolvidos: {gapDiff.resolved.map((gap) => gap.sectionName).join(", ") || "nenhum"}.</p></div>
     {candidate.gaps.length > 0 && <div className="space-y-2 rounded-md border border-amber-300 bg-amber-50 p-3">
       <h4 className="text-sm font-semibold">Gaps do catálogo vigente</h4>
-      <ul className="space-y-1 text-sm">{candidate.gaps.map((gap) => <li key={`${gap.audienceScope}:${gap.itemKey}`}><strong>{gap.sectionName}</strong> — prioridade {gap.sourcePriority}, ordem {gap.sourceOrder}: {gap.reason} Impacto: {gap.impact}</li>)}</ul>
+      <ul className="space-y-1 text-sm">{candidate.gaps.map((gap) => <li key={gap.coverageId}><strong>{gap.sectionName}</strong> — prioridade {gap.sourcePriority}, ordem {gap.sourceOrder}: {gap.reason} Impacto: {gap.impact}</li>)}</ul>
       <label className="block text-sm font-medium">Decisão humana<Select value={gapDecision} onChange={(event) => onGapDecision(event.target.value as GenerationProfileGapDecision | "")} disabled={pending}><option value="">Selecione</option><option value="wait_for_modules">Aguardar criacao dos modulos</option><option value="proceed_with_available">Prosseguir com os disponiveis</option></Select></label>
     </div>}
     <div className="flex flex-wrap gap-2"><Button onClick={onApply} disabled={pending || (candidate.gaps.length > 0 && !gapDecision)}>Aplicar proposta</Button><Button className="bg-secondary text-secondary-foreground hover:bg-secondary/80" onClick={onDiscard} disabled={pending}>Descartar proposta</Button></div>

--- a/lib/conversion-content/landing-page/generation-profile/admin-contracts.ts
+++ b/lib/conversion-content/landing-page/generation-profile/admin-contracts.ts
@@ -51,6 +51,7 @@ export type GenerationProfileCoverageIdentity = Readonly<{
 }>;
 
 export type GenerationProfileCoverage = Readonly<{
+  coverageId: string;
   audienceScope: "business_buyer" | "end_customer";
   itemKey: string;
   sectionName: string;
@@ -63,6 +64,7 @@ export type GenerationProfileCoverage = Readonly<{
 }>;
 
 export type GenerationProfileGap = Readonly<{
+  coverageId: string;
   audienceScope: "business_buyer" | "end_customer";
   itemKey: string;
   sectionName: string;

--- a/lib/conversion-content/landing-page/generation-profile/editor-assistance.ts
+++ b/lib/conversion-content/landing-page/generation-profile/editor-assistance.ts
@@ -110,8 +110,8 @@ export function diffGenerationProfileGaps(input: {
   previousCandidate: GenerationProfileProposal | null;
   gaps: readonly GenerationProfileGap[];
 }) {
-  const previous = new Map((input.previousCandidate?.gaps ?? []).map((gap) => [`${gap.audienceScope}:${gap.itemKey}`, gap]));
-  const current = new Map(input.gaps.map((gap) => [`${gap.audienceScope}:${gap.itemKey}`, gap]));
+  const previous = new Map((input.previousCandidate?.gaps ?? []).map((gap) => [gap.coverageId, gap]));
+  const current = new Map(input.gaps.map((gap) => [gap.coverageId, gap]));
   return {
     added: [...current.entries()].filter(([key]) => !previous.has(key)).map(([, gap]) => gap),
     resolved: [...previous.entries()].filter(([key]) => !current.has(key)).map(([, gap]) => gap),

--- a/lib/conversion-content/landing-page/generation-profile/proposal-server.ts
+++ b/lib/conversion-content/landing-page/generation-profile/proposal-server.ts
@@ -19,6 +19,7 @@ import {
   mapProviderFailureToProposalError,
   mapResearchErrorToProposalError,
   normalizeGenerationProfileCandidate,
+  validateGenerationProfileResearchPriorities,
   validateGenerationProfileProviderPayload,
 } from "./proposal";
 
@@ -86,6 +87,17 @@ export async function proposeLandingPageGenerationProfile(input: {
       "Required research is unavailable or invalid.",
       { taxonId: input.taxonId, platformAdminId: input.actorUserId, requestKind, model, startedAt, researchCode: research.error.code },
     );
+  }
+  if (!validateGenerationProfileResearchPriorities(research.value)) {
+    return finishFailure(requestId, "invalid_data", "Required research contains an unsupported lp_sections priority.", {
+      taxonId: input.taxonId,
+      platformAdminId: input.actorUserId,
+      requestKind,
+      model,
+      startedAt,
+      researchVersions: research.value.versions,
+      researchProvenance: getResearchProvenance(research.value),
+    });
   }
 
   const detail = await readAdminGenerationProfileDetail({ taxonId: input.taxonId });

--- a/lib/conversion-content/landing-page/generation-profile/proposal.ts
+++ b/lib/conversion-content/landing-page/generation-profile/proposal.ts
@@ -56,6 +56,7 @@ export type GenerationProfileProviderResult =
 
 export type GenerationProfileProviderValidationReason =
   | "payload_schema_invalid"
+  | "coverage_source_priority_invalid"
   | "coverage_items_mismatch"
   | "coverage_identity_count_invalid"
   | "coverage_identity_invalid";
@@ -137,6 +138,7 @@ const candidateIdentitySchema = z.object({
 });
 
 const candidateGapSchema = z.object({
+  coverageId: z.string().trim().min(1),
   audienceScope: z.enum(["business_buyer", "end_customer"]),
   itemKey: z.string().trim().min(1),
   sectionName: z.string().trim().min(1),
@@ -149,6 +151,7 @@ const candidateGapSchema = z.object({
 
 const candidateSchema = z.object({
   coverage: z.array(z.object({
+    coverageId: z.string().trim().min(1),
     audienceScope: z.enum(["business_buyer", "end_customer"]),
     itemKey: z.string().trim().min(1),
     sectionName: z.string().trim().min(1),
@@ -220,8 +223,16 @@ export function normalizeGenerationProfileCandidate(input: unknown):
       if (!identity.ok) return { ok: false, message: "Current candidate coverage contains an invalid identity." };
     }
   }
-  const gapKeys = new Set(candidate.gaps.map((gap) => `${gap.audienceScope}:${gap.itemKey}`));
-  const derivedGapKeys = new Set(candidate.coverage.filter((item) => item.status !== "covered").map((item) => `${item.audienceScope}:${item.itemKey}`));
+  const coverageIds = candidate.coverage.map((item) => item.coverageId);
+  if (new Set(coverageIds).size !== coverageIds.length) {
+    return { ok: false, message: "Current candidate coverage identities are not unique." };
+  }
+  const gapIds = candidate.gaps.map((gap) => gap.coverageId);
+  const gapKeys = new Set(gapIds);
+  if (gapKeys.size !== gapIds.length) {
+    return { ok: false, message: "Current candidate gap identities are not unique." };
+  }
+  const derivedGapKeys = new Set(candidate.coverage.filter((item) => item.status !== "covered").map((item) => item.coverageId));
   if (gapKeys.size !== derivedGapKeys.size || [...gapKeys].some((key) => !derivedGapKeys.has(key))) {
     return { ok: false, message: "Current candidate gaps do not match coverage." };
   }
@@ -243,7 +254,7 @@ export function buildGenerationProfileResponsesRequest(input: GenerationProfileP
     current_candidate: input.currentCandidate
       ? {
           coverage: input.currentCandidate.coverage.map((item) => ({
-            coverage_id: `${item.audienceScope}:${item.itemKey}`,
+            coverage_id: item.coverageId,
             status: item.status,
             compatible_aliases: item.compatibleIdentities.map(identityAlias),
             ...(item.status === "covered" ? {} : { reason: item.reason, impact: item.impact }),
@@ -339,6 +350,9 @@ export function validateGenerationProfileProviderPayload(input: {
   if (!parsed.success) return { ok: false as const, reason: "payload_schema_invalid" as const, message: "Proposal payload is invalid." };
 
   const sections = readLpSections(input.research);
+  if (!sections) {
+    return { ok: false as const, reason: "coverage_source_priority_invalid" as const, message: "lp_sections contains an unsupported priority." };
+  }
   const coverageKeys = parsed.data.coverage.map((item) => item.coverage_id);
   if (new Set(coverageKeys).size !== coverageKeys.length || sections.length !== parsed.data.coverage.length) {
     return { ok: false as const, reason: "coverage_items_mismatch" as const, message: "Coverage must contain every lp_sections item exactly once." };
@@ -370,6 +384,7 @@ export function validateGenerationProfileProviderPayload(input: {
     const item = analysisByKey.get(coverageIdentityKey(source));
     if (!item) throw new Error("Validated coverage is missing a canonical section.");
     return {
+      coverageId: coverageIdentityKey(source),
       audienceScope: source.audience_scope,
       itemKey: source.item_key,
       sectionName: source.section_name,
@@ -383,7 +398,7 @@ export function validateGenerationProfileProviderPayload(input: {
   const recommendations = deriveRecommendations(coverage);
   const gaps = coverage
     .filter((item): item is GenerationProfileCoverage & { status: "partial" | "missing"; reason: string; impact: string } => item.status !== "covered")
-    .map((item) => ({ audienceScope: item.audienceScope, itemKey: item.itemKey, sectionName: item.sectionName, sourcePriority: item.sourcePriority, sourceOrder: item.sourceOrder, status: item.status, reason: item.reason, impact: item.impact }));
+    .map((item) => ({ coverageId: item.coverageId, audienceScope: item.audienceScope, itemKey: item.itemKey, sectionName: item.sectionName, sourcePriority: item.sourcePriority, sourceOrder: item.sourceOrder, status: item.status, reason: item.reason, impact: item.impact }));
   const diff = deriveGenerationProfileProposalDiff({
     editor: input.currentEditor ?? { generationGuidance: "", recommendations: [] },
     previousCandidate: input.previousCandidate ?? null,
@@ -404,21 +419,44 @@ export function validateGenerationProfileProviderPayload(input: {
 }
 
 function readLpSections(research: ResolvedLandingPageResearch) {
-  return [research.businessBuyer, research.endCustomer].flatMap((audience) =>
-    audience.researches
-      .filter((parent) => parent.researchBlock === "lp_sections")
-      .flatMap((parent) => parent.items.map((item) => ({
-        audience_scope: audience.audienceScope,
-        item_key: item.itemKey,
-        section_name: item.itemText,
-        source_priority: item.priority as 1 | 2 | 3,
-        source_order: item.sortOrder,
-      }))),
-  );
+  const sections: Array<{
+    audience_scope: "business_buyer" | "end_customer";
+    item_id: string;
+    item_key: string;
+    section_name: string;
+    source_priority: 1 | 2 | 3;
+    source_order: number;
+  }> = [];
+  for (const audience of [research.businessBuyer, research.endCustomer]) {
+    for (const parent of audience.researches) {
+      if (parent.researchBlock !== "lp_sections") continue;
+      for (const item of parent.items) {
+        const sourcePriority = normalizeSourcePriority(item.priority);
+        if (sourcePriority === null) return null;
+        sections.push({
+          audience_scope: audience.audienceScope,
+          item_id: item.itemId,
+          item_key: item.itemKey,
+          section_name: item.itemText,
+          source_priority: sourcePriority,
+          source_order: item.sortOrder,
+        });
+      }
+    }
+  }
+  return sections;
 }
 
-function coverageIdentityKey(value: { audience_scope: string; item_key: string }) {
-  return `${value.audience_scope}:${value.item_key}`;
+export function validateGenerationProfileResearchPriorities(research: ResolvedLandingPageResearch) {
+  return readLpSections(research) !== null;
+}
+
+function normalizeSourcePriority(value: number): 1 | 2 | 3 | null {
+  return value === 1 || value === 2 || value === 3 ? value : null;
+}
+
+function coverageIdentityKey(value: { audience_scope: string; item_id: string }) {
+  return `${value.audience_scope}:${value.item_id}`;
 }
 
 function compactResearch(research: ResolvedLandingPageResearch) {
@@ -439,7 +477,7 @@ function compactResearchAudience(audience: ResolvedLandingPageResearch["business
     lp_sections: audience.researches
       .filter((parent) => parent.researchBlock === "lp_sections")
       .flatMap((parent) => parent.items.map((item) => ({
-        coverage_id: `${audience.audienceScope}:${item.itemKey}`,
+        coverage_id: `${audience.audienceScope}:${item.itemId}`,
         text: item.itemText,
       }))),
   };

--- a/lib/conversion-content/landing-page/generation-profile/validation-cases.ts
+++ b/lib/conversion-content/landing-page/generation-profile/validation-cases.ts
@@ -26,6 +26,7 @@ import {
   mapProviderFailureToProposalError,
   mapResearchErrorToProposalError,
   normalizeGenerationProfileIncompleteMetadata,
+  validateGenerationProfileResearchPriorities,
   validateGenerationProfileProviderPayload,
 } from "./proposal";
 import { listLandingPageModuleIdentities } from "../module-catalog";
@@ -41,6 +42,12 @@ import { resolveLandingPageGenerationProfile } from "./resolver";
 const SEGMENT_ID = "10000000-0000-4000-8000-000000000001";
 const NICHE_ID = "10000000-0000-4000-8000-000000000002";
 const ULTRA_ID = "10000000-0000-4000-8000-000000000003";
+const BUYER_SECTION_ITEM_ID = "42000000-0000-4000-8000-000000000001";
+const CUSTOMER_SECTION_ITEM_ID = "42000000-0000-4000-8000-000000000002";
+const REPEATED_BUYER_SECTION_ITEM_ID = "42000000-0000-4000-8000-000000000003";
+const BUYER_COVERAGE_ID = `business_buyer:${BUYER_SECTION_ITEM_ID}`;
+const CUSTOMER_COVERAGE_ID = `end_customer:${CUSTOMER_SECTION_ITEM_ID}`;
+const REPEATED_BUYER_COVERAGE_ID = `business_buyer:${REPEATED_BUYER_SECTION_ITEM_ID}`;
 
 function compactResearchParent(
   audienceScope: "business_buyer" | "end_customer",
@@ -109,7 +116,7 @@ const structuralResearch = {
       version: 1,
       sourceTaxonId: NICHE_ID,
       items: [{
-        itemId: "42000000-0000-4000-8000-000000000001",
+        itemId: BUYER_SECTION_ITEM_ID,
         researchId: "41000000-0000-4000-8000-000000000001",
         itemKey: "buyer_faq",
         itemText: "FAQ comercial",
@@ -140,7 +147,7 @@ const structuralResearch = {
       version: 1,
       sourceTaxonId: NICHE_ID,
       items: [{
-        itemId: "42000000-0000-4000-8000-000000000002",
+        itemId: CUSTOMER_SECTION_ITEM_ID,
         researchId: "41000000-0000-4000-8000-000000000002",
         itemKey: "customer_hero",
         itemText: "Hero de conversao",
@@ -161,17 +168,53 @@ const structuralResearch = {
 const structuralPayload = {
   coverage: [
     {
-      coverage_id: "business_buyer:buyer_faq",
+      coverage_id: BUYER_COVERAGE_ID,
       status: "covered" as const,
       compatible_aliases: ["faq.accordion"],
     },
     {
-      coverage_id: "end_customer:customer_hero",
+      coverage_id: CUSTOMER_COVERAGE_ID,
       status: "covered" as const,
       compatible_aliases: ["hero.form"],
     },
   ],
 };
+
+function withBuyerSectionPriority(priority: number): ResolvedLandingPageResearch {
+  return {
+    ...structuralResearch,
+    businessBuyer: {
+      ...structuralResearch.businessBuyer,
+      researches: structuralResearch.businessBuyer.researches.map((parent) => parent.researchBlock === "lp_sections"
+        ? { ...parent, items: parent.items.map((item) => ({ ...item, priority })) }
+        : parent),
+    },
+  };
+}
+
+function withRepeatedBuyerItemKey(): ResolvedLandingPageResearch {
+  return {
+    ...structuralResearch,
+    businessBuyer: {
+      ...structuralResearch.businessBuyer,
+      researches: structuralResearch.businessBuyer.researches.map((parent) => parent.researchBlock === "lp_sections"
+        ? {
+            ...parent,
+            items: [
+              ...parent.items,
+              {
+                ...parent.items[0],
+                itemId: REPEATED_BUYER_SECTION_ITEM_ID,
+                itemText: "FAQ para objecoes",
+                priority: 2,
+                sortOrder: 2,
+              },
+            ],
+          }
+        : parent),
+    },
+  };
+}
 
 const expectedStructuralRecommendations = [
   { moduleKey: "hero", moduleVersion: 1, variantKey: "hero.form", variantVersion: 1, priority: "P1" as const, recommendedOrder: 10 },
@@ -500,14 +543,15 @@ const cases: readonly Readonly<{
       assert.equal(valid.ok, true, valid.ok ? undefined : valid.message);
       if (valid.ok) {
         assert.deepEqual(valid.value.coverage.map((item) => ({
+          coverageId: item.coverageId,
           audienceScope: item.audienceScope,
           itemKey: item.itemKey,
           sectionName: item.sectionName,
           sourcePriority: item.sourcePriority,
           sourceOrder: item.sourceOrder,
         })), [
-          { audienceScope: "business_buyer", itemKey: "buyer_faq", sectionName: "FAQ comercial", sourcePriority: 2, sourceOrder: 2 },
-          { audienceScope: "end_customer", itemKey: "customer_hero", sectionName: "Hero de conversao", sourcePriority: 3, sourceOrder: 1 },
+          { coverageId: BUYER_COVERAGE_ID, audienceScope: "business_buyer", itemKey: "buyer_faq", sectionName: "FAQ comercial", sourcePriority: 2, sourceOrder: 2 },
+          { coverageId: CUSTOMER_COVERAGE_ID, audienceScope: "end_customer", itemKey: "customer_hero", sectionName: "Hero de conversao", sourcePriority: 3, sourceOrder: 1 },
         ]);
         assert.deepEqual(valid.value.recommendations, expectedStructuralRecommendations);
       }
@@ -517,7 +561,7 @@ const cases: readonly Readonly<{
       assert.equal(validate({ ...structuralPayload, recommendations: [] }).ok, false);
       assert.equal(validate({ ...structuralPayload, coverage: [{ ...structuralPayload.coverage[0], section_name: "Drift" }, structuralPayload.coverage[1]] }).ok, false);
       assert.equal(validate({ ...structuralPayload, coverage: structuralPayload.coverage.slice(1) }).ok, false);
-      assert.equal(validate({ ...structuralPayload, coverage: [{ ...structuralPayload.coverage[0], coverage_id: "business_buyer:unknown" }, structuralPayload.coverage[1]] }).ok, false);
+      assert.equal(validate({ ...structuralPayload, coverage: [{ ...structuralPayload.coverage[0], coverage_id: "business_buyer:00000000-0000-4000-8000-000000000000" }, structuralPayload.coverage[1]] }).ok, false);
       assert.equal(validate({ ...structuralPayload, coverage: [structuralPayload.coverage[1], structuralPayload.coverage[0]] }).ok, true);
       assert.equal(validate({
         ...structuralPayload,
@@ -535,6 +579,82 @@ const cases: readonly Readonly<{
         ...structuralPayload,
         coverage: [{ ...structuralPayload.coverage[0], status: "missing", compatible_aliases: ["faq.accordion"], reason: "Modulo indisponivel.", impact: "Estrutura incompleta." }, structuralPayload.coverage[1]],
       }).ok, false);
+    },
+  },
+  {
+    name: "lp_sections priority accepts only the explicit one-to-three mapping",
+    run: () => {
+      for (const [sourcePriority, expectedPriority] of [[1, "P3"], [2, "P2"], [3, "P1"]] as const) {
+        const research = withBuyerSectionPriority(sourcePriority);
+        assert.equal(validateGenerationProfileResearchPriorities(research), true);
+        const validated = validateGenerationProfileProviderPayload({ payload: structuralPayload, research, moduleIdentities: listLandingPageModuleIdentities() });
+        assert.equal(validated.ok, true, validated.ok ? undefined : validated.message);
+        if (validated.ok) assert.equal(validated.value.recommendations.find((item) => item.moduleKey === "faq")?.priority, expectedPriority);
+      }
+      for (const invalidPriority of [0, -1, 4]) {
+        const research = withBuyerSectionPriority(invalidPriority);
+        assert.equal(validateGenerationProfileResearchPriorities(research), false);
+        const validated = validateGenerationProfileProviderPayload({ payload: structuralPayload, research, moduleIdentities: listLandingPageModuleIdentities() });
+        assert.equal(validated.ok, false);
+        if (!validated.ok) assert.equal(validated.reason, "coverage_source_priority_invalid");
+      }
+    },
+  },
+  {
+    name: "repeated item_key remains distinct through provider candidate refinement gaps and diff",
+    run: () => {
+      const research = withRepeatedBuyerItemKey();
+      const previousPayload = {
+        coverage: [
+          { ...structuralPayload.coverage[0], status: "missing" as const, compatible_aliases: [], reason: "Modulo indisponivel.", impact: "FAQ comercial ausente." },
+          { coverage_id: REPEATED_BUYER_COVERAGE_ID, status: "covered" as const, compatible_aliases: ["faq.accordion"] },
+          structuralPayload.coverage[1],
+        ],
+      };
+      const previous = validateGenerationProfileProviderPayload({ payload: previousPayload, research, moduleIdentities: listLandingPageModuleIdentities() });
+      assert.equal(previous.ok, true, previous.ok ? undefined : previous.message);
+      if (!previous.ok) return;
+      const previousCandidate = { ...previous.value, researchVersions: research.versions, requestId: "50000000-0000-4000-8000-000000000030" };
+      const currentPayload = {
+        coverage: [
+          structuralPayload.coverage[0],
+          { coverage_id: REPEATED_BUYER_COVERAGE_ID, status: "missing" as const, compatible_aliases: [], reason: "Modulo indisponivel.", impact: "FAQ para objecoes ausente." },
+          structuralPayload.coverage[1],
+        ],
+      };
+      const current = validateGenerationProfileProviderPayload({
+        payload: currentPayload,
+        research,
+        moduleIdentities: listLandingPageModuleIdentities(),
+        previousCandidate,
+      });
+      assert.equal(current.ok, true, current.ok ? undefined : current.message);
+      if (!current.ok) return;
+
+      assert.deepEqual(current.value.coverage.filter((item) => item.itemKey === "buyer_faq").map((item) => item.coverageId), [BUYER_COVERAGE_ID, REPEATED_BUYER_COVERAGE_ID]);
+      assert.deepEqual(current.value.gaps.map((gap) => [gap.coverageId, gap.itemKey]), [[REPEATED_BUYER_COVERAGE_ID, "buyer_faq"]]);
+      assert.deepEqual(current.value.diff.gaps.added.map((gap) => gap.coverageId), [REPEATED_BUYER_COVERAGE_ID]);
+      assert.deepEqual(current.value.diff.gaps.resolved.map((gap) => gap.coverageId), [BUYER_COVERAGE_ID]);
+      assert.equal(fingerprintGenerationProfileProposal(previous.value), fingerprintGenerationProfileProposal(current.value));
+
+      const candidate = { ...current.value, researchVersions: research.versions, requestId: "50000000-0000-4000-8000-000000000031" };
+      assert.equal(normalizeGenerationProfileCandidate(candidate).ok, true);
+      assert.equal(normalizeGenerationProfileCandidate({ ...candidate, coverage: [candidate.coverage[0], { ...candidate.coverage[1], coverageId: candidate.coverage[0].coverageId }, ...candidate.coverage.slice(2)] }).ok, false);
+      assert.equal(normalizeGenerationProfileCandidate({ ...candidate, gaps: [...candidate.gaps, candidate.gaps[0]] }).ok, false);
+
+      const request = buildGenerationProfileResponsesRequest({
+        model: GENERATION_PROFILE_APPROVED_MODEL,
+        research,
+        moduleIdentities: listLandingPageModuleIdentities(),
+        requestKind: "evolution",
+        activeBaseline: null,
+        currentCandidate: candidate,
+      });
+      assert.equal(request.ok, true);
+      const input = JSON.parse(request.body.input[1].content[0].text);
+      assert.deepEqual(input.research.business_buyer.lp_sections.map((item: { coverage_id: string }) => item.coverage_id), [BUYER_COVERAGE_ID, REPEATED_BUYER_COVERAGE_ID]);
+      assert.equal(input.research.business_buyer.lp_sections.some((item: Record<string, unknown>) => Object.hasOwn(item, "item_id")), false);
+      assert.deepEqual(input.current_candidate.coverage.map((item: { coverage_id: string }) => item.coverage_id), [BUYER_COVERAGE_ID, REPEATED_BUYER_COVERAGE_ID, CUSTOMER_COVERAGE_ID]);
     },
   },
   {
@@ -690,8 +810,8 @@ const cases: readonly Readonly<{
       assert.equal(Object.hasOwn(input, "previous_active_profile"), false);
       assert.equal(input.active_baseline, null);
       assert.equal(Object.hasOwn(input, "raw_research"), false);
-      assert.deepEqual(input.research.business_buyer.lp_sections, [{ coverage_id: "business_buyer:buyer_faq", text: "FAQ comercial" }]);
-      assert.deepEqual(input.research.end_customer.lp_sections, [{ coverage_id: "end_customer:customer_hero", text: "Hero de conversao" }]);
+      assert.deepEqual(input.research.business_buyer.lp_sections, [{ coverage_id: BUYER_COVERAGE_ID, text: "FAQ comercial" }]);
+      assert.deepEqual(input.research.end_customer.lp_sections, [{ coverage_id: CUSTOMER_COVERAGE_ID, text: "Hero de conversao" }]);
       assert.deepEqual(input.research.business_buyer.strategic_core, ["Estratégia do comprador"]);
       assert.deepEqual(input.research.business_buyer.lp_overview, ["Visão da LP para o comprador"]);
       assert.deepEqual(input.research.business_buyer.seo, ["SEO do comprador"]);


### PR DESCRIPTION
## Contexto

Correção pós-merge do PR #663, limitada às três threads de review não obsoletas ainda abertas. O PR permanece em draft e não responde nem resolve as threads antigas.

Base: merge commit `6db85ef588a84a875988787a870bb56af76c65a8` do PR #663.

## Correções

- Prioridade de `lp_sections`: valida explicitamente apenas 1, 2 e 3 antes da chamada paga; valores fora da faixa retornam `invalid_data`, preservando editor/draft/active.
- Candidata em revisão: bloqueia semanticamente os campos e ações de edição, adição, remoção e salvamento enquanto mantém feedback, refinamento, decisão de gaps, aplicar e descartar disponíveis.
- Identidade transitória: usa `coverageId = audienceScope:itemId` em request/response, candidata, gaps, diff, mapas internos e React keys; `itemKey` continua na UI e auditoria. Nada foi adicionado a fingerprint, RPC, banco, migration ou audit log.

## Mapeamento das threads

- https://github.com/AlcinoAfonso/LP-Factory-10/pull/663#discussion_r3691066530 — `proposal-server.ts`, `proposal.ts` e regressões de prioridade em `validation-cases.ts`.
- https://github.com/AlcinoAfonso/LP-Factory-10/pull/663#discussion_r3691066537 — bloqueio semântico e aviso em `GenerationProfileEditor.tsx`.
- https://github.com/AlcinoAfonso/LP-Factory-10/pull/663#discussion_r3691066544 — contratos, derivação/diff, provider/refinement, React keys e caso de `item_key` repetido.

## Validação

- `npm ci` — aprovado; audit informativo: 14 vulnerabilidades preexistentes (3 low, 2 moderate, 9 high), sem `npm audit fix` fora do escopo.
- `npm run check` — aprovado; 24 warnings preexistentes fora do recorte, zero erros.
- `npm run validate:landing-page-research` — aprovado.
- `npm run validate:landing-page-generation-profile` — aprovado, incluindo prioridades 1-3/fora da faixa e colisão de `item_key`.
- `npm run validate:landing-page-module-catalog` — aprovado, 35 casos.
- `git diff --check` — aprovado.
- `npm run dev` — servidor compilou; a rota local foi bloqueada antes da tela por ausência das variáveis locais de Supabase. Não foram importadas credenciais nem fabricada candidata. Validação desktop/mobile do estado com candidata permanece gate humano.

## Limites confirmados

Não houve chamada OpenAI, leitura/escrita de dados Supabase, migration, Vercel/Production, mudança de contrato global E10.8 ou alteração funcional de modelo, prompt, tokens, lifecycle, RPC ou auditoria.

## Fontes

`README.md`, `AGENTS.md`, `docs/base-tecnica.md`, `docs/roadmap.md`, `docs/template-briefing-codex.md`, `docs/lousa-plano-base-e10-8.md` v3, `docs/lousa-plano-base-e12-4.md` v2.5, implementação incorporada pelo PR #663 e as três threads acima.