### PR TITLE
docs: atualizar estado OpenAI do perfil

### DIFF
--- a/docs/platform-config.md
+++ b/docs/platform-config.md
@@ -2,8 +2,8 @@
 
 0.1 Cabeçalho
 • Documento: LP Factory 10 — Platform Config
-• Versão: v0.1.15
-• Data: 30/07/2026
+• Versão: v0.1.16
+• Data: 31/07/2026
 
 0.2 Contrato do documento
 • O QUE É: snapshot operacional e fonte única das configurações de plataformas externas do LP Factory 10, refletindo o estado conhecido/cadastrado nas plataformas conforme indicado.
@@ -157,6 +157,7 @@
 • `OPENAI_API_KEY`
 • Finalidade: chave server-side da OpenAI para resolvedor IA e/ou integrações server-side autorizadas.
 • Escopo: Production e Preview, conforme necessidade do recurso.
+• Estado atual: configurada em Production e Preview; presença confirmada operacionalmente em 31/07/2026 sem exposição do valor.
 • Valor real: não versionar.
 
 • `OPENAI_NICHE_RESOLVER_MODEL`
@@ -170,7 +171,9 @@
 • Finalidade: selecionar o modelo usado pela proposta administrativa opcional do perfil de orientação de `landing_page`.
 • Escopo: Production e Preview.
 • Valor permitido: `gpt-5.4-mini`.
-• Estado: configuração e validação operacional pendentes; sem a variável, sem `OPENAI_API_KEY` ou com qualquer outro modelo, a assistência fica indisponível e o fluxo manual permanece funcional.
+• Estado atual: configurada em Production e Preview com `gpt-5.4-mini`.
+• Validação operacional: redeploy de Production concluído em 31/07/2026 no commit `072d6d3f25368cf80c539519fe5f74bd6c4db359`; assistência habilitada no domínio oficial e primeira chamada real concluída.
+• Fallback: sem a variável, sem `OPENAI_API_KEY` ou com qualquer outro modelo, a assistência fica indisponível e o fluxo manual permanece funcional.
 • Valor real: não versionar.
 • Regra: deve conter apenas o ID do modelo; nunca inserir `OPENAI_API_KEY` nessa variável.
 
@@ -309,7 +312,8 @@
 • Finalidade: selecionar o modelo usado pela proposta administrativa opcional do perfil de orientação de `landing_page`.
 • Escopo: Production e Preview.
 • Valor permitido: `gpt-5.4-mini`.
-• Estado: configuração e validação operacional pendentes; sem a variável, sem `OPENAI_API_KEY` ou com qualquer outro modelo, a assistência fica indisponível e o fluxo manual permanece funcional.
+• Estado operacional: configurada e validada em Production e Preview em 31/07/2026; detalhes em 3.5.
+• Fallback: sem a variável, sem `OPENAI_API_KEY` ou com qualquer outro modelo, a assistência fica indisponível e o fluxo manual permanece funcional.
 • Valor real: não versionar.
 • Regra: deve conter apenas o ID do modelo; nunca inserir `OPENAI_API_KEY` nessa variável.
 
@@ -459,6 +463,8 @@ Regra:
 • Configurações de plataformas, secrets por nome, workflows, ambientes e endpoints usados por automações devem ser registrados neste documento.
 
 99. Changelog
+v0.1.16 — 31/07/2026 — Registradas a correção de `OPENAI_LANDING_PAGE_GENERATION_PROFILE_MODEL` para `gpt-5.4-mini`, a ampliação para Production e Preview, o redeploy e a validação operacional da assistência no domínio oficial.
+
 v0.1.15 — 30/07/2026 — Registrados o merge do PR #656, a habilitação do gate, o redeploy e o smoke final aprovado em Production.
 
 v0.1.14 — 30/07/2026 — Registrada a aprovação dos testes humanos da correção do transporte concorrente no Preview autorizado, removida a pendência de reteste e mantida Production desabilitada até o merge humano do PR #656.

--- a/docs/platform-config.md
+++ b/docs/platform-config.md
@@ -157,7 +157,7 @@
 • `OPENAI_API_KEY`
 • Finalidade: chave server-side da OpenAI para resolvedor IA e/ou integrações server-side autorizadas.
 • Escopo: Production e Preview, conforme necessidade do recurso.
-• Estado atual: configurada em Production e Preview; presença confirmada operacionalmente em 31/07/2026 sem exposição do valor.
+• Estado atual: configurada em Production e Preview; presença confirmada na configuração em 31/07/2026 sem exposição do valor.
 • Valor real: não versionar.
 
 • `OPENAI_NICHE_RESOLVER_MODEL`
@@ -173,6 +173,7 @@
 • Valor permitido: `gpt-5.4-mini`.
 • Estado atual: configurada em Production e Preview com `gpt-5.4-mini`.
 • Validação operacional: redeploy de Production concluído em 31/07/2026 no commit `072d6d3f25368cf80c539519fe5f74bd6c4db359`; assistência habilitada no domínio oficial e primeira chamada real concluída.
+• Preview: configuração presente, sem novo redeploy ou smoke específico comprovado após a correção.
 • Fallback: sem a variável, sem `OPENAI_API_KEY` ou com qualquer outro modelo, a assistência fica indisponível e o fluxo manual permanece funcional.
 • Valor real: não versionar.
 • Regra: deve conter apenas o ID do modelo; nunca inserir `OPENAI_API_KEY` nessa variável.
@@ -312,7 +313,7 @@
 • Finalidade: selecionar o modelo usado pela proposta administrativa opcional do perfil de orientação de `landing_page`.
 • Escopo: Production e Preview.
 • Valor permitido: `gpt-5.4-mini`.
-• Estado operacional: configurada e validada em Production e Preview em 31/07/2026; detalhes em 3.5.
+• Estado operacional: configurada em Production e Preview; validada operacionalmente somente em Production em 31/07/2026; Preview permanece sem novo redeploy ou smoke comprovado; detalhes em 3.5.
 • Fallback: sem a variável, sem `OPENAI_API_KEY` ou com qualquer outro modelo, a assistência fica indisponível e o fluxo manual permanece funcional.
 • Valor real: não versionar.
 • Regra: deve conter apenas o ID do modelo; nunca inserir `OPENAI_API_KEY` nessa variável.
@@ -463,7 +464,7 @@ Regra:
 • Configurações de plataformas, secrets por nome, workflows, ambientes e endpoints usados por automações devem ser registrados neste documento.
 
 99. Changelog
-v0.1.16 — 31/07/2026 — Registradas a correção de `OPENAI_LANDING_PAGE_GENERATION_PROFILE_MODEL` para `gpt-5.4-mini`, a ampliação para Production e Preview, o redeploy e a validação operacional da assistência no domínio oficial.
+v0.1.16 — 31/07/2026 — Registradas a correção de `OPENAI_LANDING_PAGE_GENERATION_PROFILE_MODEL` para `gpt-5.4-mini`, a ampliação para Production e Preview, o redeploy e a validação operacional da assistência somente em Production no domínio oficial.
 
 v0.1.15 — 30/07/2026 — Registrados o merge do PR #656, a habilitação do gate, o redeploy e o smoke final aprovado em Production.
 


### PR DESCRIPTION
## 1. Objetivo

Atualizar o snapshot operacional de `docs/platform-config.md` após a correção e validação da assistência por IA do perfil de orientação.

## 2. Alterações

- versão do documento atualizada para `v0.1.16` em 31/07/2026;
- presença de `OPENAI_API_KEY` registrada em Production e Preview, sem expor o valor;
- `OPENAI_LANDING_PAGE_GENERATION_PROFILE_MODEL` registrada com `gpt-5.4-mini` em Production e Preview;
- redeploy e validação operacional no domínio oficial registrados;
- referência resumida preservada na seção OpenAI Platform;
- changelog atualizado.

## 3. Limites

- nenhuma variável ou configuração foi alterada por este PR;
- nenhum secret foi versionado;
- a lacuna funcional de seleção de variantes permanece no documento próprio da E12.4 e não foi duplicada no Platform Config.

## 4. Fontes

- `README.md` v5;
- `AGENTS.md`;
- `docs/platform-config.md` v0.1.15;
- estado real validado na Vercel e no domínio oficial em Production.

## 5. Validação

- diff revisado: somente `docs/platform-config.md`;
- `npm ci`: não aplicável;
- `npm run check`: não aplicável.