### PR TITLE
docs: preservar estratégia e rastreabilidade dos updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 0. Introdução
 0.1. Cabeçalho
 • Documento: README — LP Factory 10 (MVP)
-• Versão: 5 — 21/07/2026
-• Data: 21/07/2026
+• Versão: 6 — 04/08/2026
+• Data: 04/08/2026
 • Escopo: visão geral do produto + documentos de referência + pendências estratégicas
 
 1. Visão geral do produto
@@ -46,6 +46,7 @@
 • Todo recurso candidato deve ser classificado quanto à relação com a stack e a arquitetura — complementar, sobreposto, substituto ou incompatível — e avaliado por benefício, maturidade das fontes, custo, complexidade, segurança, manutenção e horizonte de adoção.
 • Incompatibilidade pode justificar descarte. Recursos sobrepostos ou substitutos só devem permanecer como condicionais quando houver hipótese concreta de superioridade e gatilho objetivo para comparação ou adoção.
 • A simplicidade do MVP limita a implementação do momento, não o radar tecnológico nem a preservação de diferenciais estratégicos para a evolução dos planos.
+• O WhatsApp é canal comercial prioritário para aquisição, atendimento, qualificação, venda e nutrição; suas capacidades oficiais de mensageria, automação e IA devem permanecer no radar e ser distribuídas progressivamente entre os planos, sem autorizar adoção antecipada.
 • Avaliação ou catalogação não autoriza implementação, mudança de stack, nova infraestrutura nem ampliação de escopo.
 • Em cada plano-base, fase ou recorte, o Gestor de Updates recomenda a aplicabilidade dos recursos catalogados, e o Estrategista decide sua consolidação no plano-base dentro do escopo aprovado.
 • A intervenção humana é necessária somente quando faltar autoridade ou definição indispensável de produto, ou quando houver ampliação do escopo aprovado; a materialidade, isoladamente, não constitui bloqueio.

--- a/docs/workflow-atualizacao-updates.md
+++ b/docs/workflow-atualizacao-updates.md
@@ -1,4 +1,5 @@
 22/07/2026 — Workflow de Atualização dos Catálogos de Updates
+Atualizado em 04/08/2026
 
 Fontes: chat, repositório e documentos indicados nos itens 2 e 3
 
@@ -13,13 +14,14 @@ Ao final de uma única execução:
 - os quatro catálogos foram analisados na ordem do item 2;
 - cada catálogo foi concluído da leitura ao relatório e ao draft PR ou à justificativa antes do início da análise do seguinte, sem processamento em lote ou paralelo;
 - cada ajuste real está em branch própria criada do mesmo SHA inicial de `main`, alterando somente o documento-alvo;
-- IDs e lacunas históricas foram preservados, sem renumeração ou reutilização;
+- todos os IDs publicados continuam localizáveis no catálogo, sem renumeração, reutilização ou desaparecimento físico;
+- itens implementados, parcialmente implementados, absorvidos, superados ou rejeitados preservam registro histórico e referências;
 - ausências de ajuste, bloqueios e exceções foram registradas;
 - nenhum PR foi mergeado nem a catalogação transformada em implementação.
 
 ### 1.2. Papel
 
-- Manter os catálogos de updates atuais, úteis e baseados em fontes oficiais, sem aprovação humana intermediária entre eles.
+- Manter os catálogos de updates atuais, úteis, rastreáveis e baseados em fontes oficiais, sem aprovação humana intermediária entre eles.
 
 ## 2. Documentos-alvo e ordem
 
@@ -28,19 +30,22 @@ Ao final de uma única execução:
 3. `docs/github-up.md`
 4. `docs/prod-up.md`
 
-Os demais catálogos podem ser consultados apenas para detectar duplicações. Isso não inicia sua análise.
+Os demais catálogos podem ser consultados para detectar duplicações, absorções e referências cruzadas. Isso não inicia sua análise completa.
 
 ## 3. Fontes
 
 Consultar, para o catálogo em execução:
 
-- o `README.md`, como política geral de avaliação tecnológica;
+- o `README.md`, como política geral de avaliação tecnológica e fonte dos pilares e canais estratégicos;
 - o documento-alvo no SHA inicial;
-- o repositório e os documentos técnicos relacionados aos itens avaliados;
+- `docs/roadmap.md`, Base Técnica, schema, configurações de plataforma, matrizes e lousas relacionadas;
+- código, migrations, testes, workflows, dependências e histórico de PRs ou commits quando necessários para confirmar implementação;
 - os relatórios e diffs dos catálogos anteriores já concluídos nesta execução;
 - fontes oficiais externas correspondentes.
 
 Para Supabase, usar documentação, changelog e blog oficiais. Para Vercel, usar fontes oficiais da Vercel, Next.js e React. Para GitHub e produto, seguir as fontes prioritárias definidas nos próprios catálogos.
+
+Para cada pilar ou canal declarado estratégico no `README.md`, pesquisar explicitamente as fontes oficiais aplicáveis e registrar também quando não houver novidade relevante. O WhatsApp deve ser coberto por fontes oficiais da WhatsApp Business Platform ou Meta Business Messaging.
 
 Fontes secundárias podem apoiar, mas não substituir a fonte oficial.
 
@@ -49,39 +54,56 @@ Fontes secundárias podem apoiar, mas não substituir a fonte oficial.
 1. Congelar o SHA inicial de `main` e confirmar o `README.md` e os quatro documentos-alvo.
 2. Para cada catálogo, na ordem do item 2, concluir todo o ciclo antes de iniciar a análise do seguinte:
    - ler as fontes aplicáveis e as regras do catálogo;
-   - identificar o maior ID histórico e preservar todos os IDs e lacunas, atribuindo novo ID somente acima do maior já utilizado;
-   - verificar no repositório o estado real dos itens, duplicações, uso global e registro na Base Técnica;
-   - pesquisar recursos novos, alterados, deprecados ou superados;
+   - identificar o maior ID histórico, preservar todos os IDs publicados e atribuir novo ID somente acima do maior já utilizado;
+   - executar gate de rastreabilidade antes de reclassificar qualquer item:
+     - buscar o ID exato em todo o repositório;
+     - buscar semanticamente o título, a capacidade e os artefatos associados, mesmo quando o ID não estiver citado;
+     - identificar casos E*, documentos, código, migrations, testes, configurações, PRs e decisões que aplicaram ou rejeitaram o item;
+     - classificar o uso como não implementado, futuro aprovado, implementado parcialmente, implementado integralmente, referência, trava, absorvido, superado ou rejeitado;
+   - verificar no repositório o estado real dos itens, duplicações, uso global e registro nos documentos competentes;
+   - pesquisar recursos novos, alterados, deprecados ou superados, cobrindo os pilares e canais estratégicos do `README.md`;
    - avaliar função, natureza de uso, relação com a stack, caso de uso, valor, maturidade das fontes, custo, complexidade, segurança, manutenção, dependências, riscos e horizonte;
+   - registrar horizonte como Starter, Lite, Pro, Ultra ou indefinido quando houver evidência suficiente, sem transformar a classificação em decisão final de plano;
    - exigir hipótese de superioridade e gatilho objetivo para recurso sobreposto ou substituto;
-   - classificar itens existentes como manter, ajustar ou remover, e recursos pesquisados como adicionar, não adicionar ou não validado;
-   - manter item com uso real sem registro na Base Técnica como lacuna documental; remover item usado globalmente somente quando esse uso estiver documentado;
+   - classificar itens existentes como manter, ajustar ou arquivar/absorver, e recursos pesquisados como adicionar, não adicionar ou não validado;
+   - nunca apagar um ID publicado; quando o item sair do catálogo ativo, manter registro histórico compacto com título original, estado final, evidências, recortes e eventual substituto;
+   - manter item implementado total ou parcialmente com os recortes aplicados e o escopo ainda não implementado;
+   - manter item com uso real sem registro no documento técnico competente como lacuna documental;
    - adicionar somente recurso compatível com o `README.md`, com fonte oficial, valor concreto e horizonte plausível; recurso futuro ou condicional pode entrar sem autorizar implementação;
-   - não adicionar ou remover, conforme aplicável, recurso incompatível, duplicado, absorvido, deprecado, superado, sem valor concreto ou com custo ou risco desproporcional;
+   - não rejeitar nem arquivar um recurso somente por estar fora do Starter ou do MVP atual;
+   - arquivar como incompatível, duplicado, absorvido, deprecado, superado, sem valor concreto ou com custo ou risco desproporcional somente com evidência e preservação do registro;
    - classificar como não validado quando faltar fonte oficial ou evidência suficiente;
    - produzir o relatório obrigatório;
    - quando houver ajuste, criar branch do SHA inicial, alterar somente o documento-alvo, validar o diff e abrir draft PR com o relatório;
    - quando não houver ajuste, registrar a justificativa sem criar alteração artificial;
-   - confirmar documento, IDs e lacunas, resultado do diff e URL do PR ou justificativa antes de seguir.
+   - confirmar documento, IDs, referências, resultado do diff e URL do PR ou justificativa antes de seguir.
 3. Seguir automaticamente ao próximo catálogo, sem aguardar aprovação ou merge.
-4. Ao final, conferir a sequência executada, a base comum, os arquivos alterados, os IDs e o estado dos PRs. Se houver divergência, informá-la e não declarar execução integralmente aderente.
+4. Ao final, conferir a sequência executada, a base comum, os arquivos alterados, a cobertura dos canais estratégicos, os IDs e o estado dos PRs. Se houver divergência, informá-la e não declarar execução integralmente aderente.
 
 ## 5. Relatório obrigatório
 
 1. Veredito.
 2. Fontes consultadas.
-3. Itens mantidos:
-   - IDs.
-4. Itens ajustados:
+3. Cobertura estratégica:
+   - pilares e canais pesquisados;
+   - fontes oficiais;
+   - novidades encontradas ou confirmação de ausência de novidade relevante.
+4. Itens mantidos:
+   - IDs;
+   - estado e horizonte.
+5. Itens ajustados:
    - ID;
    - ajuste;
    - motivo;
-   - fonte.
-5. Itens removidos:
-   - ID;
-   - motivo;
-   - evidência.
-6. Itens adicionados:
+   - fonte;
+   - referências e recortes.
+6. Itens arquivados, absorvidos ou superados:
+   - ID e título original;
+   - estado final;
+   - motivo e evidência;
+   - referências e recortes preservados;
+   - ID substituto, quando houver.
+7. Itens adicionados:
    - ID;
    - título;
    - natureza de uso;
@@ -92,18 +114,19 @@ Fontes secundárias podem apoiar, mas não substituir a fonte oficial.
    - fonte;
    - dependências, riscos e limite;
    - confirmação de que o registro não autoriza implementação.
-7. Itens avaliados e não adicionados:
+8. Itens avaliados e não adicionados:
    - recurso;
    - motivo objetivo;
-   - confirmação de que não foi rejeitado somente por estar fora do MVP.
-8. Pontos não validados ou lacunas documentais:
+   - confirmação de que não foi rejeitado somente por estar fora do MVP ou do Starter.
+9. Pontos não validados ou lacunas documentais:
    - item;
    - evidência faltante;
    - forma de validação.
-9. Validação:
+10. Validação:
    - confirmar que o catálogo foi concluído antes do início da análise do seguinte;
    - informar branch e draft PR ou justificar a ausência de alteração;
-   - confirmar que não houve renumeração, reutilização de ID ou remoção sem evidência suficiente;
+   - confirmar que nenhum ID desapareceu, foi renumerado ou reutilizado;
+   - confirmar a busca por referências explícitas e implementação semântica antes de cada arquivamento;
    - confirmar aderência ao `README.md`;
    - confirmar que novidade, modernidade ou distância do MVP não determinaram isoladamente a decisão.
 
@@ -111,7 +134,7 @@ Fontes secundárias podem apoiar, mas não substituir a fonte oficial.
 
 - Não alterar código, roadmap, Base Técnica, schema, configuração ou outro catálogo.
 - Não transformar catalogação em implementação, mudança de stack, nova infraestrutura ou novo escopo do MVP.
-- Não decidir aplicação em plano-base, fase ou recorte; o Gestor de Updates recomenda e o Estrategista consolida no fluxo competente.
+- Não decidir aplicação final em plano-base, fase ou recorte; o Gestor de Updates recomenda horizonte e o Estrategista consolida no fluxo competente.
 - Não adicionar item sem fonte oficial, valor concreto e compatibilidade com o `README.md`.
 - Não realizar merge dos PRs.
 - Quando faltar fonte obrigatória, houver conflito material ou faltar permissão, informar exatamente o bloqueio e parar.


### PR DESCRIPTION
## 1. Objetivo

Corrigir a governança dos catálogos de updates para preservar capacidades estratégicas e a rastreabilidade dos IDs.

## 2. Ajustes

- explicita o WhatsApp como canal comercial prioritário;
- preserva o radar de capacidades avançadas entre Starter, Lite, Pro e Ultra;
- proíbe o desaparecimento físico de IDs publicados;
- exige busca reversa pelo ID e pela implementação semântica;
- diferencia implementação total, parcial, referência, trava, absorção e rejeição;
- exige cobertura dos canais estratégicos nas pesquisas;
- substitui remoção por registro histórico rastreável.

## 3. Impacto

A mudança é somente documental. Não altera código, banco, configuração, roadmap, stack, planos comerciais nem autoriza implementação.

## 4. Validação

- estrutura e numeração existentes preservadas;
- regras conflitantes de remoção substituídas;
- README permanece como política geral;
- regras operacionais detalhadas permanecem no workflow.
