### PR TITLE
fix(taxonomy): garantir um primário ativo por conta

### DIFF
--- a/docs/lousa-plano-base-e12-4.md
+++ b/docs/lousa-plano-base-e12-4.md
@@ -1,8 +1,8 @@
 # Plano-base — E12.4 — Gestão do perfil de orientação
 
 - Data: 04/08/2026.
-- Versão: v2.9.
-- Status: E12.4.3, E12.4.3.1 e E12.4.3.2 implementadas e incorporadas à `main` pelo PR #672; correção técnica aprovada no PR draft #681, gate funcional hospedado aprovado e inspeção final do Estrategista aprovada; somente o merge humano permanece pendente.
+- Versão: v2.10.
+- Status: E12.4.3, E12.4.3.1 e E12.4.3.2 implementadas e incorporadas à `main`, incluindo a correção técnica do PR #681; gate funcional hospedado e inspeção final do Estrategista aprovados. A E12.4.4 foi retirada da implementação e absorvida pela jornada simplificada, sem ser concluída.
 - Recorte previsto para o roadmap: `12.4 — Gestão do perfil de orientação`.
 - Recorte executável inicial: `12.4.3 — Proposta, revisão, aprovação e ativação do perfil`.
 - Recorte corretivo planejado: `12.4.3.2 — Criação e evolução estrutural baseada em lp_sections, catálogo vigente e debate humano–IA`.
@@ -89,7 +89,7 @@
   - prosseguir com os disponíveis, mantendo aviso explícito da pendência.
 - E18.4, E18.5, E10.8 e o perfil orientam somente a geração inicial.
 - Depois de materializada, a LP pertence à conta e permanece independente dessas fontes; mudanças nelas não alteram nem governam automaticamente a LP existente.
-- A E12.4.4 e a E19.4 permanecem fora da implementação deste plano, com pendências explícitas registradas em 1.4.
+- A E12.4.4 foi retirada da implementação e absorvida pela jornada simplificada, sem ser concluída; a E19.4 permanece fora da implementação deste plano.
 
 ### 1.4. Fronteiras de responsabilidade
 
@@ -97,12 +97,9 @@
 - E18.4 e E18.5 fornecem limites e identidades vigentes para a geração inicial; a E12.4.3.2 não os redefine nem cria módulos.
 - Tornar `generation_guidance` opcional altera o contrato de domínio da E20.3; a evolução é formalizada na E20.3.5 e implementada no mesmo PR técnico da E12.4.3.2.
 - E12.4.3.2 corrige a criação e o refinamento estrutural do perfil no Admin Dashboard.
-- E12.4.4 deverá, obrigatoriamente:
-  - recalcular ou recuperar os gaps antes de autorizar geração;
-  - registrar adiamento com justificativa, impacto, responsável e condição de retomada;
-  - classificar se o gap é impeditivo;
-  - bloquear autorização enquanto houver gap impeditivo;
-  - verificar incompatibilidades entre exceções humanas e os contratos usados na geração inicial.
+- A E12.4.4 não será implementada neste fluxo e não constitui dependência futura de recálculo ou reclassificação de gaps.
+- A decisão do lifecycle vigente é suficiente: `wait_for_modules` bloqueia a ativação e `proceed_with_available` permite a ativação com a decisão auditada.
+- Não existe novo gate de autorização ou revogação por conta; validações dos consumidores futuros permanecem nos domínios responsáveis.
 - O snapshot das fontes e a independência da LP materializada permanecem decisões consolidadas para consumo futuro pela E19.4.
 - O futuro plano-base da E19.4 deverá decidir, sem antecipação neste plano:
   - quais edições o cliente poderá fazer após a materialização;
@@ -160,7 +157,7 @@
   - `Prosseguir com os disponíveis` usa somente recomendações válidas e mantém aviso visível na sessão corrente;
   - nenhuma nova tabela é criada e os gaps não integram as tabelas do perfil;
   - ao salvar o rascunho, registrar no evento de auditoria vigente a decisão `wait_for_modules` ou `proceed_with_available`, os `item_key` afetados, quantidade de gaps, impacto resumido, versões das fontes usadas e, quando utilizada, referência segura da pesquisa bruta com path, versão declarada, commit ou blob, público e taxon de origem;
-  - a auditoria preserva a decisão, mas não substitui o recálculo obrigatório dos gaps pela E12.4.4 antes da prontidão.
+  - a auditoria preserva a decisão do lifecycle; não existe recálculo obrigatório posterior pela E12.4.4.
 - Validação:
   - validar taxon, agregado, identidades e versões antes de salvar, ativar ou arquivar;
   - rejeitar saída ou mutação incompatível sem alterar o `draft` nem o `active`.
@@ -214,7 +211,7 @@
 - Prioridade e ordem permanecem orientativas e nenhum campo transforma módulo em obrigatório.
 - Identidade ausente ou incompatível falha fechado e não é criada ou corrigida automaticamente.
 - A E12.4.3.2 não interpreta semanticamente as exceções humanas nem permite que alterem E18.4 ou E18.5.
-- Exceção humana incompatível pode permanecer no perfil, mas não autoriza geração: a E12.4.4 deve classificá-la como não pronta e a futura geração deve falhar fechado.
+- Exceção humana incompatível pode permanecer no perfil; ela não cria dependência de recálculo pela E12.4.4, e cada consumidor futuro deve validar seu próprio contrato de forma fail-closed.
 - Os gaps da proposta não são persistidos nas tabelas do perfil neste recorte.
 
 ### 2.3. Lifecycle, atomicidade e auditoria
@@ -301,7 +298,7 @@
 - Quando houver gaps, mostrar seção, prioridade, ordem, motivo e impacto, com:
   - `Aguardar criação dos módulos`;
   - `Prosseguir com os disponíveis`.
-- O aviso permanece visível na sessão corrente quando o humano prosseguir; após recarga, a E12.4.3.2 não promete reconstruí-lo pelas tabelas do perfil, e a E12.4.4 deverá recalcular os gaps.
+- O aviso permanece visível na sessão corrente quando o humano prosseguir; após recarga, a E12.4.3.2 não promete reconstruí-lo pelas tabelas do perfil.
 - Ações visuais:
   - criar nova versão;
   - `Criar perfil com IA` ou `Evoluir perfil com IA`, conforme o contexto;
@@ -405,7 +402,7 @@
 
 #### 3.1.2. E12.4.3.2 — Proposta estrutural baseada em `lp_sections` e delta do catálogo
 
-- Status: implementada e incorporada à `main` pelo PR #672; correção localizada do contrato de cardinalidade aprovada no PR draft #681, com gate funcional e inspeção final do Estrategista aprovados; somente o merge humano permanece pendente.
+- Status: implementada e incorporada à `main` pelo PR #672, com correção localizada do contrato de cardinalidade incorporada pelo PR #681; gate funcional e inspeção final do Estrategista aprovados.
 - Ocorrência corretiva de 03/08/2026:
   - a evolução do perfil foi rejeitada de forma fail-closed como `coverage_identity_count_invalid`, sob o Request ID `c2287d63-0ff9-4fe5-8bc0-641f1e387a7a`;
   - o perfil `active v1` permaneceu preservado e nenhum `draft v2` foi criado;
@@ -416,7 +413,7 @@
   - Request ID `e360a900-082a-4707-9610-ef4f9cdfa2d9`, `proposalMode: evolution`, uma única chamada e resultado `success`;
   - candidata revisada e descartada, sem retry, salvamento ou ativação; somente o perfil `active v1` permaneceu preservado, sem criação de `draft v2`;
   - como observação não bloqueante, `rodape_contato` foi classificado como `covered`, com `compatible_aliases` `final_cta.standard` e `trust_bar.standard` e `selected_aliases` `final_cta.standard`;
-  - a avaliação humana considera `rodape_contato` uma possível necessidade global de composição não integralmente coberta pelo catálogo modular; a E12.4.4 deverá recalcular e classificar o item, sem criação automática de módulo ou variante.
+  - a avaliação humana considera `rodape_contato` uma possível necessidade global de composição não integralmente coberta pelo catálogo modular; a observação não cria dependência de recálculo pela E12.4.4 nem autoriza criação automática de módulo ou variante.
 - Objetivo:
   - corrigir a criação e a evolução estrutural, o debate humano–IA, o contrato da proposta e a opcionalidade das exceções humanas sem refazer o lifecycle entregue.
 - Entregas:
@@ -433,7 +430,7 @@
   - tornar `generation_guidance` opcional por migration incremental;
   - preservar `item_guidance` opcional;
   - impedir alteração de exceções humanas pela IA;
-  - registrar em E12.4.4 a obrigação de recuperar gaps e decidir prontidão;
+  - registrar a retirada da E12.4.4 e a ausência de dependência futura de recálculo de gaps ou autorização por conta;
   - registrar em E19.4 a independência da LP materializada.
 - Critérios de aceite:
   - `coverage[]` avalia exatamente cada item de `lp_sections` como atendido, parcialmente atendido ou faltante e não é persistido;
@@ -445,7 +442,7 @@
   - módulo-base sem variante exige seleção explícita e conflitos de identidade do mesmo módulo falham fechados sem usar prioridade, ordem ou posição;
   - a prioridade de origem é convertida por `3 → P1`, `2 → P2`, `1 → P3` e a ordem final é determinística, positiva e única;
   - gaps exibem seção, motivo, impacto e decisão humana;
-  - a decisão é auditada no salvamento, `wait_for_modules` bloqueia ativação e a E12.4.4 recalcula gaps;
+  - a decisão é auditada no salvamento, `wait_for_modules` bloqueia a ativação e `proceed_with_available` permite a ativação;
   - IA não produz nem altera `generation_guidance` ou `item_guidance`;
   - prosseguir não oculta a pendência e aguardar não cria módulo automaticamente;
   - lifecycle, auditoria e resolver active-only permanecem funcionais;
@@ -460,14 +457,14 @@
 - Preservar o PR #669 incorporado, sem revertê-lo.
 - Preservar o PR #672 incorporado e não reutilizá-lo para a correção de cardinalidade.
 - Considerar aprovadas a correção técnica, o gate funcional único no Preview do HEAD `e6f694454b11388f30355ddbf231bb8350ecef1f` e a inspeção final do Estrategista, sem repetir a chamada à OpenAI.
-- Manter o PR draft; somente o merge humano permanece pendente.
+- Preservar o PR #681 incorporado, sem reabri-lo para esta reconciliação.
 - Preservar `vercel#1 — AI Gateway` e `supa#63 — rlsautotest` apenas como oportunidades estratégicas condicionais.
 
 ## 4. Escopo negativo e critérios de parada
 
 ### 4.1. Escopo negativo
 
-- Implementação da E12.4.4; somente o registro explícito de suas pendências integra este plano.
+- Implementação da E12.4.4, retirada e absorvida pela jornada simplificada sem ser concluída.
 - Autorização ou revogação por conta, taxon e plano.
 - E12.4.5, E12.4.6 e implementação da E19.4; somente o registro da independência da LP integra este plano.
 - Geração, materialização, preview, publicação ou alteração de LP.
@@ -490,7 +487,7 @@
 ### 4.2. Critérios de parada imediata
 
 - Parar e devolver ao Estrategista se:
-  - o fluxo exigir ampliar a E12.4.3 ou alcançar a E12.4.4;
+  - o fluxo exigir ampliar a E12.4.3 ou reintroduzir a E12.4.4;
   - surgir necessidade de perfil próprio de ultranicho;
   - a mutação segura e atômica exigir nova tabela, nova infraestrutura ou mudança material de arquitetura;
   - a categoria aprovada não atender ao requisito;
@@ -510,12 +507,11 @@
   - IA limitada a informar `compatible_aliases` e `selected_aliases`, com prioridade e ordem derivadas deterministicamente pelo servidor e gaps derivados da cobertura;
   - `generation_guidance` e `item_guidance` como exceções opcionais humanas;
   - decisão entre aguardar ou prosseguir com aviso;
-  - pendências explícitas da E12.4.4 e E19.4;
+  - retirada da E12.4.4, ausência de dependência futura de recálculo e E19.4 fora do escopo;
   - PR #656 preservado fora do escopo;
   - ausência de nova tabela, agente, job, fila, service ou infraestrutura.
 - Para este delta corretivo, executar `npm ci`, `npm run check`, as validações do catálogo e do perfil, revisão do diff e verificação de whitespace; banco não se aplica porque a correção não contém nem exige schema ou migration.
 
 ### 4.4. Critérios de encerramento do plano
 
-- O plano v2.9 está tecnicamente concluído, com decisão conceitual, implementação, migration histórica, validações técnicas e visuais, registro das pendências futuras e reconciliação documental aprovados.
-- Permanece pendente somente o merge humano.
+- O plano v2.10 está tecnicamente concluído, com decisão conceitual, implementação, migration histórica, validações técnicas e visuais e reconciliação documental aprovados.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 0.1 Cabeçalho
 • Data: 04/08/2026
-• Versão: v1.5.121
+• Versão: v1.5.122
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -812,6 +812,9 @@
 • `account_taxonomy` é o vínculo oficial da conta com taxon aprovado.
 • Gravação automática apenas em alta confiança determinística.
 • Não substitui automaticamente vínculo primário diferente.
+• O banco garante no máximo um vínculo com `is_primary = true` e `status = 'active'` por conta; zero primários ativos e múltiplos vínculos não primários ou inativos permanecem permitidos.
+• As leituras de primário ativo não limitam o resultado antes de `maybeSingle()`: zero continua ausência e cardinalidade maior que um falha fechada, sem escolha silenciosa.
+• Artefatos: `supabase/migrations/20260804201831_account_taxonomy_one_active_primary.sql`, `supabase/tests/account_taxonomy_one_active_primary.test.sql`, `supabase/snippets/account_taxonomy_one_active_primary_verify.sql` e `lib/onboarding/niche-resolution/adapters/accountTaxonomyAdapter.ts`.
 
 10.5.6.5 IA estruturada e persistência `ai_*`
 • Status: Concluído
@@ -1469,7 +1472,7 @@ Repositório — Ajustados
 
 12.4 Gestão do perfil de orientação
 - Objetivo: Definir a operação administrativa do perfil de orientação que direciona gerações futuras de landing pages sem materializar nem alterar LPs.
-- Status: E12.4.3, E12.4.3.1 e E12.4.3.2 concluídas e integradas à `main`; correção técnica aprovada no PR draft #681, gate funcional único no Preview aprovado e inspeção final do Estrategista aprovada; somente o merge humano permanece pendente.
+- Status: E12.4.3, E12.4.3.1 e E12.4.3.2 concluídas e integradas à `main`, incluindo a correção técnica do PR #681; gate funcional único no Preview e inspeção final do Estrategista aprovados.
 
 12.4.1 Objetivo e status
 - Objetivo: Entregar a operação manual completa de criação, edição, revisão, ativação e arquivamento de versões do perfil, com proposta opcional por IA no mesmo editor.
@@ -1485,7 +1488,7 @@ Repositório — Ajustados
   - A E12.4.3 reutiliza o contrato e a persistência da E20.3 sem alterar o resolver público do perfil ativo próprio ou herdado.
   - Dependência técnica atendida em 28/07/2026: PR #655 mergeado, branch sincronizada com a `main` e `next`/`eslint-config-next` confirmados em `16.2.11` no lockfile antes da implementação.
   - A proposta por IA exige resolução completa da E10.8 e identidades públicas vigentes da E18.5; ausência ou indisponibilidade da assistência não bloqueia o fluxo manual.
-  - E12.4.4 e subseções posteriores, autorização por conta, geração, materialização, preview, publicação e alteração de LP permanecem fora do recorte.
+  - A E12.4.4 foi retirada da implementação e absorvida pela jornada simplificada; geração, materialização, preview, publicação e alteração de LP permanecem fora do recorte.
 - Registros de implementação:
   - Admin Dashboard: listagem e editor em `app/admin/(protected)/perfis-de-orientacao/`, com salvar draft, ativar e arquivar protegidos por `platform_admin`.
   - Boundary e adapters: contratos administrativos, validação estrita, correlação da proposta, acesso server-only e integração opcional com Responses API em `lib/conversion-content/`.
@@ -1503,7 +1506,7 @@ Repositório — Ajustados
   - Não existe conversa persistente, histórico de mensagens, agente ou memória própria.
 
 12.4.3.2 Criação e evolução estrutural baseada em `lp_sections`, catálogo vigente e debate humano–IA
-- Status: Implementada e integrada à `main` pelo PR #672; correção localizada de cardinalidade aprovada no Preview do HEAD funcional `e6f694454b11388f30355ddbf231bb8350ecef1f`, com inspeção final do Estrategista aprovada e somente o merge humano pendente, sem banco ou migration e sem reabrir lifecycle.
+- Status: Implementada e integrada à `main` pelo PR #672, com correção localizada de cardinalidade integrada pelo PR #681; gate funcional no HEAD `e6f694454b11388f30355ddbf231bb8350ecef1f` e inspeção final do Estrategista aprovados, sem banco ou migration e sem reabrir lifecycle.
 - Conteúdo:
   - Sem perfil próprio, a ação será `Criar perfil com IA`; com perfil `active` próprio, será `Evoluir perfil com IA`; o fluxo manual permanece completo.
   - A evolução inicializará o editor da nova versão com a estrutura ativa completa como baseline não persistido e revalidará cada recomendação contra as versões vigentes da E10.8 e da E18.5.
@@ -1517,8 +1520,8 @@ Repositório — Ajustados
   - Aplicar alterará somente o editor; `Salvar rascunho`, aprovação, ativação e arquivamento continuarão separados e humanos.
   - A pesquisa bruta será contexto complementar opcional, resolvido pela proveniência efetiva da E10.8 e incluído apenas quando existir e couber integralmente no limite da requisição; ausência ou omissão não criarão gate.
   - A IA não preencherá nem modificará `generation_guidance` ou `item_guidance`, que serão exceções humanas opcionais.
-  - A decisão `wait_for_modules` ou `proceed_with_available` será registrada no evento de auditoria do rascunho; aguardar bloqueará ativação.
-  - A E12.4.4 recalculará os gaps antes da prontidão, sem nova tabela neste recorte.
+  - A decisão `wait_for_modules` ou `proceed_with_available` é registrada no evento de auditoria do rascunho; `wait_for_modules` bloqueia a ativação e `proceed_with_available` permite a ativação com a decisão auditada.
+  - Não existe dependência futura de recálculo dos gaps pela E12.4.4 nem novo gate de autorização por conta.
   - A evolução E20.3.5 tornará `generation_guidance` opcional no mesmo PR técnico, sem reabrir E20.3.3 ou E20.3.4.
   - Snapshot e independência da LP permanecem consolidados; liberdade de edição e comportamento de regeneração serão decididos apenas no futuro plano-base da E19.4.
   - Registros da implementação candidata:
@@ -1532,18 +1535,16 @@ Repositório — Ajustados
   - Substituir a digitação livre de módulo e variante por seleção vinculada ao catálogo público vigente.
   - Derivar automaticamente as versões de módulo e variante, ou apresentá-las como somente leitura, evitando entrada numérica livre.
   - Desabilitar `Salvar rascunho` quando o editor não possuir alterações pendentes.
-  - Avaliar, no documento próprio da E10.8 ou no recálculo previsto da E12.4.4, se `formato_medio` e `formato_longo` devem permanecer como itens de `lp_sections`.
+  - Avaliar no documento próprio da E10.8 se `formato_medio` e `formato_longo` devem permanecer como itens de `lp_sections`.
   - Os gaps de `formato_medio` e `formato_longo` não autorizam automaticamente a criação de módulo ou variante na E18.5.
 
 12.4.4 Prontidão, autorização e revogação por conta, taxon e plano
-- Status: Planejada; não implementada no PR #681.
-- Objetivo: Recalcular e classificar as pendências antes da prontidão e da autorização, preservando revogação explícita por conta, taxon e plano.
-- Classificação futura obrigatória:
-  - gaps de módulo ou variante;
-  - problemas de pesquisa ou modelagem;
-  - requisitos globais de composição não representados integralmente pelo catálogo modular.
-- Evidência factual para o recálculo futuro: no gate funcional da correção, `rodape_contato` foi classificado como `covered`, com compatíveis `final_cta.standard` e `trust_bar.standard` e escolha `final_cta.standard`; a avaliação humana registrou possível necessidade global de composição.
-- Limite: essa evidência não antecipa a classificação da E12.4.4 e não autoriza criação automática de módulo ou variante, alteração da E18.5 ou implementação neste PR.
+- Status: Retirada da implementação e absorvida pela jornada simplificada; não concluída.
+- Conteúdo:
+  - A decisão sobre gaps permanece no lifecycle vigente da E12.4.3.2: `wait_for_modules` bloqueia a ativação e `proceed_with_available` permite a ativação com auditoria.
+  - Não haverá recálculo posterior obrigatório dos gaps, prontidão persistida, autorização ou revogação por `conta + taxon + plano` neste recorte.
+  - A jornada futura não depende da implementação da E12.4.4 e não cria novo gate de autorização por conta.
+  - A observação sobre `rodape_contato` não autoriza criação automática de módulo ou variante nem alteração da E18.5.
 
 13. E13 — Partner Dashboard
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2362,6 +2362,8 @@ Repositório — Ajustados
   * Não criar novo campo, estado, tabela, resolver ou infraestrutura e não reabrir E20.3.3 ou E20.3.4.
 
 99. Changelog
+v1.5.122 — 04/08/2026 — Garantido no máximo um taxon primário ativo por conta e reconciliada a retirada da E12.4.4 da implementação.
+
 v1.5.121 — 04/08/2026 — Concluída documentalmente a correção de cardinalidade da E12.4.3.2 após gate funcional aprovado; registrada a E12.4.4 para classificar gaps modulares, problemas de pesquisa ou modelagem e requisitos globais de composição, sem implementação no PR #681.
 
 v1.5.118 — 03/08/2026 — Registrada a correção localizada do contrato de cardinalidade da evolução do perfil com IA, preservando validação fail-closed, `active v1`, ausência de retry e gate único no Preview após revisão independente.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data da última atualização: 28/07/2026
-• Documento: LP Factory 10 — Schema (DB Contract) v1.0.36
+• Data da última atualização: 04/08/2026
+• Documento: LP Factory 10 — Schema (DB Contract) v1.0.37
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -346,7 +346,7 @@
 • CHECK: account_taxonomy_source_type_chk (source_type IN ('manual', 'taxonomy_match', 'user_confirmed_ai'))
 • FK: account_id → accounts(id) ON UPDATE CASCADE ON DELETE CASCADE
 • FK: taxon_id → business_taxons(id) ON UPDATE CASCADE ON DELETE RESTRICT
-• Nota: não há constraint/índice garantindo apenas um `is_primary = true` por conta nesta etapa.
+• UNIQUE parcial: account_taxonomy_one_active_primary_idx em (account_id) WHERE is_primary = true AND status = 'active'; garante no máximo um vínculo primário ativo por conta, permite zero e preserva múltiplos vínculos não primários ou inativos.
 
 1.13.2 Campos
 • account_id uuid not null

--- a/lib/onboarding/niche-resolution/adapters/accountTaxonomyAdapter.ts
+++ b/lib/onboarding/niche-resolution/adapters/accountTaxonomyAdapter.ts
@@ -38,7 +38,6 @@ export async function getActivePrimaryAccountTaxon(input: {
       .eq("account_id", input.accountId)
       .eq("is_primary", true)
       .eq("status", ACCOUNT_TAXONOMY_STATUS)
-      .limit(1)
       .maybeSingle();
 
     if (primaryError) {
@@ -141,7 +140,6 @@ async function upsertPrimaryAccountTaxonomyLink(input: {
       .eq("account_id", input.accountId)
       .eq("is_primary", true)
       .eq("status", ACCOUNT_TAXONOMY_STATUS)
-      .limit(1)
       .maybeSingle();
 
     if (existingPrimaryError) {

--- a/supabase/migrations/20260804201831_account_taxonomy_one_active_primary.sql
+++ b/supabase/migrations/20260804201831_account_taxonomy_one_active_primary.sql
@@ -1,0 +1,32 @@
+do $$
+declare
+  duplicate_account_count bigint;
+begin
+  select count(*)
+  into duplicate_account_count
+  from (
+    select account_id
+    from public.account_taxonomy
+    where is_primary = true
+      and status = 'active'
+    group by account_id
+    having count(*) > 1
+  ) duplicate_accounts;
+
+  if duplicate_account_count > 0 then
+    raise exception using
+      errcode = '23505',
+      message = format(
+        'account_taxonomy has %s account(s) with more than one active primary link',
+        duplicate_account_count
+      ),
+      detail = 'The account_taxonomy_one_active_primary_idx index was not created.',
+      hint = 'Resolve the duplicate active primary links before applying this migration again.';
+  end if;
+end;
+$$;
+
+create unique index account_taxonomy_one_active_primary_idx
+  on public.account_taxonomy (account_id)
+  where is_primary = true
+    and status = 'active';

--- a/supabase/snippets/account_taxonomy_one_active_primary_verify.sql
+++ b/supabase/snippets/account_taxonomy_one_active_primary_verify.sql
@@ -1,0 +1,74 @@
+begin;
+set transaction read only;
+set local search_path = public, pg_catalog;
+
+with index_state as (
+  select
+    index_row.indisunique,
+    index_row.indisvalid,
+    index_row.indisready,
+    pg_get_indexdef(index_row.indexrelid) as definition,
+    pg_get_expr(index_row.indpred, index_row.indrelid) as predicate
+  from pg_index index_row
+  where index_row.indexrelid = to_regclass('public.account_taxonomy_one_active_primary_idx')
+), duplicate_active_primary_accounts as (
+  select account_id, count(*) as link_count
+  from public.account_taxonomy
+  where is_primary = true
+    and status = 'active'
+  group by account_id
+  having count(*) > 1
+), unexpected_account_wide_unique_indexes as (
+  select pg_get_indexdef(index_row.indexrelid) as definition
+  from pg_index index_row
+  where index_row.indrelid = to_regclass('public.account_taxonomy')
+    and index_row.indisunique
+    and index_row.indnkeyatts = 1
+    and (
+      select attribute.attname
+      from pg_attribute attribute
+      where attribute.attrelid = index_row.indrelid
+        and attribute.attnum = index_row.indkey[0]
+    ) = 'account_id'
+    and index_row.indexrelid <> to_regclass('public.account_taxonomy_one_active_primary_idx')
+), checks as (
+  select
+    'one_active_primary_index'::text as check_name,
+    case
+      when count(*) = 1
+        and bool_and(indisunique and indisvalid and indisready)
+        and bool_and(predicate ~* 'is_primary\s*=\s*true')
+        and bool_and(predicate ~* 'status\s*=\s*''active''')
+      then 'ok'
+      else 'unexpected'
+    end as status,
+    coalesce(jsonb_agg(jsonb_build_object(
+      'definition', definition,
+      'predicate', predicate,
+      'unique', indisunique,
+      'valid', indisvalid,
+      'ready', indisready
+    )), '[]'::jsonb) as details
+  from index_state
+
+  union all
+
+  select
+    'no_duplicate_active_primary_accounts',
+    case when count(*) = 0 then 'ok' else 'unexpected' end,
+    coalesce(jsonb_agg(to_jsonb(duplicate_active_primary_accounts) order by account_id), '[]'::jsonb)
+  from duplicate_active_primary_accounts
+
+  union all
+
+  select
+    'zero_primary_non_primary_and_inactive_links_allowed',
+    case when count(*) = 0 then 'ok' else 'unexpected' end,
+    coalesce(jsonb_agg(to_jsonb(unexpected_account_wide_unique_indexes)), '[]'::jsonb)
+  from unexpected_account_wide_unique_indexes
+)
+select check_name, status, details
+from checks
+order by check_name;
+
+commit;

--- a/supabase/tests/account_taxonomy_one_active_primary.test.sql
+++ b/supabase/tests/account_taxonomy_one_active_primary.test.sql
@@ -1,0 +1,162 @@
+begin;
+set local search_path = public, pg_catalog;
+
+do $$
+declare
+  index_row record;
+begin
+  select
+    index_state.indisunique,
+    index_state.indisvalid,
+    index_state.indisready,
+    pg_get_expr(index_state.indpred, index_state.indrelid) as predicate
+  into index_row
+  from pg_index index_state
+  where index_state.indexrelid = to_regclass('public.account_taxonomy_one_active_primary_idx');
+
+  if not found
+    or index_row.indisunique is not true
+    or index_row.indisvalid is not true
+    or index_row.indisready is not true
+    or index_row.predicate !~* 'is_primary\s*=\s*true'
+    or index_row.predicate !~* 'status\s*=\s*''active'''
+  then
+    raise exception 'account_taxonomy active-primary unique index is missing or invalid';
+  end if;
+end;
+$$;
+
+insert into public.accounts (id, name, subdomain, slug, status)
+values
+  ('a1200000-0000-4000-8000-000000000001', 'Account taxonomy primary test', 'account-taxonomy-primary-test', 'account-taxonomy-primary-test', 'active'),
+  ('a1200000-0000-4000-8000-000000000002', 'Account taxonomy zero-primary test', 'account-taxonomy-zero-primary-test', 'account-taxonomy-zero-primary-test', 'active');
+
+insert into public.business_taxons (id, parent_id, level, name, slug, is_active)
+values
+  ('b1200000-0000-4000-8000-000000000001', null, 'segment', 'Account taxonomy test segment one', 'account-taxonomy-test-segment-one', true),
+  ('b1200000-0000-4000-8000-000000000002', null, 'segment', 'Account taxonomy test segment two', 'account-taxonomy-test-segment-two', true),
+  ('b1200000-0000-4000-8000-000000000003', null, 'segment', 'Account taxonomy test segment three', 'account-taxonomy-test-segment-three', true);
+
+do $$
+begin
+  if exists (
+    select 1
+    from public.account_taxonomy
+    where account_id = 'a1200000-0000-4000-8000-000000000002'
+      and is_primary = true
+      and status = 'active'
+  ) then
+    raise exception 'an account with zero active primary links must be allowed';
+  end if;
+end;
+$$;
+
+insert into public.account_taxonomy (account_id, taxon_id, is_primary, status, source_type)
+values (
+  'a1200000-0000-4000-8000-000000000001',
+  'b1200000-0000-4000-8000-000000000001',
+  true,
+  'active',
+  'manual'
+);
+
+do $$
+begin
+  begin
+    insert into public.account_taxonomy (account_id, taxon_id, is_primary, status, source_type)
+    values (
+      'a1200000-0000-4000-8000-000000000001',
+      'b1200000-0000-4000-8000-000000000002',
+      true,
+      'active',
+      'manual'
+    );
+
+    raise exception 'a second active primary link should have been rejected';
+  exception when unique_violation then
+    null;
+  end;
+end;
+$$;
+
+insert into public.account_taxonomy (account_id, taxon_id, is_primary, status, source_type)
+values (
+  'a1200000-0000-4000-8000-000000000001',
+  'b1200000-0000-4000-8000-000000000002',
+  false,
+  'active',
+  'manual'
+);
+
+insert into public.account_taxonomy (account_id, taxon_id, is_primary, status, source_type)
+values (
+  'a1200000-0000-4000-8000-000000000001',
+  'b1200000-0000-4000-8000-000000000003',
+  true,
+  'inactive',
+  'manual'
+);
+
+do $$
+begin
+  begin
+    update public.account_taxonomy
+    set status = 'active'
+    where account_id = 'a1200000-0000-4000-8000-000000000001'
+      and taxon_id = 'b1200000-0000-4000-8000-000000000003';
+
+    raise exception 'activating a second primary link should have been rejected';
+  exception when unique_violation then
+    null;
+  end;
+end;
+$$;
+
+do $$
+begin
+  if (
+    select count(*)
+    from public.account_taxonomy
+    where account_id = 'a1200000-0000-4000-8000-000000000001'
+      and is_primary = true
+      and status = 'active'
+  ) <> 1 then
+    raise exception 'the final state must contain exactly one active primary link';
+  end if;
+
+  if not exists (
+    select 1
+    from public.account_taxonomy
+    where account_id = 'a1200000-0000-4000-8000-000000000001'
+      and taxon_id = 'b1200000-0000-4000-8000-000000000002'
+      and is_primary = false
+      and status = 'active'
+  ) then
+    raise exception 'non-primary links must remain allowed';
+  end if;
+
+  if not exists (
+    select 1
+    from public.account_taxonomy
+    where account_id = 'a1200000-0000-4000-8000-000000000001'
+      and taxon_id = 'b1200000-0000-4000-8000-000000000003'
+      and is_primary = true
+      and status = 'inactive'
+  ) then
+    raise exception 'historical inactive primary links must remain allowed';
+  end if;
+
+  if exists (
+    select account_id
+    from public.account_taxonomy
+    where is_primary = true
+      and status = 'active'
+    group by account_id
+    having count(*) > 1
+  ) then
+    raise exception 'the final state contains duplicate active primary links';
+  end if;
+end;
+$$;
+
+rollback;


### PR DESCRIPTION
## Objetivo

Garantir uma taxonomia autoritativa segura por conta e reconciliar a retirada da E12.4.4, sem implementar nenhum componente da E19 nem ampliar a E20.2.

## Alterações

- adiciona precheck de duplicidades e índice UNIQUE parcial para no máximo um vínculo `is_primary = true` e `status = 'active'` por `account_id`;
- preserva contas com zero primários, vínculos não primários e primários inativos;
- remove os dois `limit(1)` que mascaravam multiplicidade nas leituras de primário antes de `maybeSingle()`;
- adiciona teste SQL transacional com rollback e verificador pós-apply read-only;
- atualiza o contrato de schema e reconcilia roadmap/lousa: E12.4.4 retirada e absorvida, não concluída, sem recálculo futuro de gaps e sem novo gate de autorização por conta;
- preserva integralmente contratos, tipos e resolver da E20.2 e não altera arquivos da E19.

## Validações

- `npm ci`: aprovado;
- `npm run check`: aprovado, 0 erros e 24 warnings preexistentes fora do diff;
- `npm run validate:landing-page-input-catalog`: aprovado em todos os casos vigentes;
- `git diff --check`: aprovado;
- asserts de escopo/secrets: aprovados;
- inspeção Supabase read-only pré-apply: 0 contas duplicadas, máximo atual de 1 primário ativo, índice candidato ausente;
- histórico remoto: migration `20260804201831` não aplicada;
- gate do Analista: `aprovado para avançar`, sem correções obrigatórias e sem teste humano;
- checks hospedados: `no-implicit-flow`, Vercel Preview Comments, `lp-factory-10` e `lpf-10-services` concluídos com sucesso.

## Validação PostgreSQL e fluxo de banco

- teste PostgreSQL transacional aprovado;
- resultado `validated_and_rolled_back`;
- rollback confirmado;
- migration ainda não aplicada;
- nenhum dado de teste persistido;
- gate técnico encerrado.