### PR TITLE
docs: fechar E19.2 apos merge

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data: 07/08/2026
-• Versão: v1.5.130
+• Data: 08/08/2026
+• Versão: v1.5.131
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -2267,7 +2267,7 @@ Repositório — Ajustados
 
 19.2.1 Objetivo e status
 - Objetivo: Criar a experiência pós-entitlement que configura a conta e os valores mínimos necessários para iniciar a primeira LP Starter, sem gerar conteúdo, materializar a LP final ou publicar.
-- Status: Implementação candidata completa no PR #700; E19.2.3, E19.2.4, E19.2.5 e E19.2.6 possuem checkpoints implementados e aprovados, com apply da migration e validação hospedada autenticada pendentes do merge humano.
+- Status: Concluído: PR #700 mergeado, migration aplicada, verificador SQL read-only aprovado e validação funcional hospedada autenticada concluída.
 
 19.2.2 Registros do recorte
 - Repositório:
@@ -2297,7 +2297,7 @@ Repositório — Ajustados
     - `prod#17`
 
 19.2.3 Contrato de configuração, completude e persistência mínima
-- Status: Checkpoint implementado e aprovado no PR #700; migration versionada, apply e validação SQL hospedada pendentes do merge humano.
+- Status: Implementado e validado após o merge: migration aplicada e verificador SQL hospedado aprovado.
 - Conteúdo:
   - O boundary `lib/lp-builder/` resolve o catálogo E20.2 por versão e taxonomia autoritativa, valida valores por `fieldKey` e escopo, reutiliza fontes autoritativas sem duplicá-las e deriva completude sem `onboarding_status`.
   - A persistência candidata usa um agregado 1:1 por conta, revisão otimista, FK tenant-safe e vínculo de `landing_page_id` write-once; o Data API permanece restrito ao adapter server-only com `service_role`, sem grants de cliente ou DELETE operacional.
@@ -2306,7 +2306,7 @@ Repositório — Ajustados
 
 19.2.4 Jornada guiada pós-entitlement e retomada
 - Objetivo: Substituir a permanência na experiência comercial por uma jornada curta de onboarding quando a conta elegível estiver incompleta.
-- Status: Checkpoint implementado e aprovado no PR #700; validação visual autenticada em Preview permanece pendente do merge/apply.
+- Status: Implementado e validado na jornada hospedada autenticada.
 - Conteúdo:
   - A superfície autenticada deriva os estados comercial, onboarding, operacional e bloqueado a partir de papel, entitlement e configuração; conta sem entitlement preserva a experiência comercial e objeto de configuração ainda indisponível mantém o fallback anterior.
   - Owner ou admin elegível com configuração incompleta recebe uma jornada responsiva em dois passos, com taxon somente leitura, valores autoritativos reutilizados e campos existentes derivados do catálogo E20.2, sem lista de domínio paralela.
@@ -2315,7 +2315,7 @@ Repositório — Ajustados
 
 19.2.5 Identidade visual mínima da conta
 - Objetivo: Permitir confirmar a identidade visual mínima necessária ao Starter sem IA e sem tornar logo obrigatório.
-- Status: Checkpoint implementado e aprovado no PR #700; validação visual autenticada em Preview permanece pendente do merge/apply.
+- Status: Implementado e validado na jornada hospedada autenticada.
 - Conteúdo:
   - A E19.2.5 adiciona um terceiro passo à jornada, com três paletas iniciais e edição humana dos cinco papéis canônicos `primary`, `secondary`, `accent`, `background` e `text`, sem catálogo paralelo de campos.
   - O boundary valida formato e contraste de modo determinístico: texto exige razão mínima 4,5:1 contra o fundo e cores principal, secundária e de destaque exigem 3:1.
@@ -2324,7 +2324,7 @@ Repositório — Ajustados
 
 19.2.6 Revisão, conclusão e transição para LP `draft`
 - Objetivo: Concluir a configuração derivada e transferir a conta para o espaço operacional sem criar LP antes da hora.
-- Status: Checkpoint implementado e aprovado no PR #700; validação autenticada do fluxo integrado permanece pendente do merge/apply.
+- Status: Implementado e validado no fluxo hospedado autenticado integrado.
 - Conteúdo:
   - Configuração completa sem vínculo entra em revisão final; configuração incompleta não consulta nem cria LP, e configuração já vinculada segue para o estado operacional sem persistir `onboarding_status`.
   - A leitura server-only do boundary `lib/lp-builder/` retorna zero, um ou vários drafts legítimos da conta em ordem determinística e preserva falha operacional como erro, sem consulta direta da página, UI ou Server Action a `account_landing_pages`.
@@ -2438,6 +2438,8 @@ Repositório — Ajustados
   * Não criar novo campo, estado, tabela, resolver ou infraestrutura e não reabrir E20.3.3 ou E20.3.4.
 
 99. Changelog
+v1.5.131 — 08/08/2026 — Fechada a E19.2 após o merge do PR #700: migration aplicada, verificador SQL read-only aprovado e validação funcional hospedada autenticada concluída; preservados os limites de não geração, não publicação, ausência de tracking/CRM/capability nova e ausência de infraestrutura de assets.
+
 v1.5.128 — 07/08/2026 — Reconciliado o PR #689 com a conclusão da E9.7 integrada à `main`, preservando integralmente o contrato canônico de capacidades e a implementação candidata aprovada da E12.5; inspeção final e merge humano permanecem pendentes.
 
 v1.5.127 — 07/08/2026 — Fechada documentalmente a implementação candidata da E12.5 para diagnóstico e navegação operacional do Admin Dashboard, com contratos existentes preservados, QA visual autenticado aprovado e inspeção final pós-reconciliação com a `main` ainda pendente.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data da última atualização: 04/08/2026
-• Documento: LP Factory 10 — Schema (DB Contract) v1.0.37
+• Data da última atualização: 08/08/2026
+• Documento: LP Factory 10 — Schema (DB Contract) v1.0.38
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -244,6 +244,7 @@
 • account_landing_pages_slug_chk: slug no padrão seguro `^[a-z0-9]+(-[a-z0-9]+)*$`.
 • account_landing_pages_name_chk: nome não vazio após trim.
 • account_landing_pages_account_slug_uidx: UNIQUE (account_id, slug).
+• account_landing_pages_id_account_id_key: UNIQUE (id, account_id), usado pelo vínculo tenant-safe da configuração de onboarding.
 
 1.9.5 Índices
 • account_landing_pages_account_id_idx em account_id.
@@ -811,6 +812,45 @@
 • Trigger Hub e auditoria: não.
 • `landing_page_generation_profile_items_set_updated_at`: executa `public.tg_set_updated_at()` antes de UPDATE.
 
+1.26 account_landing_page_onboarding_configurations
+1.26.1 Função
+• Agregado versionado e retomável da configuração mínima de onboarding da primeira LP Starter por conta.
+• A completude é derivada dos valores válidos do catálogo aplicável; não há `onboarding_status` persistido.
+
+1.26.2 Colunas
+• account_id uuid primary key
+• landing_page_id uuid null
+• catalog_version integer not null
+• `values` jsonb not null default '{}'::jsonb
+• revision bigint not null default 1
+• created_by uuid not null
+• updated_by uuid not null
+• created_at timestamptz not null default now()
+• updated_at timestamptz not null default now()
+
+1.26.3 Relacionamentos e constraints
+• account_id referencia public.accounts(id) com ON UPDATE CASCADE e ON DELETE CASCADE.
+• `(landing_page_id, account_id)` referencia `(id, account_id)` de public.account_landing_pages com ON UPDATE CASCADE e ON DELETE RESTRICT.
+• created_by e updated_by referenciam auth.users(id) com ON UPDATE CASCADE e ON DELETE RESTRICT.
+• `catalog_version > 0`, `revision > 0` e `jsonb_typeof(values) = 'object'`.
+• A PK em account_id mantém exatamente uma configuração por conta.
+
+1.26.4 Índice
+• `account_landing_page_onboarding_configurations_landing_page_id_idx`: btree parcial em landing_page_id quando não nulo.
+
+1.26.5 Segurança e triggers
+• RLS habilitado e nenhuma policy.
+• public, anon, authenticated e ai_readonly: sem grants.
+• service_role: SELECT, INSERT e UPDATE; sem DELETE.
+• `account_landing_page_onboarding_configurations_set_updated_at`: executa `public.tg_set_updated_at()` antes de UPDATE.
+• `account_landing_page_onboarding_configurations_prevent_rebind`: trigger BEFORE UPDATE de landing_page_id; permite somente NULL → draft válido da mesma conta e rejeita rebind ou desvinculação.
+• `public.prevent_account_landing_page_onboarding_rebind()`: SECURITY INVOKER, search_path fixado e sem EXECUTE para roles externas.
+
+1.26.6 Observações de escopo
+• A configuração parcial permanece neste agregado e não é copiada para `account_landing_pages`.
+• Logo permanece opcional; não há bucket, Storage, Blob, URL ou infraestrutura de assets neste contrato.
+• O agregado não participa do Trigger Hub.
+
 2. Views
 
 2.1 v_access_context_v2
@@ -1064,6 +1104,8 @@
 • Rollback: não remove automaticamente a extensão, pois pode ser reutilizada por outros recursos
 
 99. Changelog
+v1.0.38 (08/08/2026) — E19.2: registrado o agregado `account_landing_page_onboarding_configurations`, a unicidade composta de `account_landing_pages` usada pelo FK tenant-safe, os checks, RLS, grants mínimos, triggers de atualização/write-once e a ausência de persistência prematura na tabela de LP.
+
 v1.0.33 (26/07/2026) — E20.3: perfil de orientação para geração
 • Registrado o contrato versionado das tabelas `landing_page_generation_profiles` e `landing_page_generation_profile_items`, sem perfis ou itens oficiais.
 • Registradas FKs, checks, unicidades, RLS sem policies, ausência de acesso por papéis públicos e leitura exclusiva por `service_role`.


### PR DESCRIPTION
## O que mudou

- Reconcilia `docs/roadmap.md` com o estado pós-merge da E19.2.
- Registra em `docs/schema.md` o agregado real de onboarding, FK tenant-safe, RLS, grants e write-once.
- Preserva os limites de não geração, não publicação, tracking/CRM, capabilities novas e assets.

## Validação

- `git diff --check`: aprovado.
- `npm ci`: não aplicável; mudança exclusivamente documental.
- `npm run check`: não aplicável; mudança exclusivamente documental.
- PR #700 mergeado, migration aplicada, verificador SQL aprovado e validação funcional hospedada autenticada concluída.

Merge exclusivamente humano; PR documental mínimo para avaliação final.