### PR TITLE
docs: atualizar catálogo Supabase em 10/08/2026

### DIFF
--- a/docs/supa-up.md
+++ b/docs/supa-up.md
@@ -1860,13 +1860,82 @@ Catalogado em 2026-08-04
 
 ---
 
-## Registro da rodada — Supabase Update August 2026
+## 68 — Postgres Changes com filtros compostos e seleção de colunas *(🟦 Disponível; adoção condicional)*
+
+2026-08-05
+Catalogado em 2026-08-10
+
+### Status no Projeto
+
+- Status: não implementado; capacidade futura condicionada a um caso real de atualização em tempo real.
+- Evidência: não há assinatura `postgres_changes`, `channel()` ou publicação de tabela para Realtime no código; `package-lock.json` resolve `@supabase/supabase-js` em `2.89.0`.
+- Natureza de uso: redução de eventos e payloads em assinaturas Realtime, sem alterar a autoridade do Postgres nem da RLS.
+- Relação com a stack: complementar ao Supabase/Postgres; não substitui SSR, consulta sob demanda, polling simples ou Broadcast quando esses mecanismos forem suficientes.
+- Horizonte: Lite, Pro ou indefinido, conforme necessidade mensurável definida pelo Estrategista.
+
+### Descrição
+
+Postgres Changes passou a aceitar filtros combinados por `AND`, novos operadores (`like`, `ilike`, `is`, `match`, `imatch`, `isdistinct` e negações) e seleção explícita das colunas entregues em cada evento.
+
+Filtros rejeitam eventos antes de chegarem ao cliente e a seleção reduz o payload, o que pode diminuir mensagens e egress cobrados. A seleção de colunas exige `@supabase/supabase-js` `2.109.0` ou superior; assinaturas existentes continuam recebendo a linha completa até optarem pelo recurso.
+
+### Valor para o Projeto
+
+- Pode reduzir tráfego e exposição desnecessária de campos em uma futura interface realmente dependente de atualização em tempo real.
+- Permite filtrar no servidor por conta, estado e outro critério autorizado sem entregar ao cliente eventos que ele descartaria localmente.
+- Mantém a RLS como controle obrigatório e pode reduzir custo de mensagens e egress em cenários com vários assinantes.
+
+### Gatilho futuro de avaliação
+
+Avaliar somente quando houver:
+
+1. caso aprovado que exija atualização em tempo real e não seja atendido adequadamente por consulta sob demanda ou polling simples;
+2. tabelas, eventos, papéis e políticas RLS definidos no recorte competente;
+3. benefício mensurável de filtrar eventos ou reduzir payloads;
+4. orçamento de mensagens e egress, limites de DELETE e comportamento de reconexão avaliados;
+5. atualização deliberada e validada do `supabase-js` caso a seleção de colunas seja necessária.
+
+### Dependências, riscos e limite
+
+- Somente composição `AND` está disponível; `OR`, filtros de array/JSON, busca textual e operadores de range não estão incluídos.
+- Eventos DELETE carregam apenas a chave primária e não podem ser avaliados por filtros de coluna.
+- Toda coluna selecionada precisa ser visível ao papel assinante; RLS e grants continuam obrigatórios.
+- Não criar publicação, canal, subscription, migration, rota ou upgrade de dependência nesta rodada.
+
+### Fontes Oficiais
+
+- [Supabase Blog — Postgres Changes gets AND filters, new operators, and column selection](https://supabase.com/blog/postgres-changes-filters-and-column-selection)
+- [Supabase Docs — Postgres Changes](https://supabase.com/docs/guides/realtime/postgres-changes)
+- [Supabase Docs — Realtime Pricing](https://supabase.com/docs/guides/realtime/pricing)
+
+### Registro (Tipo A — Realtime)
+
+- Status: PENDENTE
+- Verificado em: 2026-08-10
+- Ambiente futuro: Supabase Realtime + cliente autorizado
+- Evidência: fontes oficiais e busca semântica no repositório no SHA inicial da rodada.
+- Observação: o registro não autoriza implementação nem atualização de dependência.
+
+---
+
+## Registro da rodada — Supabase Update August 2026 — 10/08/2026
 
 ### Updates ajustados ou incorporados
 
 - `supa#5`, `supa#12`, `supa#32`, `supa#33`, `supa#39`, `supa#41`, `supa#59` e `supa#62` foram reconciliados com fontes oficiais e o estado do projeto.
 - `supa#65` e `supa#66` foram adicionados como capacidades condicionais.
 - `supa#67` foi adicionado para registrar a depreciação de version pinning em extensões.
+- `supa#68` foi adicionado como capacidade condicional para assinaturas Postgres Changes com menor volume de eventos e payloads.
+
+### Updates avaliados e não adicionados nesta atualização
+
+- Conector Supabase para Perplexity Computer: integração oficial disponível, mas sobrepõe conectores e ferramentas assistivas já registrados sem caso operacional aprovado, hipótese de superioridade ou gatilho objetivo para comparação. Não foi descartado por distância do MVP; pode ser reavaliado se houver fluxo multiapp concreto que as ferramentas atuais não atendam.
+
+### Cobertura estratégica desta atualização
+
+- Landing pages, Instagram, WhatsApp e e-mail foram pesquisados contra as fontes oficiais Supabase aplicáveis.
+- A melhoria de Postgres Changes pode apoiar interfaces futuras do produto, mas não altera nem autoriza os fluxos atuais desses canais.
+- Não foi encontrada, entre 05/08/2026 e 10/08/2026, outra novidade oficial Supabase com valor concreto e horizonte plausível para os canais estratégicos do projeto.
 
 ### IDs preservados por rastreabilidade
 
@@ -1884,6 +1953,7 @@ Catalogado em 2026-08-04
 - Passkeys e CipherStash: preços, maturidade operacional e adequação só devem ser levantados se os gatilhos ocorrerem.
 - Grafana Cloud: acesso, retenção e responsabilidade operacional ainda não definidos.
 - Version pinning: a presença de cláusulas explícitas nas migrations deve ser confirmada em recorte técnico antes de qualquer ajuste.
+- Postgres Changes: não há caso Realtime aprovado; seleção de colunas depende de `supabase-js` `2.109.0` ou superior, acima da versão resolvida atual.
 
 ### Validação de IDs
 


### PR DESCRIPTION
## 1. Veredito

- Atualização documental concluída com um novo item condicional, sem implementação, mudança de stack ou configuração.
- O catálogo Supabase foi concluído integralmente antes do início do catálogo Vercel.

## 2. Fontes consultadas

- SHA inicial comum de `main`: `70268fec5aec43b79e8fea53abb70fec704821a8`.
- `README.md`, `AGENTS.md`, `docs/workflow-atualizacao-updates.md`, `docs/supa-up.md`, `docs/roadmap.md`, `docs/base-tecnica.md`, `docs/schema.md`, `docs/platform-config.md`, `docs/automations.md`, `docs/services.md`, código, migrations, `package.json` e `package-lock.json`.
- Histórico Git do catálogo e buscas explícitas e semânticas por IDs, Realtime, `postgres_changes`, canais e dependências.
- Supabase Blog: [Postgres Changes gets AND filters, new operators, and column selection](https://supabase.com/blog/postgres-changes-filters-and-column-selection).
- Supabase Docs: [Postgres Changes](https://supabase.com/docs/guides/realtime/postgres-changes) e [Realtime Pricing](https://supabase.com/docs/guides/realtime/pricing).
- Supabase Blog: [Supabase is now a connector on Perplexity Computer](https://supabase.com/blog/supabase-is-now-a-connector-on-perplexity-computer).
- Supabase Changelog e Blog oficiais pesquisados até 10/08/2026.

## 3. Cobertura estratégica

- Pilares e canais pesquisados: stack Supabase/Postgres, IA e automações controladas, landing pages, Instagram, WhatsApp e e-mail.
- Novidade relevante: evolução oficial de Postgres Changes, disponível desde 05/08/2026.
- Ausência relevante: nenhuma outra novidade Supabase publicada entre 05/08/2026 e 10/08/2026 apresentou simultaneamente fonte oficial, valor concreto e horizonte plausível para os canais estratégicos.
- A melhoria pode apoiar interfaces futuras, mas não altera os fluxos atuais de landing pages, Instagram, WhatsApp ou e-mail.

## 4. Itens mantidos

- Todos os IDs existentes `supa#2` a `supa#67` presentes no catálogo foram mantidos sem renumeração, reutilização ou desaparecimento.
- Estados e horizontes vigentes foram preservados; nenhum item existente foi reclassificado nesta atualização.
- Registros históricos, implementações parciais, referências, travas e capacidades condicionais continuam localizáveis.

## 5. Itens ajustados

- Nenhum item existente foi ajustado.
- O registro da rodada foi atualizado apenas para incorporar a nova análise, a cobertura estratégica e a lacuna de compatibilidade de versão.

## 6. Itens arquivados, absorvidos ou superados

- Nenhum item foi arquivado, absorvido ou superado nesta atualização.
- Os registros históricos anteriores e seus substitutos foram preservados integralmente.

## 7. Itens adicionados

- `supa#68` — Postgres Changes com filtros compostos e seleção de colunas.
- Natureza: otimização de assinaturas Realtime por filtros AND, novos operadores e payload seletivo.
- Relação com a stack: complementar ao Supabase/Postgres e à RLS; não substitui SSR, consulta sob demanda, polling simples ou Broadcast.
- Horizonte: Lite, Pro ou indefinido, sujeito à necessidade mensurável.
- Valor: pode reduzir eventos, egress, custo e exposição desnecessária de campos em um caso real de tempo real.
- Gatilho: caso aprovado não atendido adequadamente por mecanismo mais simples, RLS e eventos definidos, benefício mensurável, custos avaliados e versão compatível do cliente.
- Dependências e riscos: `supabase-js >= 2.109.0` para seleção de colunas, apenas composição AND, limites em DELETE, permissões por coluna, mensagens, egress e reconexão.
- O registro não autoriza subscription, publicação, migration, rota, upgrade ou qualquer implementação.

## 8. Itens avaliados e não adicionados

- Conector Supabase para Perplexity Computer.
- Motivo: sobrepõe ferramentas assistivas já registradas e não existe caso aprovado, hipótese de superioridade nem gatilho objetivo para comparação.
- Não foi excluído por estar fora do MVP ou do Starter; pode ser reavaliado diante de um fluxo multiapp concreto não atendido pelas ferramentas atuais.

## 9. Pontos não validados ou lacunas documentais

- Não existe caso Realtime aprovado no projeto.
- O lockfile resolve `@supabase/supabase-js` em `2.89.0`; a seleção de colunas exige `2.109.0` ou superior.
- A adequação de mensagens, egress, reconexão e políticas só pode ser validada no recorte que apresentar necessidade real.
- Permanecem as lacunas anteriores do catálogo, sem ampliação técnica nesta atualização.

## 10. Validação

- Catálogo concluído antes do início da análise Vercel.
- Branch: `agent/updates-supabase-2026-08-10`, criada diretamente do SHA inicial comum.
- Diff: somente `docs/supa-up.md`; 71 inserções e 1 alteração.
- `git diff --check`: aprovado.
- IDs: somente `supa#68` foi acrescentado; nenhum ID desapareceu, foi renumerado ou reutilizado.
- Rastreabilidade: buscas explícitas e semânticas foram executadas; não houve arquivamento nesta atualização.
- Aderência: README, simplicidade, segurança, custo, maturidade, manutenção e horizonte foram considerados.
- Novidade, modernidade e distância do MVP não determinaram isoladamente a decisão.
- `npm ci` e `npm run check`: não aplicáveis a alteração exclusivamente documental.
- Nenhum merge foi realizado.