### PR TITLE
docs: referenciar governança E21.1 no Gestor de Automações

### DIFF
--- a/docs/gestor-automations.md
+++ b/docs/gestor-automations.md
@@ -92,6 +92,7 @@ Quando houver hipótese concreta e material de uso da OpenAI, o Gestor deve cons
 * Quando o caso estiver sendo encerrado e não existir fase posterior real e registrada, não deixar recurso relevante para avaliação futura.
 * “Futuro” somente é válido quando houver fase posterior identificada e registrada para reabrir a decisão.
 * Registrar no parecer as fontes oficiais efetivamente consultadas.
+* Quando a recomendação envolver workload OpenAI de produto, identificar explicitamente o workload afetado e respeitar a governança transversal estabelecida em `E21.1 — Fundação, normalização e leitura dos workloads OpenAI` de `docs/roadmap.md`; consultar o contrato técnico vigente em `docs/base-tecnica.md` e a configuração operacional correspondente em `docs/platform-config.md`, sem duplicar neste documento catálogo, modelo, reasoning effort, configuração efetiva ou estado de implementação.
 
 Este documento não mantém catálogo permanente de modelos, preços, parâmetros ou recursos OpenAI. Esses detalhes devem ser verificados no caso concreto.
 


### PR DESCRIPTION
## 1. Objetivo

Adicionar ao `docs/gestor-automations.md` uma regra transversal curta para conectar avaliações de workloads OpenAI à governança já estabelecida pela E21.1.

## 2. Alteração

- Referencia explicitamente `E21.1 — Fundação, normalização e leitura dos workloads OpenAI` em `docs/roadmap.md`.
- Exige identificar o workload de produto afetado.
- Direciona o contrato técnico para `docs/base-tecnica.md` e a configuração operacional para `docs/platform-config.md`.
- Proíbe duplicar no Gestor catálogo, modelo, reasoning effort, configuração efetiva ou estado de implementação.

## 3. Escopo e validação

- Somente `docs/gestor-automations.md` foi alterado.
- 1 linha adicionada; nenhuma exclusão.
- Branch parte da `main` atual e está 1 commit à frente, sem divergência.
- Alteração exclusivamente documental; checks de runtime não se aplicam.

## 4. Documentação usada

- `README.md`
- `docs/roadmap.md`
- `docs/gestor-automations.md`
- `docs/base-tecnica.md`
- `docs/platform-config.md`