### PR TITLE
docs: amplia governança de IA e laboratório de capacidades

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@
 • O produto ajuda empresas a transformar pesquisa, dados e canais comerciais em comunicação pronta para venda.
 • O produto entrega canais de comunicação como landing pages, Instagram, WhatsApp e e-mail.
 • O dashboard prioriza automações internas, recursos de IA e agentes controlados para reduzir operação, validar processos e acelerar melhorias com revisão humana quando necessário.
-• IA, automações e agentes são capacidades evolutivas do produto e podem ampliar qualidade, eficiência e diferenciação comercial sem deslocar o foco atual do MVP em comunicação comercial por nicho.
 
 1.3. Proposta de valor
 • Oferecer comunicação comercial por nicho, com canais prontos para uso e acompanhamento contínuo de performance.
@@ -31,9 +30,8 @@
 1.4.2. Inteligente
 • Recursos orientados por dados, tracking, recomendações e automações internas com IA, em fluxos simples, seguros e mensuráveis.
 • Responses API como base programática preferencial dos workloads OpenAI, com recursos adicionais avaliados conforme o problema real e o custo-benefício demonstrado.
-• Agents SDK TypeScript quando houver orquestração real e controlada com tools, decisões intermediárias, estado, aprovações ou handoffs.
+• Agents SDK TypeScript quando houver benefício concreto em framework de orquestração agentic, como handoffs, sessions, guardrails, tracing ou workflows reutilizáveis; não é evolução automática da Responses API.
 • Sandbox Agent como camada de laboratório técnico para tarefas com arquivos, repositório, worktree, branch experimental, testes isolados ou geração de artefatos.
-• As tecnologias citadas representam os padrões vigentes de implementação, não uma proibição de avaliar alternativas capazes de gerar valor e aderentes à arquitetura.
 
 1.4.3. Dashboard
 • Suporte para ajustes e testes guiados por dados.
@@ -42,10 +40,8 @@
 • O MVP prioriza simplicidade, não fragilidade.
 • Runtime não pode depender de objetos ou comportamentos de banco ainda não aplicados e validados no ambiente alvo.
 • A stack base do MVP permanece Next.js, Supabase e TypeScript.
-• Automações e agentes devem ser introduzidos de forma incremental, começando por fluxos simples, seguros e mensuráveis.
-• Recursos de IA, automação e agentes devem evoluir por problema real e benefício mensurável em qualidade, custo, latência, controle ou valor ao cliente; sofisticação tecnológica, isoladamente, não justifica adoção.
-• A escolha entre backend determinístico, chamadas de IA, tools e arquitetura agentic deve preservar a menor complexidade capaz de cumprir os gates do workload.
-• O grau de determinismo deve acompanhar a natureza do resultado: regras verificáveis, segurança, fatos, estado e contratos permanecem determinísticos quando possível; decisões semânticas, criativas ou persuasivas devem preservar flexibilidade suficiente para a IA produzir a melhor solução dentro dos limites aprovados.
+• IA, automações e agentes devem evoluir incrementalmente, por problema real e benefício mensurável em qualidade, custo, latência, controle ou valor ao cliente; sofisticação tecnológica, isoladamente, não justifica adoção.
+• A escolha entre backend determinístico, chamadas de IA, tools e arquitetura agentic deve preservar a menor complexidade capaz de cumprir os gates, e o grau de determinismo deve acompanhar a natureza do resultado: regras verificáveis, segurança, fatos, estado e contratos permanecem determinísticos quando possível; decisões semânticas, criativas ou persuasivas preservam flexibilidade controlada da IA.
 • Não antecipar deterministicamente uma decisão que o workload existe justamente para a IA tomar.
 • A stack e a arquitetura adotadas são o padrão vigente; o produto permanece aberto à avaliação de recursos tecnológicos com caso de uso e valor plausível.
 • Todo recurso candidato deve ser classificado quanto à relação com a stack e a arquitetura — complementar, sobreposto, substituto ou incompatível — e avaliado por benefício, maturidade das fontes, custo, complexidade, segurança, manutenção e horizonte de adoção.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@
 • Automações e agentes devem ser introduzidos de forma incremental, começando por fluxos simples, seguros e mensuráveis.
 • Recursos de IA, automação e agentes devem evoluir por problema real e benefício mensurável em qualidade, custo, latência, controle ou valor ao cliente; sofisticação tecnológica, isoladamente, não justifica adoção.
 • A escolha entre backend determinístico, chamadas de IA, tools e arquitetura agentic deve preservar a menor complexidade capaz de cumprir os gates do workload.
+• O grau de determinismo deve acompanhar a natureza do resultado: regras verificáveis, segurança, fatos, estado e contratos permanecem determinísticos quando possível; decisões semânticas, criativas ou persuasivas devem preservar flexibilidade suficiente para a IA produzir a melhor solução dentro dos limites aprovados.
+• Não antecipar deterministicamente uma decisão que o workload existe justamente para a IA tomar.
 • A stack e a arquitetura adotadas são o padrão vigente; o produto permanece aberto à avaliação de recursos tecnológicos com caso de uso e valor plausível.
 • Todo recurso candidato deve ser classificado quanto à relação com a stack e a arquitetura — complementar, sobreposto, substituto ou incompatível — e avaliado por benefício, maturidade das fontes, custo, complexidade, segurança, manutenção e horizonte de adoção.
 • Incompatibilidade pode justificar descarte. Recursos sobrepostos ou substitutos só devem permanecer como condicionais quando houver hipótese concreta de superioridade e gatilho objetivo para comparação ou adoção.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 0. Introdução
 0.1. Cabeçalho
 • Documento: README — LP Factory 10 (MVP)
-• Versão: 6 — 04/08/2026
-• Data: 04/08/2026
+• Versão: 7 — 13/08/2026
+• Data: 13/08/2026
 • Escopo: visão geral do produto + documentos de referência + pendências estratégicas
 
 1. Visão geral do produto
@@ -16,6 +16,7 @@
 • O produto ajuda empresas a transformar pesquisa, dados e canais comerciais em comunicação pronta para venda.
 • O produto entrega canais de comunicação como landing pages, Instagram, WhatsApp e e-mail.
 • O dashboard prioriza automações internas, recursos de IA e agentes controlados para reduzir operação, validar processos e acelerar melhorias com revisão humana quando necessário.
+• IA, automações e agentes são capacidades evolutivas do produto e podem ampliar qualidade, eficiência e diferenciação comercial sem deslocar o foco atual do MVP em comunicação comercial por nicho.
 
 1.3. Proposta de valor
 • Oferecer comunicação comercial por nicho, com canais prontos para uso e acompanhamento contínuo de performance.
@@ -29,7 +30,7 @@
 
 1.4.2. Inteligente
 • Recursos orientados por dados, tracking, recomendações e automações internas com IA, em fluxos simples, seguros e mensuráveis.
-• Responses API para fluxos lineares de geração, revisão ou adaptação de conteúdo.
+• Responses API como base programática preferencial dos workloads OpenAI, com recursos adicionais avaliados conforme o problema real e o custo-benefício demonstrado.
 • Agents SDK TypeScript quando houver orquestração real e controlada com tools, decisões intermediárias, estado, aprovações ou handoffs.
 • Sandbox Agent como camada de laboratório técnico para tarefas com arquivos, repositório, worktree, branch experimental, testes isolados ou geração de artefatos.
 • As tecnologias citadas representam os padrões vigentes de implementação, não uma proibição de avaliar alternativas capazes de gerar valor e aderentes à arquitetura.
@@ -42,6 +43,8 @@
 • Runtime não pode depender de objetos ou comportamentos de banco ainda não aplicados e validados no ambiente alvo.
 • A stack base do MVP permanece Next.js, Supabase e TypeScript.
 • Automações e agentes devem ser introduzidos de forma incremental, começando por fluxos simples, seguros e mensuráveis.
+• Recursos de IA, automação e agentes devem evoluir por problema real e benefício mensurável em qualidade, custo, latência, controle ou valor ao cliente; sofisticação tecnológica, isoladamente, não justifica adoção.
+• A escolha entre backend determinístico, chamadas de IA, tools e arquitetura agentic deve preservar a menor complexidade capaz de cumprir os gates do workload.
 • A stack e a arquitetura adotadas são o padrão vigente; o produto permanece aberto à avaliação de recursos tecnológicos com caso de uso e valor plausível.
 • Todo recurso candidato deve ser classificado quanto à relação com a stack e a arquitetura — complementar, sobreposto, substituto ou incompatível — e avaliado por benefício, maturidade das fontes, custo, complexidade, segurança, manutenção e horizonte de adoção.
 • Incompatibilidade pode justificar descarte. Recursos sobrepostos ou substitutos só devem permanecer como condicionais quando houver hipótese concreta de superioridade e gatilho objetivo para comparação ou adoção.
@@ -54,6 +57,7 @@
 1.5. Modelo de oferta
 • Planos em camadas (Starter → Lite → Pro → Ultra), com capacidades escalando ao longo do tempo.
 • Capacidades futuras ou condicionais podem ser preservadas como diferenciais potenciais, sem representar promessa comercial, requisito imediato ou autorização técnica.
+• Capacidades de IA, automação e agentes podem compor diferenciais progressivos dos planos e, quando houver validação de demanda e operação, sustentar ofertas ou serviços especializados futuros, sem compromisso comercial adicional no MVP.
 
 2. Documentos de referência
 • docs/base-tecnica.md — regras técnicas de runtime, implementação segura, arquitetura, adapters, imports, SSR, observability e anti-regressão.

--- a/docs/openai-model-snapshot.md
+++ b/docs/openai-model-snapshot.md
@@ -2,8 +2,8 @@
 
 ## 1. Objetivo e validade
 
-- Data do snapshot: 11/08/2026.
-- Objetivo: manter uma fotografia curta e datada para decisões de custo-desempenho dos workloads OpenAI do LP Factory 10.
+- Data do snapshot: 13/08/2026.
+- Objetivo: manter uma fotografia curta e datada para decisões de custo-desempenho de modelos e para avaliação de capacidades de execução dos workloads OpenAI do LP Factory 10.
 - Este documento compara candidatos; não define sozinho o modelo em produção e não autoriza migração, implementação ou mudança de arquitetura.
 - A configuração efetivamente adotada continua registrada em `docs/platform-config.md`; a governança da decisão continua em `docs/gestor-automations.md`.
 - Preços, modelos, capacidades e parâmetros são voláteis. Antes de qualquer decisão, reconfirmar os valores nas fontes oficiais atuais e atualizar este snapshot quando houver mudança material.
@@ -15,6 +15,7 @@
   - `https://developers.openai.com/api/docs/models/gpt-5.6-terra`
   - `https://developers.openai.com/api/docs/models/gpt-5.6-sol`
   - `https://developers.openai.com/api/docs/guides/reasoning`
+  - `https://openai.github.io/openai-agents-js/`
   - `https://openai.com/pt-BR/index/gpt-5-6/`
   - `https://openai.com/pt-BR/index/advancing-the-price-performance-frontier-with-gpt-5-6/`
 
@@ -121,7 +122,8 @@
 - Preservar como capacidade futura um laboratório de avaliação que substitua escolhas intuitivas de configuração por decisões baseadas em evidência para cada workload real.
 - A unidade mínima de comparação continua sendo `workload + modelo + reasoning effort`, conforme a seção 3.2; não comparar apenas nomes de modelos.
 - Exemplos conceituais de combinações comparáveis incluem `GPT-5.6 Luna + medium`, `GPT-5.6 Luna + xhigh`, `GPT-5.6 Terra + medium`, `GPT-5.6 Terra + high`, `GPT-5.6 Sol + medium` e `GPT-5.6 Sol + high`, sem transformá-las em candidatos permanentes ou preferência antecipada.
-- Princípio de decisão: medir antes de promover uma combinação de modelo + effort como configuração preferencial.
+- O laboratório também deve permitir à governança do projeto distinguir se um problema observado de entrega está principalmente em modelo/effort, contexto, contrato de saída, uso de tools, continuidade, eficiência de contexto ou necessidade real de orquestração agentic.
+- Princípio de decisão: medir antes de promover uma combinação de modelo + effort ou uma capacidade de execução como configuração preferencial.
 
 ### 5.2 Métricas e método
 
@@ -161,3 +163,33 @@
 - Não manter nesta seção catálogo permanente de preços, modelos disponíveis, efforts, parâmetros ou capacidades específicas da API; esses elementos permanecem voláteis conforme a seção 1.
 - Quando o laboratório vier a ser planejado ou implementado, consultar a documentação oficial vigente da OpenAI, preferencialmente via `$openai-docs` no Codex.
 - O registro interno deve preservar principalmente objetivo, critérios, método, métricas e princípios de decisão.
+
+### 5.6 Recursos candidatos à experimentação
+
+- `Responses API` direta, combinada com backend determinístico quando a sequência do processo já for conhecida, permanece como referência de menor complexidade para comparação.
+- Structured Outputs é candidato quando o problema principal for controlar a forma e o contrato da saída; JSON ou schema válido não deve ser tratado como garantia de factualidade ou qualidade editorial.
+- Tool calling é candidato quando o modelo precisar escolher e acionar capacidades externas autorizadas; uma fonte consultada pelo backend não se torna tool apenas por participar do contexto.
+- Programmatic Tool Calling é candidato para workflows delimitados e intensivos em tools quando houver hipótese de ganho por coordenar chamadas e resultados intermediários; comparar sucesso, completude, tokens, latência, custo e complexidade contra o fluxo de referência.
+- Persisted reasoning é candidato para etapas relacionadas em que preservar continuidade cognitiva do modelo possa melhorar qualidade ou eficiência; não substitui estado verificável de negócio ou processo.
+- Explicit prompt caching é candidato quando prefixos estáveis e repetidos do contexto puderem ser reutilizados com benefício mensurável; não é pausa de workflow nem memória escolhida pelo modelo.
+- Multi-agent é candidato para trabalhos complexos que se decomponham de forma limpa em frentes independentes e possam se beneficiar de execução paralela e síntese; não presumir benefício quando as etapas forem fortemente dependentes entre si.
+- Agents SDK deve ser avaliado separadamente como framework de orquestração agentic quando houver benefício concreto em delegar ao runtime gestão de turns, tools, guardrails, handoffs, sessions ou tracing; não é evolução automática de um workflow baseado em Responses API.
+- A disponibilidade, suporte por modelo, parâmetros e comportamento desses recursos são voláteis e devem ser reconfirmados na documentação oficial vigente antes de cada experimento.
+
+### 5.7 Ambientes e progressão dos testes
+
+- Primeiro compreender conceitualmente o recurso e observar o que a aplicação envia, o que a plataforma executa e o que retorna na requisição.
+- Quando útil, realizar experimento isolado fora do runtime da LP Factory, em ambiente a ser definido no recorte do teste, sem criar por esta seção infraestrutura permanente.
+- Comparar o recurso contra uma baseline explícita usando a mesma tarefa representativa e mantendo constantes as demais variáveis sempre que possível.
+- Testar inicialmente um recurso ou variável por vez quando isso for suficiente para atribuir causa ao ganho ou à regressão observada.
+- Somente depois de evidência isolada suficiente, avaliar combinações de recursos aprovados e medir novamente o conjunto.
+- Um resultado positivo em simulação não autoriza automaticamente adoção no runtime; o workload real deve justificar o teste e a promoção.
+- O resultado possível de cada avaliação é adotar, rejeitar ou preservar o recurso como oportunidade condicional para novo teste quando houver gatilho objetivo.
+
+### 5.8 Regra de promoção
+
+- A sequência de decisão deve ser: problema observado → hipótese de causa → recurso ou configuração candidata → teste representativo → métricas → decisão.
+- Nenhum recurso se torna padrão por novidade, sofisticação ou por estar disponível no modelo mais capaz.
+- A promoção exige benefício demonstrável nos gates relevantes do workload, considerando qualidade, taxa de sucesso, intervenção humana, custo, latência, estabilidade e, quando material, segurança, manutenção e complexidade operacional.
+- O recurso mais simples que cumpra os gates permanece preferível a uma arquitetura mais sofisticada sem ganho mensurável.
+- A governança deve produzir evidência compreensível para decisão de produto sem exigir que o proprietário domine a implementação do código; detalhes técnicos permanecem responsabilidade do recorte de implementação.

--- a/docs/openai-model-snapshot.md
+++ b/docs/openai-model-snapshot.md
@@ -3,7 +3,7 @@
 ## 1. Objetivo e validade
 
 - Data do snapshot: 13/08/2026.
-- Objetivo: manter uma fotografia curta e datada para decisões de custo-desempenho de modelos e para avaliação de capacidades de execução dos workloads OpenAI do LP Factory 10.
+- Objetivo: manter uma referência datada para decisões de custo-desempenho de modelos e avaliação de capacidades de execução dos workloads OpenAI do LP Factory 10.
 - Este documento compara candidatos; não define sozinho o modelo em produção e não autoriza migração, implementação ou mudança de arquitetura.
 - A configuração efetivamente adotada continua registrada em `docs/platform-config.md`; a governança da decisão continua em `docs/gestor-automations.md`.
 - Preços, modelos, capacidades e parâmetros são voláteis. Antes de qualquer decisão, reconfirmar os valores nas fontes oficiais atuais e atualizar este snapshot quando houver mudança material.
@@ -85,7 +85,7 @@
 
 - Fonte: OpenAI, página oficial do GPT-5.6, com referência ao `Artificial Analysis Intelligence Index v4.1`: `https://openai.com/pt-BR/index/gpt-5-6/`.
 - O índice é apresentado como uma medida ampla de inteligência que combina trabalho agentic, programação, raciocínio científico e capacidades gerais; portanto, serve como evidência externa de eficiência geral, não como benchmark específico da LP Factory.
-- No gráfico, os pontos do GPT-5.6 Luna ocupam uma faixa de custo por tarefa substancialmente menor enquanto a pontuação aumenta com mais computação, reforçando Luna como candidato prioritário quando custo-desempenho for material.
+- O gráfico fornece evidência externa de custo-desempenho a considerar na seleção de candidatos, sem definir prioridade para workloads da LP Factory.
 - O gráfico não identifica cada ponto do Luna por `reasoning.effort`; não inferir que um ponto corresponde a `medium`, `high`, `xhigh` ou `max` sem evidência específica.
 - O benchmark não substitui a comparação representativa do workload prevista na seção 4.1 nem autoriza promover Luna, `xhigh` ou qualquer outra combinação por padrão.
 
@@ -121,7 +121,6 @@
 
 - Preservar como capacidade futura um laboratório de avaliação que substitua escolhas intuitivas de configuração por decisões baseadas em evidência para cada workload real.
 - A unidade mínima de comparação continua sendo `workload + modelo + reasoning effort`, conforme a seção 3.2; não comparar apenas nomes de modelos.
-- Exemplos conceituais de combinações comparáveis incluem `GPT-5.6 Luna + medium`, `GPT-5.6 Luna + xhigh`, `GPT-5.6 Terra + medium`, `GPT-5.6 Terra + high`, `GPT-5.6 Sol + medium` e `GPT-5.6 Sol + high`, sem transformá-las em candidatos permanentes ou preferência antecipada.
 - O laboratório também deve permitir à governança do projeto distinguir se um problema observado de entrega está principalmente em modelo/effort, contexto, contrato de saída, uso de tools, continuidade, eficiência de contexto ou necessidade real de orquestração agentic.
 - Princípio de decisão: medir antes de promover uma combinação de modelo + effort ou uma capacidade de execução como configuração preferencial.
 
@@ -129,9 +128,6 @@
 
 - O laboratório deverá aplicar o protocolo da seção 4.1 e as regras de custo das seções 3.2 e 3.3 sobre a mesma tarefa representativa, mantendo constantes as demais variáveis sempre que possível.
 - Para cada combinação testada, avaliar: qualidade da entrega, taxa de sucesso, necessidade de correção humana, `input_tokens`, `cached input tokens` quando aplicável, `output_tokens`, `reasoning_tokens`, custo financeiro efetivo, latência e estabilidade/repetibilidade.
-- O preço unitário dos tokens é determinado pelo modelo; alterar o reasoning effort não cria tarifa unitária própria.
-- Effort maior pode produzir mais reasoning/output tokens e, portanto, elevar o custo financeiro total; também pode aumentar a latência.
-- Reasoning tokens fazem parte dos output tokens e não constituem uma terceira tarifa independente.
 
 | Configuração conceitual | Qualidade | Custo | Latência |
 |---|---|---|---|
@@ -144,11 +140,9 @@
 
 ### 5.3 Perguntas de decisão
 
-- O ganho de `high` ou `xhigh` sobre `medium` justifica custo e espera adicionais?
-- Luna + xhigh entrega a qualidade exigida antes de escalar para Terra ou Sol?
-- Terra + high entrega resultado equivalente a Sol + medium por custo menor?
-- Quais workloads realmente precisam de configurações mais fortes?
-- Quais workloads podem operar com modelos ou esforços mais econômicos sem perder os gates exigidos?
+- Esforço maior produz ganho suficiente para justificar custo e latência adicionais?
+- Uma combinação mais econômica entrega qualidade equivalente à configuração mais forte para o workload?
+- Qual é a menor configuração que cumpre os gates exigidos daquele workload?
 
 ### 5.4 Escopo e limites
 
@@ -174,7 +168,6 @@
 - Explicit prompt caching é candidato quando prefixos estáveis e repetidos do contexto puderem ser reutilizados com benefício mensurável; não é pausa de workflow nem memória escolhida pelo modelo.
 - Multi-agent é candidato para trabalhos complexos que se decomponham de forma limpa em frentes independentes e possam se beneficiar de execução paralela e síntese; não presumir benefício quando as etapas forem fortemente dependentes entre si.
 - Agents SDK deve ser avaliado separadamente como framework de orquestração agentic quando houver benefício concreto em delegar ao runtime gestão de turns, tools, guardrails, handoffs, sessions ou tracing; não é evolução automática de um workflow baseado em Responses API.
-- A disponibilidade, suporte por modelo, parâmetros e comportamento desses recursos são voláteis e devem ser reconfirmados na documentação oficial vigente antes de cada experimento.
 
 ### 5.7 Ambientes e progressão dos testes
 


### PR DESCRIPTION
## 1. Objetivo

Atualizar de forma sutil a direção estratégica de IA no `README.md` e ampliar `docs/openai-model-snapshot.md` para governar experimentação de recursos de IA por evidência, sem alterar o rumo do MVP.

## 2. Escopo

- altera somente `README.md` e `docs/openai-model-snapshot.md`;
- preserva a identidade da LP Factory 10 como hub de comunicação comercial por nicho;
- não cria implementação, banco, rota, job, engine, agente, automação, migration ou nova infraestrutura.

## 3. README

- reforça IA, automações e agentes como capacidades evolutivas do produto;
- mantém Responses API como base programática preferencial, sem tratá-la como limite absoluto;
- registra adoção por problema real e benefício mensurável;
- preserva a menor complexidade capaz de cumprir os gates do workload;
- reconhece potencial futuro de diferenciais de planos e serviços especializados sem compromisso comercial adicional no MVP.

## 4. OpenAI Model Snapshot

- amplia o laboratório para avaliar não só `modelo + reasoning effort`, mas também capacidades de execução;
- registra como candidatos: Responses API direta, Structured Outputs, tool calling, Programmatic Tool Calling, persisted reasoning, explicit prompt caching, Multi-agent e Agents SDK como alternativa arquitetural separada;
- diferencia simulação isolada de teste em workload real;
- estabelece progressão: compreensão → teste isolado → benchmark → combinação → eventual promoção;
- mantém disponibilidade, parâmetros e suporte por modelo como dados voláteis a reconfirmar em fonte oficial vigente.

## 5. Regra de decisão

- problema observado → hipótese de causa → recurso/configuração candidata → teste representativo → métricas → decisão;
- novidade ou sofisticação não autoriza adoção;
- resultado positivo em simulação não autoriza automaticamente promoção ao runtime.

## 6. Validação

- branch: `docs/ai-capabilities-governance`;
- diff contra `main`: somente 2 arquivos;
- `README.md`: 7 adições, 3 exclusões;
- `docs/openai-model-snapshot.md`: 35 adições, 3 exclusões;
- documentação oficial OpenAI vigente consultada para confirmar a natureza atual dos recursos citados.