### PR TITLE
docs: relaxar sincronização de branches paralelas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@ Fluxos auxiliares de GitHub devem respeitar estas regras. Em caso de divergênci
 
 Não editar nem commitar na `main`; usar branch dedicada por tarefa ou etapa. Ao usar a `main` local como base, atualizar com `git pull --ff-only`. O merge final deve ocorrer somente pelo GitHub Web.
 
+Branches e PRs abertos não devem ser sincronizados ou rebaseados apenas porque a `main` avançou. Em frentes paralelas, essa divergência é normal. Atualizar a branch somente quando houver conflito que impeça o merge ou necessidade concreta identificada durante o trabalho.
+
 Se o ambiente não estiver claro, perguntar antes de publicar.
 
 ### Modo simples


### PR DESCRIPTION
## 1. Objetivo

Evitar sincronização ou rebase desnecessários em PRs paralelos apenas porque a `main` avançou.

## 2. Alteração

- adiciona ao `AGENTS.md` que divergência de branches abertas em relação à `main` é normal em frentes paralelas;
- exige atualização apenas quando houver conflito que impeça o merge ou necessidade concreta identificada durante o trabalho.

## 3. Escopo

- somente `AGENTS.md`;
- nenhuma alteração de código, banco, rota, infraestrutura ou workflow.

## 4. Validação

- diff final contra `main`: 1 arquivo, 2 linhas adicionadas, 0 removidas;
- `npm ci`: não aplicável;
- `npm run check`: não aplicável.