### PR TITLE
docs: evitar sincronização preventiva de PRs paralelos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@ Fluxos auxiliares de GitHub devem respeitar estas regras. Em caso de divergênci
 
 Não editar nem commitar na `main`; usar branch dedicada por tarefa ou etapa. Ao usar a `main` local como base, atualizar com `git pull --ff-only`. O merge final deve ocorrer somente pelo GitHub Web.
 
+Branches e PRs já abertos não precisam ser sincronizados, rebaseados ou atualizados com a `main` apenas porque ela avançou. Em frentes paralelas, essa divergência é normal. Sincronizar somente quando houver conflito apontado pelo GitHub, quando a tarefa depender materialmente de contrato, arquivo ou dependência alterado na `main`, ou por solicitação humana explícita. Não fazer sincronização preventiva por rotina.
+
 Se o ambiente não estiver claro, perguntar antes de publicar.
 
 ### Modo simples
@@ -37,7 +39,7 @@ Usar somente quando houver frente paralela ou necessidade real de isolamento:
 1 branch = 1 PR
 ```
 
-Após o merge, atualizar a base e criar nova branch na mesma worktree. Não criar outra worktree para continuar a mesma frente.
+Após o merge, ao iniciar a próxima etapa, atualizar a base e criar nova branch na mesma worktree. Não criar outra worktree para continuar a mesma frente.
 
 Publicar com `git push`. Não alterar configurações SSH durante a tarefa; se o push falhar, parar e informar o erro exato.
 


### PR DESCRIPTION
PR documental exclusivo para ajustar `AGENTS.md`: branches e PRs já abertos não precisam ser sincronizados apenas porque a `main` avançou; a atualização fica reservada a conflito apontado pelo GitHub, dependência material alterada ou solicitação humana explícita. Também esclarece que a atualização após merge se aplica ao início da próxima etapa. Escopo: somente `AGENTS.md`. `npm ci` e `npm run check`: não aplicáveis.