### PR TITLE
Ajusta prompt de pesquisa por nicho

### DIFF
--- a/docs/prompt-nicho-identificacao.md
+++ b/docs/prompt-nicho-identificacao.md
@@ -89,7 +89,7 @@ Não refaça a identificação do taxon.
 
 Pesquise apenas os `research_blocks` definidos em `research_blocks_order`.
 
-Ao final, informe que a pesquisa bruta está pronta para estruturação dos itens.
+Ao final, informe que a pesquisa bruta foi concluída.
 ```
 
 ## 6. Parada

--- a/docs/prompt-nicho-pesquisa.md
+++ b/docs/prompt-nicho-pesquisa.md
@@ -12,7 +12,7 @@ A entrega deve servir como fonte para uma etapa posterior de estruturação dos 
 
 ## 3. Entrada obrigatória
 
-Use como fonte de verdade o relatório-instrução gerado por `docs/prompt-nicho-identificacao.md`.
+Use somente o relatório-instrução confirmado nesta execução; se ele estiver ausente ou incompleto, peça-o e pare.
 
 A entrada deve conter:
 
@@ -25,7 +25,7 @@ A entrada deve conter:
 - `audience_scope`
 - `research_blocks_order`
 
-As fontes devem ser escolhidas conforme o taxon pesquisado.
+Pesquise em fontes pertinentes ao taxon, priorizando evidência verificável e distinguindo achado de inferência.
 
 ## 4. Direção da pesquisa por bloco
 
@@ -57,9 +57,9 @@ Observe intenção de busca, termos comerciais, termos de apoio, termos locais, 
 
 Não invente fontes, dados de cliente, provas, certificações, garantias, resultados, volume de busca, CPC ou dificuldade de palavra-chave.
 
-Não complete lacunas com suposição.
+Não complete lacunas por suposição; quando faltar evidência, declare a limitação.
 
-Quando faltar evidência, declare a limitação.
+Não prossiga com taxon, `audience_scope` ou `research_blocks` não confirmados.
 
 Não transforme a pesquisa em itens estruturados, SQL, copy final ou template.
 

--- a/docs/prompt-nicho-pesquisa.md
+++ b/docs/prompt-nicho-pesquisa.md
@@ -8,7 +8,7 @@ Atue como pesquisador de nicho para o LP Factory 10.
 
 Produzir uma pesquisa bruta, rica e contextual sobre o taxon confirmado, usando os `research_blocks` definidos em `research_blocks_order`.
 
-A entrega deve servir como fonte para uma etapa posterior de estruturação dos itens da pesquisa.
+A entrega deve ser uma fonte rica, contextual e verificável, preservando evidências, limitações e inferências para consumidores posteriores.
 
 ## 3. Entrada obrigatória
 


### PR DESCRIPTION
## 1. O que mudou

- exige o relatório-instrução confirmado na execução atual e para se ele estiver ausente ou incompleto;
- reforça que taxon, `audience_scope` e `research_blocks` precisam estar confirmados;
- melhora a disciplina de fontes, priorizando evidência verificável e separando achado de inferência;
- mantém o tamanho do prompt: 88 linhas antes e 88 depois.

## 2. Por que

O prompt tinha entrada obrigatória, mas não uma trava inequívoca contra prosseguir sem a entrada confirmada. O ajuste aproxima `docs/prompt-nicho-pesquisa.md` de `docs/template-prompts.md` sem aumentar o documento.