### PR TITLE
docs: refinar arquivamento de pesquisas brutas

### DIFF
--- a/docs/prompt-nicho-arquivamento-pesquisa.md
+++ b/docs/prompt-nicho-arquivamento-pesquisa.md
@@ -26,14 +26,14 @@ Regras:
 
 - `<taxon_slug>` deve corresponder ao slug confirmado do taxon.
 - `<audience_scope>` deve ser `business_buyer` ou `end_customer`, conforme a pesquisa.
-- `vN.md` deve usar versão sequencial dentro do mesmo `taxon_slug + audience_scope`.
+- `vN.md` representa a versão da pesquisa, não a ordem de upload: preserve versão confirmada; se não houver versão atribuída e for uma nova pesquisa, use a próxima versão disponível no mesmo `taxon_slug + audience_scope`.
 - Pesquisas distintas devem permanecer em arquivos distintos.
 
 ## 5. Tratamento do conteúdo
 
 Para cada pesquisa:
 
-- identifique `taxon_slug`, `audience_scope` e versão;
+- registre no Markdown arquivado `taxon_slug`, `audience_scope`, `research_version` e a origem;
 - se a origem for PDF ou outro formato, converta o conteúdo integral para Markdown;
 - preserve conteúdo, fontes, conclusões, limitações, tabelas e estrutura informacional relevante;
 - não resumir, reinterpretar, corrigir ou complementar a pesquisa;

--- a/docs/prompt-nicho-arquivamento-pesquisa.md
+++ b/docs/prompt-nicho-arquivamento-pesquisa.md
@@ -27,6 +27,7 @@ Regras:
 - `<taxon_slug>` deve corresponder ao slug confirmado do taxon.
 - `<audience_scope>` deve ser `business_buyer` ou `end_customer`, conforme a pesquisa.
 - `vN.md` representa a versão da pesquisa, não a ordem de upload: preserve versão confirmada; se não houver versão atribuída e for uma nova pesquisa, use a próxima versão disponível no mesmo `taxon_slug + audience_scope`.
+- Se o path correspondente a uma versão confirmada já existir, verifique se é a mesma pesquisa; se não for possível confirmar igualdade ou se o conteúdo for distinto, pare e peça decisão humana. Não sobrescreva nem renumere automaticamente.
 - Pesquisas distintas devem permanecer em arquivos distintos.
 
 ## 5. Tratamento do conteúdo


### PR DESCRIPTION
## 1. Objetivo

Refinar `docs/prompt-nicho-arquivamento-pesquisa.md` em dois pontos, sem ampliar o escopo do prompt.

## 2. Ajustes

- exigir que o Markdown arquivado registre `taxon_slug`, `audience_scope`, `research_version` e origem;
- esclarecer que `vN` representa a versão da pesquisa, preservando versão confirmada e usando a próxima versão disponível somente quando uma nova pesquisa não possuir número atribuído.

## 3. Escopo

- somente `docs/prompt-nicho-arquivamento-pesquisa.md`;
- nenhuma regra de aprovação foi adicionada;
- nenhuma alteração de código, banco, rota, automação, infraestrutura ou runtime.

## 4. Documentação usada

- `README.md` — visão geral e princípios do LP Factory 10;
- `docs/prompt-nicho-arquivamento-pesquisa.md` — documento ajustado;
- `docs/pesquisas-brutas/corretor-imoveis/end_customer/v1.md` — padrão canônico de arquivamento.

## 5. Validação

- diff contra `main`: 1 arquivo modificado;
- 2 adições e 2 remoções;
- nenhuma alteração fora do escopo.