### PR TITLE
docs: simplificar prompt de pesquisa por nicho

### DIFF
--- a/docs/prompt-nicho-pesquisa.md
+++ b/docs/prompt-nicho-pesquisa.md
@@ -6,9 +6,9 @@ Atue como pesquisador de nicho para o LP Factory 10.
 
 ## 2. Objetivo
 
-Produzir uma pesquisa bruta rica, contextual, verificável e concisa sobre o taxon confirmado, sem pré-planejar uma landing page específica.
+Produzir uma pesquisa bruta rica, contextual, verificável e concisa sobre o taxon confirmado.
 
-A entrega deve ser uma fonte rica, contextual e verificável, preservando evidências, limitações e inferências para consumidores posteriores.
+Descreva o espaço de decisão; não escolha nem produza a solução que um consumidor posterior deverá construir a partir da pesquisa.
 
 ## 3. Entrada obrigatória
 
@@ -31,58 +31,28 @@ Pesquise em fontes pertinentes ao taxon, priorizando evidência verificável e d
 
 ### strategic_core
 
-Pesquise o núcleo estratégico do público e do mercado: dores, desejos, objeções, linguagem, crenças, medos, gatilhos de decisão, provas necessárias, tendências e oportunidades de posicionamento.
-
-Priorize o mercado brasileiro. Use referências dos EUA apenas como apoio comparativo quando forem relevantes.
+Pesquise dores, desejos, objeções, linguagem, crenças, medos, gatilhos de decisão, provas necessárias, tendências e oportunidades de posicionamento. Priorize o mercado brasileiro; use referências dos EUA apenas quando agregarem contexto relevante.
 
 ### lp_overview
 
-Pesquise padrões, alternativas e trade-offs observáveis de landing pages e páginas comerciais do taxon no Brasil e nos EUA.
-
-Observe narrativa, tom visual, densidade, imagem, extensão, confiança, provas, CTA e mobile como possibilidades condicionais, sem escolher a solução final da futura LP.
+Pesquise padrões, alternativas e trade-offs observáveis de landing pages e páginas comerciais do taxon, incluindo narrativa, tom visual, densidade, imagem, confiança, provas, CTA e mobile.
 
 ### lp_sections
 
-Pesquise tipos de seção observados e sua função comercial, recorrência observada, condições de uso, alternativas e trade-offs.
-
-Não produza wireframe final, sequência obrigatória, headings finais, número fixo de seções ou arquitetura definitiva da LP.
+Pesquise tipos de seção observados, função comercial, recorrência observada, condições de uso, alternativas e trade-offs.
 
 ### seo
 
-Pesquise insumos de SEO úteis para landing pages do taxon.
-
-Observe intenção de busca, termos comerciais, termos de apoio, termos locais, dúvidas frequentes, objeções pesquisadas e oportunidades úteis para conversão.
+Pesquise intenção de busca, termos comerciais e de apoio, termos locais, dúvidas frequentes, objeções pesquisadas e oportunidades úteis para conversão.
 
 ## 5. Limites
 
-Não invente fontes, dados de cliente, provas, certificações, garantias, resultados, volume de busca, CPC ou dificuldade de palavra-chave.
+Não invente fontes, dados de cliente, provas, certificações, garantias, resultados ou métricas sem fonte verificável; quando ausentes, declare-os não especificados.
 
-Não complete lacunas por suposição; quando faltar evidência, declare a limitação.
+Não complete lacunas por suposição nem use decisões internas do LP Factory como evidência de mercado.
 
-Não prossiga com taxon, `audience_scope` ou `research_blocks` não confirmados.
-
-Não transforme a pesquisa em itens estruturados, SQL, copy final ou template; não use decisões internas do LP Factory como evidência de mercado nem transforme padrões observados em regras universais.
+Não transforme a pesquisa em solução da futura LP, itens estruturados, SQL, copy ou template.
 
 ## 6. Entrega esperada
 
-Entregue em Markdown, maximizando informação útil por volume de texto e evitando repetição ou detalhe que não altere a compreensão do mercado, público, evidências ou limitações.
-
-Estrutura mínima:
-
-```md
-# Pesquisa bruta — [taxon_name]
-
-## Entrada confirmada
-
-## strategic_core
-
-## lp_overview
-
-## lp_sections
-
-## seo
-
-## Observações gerais
-
-## Limitações da pesquisa
-```
+Entregue em Markdown, seguindo somente os `research_blocks` confirmados, na ordem recebida. Identifique as fontes utilizadas e limitações relevantes. Registre cada achado no bloco mais adequado e evite repetição, salvo referência curta necessária ao contexto.


### PR DESCRIPTION
## 1. Objetivo

Simplificar `docs/prompt-nicho-pesquisa.md` para reduzir microinstruções e tornar o prompt mais aderente ao princípio de concisão de `docs/template-prompts.md`, preservando o Cenário E.

## 2. Alterações

- mantém a estrutura numerada existente e os quatro `research_blocks`;
- substitui microtravas por poucos princípios fortes;
- centraliza a fronteira: a pesquisa descreve o espaço de decisão, mas não produz a solução que o consumidor posterior deverá construir;
- remove o esqueleto fixo de headings da entrega e deixa `research_blocks_order` como autoridade estrutural;
- reduz instruções específicas de `lp_overview` e `lp_sections` sem perder padrões, alternativas e trade-offs;
- consolida regras de evidência, ausência de métricas e não uso de decisões internas do LP Factory como evidência de mercado;
- reforça identificação de fontes, limitações e não repetição na entrega.

## 3. Escopo

- altera somente `docs/prompt-nicho-pesquisa.md`;
- nenhuma alteração de código, banco, rota, runtime, automação ou infraestrutura.

## 4. Documentação usada

- `README.md` v7;
- `docs/template-prompts.md`;
- `docs/prompt-nicho-pesquisa.md` vigente;
- decisões do Cenário E registradas no debate da E19.4.

## 5. Validação

- branch exclusiva: `agent/simplifica-prompt-nicho-pesquisa`;
- diff contra `main`: somente `docs/prompt-nicho-pesquisa.md`;
- 10 adições e 40 remoções;
- branch 1 commit à frente e 0 atrás de `main` no momento da validação;
- alteração exclusivamente documental; checks de aplicação não se aplicam.