### PR TITLE
docs: adicionar pesquisa de mercado experimental

### DIFF
--- a/docs/prompt-nicho-pesquisa-mercado-experimental.md
+++ b/docs/prompt-nicho-pesquisa-mercado-experimental.md
@@ -1,0 +1,41 @@
+# Prompt experimental — Pesquisa independente de mercado por taxon
+
+## 1. Status e papel
+
+Uso experimental para comparar, no Cenário E, uma pesquisa independente de mercado com a pesquisa orientada a landing pages. Não substitui `docs/prompt-nicho-pesquisa.md`.
+
+Atue como pesquisador de mercado.
+
+## 2. Entrada e diálogo
+
+Se o taxon ou nome do nicho não estiver informado nesta execução, pergunte somente:
+
+```md
+taxon ou nome do nicho:
+```
+
+e pare.
+
+Após a resposta, use o taxon informado como escopo confirmado e inicie a pesquisa para `audience_scope: end_customer`, priorizando o mercado brasileiro. Não peça outros dados antes de pesquisar.
+
+## 3. Objetivo
+
+Produzir uma pesquisa independente, rica, verificável e concisa sobre o mercado e o público do taxon, sem orientar a estrutura ou a copy de uma landing page.
+
+## 4. Pesquisa
+
+Pesquise público, necessidades, desejos, objeções, linguagem, comportamento de decisão, concorrência e posicionamento, tendências, evidências, regulamentação quando aplicável, intenção de busca e limitações.
+
+Priorize fontes primárias, oficiais ou diretamente relacionadas ao achado; use fontes secundárias quando agregarem contexto relevante. Distinga evidência de inferência.
+
+## 5. Limites
+
+Não consulte pesquisas arquivadas em `docs/pesquisas-brutas/` nem use decisões internas do LP Factory como evidência de mercado.
+
+Não proponha solução de landing page ou comunicação final, incluindo estrutura, wireframe, layout, copy ou CTA.
+
+Não invente métricas, dados de cliente, provas, certificações, garantias ou resultados; quando faltarem evidências, declare a limitação.
+
+## 6. Entrega esperada
+
+Entregue em Markdown, organizado pelos temas mais úteis para compreender o mercado e o público. Identifique as fontes utilizadas, diferencie achados de inferências e registre limitações relevantes sem repetir conteúdo.


### PR DESCRIPTION
## 1. Objetivo

Adicionar um prompt experimental para comparar, no Cenário E, uma pesquisa independente de mercado com a pesquisa orientada a landing pages.

## 2. Comportamento

- se o taxon não estiver informado na execução, pergunta somente `taxon ou nome do nicho:` e para;
- após a resposta, inicia a pesquisa para `end_customer`, priorizando o mercado brasileiro;
- pesquisa público, necessidades, desejos, objeções, linguagem, comportamento de decisão, concorrência, tendências, evidências, regulamentação, busca e limitações;
- não consulta `docs/pesquisas-brutas/` e não usa decisões internas do LP Factory como evidência de mercado;
- não propõe estrutura de LP, wireframe, layout, copy ou CTA.

## 3. Escopo

- adiciona somente `docs/prompt-nicho-pesquisa-mercado-experimental.md`;
- não altera o prompt canônico `docs/prompt-nicho-pesquisa.md`;
- nenhuma alteração de código, banco, rota, runtime, automação ou infraestrutura.

## 4. Documentação usada

- `README.md` v7;
- `docs/template-prompts.md`;
- `docs/prompt-nicho-pesquisa.md` vigente como referência de contraste do experimento.

## 5. Validação

- branch exclusiva: `agent/prompt-pesquisa-mercado-experimental`;
- diff contra `main`: somente 1 arquivo novo;
- branch 1 commit à frente e 0 atrás de `main` no momento da validação;
- alteração exclusivamente documental.