### PR TITLE
Ajusta fluxo automatizado da Opção 2 para v1

### DIFF
--- a/.agents/skills/lp-factory-abc/SKILL.md
+++ b/.agents/skills/lp-factory-abc/SKILL.md
@@ -52,6 +52,8 @@ Permitir somente seções e subseções do recorte, identificadores, títulos, o
 
 Não aplicar o delta, editar documentos, alterar outra residência documental, completar lacunas por suposição ou registrar estado operacional como planejado. A aplicação pertence ao executor autorizado.
 
+Exceção estreita: após escolha humana explícita da Opção 2 definida em `docs/prompt-estrategista.md`, o Estrategista pode aplicar literalmente, no próprio PR da v1, somente o delta emitido em modo Planejamento para `DOC_ALVO: docs/roadmap.md`, usando a v1 aprovada como `RELATÓRIO`. A skill continua responsável apenas por gerar e verificar o ABC; a exceção não autoriza aplicação em outro documento, outro modo, v2 ou implementação.
+
 ## Verificar
 
 Antes de devolver, confirmar fontes, referência, residência, menor delta, formato literal e ausência de secrets, PII, hipóteses ou histórico superado.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Fluxos auxiliares de GitHub devem respeitar estas regras. Em caso de divergênci
 
 ## Branch, worktree e publicação
 
-Não editar nem commitar na `main`; usar branch dedicada por tarefa ou etapa. Ao usar a `main` local como base, atualizar com `git pull --ff-only`. O merge final deve ocorrer somente pelo GitHub Web.
+Não editar nem commitar na `main`; usar branch dedicada por tarefa ou etapa. Ao usar a `main` local como base, atualizar com `git pull --ff-only`. O merge final deve ocorrer somente pelo GitHub Web. Exceção: após escolha humana explícita da Opção 2 definida em `docs/prompt-estrategista.md` e conclusão dos gates da v1, o Estrategista pode executar exclusivamente o merge remoto do PR da v1 por ferramenta GitHub conectada e autorizada. Essa exceção não se aplica ao merge final da implementação. Merge local pela `main` permanece proibido.
 
 Branches e PRs já abertos não precisam ser sincronizados, rebaseados ou atualizados com a `main` apenas porque ela avançou. Em frentes paralelas, essa divergência é normal. Sincronizar somente quando houver conflito apontado pelo GitHub, quando a tarefa depender materialmente de contrato, arquivo ou dependência alterado na `main`, ou por solicitação humana explícita. Não fazer sincronização preventiva por rotina.
 

--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -74,7 +74,7 @@ Após concluir o item 3, apresentar ao humano as duas opções:
 • Opção 1 — Processo atual: seguir para o item 5.
 
 • Opção 2 — Processo automatizado: após a escolha humana explícita, o Estrategista deve, nesta ordem:
-   • executar `$lp-factory-abc` em modo Planejamento para `DOC_ALVO: docs/roadmap.md`, usando a v1 aprovada como `RELATÓRIO` e o próprio PR da v1 como referência competente;
+   • executar `$lp-factory-abc` em modo Planejamento para `DOC_ALVO: docs/roadmap.md`, usando a v1 aprovada como `RELATÓRIO` e a branch ou o commit atual do PR da v1 como `REF`;
    • aplicar literalmente no mesmo PR somente o delta emitido pelo ABC; se o resultado for `SEM ALTERAÇÕES NECESSÁRIAS`, preservar o roadmap;
    • revisar o PR completo e confirmar que a v1, o roadmap planejado, o diff e os gates aplicáveis estão coerentes e prontos para merge;
    • realizar exclusivamente o merge remoto do PR da v1 por ferramenta GitHub conectada e autorizada, conforme `AGENTS.md`; não fazer merge local pela `main`;

--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -1,6 +1,6 @@
-08/08/2026 — Fluxo do Estrategista
+15/08/2026 — Fluxo do Estrategista
 
-Versão: v29
+Versão: v30
 
 0. Papel do Estrategista
 Você é o Estrategista do LP Factory 10. Sua função é transformar casos em plano-base, coordenar análises, orientar execução por fase e consolidar a decisão final, preservando o escopo aprovado, a simplicidade proporcional e os diferenciais estratégicos condicionais.
@@ -64,7 +64,7 @@ Regra:
 • não usar X.Y.1 e X.Y.2 como fases; entregas implementáveis usam X.Y.3 até X.Y.n, conforme docs/template-roadmap.md;
 • não criar fase administrativa, de governança, handoff, revisão ou fechamento; validação e fechamento documental pelo Prompt ABC integram a fase implementável correspondente;
 • validação entra como critério de aceite da fase, salvo risco técnico próprio;
-• após concluir a v1, orientar o Executor a ajustar `docs/roadmap.md` no mesmo PR, conforme `docs/prompt-abc.md` e `docs/template-roadmap.md`, registrando somente seções, subseções, títulos, objetivos e status planejado, sem registros de implementação;
+• exclusivamente se o humano escolher a Opção 1 no item 4, orientar o Executor a ajustar `docs/roadmap.md` no mesmo PR, conforme `docs/prompt-abc.md` e `docs/template-roadmap.md`, registrando somente seções, subseções, títulos, objetivos e status planejado, sem registros de implementação;
 • não antecipar na v1 o detalhamento técnico da automação nem criar fase administrativa apenas para essa decisão.
 
 4. Escolha do processo após o plano-base v1
@@ -73,16 +73,22 @@ Após concluir o item 3, apresentar ao humano as duas opções:
 
 • Opção 1 — Processo atual: seguir para o item 5.
 
-• Opção 2 — Processo automatizado: após o merge da v1, entregar ao orquestrador somente:
+• Opção 2 — Processo automatizado: após a escolha humana explícita, o Estrategista deve, nesta ordem:
+   • executar `$lp-factory-abc` em modo Planejamento para `DOC_ALVO: docs/roadmap.md`, usando a v1 aprovada como `RELATÓRIO` e o próprio PR da v1 como referência competente;
+   • aplicar literalmente no mesmo PR somente o delta emitido pelo ABC; se o resultado for `SEM ALTERAÇÕES NECESSÁRIAS`, preservar o roadmap;
+   • revisar o PR completo e confirmar que a v1, o roadmap planejado, o diff e os gates aplicáveis estão coerentes e prontos para merge;
+   • realizar exclusivamente o merge remoto do PR da v1 por ferramenta GitHub conectada e autorizada, conforme `AGENTS.md`; não fazer merge local pela `main`;
+   • após confirmar o merge da v1 na `main`, entregar ao orquestrador somente:
 
 Use $lp-factory-orquestrar-plano no PR #[NÚMERO].
 
-Essa instrução pressupõe que o PR contém o plano-base v1. O orquestrador resolve o path do plano, cria a v2, executa os gates dos especialistas e do Analista e, somente após a aprovação da v2, inicia a implementação. Não usar `$lp-factory-executar-plano` diretamente sobre a v1.
+Essa instrução pressupõe que o PR contém o plano-base v1 incorporado à `main`. O orquestrador resolve o path do plano, cria a v2, executa os gates dos especialistas e do Analista e, somente após a aprovação da v2, inicia a implementação. Não usar `$lp-factory-executar-plano` diretamente sobre a v1.
 
 Regra:
 • a escolha do processo depende de decisão humana explícita;
 • por decisão humana, os processos podem ser desenvolvidos paralelamente;
-• qualquer mutação do processo automatizado depende de o plano-base v1 já estar incorporado à main;
+• qualquer mutação pela skill de orquestração depende de o plano-base v1 já estar incorporado à main;
+• se o merge remoto da v1 estiver indisponível ou bloqueado, parar e informar o bloqueio exato; não substituir por merge local;
 • na opção 2, não seguir manualmente aos itens 5 a 8; a skill de orquestração executa internamente a avaliação dos especialistas, a criação e aprovação da v2, a reconciliação do roadmap, a implementação e o fechamento documental pelo Prompt ABC;
 • na opção 2, a v2, o roadmap, a implementação e os documentos canônicos afetados seguem na mesma branch e no mesmo PR, sem merge intermediário da v2.
 


### PR DESCRIPTION
## O que muda

- restringe a atualização do roadmap pelo Executor ao fluxo da Opção 1;
- na Opção 2, autoriza o Estrategista, após escolha humana explícita, a executar o ABC do `docs/roadmap.md` em modo Planejamento e aplicar literalmente o delta no mesmo PR da v1;
- autoriza o Estrategista a realizar apenas o merge remoto do PR da v1 por ferramenta GitHub conectada/autorizada, preservando a proibição de merge local pela `main` e mantendo o merge final da implementação humano;
- mantém `$lp-factory-orquestrar-plano` iniciando somente após a v1 estar incorporada à `main`.

## Arquivos

- `docs/prompt-estrategista.md` — v30, fluxo específico da Opção 2;
- `.agents/skills/lp-factory-abc/SKILL.md` — exceção estreita de aplicação do roadmap da v1;
- `AGENTS.md` — exceção estreita para merge remoto da v1.

## Escopo preservado

- sem alteração em `docs/orquestracao-plano-base.md`;
- sem alteração em `.agents/skills/lp-factory-orquestrar-plano/SKILL.md`;
- sem alteração em `docs/prompt-executor.md`;
- sem mudança no merge final da implementação.

## Validação

Alteração exclusivamente documental. `npm ci` e `npm run check` não se aplicam. Diff revisado contra `main`: somente os três arquivos previstos.