### PR TITLE
docs: fechar E20.5 apos ativacao

### DIFF
--- a/docs/lousa-plano-base-e20-5.md
+++ b/docs/lousa-plano-base-e20-5.md
@@ -2,7 +2,7 @@
 
 - Data: 14/08/2026.
 - Versão: v2 aprovada.
-- Status: checkpoints E20.5.3, E20.5.4 e E20.5.5 concluídos, validados e aprovados pelo mesmo Analista; correção SQL posterior validada localmente, dry-run Vercel e inspeção autenticada gate-off aprovados. A inspeção final do Estrategista e o merge humano permanecem pendentes; apply, prova SQL, ativação e testes gate-on continuam obrigatoriamente pós-merge.
+- Status: plano encerrado em 15/08/2026; PR #746 mergeado, migration aplicada pelo workflow canônico, prova SQL aprovada, flag ativada e smokes autenticados gate-on aprovados em Preview e Production. A decisão humana `corretor-imoveis → v1` foi persistida e confirmada após reload.
 - Recorte previsto para roadmap: `20.5 — Seleção da pesquisa integral end_customer por taxon`.
 - Path canônico: `docs/lousa-plano-base-e20-5.md`.
 - Fonte imutável v1: blob `8a53a73f29448a537e0036291e59582cd62c5c91`, integrado à `main` pelo PR #744.
@@ -173,7 +173,7 @@
 
 ### 3.1. E20.5.3 — Leitura e validação repo-only da pesquisa integral
 
-- Status: implementação candidata concluída, validada e aprovada pelo Analista no PR draft #746.
+- Status: concluída, validada e integrada à `main` pelo PR #746.
 - Objetivo: criar o boundary capaz de validar uma versão candidata antes que qualquer seleção seja persistida.
 - Automação: não.
 - Escopo executável:
@@ -196,7 +196,7 @@
 
 ### 3.2. E20.5.4 — Persistência e seleção humana mínima
 
-- Status: checkpoint aprovado pelo Analista no PR draft #746; correção SQL posterior validada localmente, dry-run Vercel e inspeção autenticada gate-off aprovados; inspeção final do Estrategista e merge humano permanecem pendentes.
+- Status: concluída e ativada; migration aplicada, prova SQL aprovada, seleção humana persistida e smokes autenticados gate-on aprovados em Preview e Production.
 - Objetivo: adicionar a referência mínima de versão selecionada e permitir sua alteração somente por ação humana administrativa explícita, reutilizando a validação da E20.5.3.
 - Automação: não.
 - Escopo executável:
@@ -231,7 +231,7 @@
 
 ### 3.3. E20.5.5 — Contrato de consumo da seleção válida
 
-- Status: implementação candidata concluída, validada e aprovada pelo mesmo Analista no PR draft #746; merge e ativação permanecem decisões humanas separadas.
+- Status: concluída, integrada à `main` e validada com a funcionalidade ativa em Preview e Production.
 - Objetivo: disponibilizar ao recorte seguinte uma leitura única que prove taxon ativo e pesquisa integral selecionada válida, sem antecipar o gate final de preparação.
 - Automação: não.
 - Escopo executável:

--- a/docs/platform-config.md
+++ b/docs/platform-config.md
@@ -2,8 +2,8 @@
 
 0.1 Cabeçalho
 • Documento: LP Factory 10 — Platform Config
-• Versão: v0.1.20
-• Data: 14/08/2026
+• Versão: v0.1.21
+• Data: 15/08/2026
 
 0.2 Contrato do documento
 • O QUE É: snapshot operacional e fonte única das configurações de plataformas externas do LP Factory 10, refletindo o estado conhecido/cadastrado nas plataformas conforme indicado.
@@ -134,9 +134,9 @@
 
 • `E20_5_SELECTED_RESEARCH_ENABLED`
 • Finalidade: gate server-only e fail-closed da leitura, seleção administrativa e consumo da pesquisa integral `end_customer` selecionada por taxon.
-• Escopo planejado: Preview e Production do projeto Core, com configuração independente por ambiente.
-• Estado atual: desligado; a variável estava ausente em Preview e Production na verificação de 14/08/2026, e a inspeção autenticada gate-off foi aprovada sem exposição da nova superfície ou erro de runtime. Ausência ou valor diferente do literal `true` desabilita todo acesso à nova coluna e sua interface, sem fallback de banco.
-• Ordem de ativação: após merge humano, aguardar o apply canônico da migration, aprovar `supabase/snippets/e20_5_selected_end_customer_research_version_verify.sql`, configurar como `true` no ambiente alvo e executar novo deploy.
+• Escopo: Preview e Production do projeto Core, com configuração independente por ambiente.
+• Estado atual: `true` em Production; a ativação gate-on foi validada em Preview e Production em 15/08/2026. Ausência ou valor diferente do literal `true` desabilita todo acesso à nova coluna e sua interface, sem fallback de banco.
+• Estado operacional: migration aplicada pelo workflow canônico, snippet SQL read-only aprovado, redeploy concluído e smokes autenticados gate-on aprovados em Preview e Production.
 • Regra operacional: validar primeiro em Preview autenticado; Production só pode ser habilitada após as evidências aplicáveis, sem registrar valor sensível ou branch override como estado canônico.
 
 • `INVITE_STATE_SECRET`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data: 14/08/2026
-• Versão: v1.5.146
+• Data: 15/08/2026
+• Versão: v1.5.147
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -2447,7 +2447,7 @@ Repositório — Ajustados
 20. E20 — Preparação e liberação de taxons para geração de landing pages
 
 * Objetivo: consolidar catálogo de entradas por taxon e plano, perfis versionados de orientação à geração, herança e, em recortes futuros, prontidão e liberação antes da geração de LPs por conta.
-* Status: E20.2 concluída e refinada; E20.3 concluída; checkpoints E20.5.3, E20.5.4 e E20.5.5 aprovados pelo mesmo Analista no PR draft #746; correção SQL posterior validada localmente e inspeção autenticada gate-off aprovada, com inspeção final do Estrategista e merge humano pendentes.
+* Status: E20.2 concluída e refinada; E20.3 concluída; E20.5 concluída e ativada após merge do PR #746, apply canônico, prova SQL e smokes autenticados em Preview e Production.
 
 20.2 Catálogo de entradas por taxon
 
@@ -2545,9 +2545,15 @@ Repositório — Ajustados
 20.5.1 Objetivo e status
 
 * Objetivo: permitir que um taxon ativo possua exatamente uma versão integral `end_customer` explicitamente selecionada por decisão humana autorizada e que essa versão possa ser lida integralmente por um boundary server-side, com validação de identidade e falha fechada.
-* Status: Plano-base v2 aprovado; checkpoints E20.5.3, E20.5.4 e E20.5.5 aprovados pelo mesmo Analista. A correção SQL posterior está validada localmente, e o dry-run Vercel, a configuração gate-off e a inspeção autenticada gate-off foram aprovados; inspeção final do Estrategista e merge humano permanecem pendentes. Apply, prova SQL, ativação e testes gate-on continuam pós-merge.
+* Status: Concluída e ativada em 15/08/2026; PR #746 mergeado, migration aplicada, prova SQL aprovada e smokes autenticados gate-on aprovados em Preview e Production. O taxon `corretor-imoveis` mantém a versão integral `end_customer` v1 selecionada por decisão humana.
 
 20.5.2 Registros do recorte
+
+* Banco:
+
+  * Ajustados:
+
+    * `public.business_taxons`
 
 * Repositório:
 
@@ -2575,10 +2581,11 @@ Repositório — Ajustados
 
   * Plano-base E20.5: `docs/lousa-plano-base-e20-5.md` — seções 3.1, 3.2 e 3.3.
   * Configuração do gate: `docs/platform-config.md` — seção 3.5, secrets e variáveis server-side no Vercel.
+  * Contrato de banco: `docs/schema.md` — seção 1.11.
 
 20.5.3 Leitura e validação repo-only da pesquisa integral
 
-* Status: Implementação candidata concluída, validada e aprovada pelo Analista no PR draft #746.
+* Status: Concluída, validada e integrada à `main` pelo PR #746.
 * Conteúdo:
 
   * O boundary repo-only deriva exclusivamente o path canônico de uma versão candidata `end_customer`, confina a leitura a `docs/pesquisas-brutas/` e nunca consulta a API do GitHub.
@@ -2588,20 +2595,19 @@ Repositório — Ajustados
 20.5.4 Persistência e seleção humana mínima
 
 * Objetivo: adicionar a referência mínima de versão selecionada e permitir sua alteração somente por ação humana administrativa explícita, reutilizando a validação da E20.5.3.
-* Status: Checkpoint aprovado pelo Analista no PR draft #746; correção SQL posterior validada localmente e inspeção autenticada gate-off aprovada; inspeção final do Estrategista e merge humano permanecem pendentes, com ativação pós-merge.
+* Status: Concluída e ativada; migration aplicada, prova SQL aprovada e seleção humana validada em Preview e Production.
 * Conteúdo:
 
-  * A migration adiciona somente `selected_end_customer_research_version integer null`, com check positivo quando preenchida, sem nova tabela, lifecycle ou histórico; ela preserva RLS/policies, revoga o `UPDATE` de tabela inteira de `service_role` e mantém somente os grants de coluna usados pelo editor vigente (`name`, `slug`, `is_active`) e pela seleção. O snippet read-only comprovará esse conjunto exato após o apply.
+  * A migration adiciona somente `selected_end_customer_research_version integer null`, com check positivo quando preenchida, sem nova tabela, lifecycle ou histórico; ela preserva RLS/policies, revoga o `UPDATE` de tabela inteira de `service_role` e mantém somente os grants de coluna usados pelo editor vigente (`name`, `slug`, `is_active`) e pela seleção. O snippet read-only comprovou esse conjunto exato após o apply.
   * O gate server-only `E20_5_SELECTED_RESEARCH_ENABLED` aceita apenas o literal `true` e antecede toda leitura ou mutação da coluna. Com o gate desligado, a interface e a ação novas permanecem inacessíveis, sem fallback para schema ausente.
   * A tela existente de detalhe do taxon recebe formulário separado com rótulos e associações programáticas; a Server Action exige `requirePlatformAdmin`, valida a candidata repo-only e atualiza somente a seleção por `id + slug + is_active`, com `.maxAffected(1)`.
-  * Validações locais e casos determinísticos permanecem verdes; o deployment Preview do checkpoint intermediário está `READY`, e as listagens read-only comprovaram a flag ausente em Preview e Production.
-  * O dry-run da Vercel CLI foi aprovado com as quatro pesquisas `end_customer` versionadas incluídas no conjunto de arquivos. A inspeção autenticada gate-off foi aprovada nas rotas de lista e detalhe da taxonomia, sem exposição da nova superfície e sem erro de runtime observado.
-  * Após merge humano permanecem obrigatórios: apply canônico, execução aprovada do snippet SQL, configuração da flag, redeploy e testes autenticados gate-on em Preview e Production conforme o plano.
+  * Apply canônico, prova SQL, ativação da flag e redeploy foram concluídos; os smokes autenticados gate-on aprovaram ausência de seleção, candidata inválida, seleção válida após reload, acesso negado a papel não autorizado, responsividade móvel e ausência de erros observados.
+  * O taxon `corretor-imoveis` possui `selected_end_customer_research_version = 1`, persistido após decisão humana explícita e confirmado no banco e na interface hospedada.
 
 20.5.5 Contrato de consumo da seleção válida
 
 * Objetivo: disponibilizar ao recorte seguinte uma leitura única que prove taxon ativo e pesquisa integral selecionada válida, sem antecipar o gate final de preparação.
-* Status: Implementação candidata concluída, validada e aprovada pelo mesmo Analista no PR draft #746; inspeção autenticada gate-off aprovada, com inspeção final do Estrategista e merge humano pendentes; a ativação continua pós-merge.
+* Status: Concluída, integrada à `main` e validada com a funcionalidade ativa em Preview e Production.
 * Conteúdo:
 
   * O adapter server-only exige `E20_5_SELECTED_RESEARCH_ENABLED` antes de criar o client Supabase ou alcançar a consulta da nova coluna.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data da última atualização: 11/08/2026
-• Documento: LP Factory 10 — Schema (DB Contract) v1.0.40
+• Data da última atualização: 15/08/2026
+• Documento: LP Factory 10 — Schema (DB Contract) v1.0.41
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -281,6 +281,7 @@
 • PK: id uuid
 • UNIQUE: slug
 • CHECK: business_taxons_level_chk (level IN ('segment', 'niche', 'ultra_niche'))
+• CHECK: business_taxons_selected_end_customer_research_version_chk (selected_end_customer_research_version IS NULL OR selected_end_customer_research_version > 0)
 • FK: parent_id → business_taxons(id) ON UPDATE CASCADE ON DELETE SET NULL
 
 1.11.2 Campos
@@ -289,11 +290,13 @@
 • name text not null
 • slug text not null
 • is_active boolean not null default true
+• selected_end_customer_research_version integer null
 
 1.11.3 Segurança
 • Trigger Hub: não
 • RLS: ativo (enable row level security)
-• service_role: SELECT
+• service_role: SELECT; UPDATE somente em name, slug, is_active e selected_end_customer_research_version
+• anon/authenticated: sem UPDATE em selected_end_customer_research_version
 
 1.11.4 Policies
 • business_taxons_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()


### PR DESCRIPTION
Consolida os documentos canônicos da E20.5 após o merge do PR #746.

## Escopo
- encerra o plano-base e o roadmap com o estado efetivamente integrado e ativado;
- registra no schema o campo, check e grants comprovados após o apply;
- registra no platform-config a ativação gate-on validada em Preview e Production;
- registra a decisão humana persistida: corretor-imoveis -> v1.

## Evidências
- migration aplicada pelo workflow canônico;
- snippet SQL read-only aprovado, incluindo ausência de UPDATE da tabela inteira para service_role;
- smokes autenticados gate-on aprovados em Preview e Production;
- diff restrito a quatro documentos, sem código, migration ou changelog novo;
- git diff --check aprovado.

## Validações
- npm ci: não aplicável, alteração exclusivamente documental;
- npm run check: não aplicável, alteração exclusivamente documental.

PR mantido em draft; merge exclusivamente humano.