### PR TITLE
docs: fechar rollout da E20.6

### DIFF
--- a/docs/automations.md
+++ b/docs/automations.md
@@ -1,6 +1,6 @@
 0.1 Cabeçalho
-Data: 12/08/2026
-Versão: v1.15
+Data: 15/08/2026
+Versão: v1.16
 Status: Alinhado ao Platform Config
 
 0.2 Função do documento
@@ -401,6 +401,45 @@ Regra técnica: `docs/base-tecnica.md`
 Configuração de modelo: `docs/platform-config.md`
 Action administrativa: `app/admin/(protected)/perfis-de-orientacao/actions.ts`
 Adapter de proposta: `lib/conversion-content/adapters/landingPageGenerationProfileOpenAiAdapter.ts`
+
+3.10 E20.6 — avaliação assistida da suficiência factual da E20.2 por taxon
+
+Objetivo:
+Confrontar a pesquisa integral `end_customer` selecionada pela E20.5 com uma versão executável explícita da E20.2 e produzir recomendação fundamentada para decisão humana.
+
+Status:
+Implementada e validada operacionalmente no primeiro taxon real, sem workload OpenAI no runtime do produto.
+
+Recurso utilizado:
+- instrução copiável no Admin;
+- Codex App;
+- registro administrativo humano explícito.
+
+Natureza:
+- Automação com IA em fluxo controlado.
+
+Ambiente principal:
+- Codex App.
+
+Participação humana:
+- O humano escolhe a versão executável, decide entre suficiência e gap factual real e, somente quando suficiente, registra a versão avaliada no Admin.
+
+Como usar:
+- Copiar no Admin a instrução vinculada ao taxon e à pesquisa E20.5 selecionada.
+- Informar explicitamente a versão E20.2; não usar maior versão, `latest` ou fallback.
+- Confrontar `starter`, `lite`, `pro` e `ultra`; falha, diferença material ou fonte incompleta produz `inconclusivo`.
+- Tratar a recomendação como transitória e não autoritativa; somente a ação administrativa humana persiste suficiência.
+
+Resultado esperado:
+- `suficiente`, `gaps candidatos` ou `inconclusivo`, com rastreabilidade das versões e sem persistência do relatório da IA.
+
+Limites:
+- Não altera a E20.2, não grava suficiência automaticamente, não cria agente, Agents SDK, rota de integração, job, fila ou automação recorrente.
+
+Referências / dependências:
+Fluxo funcional: `docs/roadmap.md` — E20.6.3.
+Configuração do gate: `docs/platform-config.md` — seção 3.5.
+Contrato técnico: `docs/base-tecnica.md` — seção 3.15.7.
 
 4. Aprendizados operacionais
 

--- a/docs/base-tecnica.md
+++ b/docs/base-tecnica.md
@@ -2,8 +2,8 @@
 
 0.1 Cabeçalho
 • Documento: Base Técnica LP Factory 10
-• Versão: v2.0.66
-• Data: 12/08/2026
+• Versão: v2.0.67
+• Data: 15/08/2026
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -309,6 +309,13 @@
 • Versão ativa é imutável; edição cria ou atualiza somente draft, com controle de concorrência por `updated_at` e validação server-side do agregado completo antes da persistência.
 • Assistência por IA é opcional, explícita e não autoritativa: a proposta validada permanece candidata transitória até aplicação humana explícita e não salva, ativa, arquiva nem altera o resolver público; orientações gerais e específicas pertencem exclusivamente ao humano e devem ser preservadas pelo fluxo assistido.
 • Prompts, payloads e respostas integrais não devem ser persistidos nem registrados; correlação deve usar identificadores, fingerprint e metadados operacionais seguros.
+
+3.15.7 Preparação factual do taxon para `landing_page`
+• Boundary canônico: `lib/conversion-content/landing-page/taxon-preparation/`; a derivação permanece pura e não persiste estado de prontidão.
+• O adapter server-only deve ler pelo caminho único da pesquisa selecionada o taxon ativo, a pesquisa E20.5 integralmente válida e a versão E20.2 avaliada; UI e componentes client não consultam esses marcadores diretamente.
+• O consumidor deve fornecer uma versão executável explícita, validada pela API pública do catálogo E20.2; maior versão, `latest` e qualquer fallback implícito são proibidos.
+• O sucesso exige igualdade exata entre a versão avaliada e a versão requerida; ausência, incompatibilidade, feature gate ou falha operacional devem permanecer erros tipados e fail-closed.
+• A avaliação semântica e a decisão de suficiência permanecem humanas e externas ao runtime; o boundary apenas aplica deterministicamente a decisão já registrada.
 
 3.16 Configuração e observabilidade de workloads OpenAI
 • O boundary transversal canônico é `lib/openai-workloads/`; consumidores de produto usam somente sua API pública para resolver modelo e reasoning effort, sem ler variáveis de modelo nem acessar o registry interno.

--- a/docs/base-tecnica.md
+++ b/docs/base-tecnica.md
@@ -315,7 +315,7 @@
 • O adapter server-only deve ler pelo caminho único da pesquisa selecionada o taxon ativo, a pesquisa E20.5 integralmente válida e a versão E20.2 avaliada; UI e componentes client não consultam esses marcadores diretamente.
 • O consumidor deve fornecer uma versão executável explícita, validada pela API pública do catálogo E20.2; maior versão, `latest` e qualquer fallback implícito são proibidos.
 • O sucesso exige igualdade exata entre a versão avaliada e a versão requerida; ausência, incompatibilidade, feature gate ou falha operacional devem permanecer erros tipados e fail-closed.
-• A avaliação semântica e a decisão de suficiência permanecem humanas e externas ao runtime; o boundary apenas aplica deterministicamente a decisão já registrada.
+• A avaliação semântica é assistida por IA no Codex App e permanece externa ao runtime do produto; a decisão final de suficiência e seu registro administrativo são humanos, e o boundary apenas aplica deterministicamente a decisão já registrada.
 
 3.16 Configuração e observabilidade de workloads OpenAI
 • O boundary transversal canônico é `lib/openai-workloads/`; consumidores de produto usam somente sua API pública para resolver modelo e reasoning effort, sem ler variáveis de modelo nem acessar o registry interno.

--- a/docs/platform-config.md
+++ b/docs/platform-config.md
@@ -2,7 +2,7 @@
 
 0.1 Cabeçalho
 • Documento: LP Factory 10 — Platform Config
-• Versão: v0.1.21
+• Versão: v0.1.22
 • Data: 15/08/2026
 
 0.2 Contrato do documento
@@ -138,6 +138,13 @@
 • Estado atual: `true` em Production; a ativação gate-on foi validada em Preview e Production em 15/08/2026. Ausência ou valor diferente do literal `true` desabilita todo acesso à nova coluna e sua interface, sem fallback de banco.
 • Estado operacional: migration aplicada pelo workflow canônico, snippet SQL read-only aprovado, redeploy concluído e smokes autenticados gate-on aprovados em Preview e Production.
 • Regra operacional: validar primeiro em Preview autenticado; Production só pode ser habilitada após as evidências aplicáveis, sem registrar valor sensível ou branch override como estado canônico.
+
+• `E20_6_INPUT_CATALOG_REVIEW_ENABLED`
+• Finalidade: gate server-only e fail-closed da avaliação administrativa da suficiência factual da E20.2 e da leitura do predicado derivado de preparação do taxon.
+• Escopo: Preview e Production do projeto Core, com configuração independente por ambiente.
+• Estado atual: `true` em Preview e Production; ausência ou valor diferente do literal `true` desabilita leitura, mutação e renderização dependentes de `reviewed_input_catalog_version`.
+• Estado operacional: migration aplicada pelo workflow canônico, snippet SQL read-only aprovado, redeploy de Production concluído e Admin autenticado gate-on validado em 15/08/2026.
+• Regra operacional: `E20_5_SELECTED_RESEARCH_ENABLED = true` permanece pré-requisito independente; mudanças futuras devem ser validadas primeiro em Preview autenticado antes de Production.
 
 • `INVITE_STATE_SECRET`
 • Finalidade: assinar o estado opaco transportado pelo convite nativo do Supabase Auth.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 0.1 Cabeçalho
 • Data: 15/08/2026
-• Versão: v1.5.151
+• Versão: v1.5.152
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -2641,10 +2641,13 @@ Repositório — Ajustados
 20.6.1 Objetivo e status
 
 * Objetivo: avaliar a suficiência factual da pesquisa integral `end_customer` selecionada pela E20.5 em conjunto com uma versão executável explícita do catálogo E20.2 e definir o predicado final de preparação do taxon, sem autorizar geração.
-* Status: Em andamento; implementação repo-side materializada, com rollout e provas operacionais pós-merge pendentes.
+* Status: Concluída em 15/08/2026; implementação, migration, gate operacional, registro humano e prova real do predicado derivado aprovados.
 
 20.6.2 Registros do recorte
 
+* Banco:
+  * Ajustados:
+    * `public.business_taxons`.
 * Repositório:
   * Criados:
     * `app/admin/(protected)/taxonomia/[taxonId]/_components/AdminTaxonInputCatalogReview.tsx`;
@@ -2672,10 +2675,14 @@ Repositório — Ajustados
     * `lib/conversion-content/landing-page/taxon-preparation/validation-cases.ts`.
 * Referências:
   * Plano-base E20.6: `docs/lousa-plano-base-e20-6.md` — seções 2 e 3.
+  * Contrato de banco: `docs/schema.md` — seção 1.11.
+  * Configuração do gate: `docs/platform-config.md` — seção 3.5.
+  * Boundary de preparação: `docs/base-tecnica.md` — seção 3.15.7.
+  * Fluxo assistido: `docs/automations.md` — seção 3.10.
 
 20.6.3 Avaliação assistida e registro humano da suficiência
 
-* Status: Implementada no repositório; a reavaliação real de `corretor-imoveis` contra a versão executável E20.2 `4` resultou em `suficiente` e foi aceita por decisão humana; permanecem pendentes pós-merge a aplicação da migration, a ativação do gate e o registro administrativo de `reviewed_input_catalog_version = 4`.
+* Status: Concluída em 15/08/2026; a reavaliação real de `corretor-imoveis` contra a versão executável E20.2 `4` resultou em `suficiente`, foi aceita por decisão humana e teve `reviewed_input_catalog_version = 4` registrado e confirmado após reload no Admin autenticado.
 * Conteúdo:
   * usar o fluxo humano `Admin → Codex → Admin`, com IA em fluxo controlado no ambiente interno do Codex e sem workload OpenAI no runtime do LP Factory;
   * confrontar integralmente a pesquisa E20.5 autorizada com uma versão executável E20.2 escolhida explicitamente pelo humano, resolvendo e comparando `starter`, `lite`, `pro` e `ultra`, sem `latest` ou fallback;
@@ -2686,10 +2693,12 @@ Repositório — Ajustados
 
 20.6.4 Gate derivado de preparação do taxon
 
-* Status: Implementada no repositório; prova real pendente pós-merge, após migration aplicada, gate habilitado e registro humano da versão explícita `4`.
+* Status: Concluída em 15/08/2026; predicado derivado comprovado para a versão executável explicitamente requerida `4`.
 * Conteúdo:
   * derivar deterministicamente a preparação por `taxon ativo + E20.5 selecionada/válida + reviewed_input_catalog_version compatível com a versão executável explicitamente requerida`;
   * falhar fechado para ausência ou incompatibilidade e não persistir estado adicional de prontidão;
+  * a prova real de `corretor-imoveis`, com pesquisa integral `end_customer` v1, `reviewed_input_catalog_version = 4` e `requiredInputCatalogVersion = 4`, retornou `prepared: true`;
+  * o controle negativo com `requiredInputCatalogVersion = 3` retornou `INPUT_CATALOG_REVIEW_VERSION_MISMATCH`, comprovando igualdade exata sem `latest` ou fallback;
   * preservar E19.2, E19.3 e E19.4 sem alteração neste recorte.
 
 21. E21 — Gestão e governança dos workloads OpenAI

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -2,7 +2,7 @@
 
 0.1 Cabeçalho
 • Data da última atualização: 15/08/2026
-• Documento: LP Factory 10 — Schema (DB Contract) v1.0.41
+• Documento: LP Factory 10 — Schema (DB Contract) v1.0.42
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -282,6 +282,7 @@
 • UNIQUE: slug
 • CHECK: business_taxons_level_chk (level IN ('segment', 'niche', 'ultra_niche'))
 • CHECK: business_taxons_selected_end_customer_research_version_chk (selected_end_customer_research_version IS NULL OR selected_end_customer_research_version > 0)
+• CHECK: business_taxons_reviewed_input_catalog_version_chk (reviewed_input_catalog_version IS NULL OR reviewed_input_catalog_version > 0)
 • FK: parent_id → business_taxons(id) ON UPDATE CASCADE ON DELETE SET NULL
 
 1.11.2 Campos
@@ -291,12 +292,13 @@
 • slug text not null
 • is_active boolean not null default true
 • selected_end_customer_research_version integer null
+• reviewed_input_catalog_version integer null
 
 1.11.3 Segurança
 • Trigger Hub: não
 • RLS: ativo (enable row level security)
-• service_role: SELECT; UPDATE somente em name, slug, is_active e selected_end_customer_research_version
-• anon/authenticated: sem UPDATE em selected_end_customer_research_version
+• service_role: SELECT; sem UPDATE da tabela inteira; UPDATE somente em is_active, name, reviewed_input_catalog_version, selected_end_customer_research_version e slug
+• anon/authenticated: sem UPDATE em selected_end_customer_research_version e reviewed_input_catalog_version
 
 1.11.4 Policies
 • business_taxons_select_admin_only (SELECT to public): is_super_admin() OU is_platform_admin()


### PR DESCRIPTION
## Resumo

- executa o Prompt ABC em consolidação final para o rollout pós-merge da E20.6;
- registra a E20.6 como concluída no roadmap, com a prova real `prepared: true` para `corretor-imoveis`, pesquisa E20.5 v1 e E20.2 v4;
- registra o controle negativo com versão requerida 3 e erro `INPUT_CATALOG_REVIEW_VERSION_MISMATCH`;
- reconcilia somente os contratos canônicos materiais de banco, configuração, boundary e automação assistida.

## Estado operacional usado como relatório

- PR #750 mergeado;
- migration aplicada pelo workflow canônico e snippet SQL read-only com `status = ok`;
- `E20_6_INPUT_CATALOG_REVIEW_ENABLED=true`, preservando o pré-requisito E20.5;
- Admin autenticado validado e registro humano `reviewed_input_catalog_version = 4` confirmado após reload;
- predicado derivado aprovado com `requiredInputCatalogVersion = 4`, sem `latest` ou fallback.

## Escopo

Somente:

- `docs/roadmap.md`
- `docs/schema.md`
- `docs/platform-config.md`
- `docs/base-tecnica.md`
- `docs/automations.md`

Nenhuma alteração de código, banco, migration, flag ou estado operacional.

## Validação

- `git diff --check`
- revisão de `origin/main..HEAD` e `origin/main...HEAD`
- `npm ci`: não aplicável, alteração exclusivamente documental
- `npm run check`: não aplicável, alteração exclusivamente documental
