### PR TITLE
docs: add security manager governance record

### DIFF
--- a/docs/gestor-seguranca.md
+++ b/docs/gestor-seguranca.md
@@ -2,127 +2,82 @@
 
 0.1 Cabeçalho
 • Documento: Gestor de Segurança (Plataformas)
-• Versão: v0.1.2
+• Versão: v0.2.0
 • Data: 16/08/2026
 
 0.2 Contrato do documento
-• O QUE É: fonte de governança do Gestor de Segurança para objetivo, escopo, limites, decisões vigentes, decisões implementadas, pendências, temas em decisão e temas para debate futuro.
-• USAR PARA: registrar o que deve ser acompanhado pelo papel e preservar decisões de segurança ao longo do projeto.
-• NÃO USAR PARA: configurações operacionais detalhadas das plataformas (usar `docs/platform-config.md`), regras técnicas de runtime/código (usar `docs/base-tecnica.md`), contrato de banco (usar `docs/schema.md`) ou status de casos E* (usar `docs/roadmap.md`).
-• REGRA: este documento é cumulativo e não deve ser resetado; deve ser atualizado conforme novas evidências e decisões surgirem.
+• O QUE É: fonte de governança do Gestor de Segurança para objetivo, limites, decisões implementadas, pendências priorizadas e temas de segurança para debate futuro.
+• USAR PARA: manter o estado decisório da segurança de plataformas sem duplicar inventário operacional ou documentação técnica.
+• NÃO USAR PARA: configurações operacionais detalhadas (usar `docs/platform-config.md`), regras técnicas de runtime/código (usar `docs/base-tecnica.md`), contrato de banco/RLS/policies (usar `docs/schema.md`) ou status de casos E* (usar `docs/roadmap.md`).
+• REGRA: este documento é cumulativo, mas deve permanecer enxuto; manter apenas decisões, pendências, regras e temas que ainda tenham valor de segurança.
 • REGRA: nunca registrar valores reais de secrets, tokens, senhas ou chaves.
 
 1. Objetivo e escopo do papel
 
 1.1 Objetivo
-• Reduzir risco de falhas de configuração, exposição de credenciais e permissões excessivas nas plataformas usadas pelo projeto.
-• Manter uma visão simples das decisões de segurança já fechadas, das decisões já implementadas, das pendências, dos temas em decisão e dos temas relevantes para debate futuro.
+• Reduzir risco de falhas de configuração, exposição de credenciais, permissões excessivas e dependências de segurança inadequadas nas plataformas usadas pelo projeto.
+• Manter uma visão simples do que já foi resolvido, do que precisa ser tratado agora e do que merece reavaliação futura.
 
 1.2 Funções
-• Monitorar configurações de segurança das plataformas.
-• Checar permissões e acessos segundo o princípio do menor privilégio.
-• Verificar armazenamento e exposição de secrets, tokens e chaves.
+• Monitorar configurações de segurança, permissões e acessos das plataformas.
+• Verificar armazenamento e possível exposição de secrets, tokens e chaves.
 • Avaliar alertas, e-mails e recomendações de segurança enviados pelas plataformas.
-• Registrar riscos, recomendações, decisões e pendências.
-• Manter registro do que precisa ser endurecido antes do GO-LIVE.
-• Inspecionar pontualmente arquivos, commits ou configurações quando necessário para confirmar exposição de secret ou evidenciar alerta de plataforma, sem assumir revisão ampla de segurança de código.
-• Avaliar tecnologias, serviços e controles cuja finalidade ou impacto material seja segurança, incluindo custo-benefício, nova superfície de risco, dependências e reversibilidade, sem assumir a decisão de arquitetura geral do produto.
+• Manter pendências de segurança em ordem de prioridade.
+• Inspecionar pontualmente arquivos, commits ou configurações quando necessário para confirmar um alerta ou possível exposição.
+• Avaliar tecnologias, serviços e controles com impacto material de segurança, considerando custo-benefício, nova superfície de risco, dependências e reversibilidade.
+• Registrar o que precisa ser endurecido antes do GO-LIVE.
 
 1.3 Limites
-• Não realizar auditoria de segurança de código, SQL, RLS ou arquitetura.
+• Não realizar auditoria ampla de segurança de código, SQL, RLS ou arquitetura.
 • Não escrever ou executar SQL como função deste papel.
-• Não alterar arquitetura do sistema nem assumir responsabilidade pela arquitetura geral do produto.
+• Não assumir a decisão de arquitetura geral do produto.
 • Não bloquear releases nem exercer veto técnico.
-• Não alterar configurações de plataforma por iniciativa própria; orientar, registrar e encaminhar execução quando aprovada.
+• Quando uma pendência exigir validação de código, DB, RLS ou arquitetura, encaminhar a análise técnica ao responsável adequado e registrar aqui apenas o resultado de segurança.
 
-2. Plataformas monitoradas
+1.4 Regras permanentes
+• Valores reais de secrets não devem ser versionados nem documentados.
+• Se houver exposição real confirmada, revogar ou rotacionar a credencial antes da limpeza documental ou do histórico aplicável.
+• Se um novo ambiente Supabase de staging for criado, controles mínimos de segurança devem existir desde a criação.
+• Um falso positivo anterior não autoriza ignorar novos alertas semelhantes.
 
-2.1 Escopo atual
-• GitHub.
-• Vercel.
-• Supabase.
-• Resend.
-• Codex.
-• ChatGPT / OpenAI.
-• Stripe, quando houver configuração de segurança relevante.
-• Registro.com / DNS, quando houver configuração de segurança relevante.
-• Zoho Mail, quando houver configuração de segurança relevante.
+2. Fontes e plataformas
 
-3. Critério de acompanhamento
+2.1 Fonte operacional
+• `docs/platform-config.md` é a fonte única do inventário de plataformas, integrações, variáveis e secrets por nome; este documento não mantém lista paralela de plataformas.
+• O Gestor de Segurança acompanha qualquer plataforma ou serviço registrado ali quando houver impacto material de segurança.
 
-3.1 Status
-• OK: configuração adequada ou risco encerrado.
-• Ajustar: melhoria recomendada ou endurecimento ainda pendente.
-• Risco: possível exposição ou configuração potencialmente perigosa.
+2.2 Fontes complementares
+• `README.md`: visão, princípios do MVP e critérios de simplicidade.
+• `docs/base-tecnica.md`: regras técnicas e de segurança do runtime.
+• `docs/schema.md`: autoridade para DB, RLS, policies, grants e funções.
+• `docs/roadmap.md`: estado dos casos E* quando a pendência depender deles.
 
-3.2 Regra de atualização
-• Atualizar este documento quando houver nova evidência, alerta relevante, decisão humana ou mudança de estado de uma pendência.
-• Não duplicar inventário operacional já mantido em `docs/platform-config.md`; registrar aqui somente o significado de segurança e a decisão correspondente.
-• Decisão vigente é uma regra ou posição atualmente válida, independentemente de já ter sido executada.
-• Decisão implementada é uma decisão já aplicada e validada operacionalmente.
-• Tema em decisão é um assunto em debate ativo que precisa chegar a uma decisão.
-• Tema para debate futuro é relevante para segurança, mas não exige decisão nem implementação no momento; deve ter gatilho objetivo de reavaliação quando possível.
-• Quando um tema em decisão for fechado, movê-lo para Decisões vigentes, Decisões implementadas ou Pendências de segurança, conforme o resultado.
-• Quando um tema para debate futuro atingir seu gatilho de reavaliação, movê-lo para Temas em decisão.
+3. Decisões implementadas
 
-4. Decisões vigentes
-
-4.1 Secrets e credenciais
-• Valores reais de secrets não devem ser versionados; somente nomes, finalidade, plataforma e escopo podem ser documentados.
-• Se houver exposição real confirmada, a primeira ação é revogar ou rotacionar a credencial antes da limpeza documental ou do histórico aplicável.
-
-4.2 Supabase STAGING futuro
-• Se um novo staging Supabase for criado, controles mínimos de segurança devem existir desde a criação, sem depender de correção posterior.
-
-4.3 Alertas de segurança
-• Alertas de plataformas devem ser avaliados individualmente.
-• Um falso positivo anterior não autoriza ignorar novas ocorrências semelhantes.
-
-5. Decisões implementadas
-
-5.1 Supabase STAGING descontinuado
+3.1 Supabase STAGING descontinuado
 • O antigo projeto `LP-Factory-10-staging` foi descontinuado e deletado em 31/03/2026 após alerta crítico de RLS desativado.
 • Não existe staging Supabase ativo decorrente daquele ambiente.
 • Risco correspondente encerrado.
 
-5.2 Alerta GitGuardian de junho de 2026
-• A investigação do alerta `Generic High Entropy Secret` concluiu falso positivo.
-• Não foi identificada exposição real de token, senha, chave privada ou connection string nos itens investigados.
-• Não houve necessidade de rotação de credenciais.
-• Ocorrência encerrada.
+4. Pendências de segurança
 
-6. Pendências de segurança
+4.1 Prioridade 1 — Supabase Security Advisor
+• Estado verificado em 16/08/2026: o projeto principal está ativo e o Security Advisor apresenta WARN/INFO que exigem triagem técnica.
+• Priorizar a classificação dos WARN relacionados a objetos visíveis no schema GraphQL para `authenticated` e funções `SECURITY DEFINER` executáveis por `authenticated`, verificando em `docs/schema.md` e no runtime se cada exposição é intencional.
+• Os INFO de RLS habilitado sem policy também devem ser classificados, sem presumir vulnerabilidade: podem representar tabelas deliberadamente sem acesso direto.
+• `Leaked Password Protection Disabled` permanece conhecido; o ajuste depende de plano Supabase compatível e deve ser reavaliado quando houver upgrade e, no máximo, antes do GO-LIVE.
+• O Gestor de Segurança não altera SQL/RLS; a validação técnica deve ser executada pelo responsável adequado e o resultado deve retornar para esta pendência.
 
-6.1 Supabase Auth — Leaked Password Protection
-• A proteção contra senhas vazadas permanece desativada no projeto principal.
-• O estado foi aceito temporariamente enquanto o recurso não estiver disponível no plano atual.
-• Reavaliar quando houver plano compatível e, no máximo, antes do GO-LIVE comercial.
+4.2 Prioridade 2 — Tornar o repositório GitHub privado
+• Estado verificado em 16/08/2026: `AlcinoAfonso/LP-Factory-10` permanece público.
+• Objetivo de segurança: tornar o repositório privado, por se tratar de produto comercial proprietário com código, documentação, migrations, workflows e regras internas.
+• Antes da mudança, validar continuidade de acesso para ChatGPT/Codex, Vercel, GitHub Actions, GitGuardian e demais integrações necessárias.
+• As páginas públicas hospedadas na Vercel são independentes da visibilidade do repositório e podem continuar públicas.
+• Ordem atual: tratar primeiro a triagem do Supabase Security Advisor e, em seguida, executar a privatização do repositório com validação das integrações.
 
-6.2 Revisão pré-GO-LIVE
-• Antes do lançamento comercial, revisar permissões, acessos, secrets, autenticação e demais endurecimentos pendentes nas plataformas efetivamente usadas.
+5. Temas para debate futuro
 
-7. Temas em decisão
-
-7.1 Visibilidade do repositório GitHub
-• Estado atual verificado em 16/08/2026: `AlcinoAfonso/LP-Factory-10` está público.
-• Recomendação do Gestor de Segurança: tornar o repositório privado por se tratar de produto comercial proprietário com código, documentação, migrations, workflows e regras internas.
-• Antes da mudança, validar continuidade de acesso para ChatGPT/Codex, Vercel, GitHub Actions, GitGuardian e demais integrações que dependam do repositório.
-• As páginas públicas do produto hospedadas na Vercel são independentes da visibilidade do repositório e podem continuar públicas com o repositório privado.
-• Status: decisão humana pendente.
-
-8. Temas para debate futuro
-
-8.1 Cloudflare AI Gateway
-• Classificação atual: opção futura de segurança; não há decisão nem pendência de implementação.
-• Potencial valor: DLP, rate limiting, limites de gasto, observabilidade e fallback dos workloads de IA.
-• Avaliação atual: o custo-benefício não justifica adoção no MVP enquanto não houver problema material que compense a nova dependência e a complexidade adicional.
-• Gatilhos de reavaliação: aumento relevante de volume ou custo de IA; processamento de PII ou conteúdo comercial sensível; necessidade de fallback entre provedores; necessidade de controles centralizados de segurança ou observabilidade além dos atuais.
-• Quando algum gatilho ocorrer, reavaliar segurança, custo, superfície de falha, exposição de dados, dependência e reversibilidade antes de decidir adoção.
-
-9. Manutenção do documento
-
-9.1 Regra contínua
-• Este documento deve evoluir por atualização incremental, preservando decisões já tomadas.
-• Evitar narrativa operacional longa; manter somente o necessário para decisão, risco, pendência e evidência.
-• Quando uma pendência for resolvida, registrar o estado final em Decisões implementadas quando houver execução validada, ou em Decisões vigentes quando o resultado for uma regra ainda não executada.
-• Temas para debate futuro não devem ser tratados como pendência nem como compromisso de implementação.
+5.1 Cloudflare AI Gateway
+• Opção futura de segurança; não há pendência de implementação no MVP atual.
+• Potencial valor: DLP, rate limiting, limites de gasto, observabilidade e fallback de workloads de IA, em troca de nova dependência e superfície operacional.
+• Reavaliar quando houver aumento relevante de volume/custo de IA, processamento de PII ou conteúdo comercial sensível, necessidade de fallback entre provedores ou controles centralizados adicionais de segurança/observabilidade.

--- a/docs/gestor-seguranca.md
+++ b/docs/gestor-seguranca.md
@@ -2,11 +2,11 @@
 
 0.1 Cabeçalho
 • Documento: Gestor de Segurança (Plataformas)
-• Versão: v0.1.1
+• Versão: v0.1.2
 • Data: 16/08/2026
 
 0.2 Contrato do documento
-• O QUE É: fonte de governança do Gestor de Segurança para objetivo, escopo, limites, decisões vigentes, decisões implementadas, pendências e temas em decisão.
+• O QUE É: fonte de governança do Gestor de Segurança para objetivo, escopo, limites, decisões vigentes, decisões implementadas, pendências, temas em decisão e temas para debate futuro.
 • USAR PARA: registrar o que deve ser acompanhado pelo papel e preservar decisões de segurança ao longo do projeto.
 • NÃO USAR PARA: configurações operacionais detalhadas das plataformas (usar `docs/platform-config.md`), regras técnicas de runtime/código (usar `docs/base-tecnica.md`), contrato de banco (usar `docs/schema.md`) ou status de casos E* (usar `docs/roadmap.md`).
 • REGRA: este documento é cumulativo e não deve ser resetado; deve ser atualizado conforme novas evidências e decisões surgirem.
@@ -16,7 +16,7 @@
 
 1.1 Objetivo
 • Reduzir risco de falhas de configuração, exposição de credenciais e permissões excessivas nas plataformas usadas pelo projeto.
-• Manter uma visão simples das decisões de segurança já fechadas, das decisões já implementadas, das pendências e dos temas ainda em debate.
+• Manter uma visão simples das decisões de segurança já fechadas, das decisões já implementadas, das pendências, dos temas em decisão e dos temas relevantes para debate futuro.
 
 1.2 Funções
 • Monitorar configurações de segurança das plataformas.
@@ -26,11 +26,12 @@
 • Registrar riscos, recomendações, decisões e pendências.
 • Manter registro do que precisa ser endurecido antes do GO-LIVE.
 • Inspecionar pontualmente arquivos, commits ou configurações quando necessário para confirmar exposição de secret ou evidenciar alerta de plataforma, sem assumir revisão ampla de segurança de código.
+• Avaliar tecnologias, serviços e controles cuja finalidade ou impacto material seja segurança, incluindo custo-benefício, nova superfície de risco, dependências e reversibilidade, sem assumir a decisão de arquitetura geral do produto.
 
 1.3 Limites
 • Não realizar auditoria de segurança de código, SQL, RLS ou arquitetura.
 • Não escrever ou executar SQL como função deste papel.
-• Não alterar arquitetura do sistema.
+• Não alterar arquitetura do sistema nem assumir responsabilidade pela arquitetura geral do produto.
 • Não bloquear releases nem exercer veto técnico.
 • Não alterar configurações de plataforma por iniciativa própria; orientar, registrar e encaminhar execução quando aprovada.
 
@@ -59,7 +60,10 @@
 • Não duplicar inventário operacional já mantido em `docs/platform-config.md`; registrar aqui somente o significado de segurança e a decisão correspondente.
 • Decisão vigente é uma regra ou posição atualmente válida, independentemente de já ter sido executada.
 • Decisão implementada é uma decisão já aplicada e validada operacionalmente.
+• Tema em decisão é um assunto em debate ativo que precisa chegar a uma decisão.
+• Tema para debate futuro é relevante para segurança, mas não exige decisão nem implementação no momento; deve ter gatilho objetivo de reavaliação quando possível.
 • Quando um tema em decisão for fechado, movê-lo para Decisões vigentes, Decisões implementadas ou Pendências de segurança, conforme o resultado.
+• Quando um tema para debate futuro atingir seu gatilho de reavaliação, movê-lo para Temas em decisão.
 
 4. Decisões vigentes
 
@@ -106,9 +110,19 @@
 • As páginas públicas do produto hospedadas na Vercel são independentes da visibilidade do repositório e podem continuar públicas com o repositório privado.
 • Status: decisão humana pendente.
 
-8. Manutenção do documento
+8. Temas para debate futuro
 
-8.1 Regra contínua
+8.1 Cloudflare AI Gateway
+• Classificação atual: opção futura de segurança; não há decisão nem pendência de implementação.
+• Potencial valor: DLP, rate limiting, limites de gasto, observabilidade e fallback dos workloads de IA.
+• Avaliação atual: o custo-benefício não justifica adoção no MVP enquanto não houver problema material que compense a nova dependência e a complexidade adicional.
+• Gatilhos de reavaliação: aumento relevante de volume ou custo de IA; processamento de PII ou conteúdo comercial sensível; necessidade de fallback entre provedores; necessidade de controles centralizados de segurança ou observabilidade além dos atuais.
+• Quando algum gatilho ocorrer, reavaliar segurança, custo, superfície de falha, exposição de dados, dependência e reversibilidade antes de decidir adoção.
+
+9. Manutenção do documento
+
+9.1 Regra contínua
 • Este documento deve evoluir por atualização incremental, preservando decisões já tomadas.
 • Evitar narrativa operacional longa; manter somente o necessário para decisão, risco, pendência e evidência.
 • Quando uma pendência for resolvida, registrar o estado final em Decisões implementadas quando houver execução validada, ou em Decisões vigentes quando o resultado for uma regra ainda não executada.
+• Temas para debate futuro não devem ser tratados como pendência nem como compromisso de implementação.

--- a/docs/gestor-seguranca.md
+++ b/docs/gestor-seguranca.md
@@ -2,7 +2,7 @@
 
 0.1 Cabeçalho
 • Documento: Gestor de Segurança (Plataformas)
-• Versão: v0.2.0
+• Versão: v0.2.1
 • Data: 16/08/2026
 
 0.2 Contrato do documento
@@ -59,21 +59,26 @@
 • Não existe staging Supabase ativo decorrente daquele ambiente.
 • Risco correspondente encerrado.
 
+3.2 Triagem do Supabase Security Advisor concluída
+• Triagem realizada em 16/08/2026 sobre 29 ocorrências atuais: 22 WARN e 7 INFO.
+• Os 7 INFO de RLS habilitado sem policy correspondem, conforme `docs/schema.md`, a objetos deliberadamente sem acesso direto por `public`/`anon`/`authenticated`; não criar policies apenas para eliminar o aviso.
+• Os 6 WARN de funções `SECURITY DEFINER` executáveis por `authenticated` correspondem a RPCs privilegiadas documentadas e controladas; não revogar `EXECUTE` nem trocar para `SECURITY INVOKER` sem novo caso técnico.
+• Os 15 WARN de objetos visíveis no schema GraphQL correspondem a objetos com acesso intencional e proteção por RLS/policies ou `security_invoker`; não foi identificada correção simples que justifique o risco de regressão.
+• Resultado: nenhuma alteração de SQL/RLS recomendada apenas para limpar esses avisos.
+• Foi identificado drift documental pontual em `docs/schema.md`; tratar separadamente como manutenção documental, não como vulnerabilidade confirmada.
+
 4. Pendências de segurança
 
-4.1 Prioridade 1 — Supabase Security Advisor
-• Estado verificado em 16/08/2026: o projeto principal está ativo e o Security Advisor apresenta WARN/INFO que exigem triagem técnica.
-• Priorizar a classificação dos WARN relacionados a objetos visíveis no schema GraphQL para `authenticated` e funções `SECURITY DEFINER` executáveis por `authenticated`, verificando em `docs/schema.md` e no runtime se cada exposição é intencional.
-• Os INFO de RLS habilitado sem policy também devem ser classificados, sem presumir vulnerabilidade: podem representar tabelas deliberadamente sem acesso direto.
-• `Leaked Password Protection Disabled` permanece conhecido; o ajuste depende de plano Supabase compatível e deve ser reavaliado quando houver upgrade e, no máximo, antes do GO-LIVE.
-• O Gestor de Segurança não altera SQL/RLS; a validação técnica deve ser executada pelo responsável adequado e o resultado deve retornar para esta pendência.
-
-4.2 Prioridade 2 — Tornar o repositório GitHub privado
+4.1 Prioridade 1 — Tornar o repositório GitHub privado
 • Estado verificado em 16/08/2026: `AlcinoAfonso/LP-Factory-10` permanece público.
 • Objetivo de segurança: tornar o repositório privado, por se tratar de produto comercial proprietário com código, documentação, migrations, workflows e regras internas.
 • Antes da mudança, validar continuidade de acesso para ChatGPT/Codex, Vercel, GitHub Actions, GitGuardian e demais integrações necessárias.
 • As páginas públicas hospedadas na Vercel são independentes da visibilidade do repositório e podem continuar públicas.
-• Ordem atual: tratar primeiro a triagem do Supabase Security Advisor e, em seguida, executar a privatização do repositório com validação das integrações.
+
+4.2 Supabase Auth — Leaked Password Protection
+• `Leaked Password Protection Disabled` permanece como warning conhecido.
+• O ajuste depende de plano Supabase compatível; reavaliar quando houver upgrade e, no máximo, antes do GO-LIVE.
+• Não há ação técnica disponível no plano atual.
 
 5. Temas para debate futuro
 

--- a/docs/gestor-seguranca.md
+++ b/docs/gestor-seguranca.md
@@ -2,7 +2,7 @@
 
 0.1 Cabeçalho
 • Documento: Gestor de Segurança (Plataformas)
-• Versão: v0.2.1
+• Versão: v0.2.2
 • Data: 16/08/2026
 
 0.2 Contrato do documento
@@ -86,3 +86,11 @@
 • Opção futura de segurança; não há pendência de implementação no MVP atual.
 • Potencial valor: DLP, rate limiting, limites de gasto, observabilidade e fallback de workloads de IA, em troca de nova dependência e superfície operacional.
 • Reavaliar quando houver aumento relevante de volume/custo de IA, processamento de PII ou conteúdo comercial sensível, necessidade de fallback entre provedores ou controles centralizados adicionais de segurança/observabilidade.
+
+5.2 Identidade estável para testes no Codex App
+• Direção aprovada conceitualmente para debate futuro: uma identidade Auth estável do LP Factory vinculada somente a uma conta inequivocamente de teste, preferencialmente como owner dessa conta, sem `platform_admin`/`super_admin` e sem acesso a contas reais.
+• Como Preview e Production usam atualmente o mesmo Supabase Auth, não criar ambiente ou infraestrutura adicional apenas para essa identidade enquanto não houver necessidade comprovada.
+• Usar caixa postal exclusiva de testes; aliases podem ser usados dentro dela para casos que realmente exijam novo usuário. Não adotar caixa postal pessoal como solução permanente.
+• Credenciais reais não devem aparecer em código, documentos, prompts, logs ou chat. GitHub Secrets permanecem adequados aos workflows; no uso interativo do Codex App, preferir sessão autenticada no navegador sem fornecer a senha ao modelo.
+• Reutilizar a identidade estável nos testes recorrentes e criar usuários descartáveis apenas quando o próprio fluxo exigir cadastro novo, convite ou papel distinto.
+• Reavaliar implementação quando houver uma janela curta que não desvie o caminho crítico da primeira landing page real; até lá, não criar nova automação, rota, tabela ou mecanismo de secrets para esse objetivo.

--- a/docs/gestor-seguranca.md
+++ b/docs/gestor-seguranca.md
@@ -1,0 +1,103 @@
+0. Introdução
+
+0.1 Cabeçalho
+• Documento: Gestor de Segurança (Plataformas)
+• Versão: v0.1.0
+• Data: 16/08/2026
+
+0.2 Contrato do documento
+• O QUE É: fonte de governança do Gestor de Segurança para objetivo, escopo, limites, decisões vigentes, pendências e temas em decisão.
+• USAR PARA: registrar o que deve ser acompanhado pelo papel e preservar decisões de segurança ao longo do projeto.
+• NÃO USAR PARA: configurações operacionais detalhadas das plataformas (usar `docs/platform-config.md`), regras técnicas de runtime/código (usar `docs/base-tecnica.md`), contrato de banco (usar `docs/schema.md`) ou status de casos E* (usar `docs/roadmap.md`).
+• REGRA: este documento é cumulativo e não deve ser resetado; deve ser atualizado conforme novas evidências e decisões surgirem.
+• REGRA: nunca registrar valores reais de secrets, tokens, senhas ou chaves.
+
+1. Objetivo e escopo do papel
+
+1.1 Objetivo
+• Reduzir risco de falhas de configuração, exposição de credenciais e permissões excessivas nas plataformas usadas pelo projeto.
+• Manter uma visão simples das decisões de segurança já fechadas, das pendências e dos temas ainda em debate.
+
+1.2 Funções
+• Monitorar configurações de segurança das plataformas.
+• Checar permissões e acessos segundo o princípio do menor privilégio.
+• Verificar armazenamento e exposição de secrets, tokens e chaves.
+• Avaliar alertas, e-mails e recomendações de segurança enviados pelas plataformas.
+• Registrar riscos, recomendações, decisões e pendências.
+• Manter registro do que precisa ser endurecido antes do GO-LIVE.
+• Inspecionar pontualmente arquivos, commits ou configurações quando necessário para confirmar exposição de secret ou evidenciar alerta de plataforma, sem assumir revisão ampla de segurança de código.
+
+1.3 Limites
+• Não realizar auditoria de segurança de código, SQL, RLS ou arquitetura.
+• Não escrever ou executar SQL como função deste papel.
+• Não alterar arquitetura do sistema.
+• Não bloquear releases nem exercer veto técnico.
+• Não alterar configurações de plataforma por iniciativa própria; orientar, registrar e encaminhar execução quando aprovada.
+
+2. Plataformas monitoradas
+
+2.1 Escopo atual
+• GitHub.
+• Vercel.
+• Supabase.
+• Resend.
+• Codex.
+• ChatGPT / OpenAI.
+• Stripe, quando houver configuração de segurança relevante.
+• Registro.com / DNS, quando houver configuração de segurança relevante.
+• Zoho Mail, quando houver configuração de segurança relevante.
+
+3. Critério de acompanhamento
+
+3.1 Status
+• OK: configuração adequada ou risco encerrado.
+• Ajustar: melhoria recomendada ou endurecimento ainda pendente.
+• Risco: possível exposição ou configuração potencialmente perigosa.
+
+3.2 Regra de atualização
+• Atualizar este documento quando houver nova evidência, alerta relevante, decisão humana ou mudança de estado de uma pendência.
+• Não duplicar inventário operacional já mantido em `docs/platform-config.md`; registrar aqui somente o significado de segurança e a decisão correspondente.
+• Quando um tema em decisão for fechado, movê-lo para Decisões vigentes ou Pendências de segurança, conforme o resultado.
+
+4. Decisões vigentes
+
+4.1 Supabase STAGING
+• O antigo projeto `LP-Factory-10-staging` foi descontinuado e deletado em 31/03/2026 após alerta crítico de RLS desativado.
+• Não existe staging Supabase ativo decorrente daquele ambiente.
+• Se um novo staging for criado no futuro, controles mínimos de segurança devem existir desde a criação, sem depender de correção posterior.
+
+4.2 Alerta GitGuardian de junho de 2026
+• A investigação do alerta `Generic High Entropy Secret` concluiu falso positivo.
+• Não foi identificada exposição real de token, senha, chave privada ou connection string nos itens investigados.
+• Não houve necessidade de rotação de credenciais.
+• Alertas futuros devem ser avaliados individualmente; classificação anterior como falso positivo não autoriza ignorar novas ocorrências.
+
+4.3 Secrets e credenciais
+• Valores reais de secrets não devem ser versionados; somente nomes, finalidade, plataforma e escopo podem ser documentados.
+• Se houver exposição real confirmada, a primeira ação é revogar ou rotacionar a credencial antes da limpeza documental ou do histórico aplicável.
+
+5. Pendências de segurança
+
+5.1 Supabase Auth — Leaked Password Protection
+• A proteção contra senhas vazadas permanece desativada no projeto principal.
+• O estado foi aceito temporariamente enquanto o recurso não estiver disponível no plano atual.
+• Reavaliar quando houver plano compatível e, no máximo, antes do GO-LIVE comercial.
+
+5.2 Revisão pré-GO-LIVE
+• Antes do lançamento comercial, revisar permissões, acessos, secrets, autenticação e demais endurecimentos pendentes nas plataformas efetivamente usadas.
+
+6. Temas em decisão
+
+6.1 Visibilidade do repositório GitHub
+• Estado atual verificado em 16/08/2026: `AlcinoAfonso/LP-Factory-10` está público.
+• Recomendação do Gestor de Segurança: tornar o repositório privado por se tratar de produto comercial proprietário com código, documentação, migrations, workflows e regras internas.
+• Antes da mudança, validar continuidade de acesso para ChatGPT/Codex, Vercel, GitHub Actions, GitGuardian e demais integrações que dependam do repositório.
+• As páginas públicas do produto hospedadas na Vercel são independentes da visibilidade do repositório e podem continuar públicas com o repositório privado.
+• Status: decisão humana pendente.
+
+7. Manutenção do documento
+
+7.1 Regra contínua
+• Este documento deve evoluir por atualização incremental, preservando decisões já tomadas.
+• Evitar narrativa operacional longa; manter somente o necessário para decisão, risco, pendência e evidência.
+• Quando uma pendência for resolvida, registrar o estado final de forma curta em Decisões vigentes.

--- a/docs/gestor-seguranca.md
+++ b/docs/gestor-seguranca.md
@@ -2,11 +2,11 @@
 
 0.1 Cabeçalho
 • Documento: Gestor de Segurança (Plataformas)
-• Versão: v0.1.0
+• Versão: v0.1.1
 • Data: 16/08/2026
 
 0.2 Contrato do documento
-• O QUE É: fonte de governança do Gestor de Segurança para objetivo, escopo, limites, decisões vigentes, pendências e temas em decisão.
+• O QUE É: fonte de governança do Gestor de Segurança para objetivo, escopo, limites, decisões vigentes, decisões implementadas, pendências e temas em decisão.
 • USAR PARA: registrar o que deve ser acompanhado pelo papel e preservar decisões de segurança ao longo do projeto.
 • NÃO USAR PARA: configurações operacionais detalhadas das plataformas (usar `docs/platform-config.md`), regras técnicas de runtime/código (usar `docs/base-tecnica.md`), contrato de banco (usar `docs/schema.md`) ou status de casos E* (usar `docs/roadmap.md`).
 • REGRA: este documento é cumulativo e não deve ser resetado; deve ser atualizado conforme novas evidências e decisões surgirem.
@@ -16,7 +16,7 @@
 
 1.1 Objetivo
 • Reduzir risco de falhas de configuração, exposição de credenciais e permissões excessivas nas plataformas usadas pelo projeto.
-• Manter uma visão simples das decisões de segurança já fechadas, das pendências e dos temas ainda em debate.
+• Manter uma visão simples das decisões de segurança já fechadas, das decisões já implementadas, das pendências e dos temas ainda em debate.
 
 1.2 Funções
 • Monitorar configurações de segurança das plataformas.
@@ -57,47 +57,58 @@
 3.2 Regra de atualização
 • Atualizar este documento quando houver nova evidência, alerta relevante, decisão humana ou mudança de estado de uma pendência.
 • Não duplicar inventário operacional já mantido em `docs/platform-config.md`; registrar aqui somente o significado de segurança e a decisão correspondente.
-• Quando um tema em decisão for fechado, movê-lo para Decisões vigentes ou Pendências de segurança, conforme o resultado.
+• Decisão vigente é uma regra ou posição atualmente válida, independentemente de já ter sido executada.
+• Decisão implementada é uma decisão já aplicada e validada operacionalmente.
+• Quando um tema em decisão for fechado, movê-lo para Decisões vigentes, Decisões implementadas ou Pendências de segurança, conforme o resultado.
 
 4. Decisões vigentes
 
-4.1 Supabase STAGING
-• O antigo projeto `LP-Factory-10-staging` foi descontinuado e deletado em 31/03/2026 após alerta crítico de RLS desativado.
-• Não existe staging Supabase ativo decorrente daquele ambiente.
-• Se um novo staging for criado no futuro, controles mínimos de segurança devem existir desde a criação, sem depender de correção posterior.
-
-4.2 Alerta GitGuardian de junho de 2026
-• A investigação do alerta `Generic High Entropy Secret` concluiu falso positivo.
-• Não foi identificada exposição real de token, senha, chave privada ou connection string nos itens investigados.
-• Não houve necessidade de rotação de credenciais.
-• Alertas futuros devem ser avaliados individualmente; classificação anterior como falso positivo não autoriza ignorar novas ocorrências.
-
-4.3 Secrets e credenciais
+4.1 Secrets e credenciais
 • Valores reais de secrets não devem ser versionados; somente nomes, finalidade, plataforma e escopo podem ser documentados.
 • Se houver exposição real confirmada, a primeira ação é revogar ou rotacionar a credencial antes da limpeza documental ou do histórico aplicável.
 
-5. Pendências de segurança
+4.2 Supabase STAGING futuro
+• Se um novo staging Supabase for criado, controles mínimos de segurança devem existir desde a criação, sem depender de correção posterior.
 
-5.1 Supabase Auth — Leaked Password Protection
+4.3 Alertas de segurança
+• Alertas de plataformas devem ser avaliados individualmente.
+• Um falso positivo anterior não autoriza ignorar novas ocorrências semelhantes.
+
+5. Decisões implementadas
+
+5.1 Supabase STAGING descontinuado
+• O antigo projeto `LP-Factory-10-staging` foi descontinuado e deletado em 31/03/2026 após alerta crítico de RLS desativado.
+• Não existe staging Supabase ativo decorrente daquele ambiente.
+• Risco correspondente encerrado.
+
+5.2 Alerta GitGuardian de junho de 2026
+• A investigação do alerta `Generic High Entropy Secret` concluiu falso positivo.
+• Não foi identificada exposição real de token, senha, chave privada ou connection string nos itens investigados.
+• Não houve necessidade de rotação de credenciais.
+• Ocorrência encerrada.
+
+6. Pendências de segurança
+
+6.1 Supabase Auth — Leaked Password Protection
 • A proteção contra senhas vazadas permanece desativada no projeto principal.
 • O estado foi aceito temporariamente enquanto o recurso não estiver disponível no plano atual.
 • Reavaliar quando houver plano compatível e, no máximo, antes do GO-LIVE comercial.
 
-5.2 Revisão pré-GO-LIVE
+6.2 Revisão pré-GO-LIVE
 • Antes do lançamento comercial, revisar permissões, acessos, secrets, autenticação e demais endurecimentos pendentes nas plataformas efetivamente usadas.
 
-6. Temas em decisão
+7. Temas em decisão
 
-6.1 Visibilidade do repositório GitHub
+7.1 Visibilidade do repositório GitHub
 • Estado atual verificado em 16/08/2026: `AlcinoAfonso/LP-Factory-10` está público.
 • Recomendação do Gestor de Segurança: tornar o repositório privado por se tratar de produto comercial proprietário com código, documentação, migrations, workflows e regras internas.
 • Antes da mudança, validar continuidade de acesso para ChatGPT/Codex, Vercel, GitHub Actions, GitGuardian e demais integrações que dependam do repositório.
 • As páginas públicas do produto hospedadas na Vercel são independentes da visibilidade do repositório e podem continuar públicas com o repositório privado.
 • Status: decisão humana pendente.
 
-7. Manutenção do documento
+8. Manutenção do documento
 
-7.1 Regra contínua
+8.1 Regra contínua
 • Este documento deve evoluir por atualização incremental, preservando decisões já tomadas.
 • Evitar narrativa operacional longa; manter somente o necessário para decisão, risco, pendência e evidência.
-• Quando uma pendência for resolvida, registrar o estado final de forma curta em Decisões vigentes.
+• Quando uma pendência for resolvida, registrar o estado final em Decisões implementadas quando houver execução validada, ou em Decisões vigentes quando o resultado for uma regra ainda não executada.

--- a/lib/admin/docsCatalog.ts
+++ b/lib/admin/docsCatalog.ts
@@ -49,6 +49,12 @@ export const adminDocsCatalog: AdminDocCatalogItem[] = [
     description: 'Painel de avaliação de automações, agentes, services e tecnologias adjacentes.',
   },
   {
+    id: 'gestor-seguranca',
+    title: 'Gestor de Segurança',
+    path: 'docs/gestor-seguranca.md',
+    description: 'Governança de segurança de plataformas, pendências priorizadas e temas futuros.',
+  },
+  {
     id: 'automations',
     title: 'Automations',
     path: 'docs/automations.md',

--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,7 @@ const nextConfig = {
       './docs/design-system.md',
       './docs/gestor-codex.md',
       './docs/gestor-automations.md',
+      './docs/gestor-seguranca.md',
       './docs/automations.md',
       './docs/prompt-estrategista.md',
       './docs/prompt-executor.md',


### PR DESCRIPTION
## Objetivo
Criar uma fonte enxuta de governança do Gestor de Segurança (Plataformas), sem duplicar `docs/platform-config.md` nem documentação técnica, e disponibilizá-la também no leitor interno `/admin/documentacao`.

## Escopo
- adiciona `docs/gestor-seguranca.md`
- mantém objetivo, funções, limites e regras permanentes do papel
- usa `docs/platform-config.md` como fonte única do inventário de plataformas
- reduz o acompanhamento a três estados práticos: decisões implementadas, pendências de segurança e temas para debate futuro
- registra como concluída a triagem dos 29 achados atuais do Supabase Security Advisor, sem recomendar alterações de SQL/RLS apenas para limpar avisos
- promove para Prioridade 1 tornar o repositório GitHub privado após validar as integrações necessárias
- mantém `Leaked Password Protection` como pendência condicionada a plano Supabase compatível
- mantém Cloudflare AI Gateway apenas como tema para debate futuro
- registra como tema futuro a identidade estável de testes no Codex App, com conta LP Factory isolada, mailbox exclusiva e uso de sessão autenticada sem expor credenciais ao modelo
- registra `docs/gestor-seguranca.md` em `lib/admin/docsCatalog.ts`
- inclui `docs/gestor-seguranca.md` no `outputFileTracingIncludes` de `/admin/documentacao` em `next.config.js`

## Validação
- diff revisado: somente inclusão do novo documento no catálogo e no tracing da rota já existente
- Vercel `lpf-10-services`: success
- Vercel `lp-factory-10`: validação em andamento no último status consultado
- `npm ci` / `npm run check`: tentativa local bloqueada por indisponibilidade de resolução DNS do ambiente de execução; nenhuma falha do projeto foi observada