### PR TITLE
docs: devolve ajuste do roadmap ao executor

### DIFF
--- a/.agents/skills/lp-factory-abc/SKILL.md
+++ b/.agents/skills/lp-factory-abc/SKILL.md
@@ -52,8 +52,6 @@ Permitir somente seções e subseções do recorte, identificadores, títulos, o
 
 Não aplicar o delta, editar documentos, alterar outra residência documental, completar lacunas por suposição ou registrar estado operacional como planejado. A aplicação pertence ao executor autorizado.
 
-Exceção estreita: após escolha humana explícita da Opção 2 definida em `docs/prompt-estrategista.md`, o Estrategista pode aplicar literalmente, no próprio PR da v1, somente o delta emitido em modo Planejamento para `DOC_ALVO: docs/roadmap.md`, usando a v1 aprovada como `RELATÓRIO`. A skill continua responsável apenas por gerar e verificar o ABC; a exceção não autoriza aplicação em outro documento, outro modo, v2 ou implementação.
-
 ## Verificar
 
 Antes de devolver, confirmar fontes, referência, residência, menor delta, formato literal e ausência de secrets, PII, hipóteses ou histórico superado.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Fluxos auxiliares de GitHub devem respeitar estas regras. Em caso de divergênci
 
 ## Branch, worktree e publicação
 
-Não editar nem commitar na `main`; usar branch dedicada por tarefa ou etapa. Ao usar a `main` local como base, atualizar com `git pull --ff-only`. O merge final deve ocorrer somente pelo GitHub Web. Exceção: após escolha humana explícita da Opção 2 definida em `docs/prompt-estrategista.md` e conclusão dos gates da v1, o Estrategista pode executar exclusivamente o merge remoto do PR da v1 por ferramenta GitHub conectada e autorizada. Essa exceção não se aplica ao merge final da implementação. Merge local pela `main` permanece proibido.
+Não editar nem commitar na `main`; usar branch dedicada por tarefa ou etapa. Ao usar a `main` local como base, atualizar com `git pull --ff-only`. O merge final deve ocorrer somente pelo GitHub Web. Na Opção 2, após conclusão dos gates da v1, diálogo com o humano e autorização explícita para o merge, o Estrategista pode executar exclusivamente o merge remoto do PR da v1 por ferramenta GitHub conectada e autorizada. Essa exceção não se aplica ao merge final da implementação. Merge local pela `main` permanece proibido.
 
 Branches e PRs já abertos não precisam ser sincronizados, rebaseados ou atualizados com a `main` apenas porque ela avançou. Em frentes paralelas, essa divergência é normal. Sincronizar somente quando houver conflito apontado pelo GitHub, quando a tarefa depender materialmente de contrato, arquivo ou dependência alterado na `main`, ou por solicitação humana explícita. Não fazer sincronização preventiva por rotina.
 

--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -65,7 +65,7 @@ Regra:
 • não usar X.Y.1 e X.Y.2 como fases; entregas implementáveis usam X.Y.3 até X.Y.n, conforme docs/template-roadmap.md;
 • não criar fase administrativa, de governança, handoff, revisão ou fechamento; validação e fechamento documental pelo Prompt ABC integram a fase implementável correspondente;
 • validação entra como critério de aceite da fase, salvo risco técnico próprio;
-• exclusivamente se o humano escolher a Opção 1 no item 4, orientar o Executor a ajustar `docs/roadmap.md` no mesmo PR, conforme `docs/prompt-abc.md` e `docs/template-roadmap.md`, registrando somente seções, subseções, títulos, objetivos e status planejado, sem registros de implementação;
+• o ajuste de `docs/roadmap.md` pertence ao Executor/orquestrador durante a execução, conforme `docs/prompt-abc.md` e `docs/template-roadmap.md`, registrando somente seções, subseções, títulos, objetivos e status planejado, sem registros de implementação;
 • não antecipar na v1 detalhamento técnico de automação sem necessidade nem criar fase administrativa apenas para essa decisão.
 
 4. Escolha do processo após o plano-base v1
@@ -74,12 +74,7 @@ Após concluir o item 3, apresentar ao humano as duas opções:
 
 • Opção 1 — Processo atual: seguir para o item 5.
 
-• Opção 2 — Processo automatizado: após a escolha humana explícita, o Estrategista deve, nesta ordem:
-   • executar `$lp-factory-abc` em modo Planejamento para `DOC_ALVO: docs/roadmap.md`, usando a v1 aprovada como `RELATÓRIO` e a branch ou o commit atual do PR da v1 como `REF`;
-   • aplicar literalmente no mesmo PR somente o delta emitido pelo ABC; se o resultado for `SEM ALTERAÇÕES NECESSÁRIAS`, preservar o roadmap;
-   • revisar o PR completo e confirmar que a v1, o roadmap planejado, o diff e os gates aplicáveis estão coerentes e prontos para merge;
-   • realizar exclusivamente o merge remoto do PR da v1 por ferramenta GitHub conectada e autorizada, conforme `AGENTS.md`; não fazer merge local pela `main`;
-   • após confirmar o merge da v1 na `main`, entregar ao orquestrador somente:
+• Opção 2 — Processo automatizado: após a escolha humana explícita, apresentar ao humano o estado da v1 e solicitar autorização explícita para o merge; somente após essa autorização, realizar exclusivamente o merge remoto do PR da v1 por ferramenta GitHub conectada e autorizada, conforme `AGENTS.md`; não fazer merge local pela `main`. Após confirmar o merge da v1 na `main`, entregar ao orquestrador somente:
 
 Use $lp-factory-orquestrar-plano no PR #[NÚMERO].
 

--- a/docs/prompt-estrategista.md
+++ b/docs/prompt-estrategista.md
@@ -65,7 +65,7 @@ Regra:
 • não usar X.Y.1 e X.Y.2 como fases; entregas implementáveis usam X.Y.3 até X.Y.n, conforme docs/template-roadmap.md;
 • não criar fase administrativa, de governança, handoff, revisão ou fechamento; validação e fechamento documental pelo Prompt ABC integram a fase implementável correspondente;
 • validação entra como critério de aceite da fase, salvo risco técnico próprio;
-• o ajuste de `docs/roadmap.md` pertence ao Executor/orquestrador durante a execução, conforme `docs/prompt-abc.md` e `docs/template-roadmap.md`, registrando somente seções, subseções, títulos, objetivos e status planejado, sem registros de implementação;
+• o ajuste de planejamento de `docs/roadmap.md` pertence ao Executor/orquestrador durante a execução, conforme `docs/prompt-abc.md` e `docs/template-roadmap.md`, registrando nessa etapa somente seções, subseções, títulos, objetivos e status planejado, sem registros de implementação;
 • não antecipar na v1 detalhamento técnico de automação sem necessidade nem criar fase administrativa apenas para essa decisão.
 
 4. Escolha do processo após o plano-base v1


### PR DESCRIPTION
## Objetivo
Retornar ao Executor/orquestrador a aplicação do ABC de `docs/roadmap.md` durante a execução, sem remover a opção de merge remoto da v1 pelo Estrategista quando houver diálogo e autorização humana explícita.

## Ajustes
- remove a exceção de aplicação do ABC pelo Estrategista;
- restringe o merge remoto da v1 à autorização humana explícita;
- preserva as mudanças posteriores do PR #749 e não toca no PR #731.

## Validação
- `git diff --check` aprovado;
- escopo confirmado em três arquivos;
- `npm ci`/`npm run check`: não aplicáveis (alteração exclusivamente documental).