### PR TITLE
fix: omitir requestId ausente no gatilho E19.4

### DIFF
--- a/app/a/[account]/landing-pages/[landingPageId]/preview/actions.ts
+++ b/app/a/[account]/landing-pages/[landingPageId]/preview/actions.ts
@@ -67,7 +67,9 @@ export async function generateLandingPageRevisionAction(
   const context = await compileLandingPageGenerationContextForDraft({
     accountId: access.context.accountId,
     landingPageId,
-    requestId: access.context.requestId ?? undefined,
+    ...(access.context.requestId == null
+      ? {}
+      : { requestId: access.context.requestId }),
   });
   if (!context.ok) {
     return actionError(
@@ -109,7 +111,9 @@ export async function generateLandingPageRevisionAction(
       const currentContext = await compileLandingPageGenerationContextForDraft({
         accountId: currentAccess.context.accountId,
         landingPageId,
-        requestId: currentAccess.context.requestId ?? undefined,
+        ...(currentAccess.context.requestId == null
+          ? {}
+          : { requestId: currentAccess.context.requestId }),
       });
       return (
         currentContext.ok &&

--- a/lib/lp-builder/generation-context-validation-cases.ts
+++ b/lib/lp-builder/generation-context-validation-cases.ts
@@ -458,6 +458,37 @@ const cases: readonly Readonly<{ name: string; run: () => void | Promise<void> }
         latency_ms: 1,
       });
 
+      dependencyCalls.length = 0;
+      logs.length = 0;
+      const withoutRequestId =
+        await compileLandingPageGenerationContextForDraftWithDependencies(
+          { accountId: ACCOUNT_ID, landingPageId: LANDING_PAGE_ID },
+          { ...dependencies, log: (payload) => logs.push(payload) },
+        );
+      assert.equal(withoutRequestId.ok, true);
+      assert.deepEqual(dependencyCalls, [
+        "revalidation-authority",
+        "landing-page",
+        "preparation",
+      ]);
+      assert.equal(Object.hasOwn(logs[0], "request_id"), false);
+
+      dependencyCalls.length = 0;
+      const invalidRequestId =
+        await compileLandingPageGenerationContextForDraftWithDependencies(
+          {
+            accountId: ACCOUNT_ID,
+            landingPageId: LANDING_PAGE_ID,
+            requestId: "invalid request id",
+          },
+          { ...dependencies, log: () => undefined },
+        );
+      assert.equal(invalidRequestId.ok, false);
+      if (!invalidRequestId.ok) {
+        assert.equal(invalidRequestId.error.code, "INVALID_INPUT");
+      }
+      assert.deepEqual(dependencyCalls, []);
+
       const unauthorizedCalls: string[] = [];
       const unauthorized =
         await compileLandingPageGenerationContextForDraftWithDependencies(

--- a/lib/lp-builder/landing-page-draft-generation-validation-cases.ts
+++ b/lib/lp-builder/landing-page-draft-generation-validation-cases.ts
@@ -744,6 +744,18 @@ const cases = [
       assert.match(action, /UNSUPPORTED_PRIMARY_CONVERSION_CHANNEL/);
       assert.match(action, /materializeLandingPageDraftRevision/);
       assert.match(action, /currentEntitlement/);
+      assert.match(
+        action,
+        /access\.context\.requestId == null[\s\S]*?requestId: access\.context\.requestId/,
+      );
+      assert.match(
+        action,
+        /currentAccess\.context\.requestId == null[\s\S]*?requestId: currentAccess\.context\.requestId/,
+      );
+      assert.doesNotMatch(
+        action,
+        /requestId:\s*(?:access|currentAccess)\.context\.requestId\s*\?\?\s*undefined/,
+      );
       const page = readFileSync(
         new URL(
           "../../app/a/[account]/landing-pages/[landingPageId]/preview/page.tsx",


### PR DESCRIPTION
## O que mudou

- omite `requestId` nas duas compilações da Server Action quando o Access Context não fornece valor;
- preserva o `requestId` existente para validação pelo boundary;
- mantém `generationContextAdapterCore.ts` inalterado;
- adiciona regressões focais para ausência, valor inválido e as duas chamadas da Action.

## Causa

O consumidor materializava `requestId: undefined`. O boundary rejeita corretamente uma propriedade explicitamente presente e inválida, resultando em `INVALID_INPUT` antes dos providers.

## Validação

- `npm ci`: aprovado;
- `npm run validate:lp-builder-generation-context`: aprovado;
- `npm run validate:landing-page-draft-generation`: aprovado;
- `npm run check`: aprovado, com 0 erros e 24 warnings preexistentes;
- `git diff --check`: aprovado.

## Limites

Nenhuma alteração em documentação, arquitetura, workloads, Storage, migrations, schema ou credenciais. Nenhuma nova geração foi executada; o gate integrado permanece aguardando merge e deploy desta correção.