### PR TITLE
fix: incluir pesquisa no tracing do Preview E19.4

### DIFF
--- a/lib/conversion-content/landing-page/taxon-preparation/validation-cases.ts
+++ b/lib/conversion-content/landing-page/taxon-preparation/validation-cases.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
 
 import type {
   EndCustomerResearchErrorCode,
@@ -44,6 +45,7 @@ const VALID_INPUT: LoadEndCustomerResearchCandidateInput = {
   taxon: { slug: "corretor-imoveis", isActive: true },
   researchVersion: 1,
 };
+const requireFromValidation = createRequire(import.meta.url);
 
 type ValidationCase = Readonly<{
   name: string;
@@ -51,6 +53,27 @@ type ValidationCase = Readonly<{
 }>;
 
 const cases: readonly ValidationCase[] = [
+  {
+    name: "research files remain traced for both hosted consumer routes",
+    run: async () => {
+      const nextConfig = requireFromValidation("../../../../next.config.js") as {
+        outputFileTracingIncludes?: Record<string, readonly string[]>;
+      };
+      const researchGlob = "./docs/pesquisas-brutas/**/end_customer/v*.md";
+
+      assert.deepEqual(
+        nextConfig.outputFileTracingIncludes?.["/admin/taxonomia/[taxonId]"],
+        [researchGlob],
+      );
+      assert.deepEqual(
+        nextConfig.outputFileTracingIncludes?.[
+          "/a/[account]/landing-pages/[landingPageId]/preview"
+        ],
+        [researchGlob],
+      );
+      assert.equal(nextConfig.outputFileTracingIncludes?.["/*"], undefined);
+    },
+  },
   {
     name: "input catalog review gate is fail-closed and accepts only literal true",
     run: async () => {

--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,9 @@ const nextConfig = {
     '/admin/taxonomia/[taxonId]': [
       './docs/pesquisas-brutas/**/end_customer/v*.md',
     ],
+    '/a/[account]/landing-pages/[landingPageId]/preview': [
+      './docs/pesquisas-brutas/**/end_customer/v*.md',
+    ],
     '/admin/documentacao': [
       './docs/roadmap.md',
       './docs/base-tecnica.md',


### PR DESCRIPTION
## O que mudou

- preserva o tracing existente das pesquisas integrais para `/admin/taxonomia/[taxonId]`;
- inclui o mesmo glob repo-only na Function de `/a/[account]/landing-pages/[landingPageId]/preview`;
- adiciona regressão focal que exige as duas rotas e impede ampliação acidental para `/*`.

## Causa

A Server Action do Preview consome a pesquisa integral pelo filesystem, mas o `outputFileTracingIncludes` cobria somente a rota administrativa. A Function hospedada encerrava a compilação com `TAXON_PREPARATION_UNAVAILABLE` antes dos providers.

## Validação

- `npm ci`: aprovado;
- `npm run validate:taxon-preparation`: aprovado;
- `npm run check`: aprovado, com zero erros e 24 warnings preexistentes;
- `git diff --check`: aprovado.

## Limites

Nenhuma alteração em `research.ts`, taxon preparation, E19.3, workloads, Storage, banco, migrations ou contratos de erro. Nenhuma nova geração foi executada; o primeiro append integrado permanece aguardando merge e deployment deste PR.