### PR TITLE
fix: observar causa segura da preparação E19.4

### DIFF
--- a/lib/lp-builder/adapters/generationContextAdapterCore.ts
+++ b/lib/lp-builder/adapters/generationContextAdapterCore.ts
@@ -48,6 +48,9 @@ export async function compileLandingPageGenerationContextForDraftWithDependencie
   const landingPageId =
     typeof input.landingPageId === "string" ? input.landingPageId.trim() : "";
   let result: CompileLandingPageGenerationContextResult;
+  let preparationReason:
+    | Extract<TaxonPreparationResult, { ok: false }>["error"]["code"]
+    | undefined;
 
   if (
     !UUID_RE.test(accountId) ||
@@ -101,6 +104,7 @@ export async function compileLandingPageGenerationContextForDraftWithDependencie
     const preparation = await dependencies.loadPreparation({
       taxonId: servedTaxon.id,
     });
+    if (!preparation.ok) preparationReason = preparation.error.code;
     result = compileLandingPageGenerationContext({
       landingPage: landingPage.landingPage,
       revalidationAuthority: revalidation.authority,
@@ -110,7 +114,13 @@ export async function compileLandingPageGenerationContextForDraftWithDependencie
     result = failure("CONTEXT_READ_FAILED", "Generation context dependencies failed.");
   }
 
-  safeLog(dependencies.log, result, requestId, now() - startedAt);
+  safeLog(
+    dependencies.log,
+    result,
+    requestId,
+    now() - startedAt,
+    preparationReason,
+  );
   return result;
 }
 
@@ -123,6 +133,10 @@ function safeLog(
   result: CompileLandingPageGenerationContextResult,
   requestId: string | undefined,
   latencyMs: number,
+  preparationReason?: Extract<
+    TaxonPreparationResult,
+    { ok: false }
+  >["error"]["code"],
 ): void {
   try {
     (logger ?? console.log)({
@@ -130,6 +144,9 @@ function safeLog(
       result: result.ok ? "success" : "failure",
       reason: result.ok ? "compiled" : result.error.code,
       ...(requestId ? { request_id: requestId } : {}),
+      ...(preparationReason
+        ? { preparation_reason: preparationReason }
+        : {}),
       ...(Number.isFinite(latencyMs) && latencyMs >= 0
         ? { latency_ms: latencyMs }
         : {}),

--- a/lib/lp-builder/generation-context-validation-cases.ts
+++ b/lib/lp-builder/generation-context-validation-cases.ts
@@ -457,6 +457,7 @@ const cases: readonly Readonly<{ name: string; run: () => void | Promise<void> }
         request_id: "req-e19-3-e",
         latency_ms: 1,
       });
+      assert.equal(Object.hasOwn(logs[0], "preparation_reason"), false);
 
       dependencyCalls.length = 0;
       logs.length = 0;
@@ -472,6 +473,51 @@ const cases: readonly Readonly<{ name: string; run: () => void | Promise<void> }
         "preparation",
       ]);
       assert.equal(Object.hasOwn(logs[0], "request_id"), false);
+      assert.equal(Object.hasOwn(logs[0], "preparation_reason"), false);
+
+      dependencyCalls.length = 0;
+      logs.length = 0;
+      const preparationFailureMessage = "must-not-enter-generation-context-log";
+      const preparationFailurePayload = "must-not-enter-log-payload";
+      const failedPreparation =
+        await compileLandingPageGenerationContextForDraftWithDependencies(
+          { accountId: ACCOUNT_ID, landingPageId: LANDING_PAGE_ID },
+          {
+            ...dependencies,
+            loadPreparation: async () => {
+              dependencyCalls.push("preparation");
+              return {
+                ok: false as const,
+                error: {
+                  code: "FILESYSTEM_READ_FAILED" as const,
+                  message: preparationFailureMessage,
+                  payload: preparationFailurePayload,
+                },
+              };
+            },
+            log: (payload) => logs.push(payload),
+          },
+        );
+      assert.equal(failedPreparation.ok, false);
+      if (!failedPreparation.ok) {
+        assert.equal(failedPreparation.error.code, "TAXON_PREPARATION_UNAVAILABLE");
+      }
+      assert.deepEqual(dependencyCalls, [
+        "revalidation-authority",
+        "landing-page",
+        "preparation",
+      ]);
+      assert.deepEqual(logs[0], {
+        event: "landing_page_generation_context_compilation",
+        result: "failure",
+        reason: "TAXON_PREPARATION_UNAVAILABLE",
+        preparation_reason: "FILESYSTEM_READ_FAILED",
+        latency_ms: 1,
+      });
+      assert.doesNotMatch(
+        JSON.stringify(logs[0]),
+        new RegExp(`${preparationFailureMessage}|${preparationFailurePayload}`),
+      );
 
       dependencyCalls.length = 0;
       const invalidRequestId =
@@ -490,6 +536,7 @@ const cases: readonly Readonly<{ name: string; run: () => void | Promise<void> }
       assert.deepEqual(dependencyCalls, []);
 
       const unauthorizedCalls: string[] = [];
+      const unauthorizedLogs: Readonly<Record<string, unknown>>[] = [];
       const unauthorized =
         await compileLandingPageGenerationContextForDraftWithDependencies(
           { accountId: ACCOUNT_ID, landingPageId: LANDING_PAGE_ID },
@@ -506,12 +553,16 @@ const cases: readonly Readonly<{ name: string; run: () => void | Promise<void> }
               unauthorizedCalls.push("preparation");
               return preparation;
             },
-            log: () => undefined,
+            log: (payload) => unauthorizedLogs.push(payload),
           },
         );
       assert.equal(unauthorized.ok, false);
       assert.equal(unauthorized.error.code, "ACCOUNT_CONTEXT_UNAUTHORIZED");
       assert.deepEqual(unauthorizedCalls, []);
+      assert.equal(
+        Object.hasOwn(unauthorizedLogs[0], "preparation_reason"),
+        false,
+      );
     },
   },
   {


### PR DESCRIPTION
## Objetivo

Acrescenta observabilidade mínima e permanente à falha de preparação do boundary de generation context.

## Escopo

- mantém o evento existente `landing_page_generation_context_compilation`;
- registra apenas `preparation_reason: preparation.error.code` quando `loadPreparation()` retorna `ok: false`;
- preserva o resultado externo `TAXON_PREPARATION_UNAVAILABLE`, o fail-closed e a ordem do fluxo;
- não registra mensagem, conteúdo, payload, fatos, PII, secrets, prompts ou respostas.

## Regressões

- falha de preparação registra o enum seguro;
- sucesso não registra `preparation_reason`;
- falha anterior a `loadPreparation()` não registra o campo;
- mensagem e payload da preparação não entram no evento.

## Validação

- `npm ci` — passou (audit reportou 15 vulnerabilidades preexistentes: 3 low, 2 moderate, 10 high);
- `npm run validate:lp-builder-generation-context` — passou;
- `npm run check` — passou com 0 erros e 24 warnings preexistentes;
- `git diff --check` — passou.

Nenhuma geração hospedada foi executada antes do merge/deploy deste PR.