### PR TITLE
fix: corrigir binding de conversão E19.4

### DIFF
--- a/app/a/[account]/landing-pages/[landingPageId]/preview/actions.ts
+++ b/app/a/[account]/landing-pages/[landingPageId]/preview/actions.ts
@@ -78,7 +78,7 @@ export async function generateLandingPageRevisionAction(
     );
   }
 
-  const binding = resolveLandingPageConversionBinding(context.value.serverContext);
+  const binding = resolveLandingPageConversionBinding(context.value);
   if (!binding.ok) {
     return actionError(
       binding.error === "UNSUPPORTED_PRIMARY_CONVERSION_CHANNEL"

--- a/lib/lp-builder/landing-page-draft-generation-validation-cases.ts
+++ b/lib/lp-builder/landing-page-draft-generation-validation-cases.ts
@@ -88,11 +88,6 @@ const context = {
         source: "account_configuration",
         provenance: [],
       },
-    ],
-    editorialLimits: { semanticRoles: [], semanticHierarchy: ["h1", "h2", "h3"] },
-  },
-  serverContext: {
-    facts: [
       {
         fieldKey: "primary_conversion_channel",
         purpose: "conversion",
@@ -101,6 +96,11 @@ const context = {
         source: "account_configuration",
         provenance: [],
       },
+    ],
+    editorialLimits: { semanticRoles: [], semanticHierarchy: ["h1", "h2", "h3"] },
+  },
+  serverContext: {
+    facts: [
       {
         fieldKey: "whatsapp_destination",
         purpose: "conversion_destination",
@@ -540,7 +540,7 @@ const cases = [
       assert.equal(budgetImageCalls, 0);
 
       const formContext = structuredClone(context);
-      const formChannel = formContext.serverContext.facts.find(
+      const formChannel = formContext.modelContext.facts.find(
         (fact) => fact.fieldKey === "primary_conversion_channel",
       );
       assert.ok(formChannel);
@@ -565,14 +565,46 @@ const cases = [
     },
   },
   {
-    name: "conversion binding maps supported channels and form fails closed",
+    name: "conversion binding keeps model channel and server destination authority",
     run: () => {
-      const supported = resolveLandingPageConversionBinding(context.serverContext);
+      assert.equal(
+        context.modelContext.facts.some(
+          (fact) => fact.fieldKey === "primary_conversion_channel",
+        ),
+        true,
+      );
+      assert.equal(
+        context.serverContext.facts.some(
+          (fact) => fact.fieldKey === "primary_conversion_channel",
+        ),
+        false,
+      );
+      assert.equal(
+        context.modelContext.facts.some((fact) =>
+          fact.fieldKey.endsWith("_destination"),
+        ),
+        false,
+      );
+      const supported = resolveLandingPageConversionBinding(context);
       assert.equal(supported.ok, true);
       assert.equal(supported.value.destinationFieldKey, "whatsapp_destination");
+      assert.equal(supported.value.destination, "+5521979658483");
 
-      const formContext = structuredClone(context.serverContext) as LandingPageGenerationContextPackage["serverContext"];
-      const channel = formContext.facts.find(
+      const missingDestinationContext = {
+        modelContext: context.modelContext,
+        serverContext: { facts: [] },
+      };
+      const missingDestination = resolveLandingPageConversionBinding(
+        missingDestinationContext,
+      );
+      assert.equal(missingDestination.ok, false);
+      assert.equal(
+        missingDestination.error,
+        "MISSING_PRIMARY_CONVERSION_DESTINATION",
+      );
+
+      const formContext = structuredClone(context);
+      const channel = formContext.modelContext.facts.find(
         (fact) => fact.fieldKey === "primary_conversion_channel",
       );
       assert.ok(channel);
@@ -580,6 +612,44 @@ const cases = [
       const form = resolveLandingPageConversionBinding(formContext);
       assert.equal(form.ok, false);
       assert.equal(form.error, "UNSUPPORTED_PRIMARY_CONVERSION_CHANNEL");
+
+      const missingChannelContext = {
+        modelContext: {
+          ...context.modelContext,
+          facts: context.modelContext.facts.filter(
+            (fact) => fact.fieldKey !== "primary_conversion_channel",
+          ),
+        },
+        serverContext: context.serverContext,
+      };
+      const missingChannel = resolveLandingPageConversionBinding(
+        missingChannelContext,
+      );
+      assert.equal(missingChannel.ok, false);
+      assert.equal(missingChannel.error, "INVALID_PRIMARY_CONVERSION_CHANNEL");
+
+      const invalidChannelContext = structuredClone(context);
+      const invalidChannel = invalidChannelContext.modelContext.facts.find(
+        (fact) => fact.fieldKey === "primary_conversion_channel",
+      );
+      assert.ok(invalidChannel);
+      (invalidChannel as { value: unknown }).value = "fax";
+      const invalid = resolveLandingPageConversionBinding(invalidChannelContext);
+      assert.equal(invalid.ok, false);
+      assert.equal(invalid.error, "INVALID_PRIMARY_CONVERSION_CHANNEL");
+
+      const candidateWorkflow = readFileSync(
+        new URL("./landingPageDraftCandidateWorkflow.ts", import.meta.url),
+        "utf8",
+      );
+      assert.match(
+        candidateWorkflow,
+        /resolveLandingPageConversionBinding\(input\.context\)/,
+      );
+      assert.doesNotMatch(
+        candidateWorkflow,
+        /resolveLandingPageConversionBinding\(input\.context\.serverContext\)/,
+      );
     },
   },
   {
@@ -742,6 +812,14 @@ const cases = [
       );
       assert.doesNotMatch(action, /generateLandingPageDraftCandidate|generateLandingPageDraftImage/);
       assert.match(action, /UNSUPPORTED_PRIMARY_CONVERSION_CHANNEL/);
+      assert.match(
+        action,
+        /resolveLandingPageConversionBinding\(context\.value\)/,
+      );
+      assert.doesNotMatch(
+        action,
+        /resolveLandingPageConversionBinding\(context\.value\.serverContext\)/,
+      );
       assert.match(action, /materializeLandingPageDraftRevision/);
       assert.match(action, /currentEntitlement/);
       assert.match(

--- a/lib/lp-builder/landingPageDraftCandidateWorkflow.ts
+++ b/lib/lp-builder/landingPageDraftCandidateWorkflow.ts
@@ -67,7 +67,7 @@ export async function prepareLandingPageDraftRevisionCandidate(
   if (isExpired(deadlineAtMs, now, signal)) {
     return failure(attemptId, requestId, "budget", "total_timeout");
   }
-  const binding = resolveLandingPageConversionBinding(input.context.serverContext);
+  const binding = resolveLandingPageConversionBinding(input.context);
   if (!binding.ok) {
     return failure(attemptId, requestId, "binding", binding.error);
   }

--- a/lib/lp-builder/landingPageDraftWorkflow.ts
+++ b/lib/lp-builder/landingPageDraftWorkflow.ts
@@ -34,13 +34,21 @@ const destinationByChannel = {
   external_url: "external_url_destination",
 } as const;
 
+type LandingPageConversionBindingContext = Pick<
+  LandingPageGenerationContextPackage,
+  "modelContext" | "serverContext"
+>;
+
 export function resolveLandingPageConversionBinding(
-  serverContext: LandingPageGenerationContextPackage["serverContext"],
+  context: LandingPageConversionBindingContext,
 ): LandingPageConversionBindingResult {
-  const values = new Map(
-    serverContext.facts.map((fact) => [fact.fieldKey, fact.value] as const),
+  const modelValues = new Map(
+    context.modelContext.facts.map((fact) => [fact.fieldKey, fact.value] as const),
   );
-  const channel = values.get("primary_conversion_channel");
+  const serverValues = new Map(
+    context.serverContext.facts.map((fact) => [fact.fieldKey, fact.value] as const),
+  );
+  const channel = modelValues.get("primary_conversion_channel");
   if (channel === "form") {
     return { ok: false, error: "UNSUPPORTED_PRIMARY_CONVERSION_CHANNEL" };
   }
@@ -49,7 +57,7 @@ export function resolveLandingPageConversionBinding(
   }
   const typedChannel = channel as LandingPageConversionChannel;
   const destinationFieldKey = destinationByChannel[typedChannel];
-  const destination = values.get(destinationFieldKey);
+  const destination = serverValues.get(destinationFieldKey);
   if (typeof destination !== "string" || !destination.trim()) {
     return { ok: false, error: "MISSING_PRIMARY_CONVERSION_DESTINATION" };
   }


### PR DESCRIPTION
## Causa

`primary_conversion_channel` pertence a `modelContext.facts`, enquanto o destino operacional correspondente pertence a `serverContext.facts`. O consumidor E19.4 entregava apenas `serverContext` ao resolver e falhava antes dos providers mesmo com a configuração hospedada válida.

## Correção

- o resolver recebe um único `Pick<LandingPageGenerationContextPackage, "modelContext" | "serverContext">`;
- o canal é lido exclusivamente de `modelContext.facts`;
- o destination field correspondente é lido exclusivamente de `serverContext.facts`;
- Action e candidate workflow passam o pacote compilado diretamente;
- `form`, canal ausente/inválido e destination ausente continuam fail-closed.

Nenhum contrato E19.3, taxon preparation, tracing, banco, Storage, workload, modelo, prompt ou credencial foi alterado.

## Regressões

- WhatsApp no model context + destination no server context produz binding válido;
- destination ausente falha;
- `form` permanece unsupported;
- canal ausente ou inválido falha;
- os dois callers não voltam a passar somente `serverContext`;
- nenhum destination operacional aparece em `modelContext` e o canal não é duplicado em `serverContext`.

## Validação

- `npm ci` — passou (audit: 15 vulnerabilidades existentes);
- `npm run validate:landing-page-draft-generation` — passou;
- `npm run validate:lp-builder-generation-context` — passou;
- `npm run typecheck` — passou;
- `npm run check` — passou com 0 erros e 24 warnings preexistentes;
- `git diff --check` — passou.

Nenhuma nova geração hospedada foi executada antes do merge/deploy humano.