### PR TITLE
fix: projetar união de seções para Structured Outputs

### DIFF
--- a/lib/conversion-content/landing-page/presentation/authority.ts
+++ b/lib/conversion-content/landing-page/presentation/authority.ts
@@ -145,8 +145,25 @@ const generatedSchema = z.toJSONSchema(landingPagePresentationCandidateSchema, {
 const { $schema: _schemaDialect, ...structuredOutputSchema } = generatedSchema;
 
 export const landingPagePresentationJsonSchema = deepFreeze(
-  structuredOutputSchema,
+  projectOpenAiStructuredOutputSchema(structuredOutputSchema),
 ) as Readonly<Record<string, unknown>>;
+
+function projectOpenAiStructuredOutputSchema(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(projectOpenAiStructuredOutputSchema);
+  }
+  if (!value || typeof value !== "object") return value;
+
+  const projected: Record<string, unknown> = {};
+  for (const [keyword, nested] of Object.entries(value)) {
+    const supportedKeyword = keyword === "oneOf" ? "anyOf" : keyword;
+    if (Object.hasOwn(projected, supportedKeyword)) {
+      throw new Error(`Conflicting JSON Schema keyword: ${supportedKeyword}`);
+    }
+    projected[supportedKeyword] = projectOpenAiStructuredOutputSchema(nested);
+  }
+  return projected;
+}
 
 export function validateLandingPagePresentationCandidate(
   candidate: unknown,

--- a/lib/conversion-content/landing-page/presentation/authority.ts
+++ b/lib/conversion-content/landing-page/presentation/authority.ts
@@ -139,30 +139,122 @@ export type LandingPagePresentationValidationResult =
       }>;
     }>;
 
+const EXPECTED_SECTION_KINDS = [
+  "header",
+  "hero",
+  "text_media",
+  "cards_grid",
+  "steps",
+  "faq",
+  "cta",
+  "footer",
+] as const;
+const SECTIONS_ONE_OF_PATH = "$.properties.sections.items.oneOf";
+
 const generatedSchema = z.toJSONSchema(landingPagePresentationCandidateSchema, {
   target: "draft-7",
 });
 const { $schema: _schemaDialect, ...structuredOutputSchema } = generatedSchema;
 
 export const landingPagePresentationJsonSchema = deepFreeze(
-  projectOpenAiStructuredOutputSchema(structuredOutputSchema),
+  projectLandingPagePresentationJsonSchemaForOpenAi(structuredOutputSchema),
 ) as Readonly<Record<string, unknown>>;
 
-function projectOpenAiStructuredOutputSchema(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map(projectOpenAiStructuredOutputSchema);
+export function projectLandingPagePresentationJsonSchemaForOpenAi(
+  value: unknown,
+): Record<string, unknown> {
+  const oneOfPaths = collectJsonSchemaKeywordPaths(value, "oneOf");
+  if (oneOfPaths.length !== 1 || oneOfPaths[0] !== SECTIONS_ONE_OF_PATH) {
+    throw new Error(
+      `OpenAI presentation schema requires oneOf only at ${SECTIONS_ONE_OF_PATH}; found ${oneOfPaths.join(", ") || "none"}`,
+    );
   }
-  if (!value || typeof value !== "object") return value;
 
-  const projected: Record<string, unknown> = {};
-  for (const [keyword, nested] of Object.entries(value)) {
-    const supportedKeyword = keyword === "oneOf" ? "anyOf" : keyword;
-    if (Object.hasOwn(projected, supportedKeyword)) {
-      throw new Error(`Conflicting JSON Schema keyword: ${supportedKeyword}`);
-    }
-    projected[supportedKeyword] = projectOpenAiStructuredOutputSchema(nested);
+  const root = jsonSchemaRecord(value, "$");
+  const properties = jsonSchemaRecord(root.properties, "$.properties");
+  const sections = jsonSchemaRecord(
+    properties.sections,
+    "$.properties.sections",
+  );
+  const items = jsonSchemaRecord(
+    sections.items,
+    "$.properties.sections.items",
+  );
+  if (Object.hasOwn(items, "anyOf")) {
+    throw new Error(`Conflicting anyOf at $.properties.sections.items`);
   }
-  return projected;
+  const variants = items.oneOf;
+  if (
+    !Array.isArray(variants) ||
+    variants.length !== EXPECTED_SECTION_KINDS.length
+  ) {
+    throw new Error(
+      `OpenAI presentation schema requires exactly ${EXPECTED_SECTION_KINDS.length} section branches`,
+    );
+  }
+
+  const kinds = variants.map((variant, index) => {
+    const branch = jsonSchemaRecord(
+      variant,
+      `${SECTIONS_ONE_OF_PATH}[${index}]`,
+    );
+    const branchProperties = jsonSchemaRecord(
+      branch.properties,
+      `${SECTIONS_ONE_OF_PATH}[${index}].properties`,
+    );
+    const kind = jsonSchemaRecord(
+      branchProperties.kind,
+      `${SECTIONS_ONE_OF_PATH}[${index}].properties.kind`,
+    );
+    if (kind.type !== "string" || typeof kind.const !== "string") {
+      throw new Error(`Section branch ${index} requires a literal string kind`);
+    }
+    return kind.const;
+  });
+  const uniqueKinds = new Set(kinds);
+  if (
+    uniqueKinds.size !== EXPECTED_SECTION_KINDS.length ||
+    EXPECTED_SECTION_KINDS.some((kind) => !uniqueKinds.has(kind))
+  ) {
+    throw new Error(`Section branches require the 8 unique contract v1 kinds`);
+  }
+
+  const { oneOf: _oneOf, ...itemsWithoutOneOf } = items;
+  return {
+    ...root,
+    properties: {
+      ...properties,
+      sections: {
+        ...sections,
+        items: { ...itemsWithoutOneOf, anyOf: variants },
+      },
+    },
+  };
+}
+
+function collectJsonSchemaKeywordPaths(
+  value: unknown,
+  keyword: string,
+  path = "$",
+): string[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((nested, index) =>
+      collectJsonSchemaKeywordPaths(nested, keyword, `${path}[${index}]`),
+    );
+  }
+  if (!value || typeof value !== "object") return [];
+
+  return Object.entries(value).flatMap(([key, nested]) => [
+    ...(key === keyword ? [`${path}.${key}`] : []),
+    ...collectJsonSchemaKeywordPaths(nested, keyword, `${path}.${key}`),
+  ]);
+}
+
+function jsonSchemaRecord(value: unknown, path: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Invalid JSON Schema object at ${path}`);
+  }
+  return value as Record<string, unknown>;
 }
 
 export function validateLandingPagePresentationCandidate(

--- a/lib/lp-builder/landing-page-draft-generation-validation-cases.ts
+++ b/lib/lp-builder/landing-page-draft-generation-validation-cases.ts
@@ -118,9 +118,75 @@ const cases = [
   {
     name: "presentation authority drives strict schema and deterministic validation",
     run: () => {
-      const schema = JSON.stringify(landingPagePresentationJsonSchema);
+      const request = buildLandingPageDraftResponsesRequest(context);
+      const providerSchema = request.text.format.schema;
+      const schema = JSON.stringify(providerSchema);
+      assert.equal(providerSchema, landingPagePresentationJsonSchema);
       assert.match(schema, /"additionalProperties":false/);
       assert.match(schema, /"required":\["contractVersion","sections"\]/);
+      assert.doesNotMatch(schema, /"oneOf"/);
+
+      const sections = schemaProperty(providerSchema, "sections");
+      assert.equal(sections.minItems, 4);
+      assert.equal(sections.maxItems, 10);
+      const sectionItems = schemaRecord(sections.items);
+      const sectionVariants = sectionItems.anyOf;
+      assert.ok(Array.isArray(sectionVariants));
+      assert.equal(sectionVariants.length, 8);
+
+      const variantsByKind = new Map(
+        sectionVariants.map((variant) => {
+          const branch = schemaRecord(variant);
+          const kind = schemaProperty(branch, "kind").const;
+          assert.equal(typeof kind, "string");
+          assert.equal(branch.additionalProperties, false);
+          assert.ok(Array.isArray(branch.required));
+          assert.ok(branch.required.includes("kind"));
+          return [kind, branch] as const;
+        }),
+      );
+      assert.deepEqual([...variantsByKind.keys()], [
+        "header",
+        "hero",
+        "text_media",
+        "cards_grid",
+        "steps",
+        "faq",
+        "cta",
+        "footer",
+      ]);
+
+      for (const [kind, field] of [
+        ["header", "ctaLabel"],
+        ["hero", "eyebrow"],
+        ["text_media", "mediaBrief"],
+        ["cards_grid", "intro"],
+        ["steps", "intro"],
+        ["cta", "body"],
+        ["footer", "tagline"],
+      ] as const) {
+        const branch = variantsByKind.get(kind);
+        assert.ok(branch);
+        const nullable = schemaProperty(branch, field).anyOf;
+        assert.ok(Array.isArray(nullable));
+        assert.deepEqual(
+          nullable.map((option) => schemaRecord(option).type),
+          ["string", "null"],
+        );
+        assert.ok((branch.required as unknown[]).includes(field));
+      }
+
+      for (const [kind, field, minItems, maxItems] of [
+        ["cards_grid", "cards", 2, 6],
+        ["steps", "items", 2, 5],
+        ["faq", "items", 2, 6],
+      ] as const) {
+        const branch = variantsByKind.get(kind);
+        assert.ok(branch);
+        const collection = schemaProperty(branch, field);
+        assert.equal(collection.minItems, minItems);
+        assert.equal(collection.maxItems, maxItems);
+      }
       assert.equal(
         validateLandingPagePresentationCandidate(candidate, context.modelContext.facts).ok,
         true,
@@ -1158,3 +1224,13 @@ const abortingFetch: typeof fetch = (_input, init) =>
     }
     init?.signal?.addEventListener("abort", abort, { once: true });
   });
+
+function schemaRecord(value: unknown): Record<string, unknown> {
+  assert.ok(value && typeof value === "object" && !Array.isArray(value));
+  return value as Record<string, unknown>;
+}
+
+function schemaProperty(schema: unknown, property: string) {
+  const properties = schemaRecord(schemaRecord(schema).properties);
+  return schemaRecord(properties[property]);
+}

--- a/lib/lp-builder/landing-page-draft-generation-validation-cases.ts
+++ b/lib/lp-builder/landing-page-draft-generation-validation-cases.ts
@@ -7,6 +7,9 @@ import {
   type LandingPagePresentationCandidate,
 } from "../conversion-content/landing-page/presentation";
 import {
+  projectLandingPagePresentationJsonSchemaForOpenAi,
+} from "../conversion-content/landing-page/presentation/authority";
+import {
   OPEN_AI_PROVIDER_ERROR_METADATA_MAX_LENGTH,
   type OpenAiImageWorkloadEvent,
   type OpenAiWorkloadEvent,
@@ -125,6 +128,7 @@ const cases = [
       assert.match(schema, /"additionalProperties":false/);
       assert.match(schema, /"required":\["contractVersion","sections"\]/);
       assert.doesNotMatch(schema, /"oneOf"/);
+      assertStrictRequiredObjects(providerSchema);
 
       const sections = schemaProperty(providerSchema, "sections");
       assert.equal(sections.minItems, 4);
@@ -155,6 +159,49 @@ const cases = [
         "cta",
         "footer",
       ]);
+
+      const generatedLikeSchema = schemaRecord(structuredClone(providerSchema));
+      const generatedLikeItems = schemaRecord(
+        schemaProperty(generatedLikeSchema, "sections").items,
+      );
+      generatedLikeItems.oneOf = generatedLikeItems.anyOf;
+      delete generatedLikeItems.anyOf;
+      assert.deepEqual(
+        projectLandingPagePresentationJsonSchemaForOpenAi(generatedLikeSchema),
+        providerSchema,
+      );
+
+      const unexpectedOneOf = structuredClone(generatedLikeSchema);
+      unexpectedOneOf.unexpected = {
+        oneOf: [{ type: "string" }, { type: "null" }],
+      };
+      assert.throws(
+        () =>
+          projectLandingPagePresentationJsonSchemaForOpenAi(unexpectedOneOf),
+        /requires oneOf only at/,
+      );
+
+      const missingBranch = structuredClone(generatedLikeSchema);
+      const missingBranchVariants = schemaRecord(
+        schemaProperty(missingBranch, "sections").items,
+      ).oneOf;
+      assert.ok(Array.isArray(missingBranchVariants));
+      missingBranchVariants.pop();
+      assert.throws(
+        () => projectLandingPagePresentationJsonSchemaForOpenAi(missingBranch),
+        /requires exactly 8 section branches/,
+      );
+
+      const duplicateKind = structuredClone(generatedLikeSchema);
+      const duplicateKindVariants = schemaRecord(
+        schemaProperty(duplicateKind, "sections").items,
+      ).oneOf;
+      assert.ok(Array.isArray(duplicateKindVariants));
+      schemaProperty(duplicateKindVariants[1], "kind").const = "header";
+      assert.throws(
+        () => projectLandingPagePresentationJsonSchemaForOpenAi(duplicateKind),
+        /require the 8 unique contract v1 kinds/,
+      );
 
       for (const [kind, field] of [
         ["header", "ctaLabel"],
@@ -1233,4 +1280,20 @@ function schemaRecord(value: unknown): Record<string, unknown> {
 function schemaProperty(schema: unknown, property: string) {
   const properties = schemaRecord(schemaRecord(schema).properties);
   return schemaRecord(properties[property]);
+}
+
+function assertStrictRequiredObjects(value: unknown): void {
+  if (Array.isArray(value)) {
+    value.forEach(assertStrictRequiredObjects);
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+
+  const schema = value as Record<string, unknown>;
+  if (Object.hasOwn(schema, "properties")) {
+    const properties = schemaRecord(schema.properties);
+    assert.equal(schema.additionalProperties, false);
+    assert.deepEqual(schema.required, Object.keys(properties));
+  }
+  Object.values(schema).forEach(assertStrictRequiredObjects);
 }


### PR DESCRIPTION
## O que mudou

- mantém `landingPagePresentationCandidateSchema` como autoridade canônica;
- projeta somente `$.properties.sections.items.oneOf` para `anyOf`;
- exige exatamente as oito branches v1, cada uma com `kind` literal único e pertencente ao conjunto esperado;
- falha explicitamente se qualquer outro `oneOf` aparecer em outro path;
- adiciona regressões sobre o schema final em `text.format.schema`.

## Diagnóstico

O schema materializado pelo Zod continha uma única ocorrência de `oneOf` em `$.properties.sections.items.oneOf`. O subset oficial de Structured Outputs aceita `anyOf`, mas não inclui `oneOf`. As branches são mutuamente exclusivas pelo discriminador literal `kind`, portanto a projeção preserva o contrato v1.

Esta é a causa técnica mais bem sustentada pelo HTTP 400 / `invalid_json_schema`, mas a correção ainda não está comprovada no provider. A comprovação definitiva depende de merge/deploy humano e uma única nova tentativa hospedada.

Referência: https://developers.openai.com/api/docs/guides/structured-outputs

## Preservado

- contrato Zod e validator server-side;
- shapes, cardinalidades, discriminadores e nullability;
- `strict: true`, modelo, effort, prompt e chamada única;
- ausência de retry/fallback;
- E19.3, P-01, P-02, Storage, banco e credenciais.

## Validação

- `npm ci`
- `npm run validate:landing-page-draft-generation`
- `npm run typecheck`
- `npm run check`
- `git diff --check`

`npm run check` passou com 24 warnings preexistentes de lint e zero erros.