### PR TITLE
docs(e21.2): concluir fechamento operacional pós-merge

### DIFF
--- a/docs/platform-config.md
+++ b/docs/platform-config.md
@@ -2,8 +2,8 @@
 
 0.1 Cabeçalho
 • Documento: LP Factory 10 — Platform Config
-• Versão: v0.1.24
-• Data: 18/08/2026
+• Versão: v0.1.25
+• Data: 21/08/2026
 
 0.2 Contrato do documento
 • O QUE É: snapshot operacional e fonte única das configurações de plataformas externas do LP Factory 10, refletindo o estado conhecido/cadastrado nas plataformas conforme indicado.
@@ -179,19 +179,20 @@
 • Finalidade: gate server-side temporário do cutover da configuração operacional dinâmica dos quatro workloads OpenAI de produto.
 • Escopo: Preview e Production do projeto Core, com configuração independente por ambiente; Development ignora o gate e permanece no baseline local.
 • Habilitação: somente o literal `true` ativa a leitura operacional no Supabase. Variável ausente, vazia ou com qualquer outro valor mantém `repo_catalog` em Preview e Production.
-• Estado inicial: desabilitada em Preview e Production durante implementação, merge, aplicação e verificação da migration.
+• Estado operacional final: configurada com `true` em Preview e Production após cutover sequencial aprovado; os dois ambientes foram redeployados com o gate ativo.
 • Regra de falha: com o gate habilitado, o runtime consulta exclusivamente o Supabase a cada execução, sem cache nem fallback para `repo_catalog`.
-• Progressão operacional: habilitar e validar primeiro em Preview; Production somente depois das evidências aprovadas de apply, invariantes, Security Controls e smoke de Preview.
+• Progressão operacional concluída: Preview foi habilitado e aprovado antes de Production; apply, invariantes, Security Controls, smoke completo de Preview e smoke mínimo de Production foram aprovados.
 • Redeploy: a habilitação ou desabilitação do gate exige redeploy do ambiente afetado; alterações ordinárias da configuração ativa após o cutover não exigem redeploy.
 • Valor real por ambiente: não versionar neste documento.
 
 • Configuração efetiva dos workloads OpenAI de produto
-• Fonte canônica: `lib/openai-workloads/registry.ts` mantém identidade, baseline local e allowlist; em Preview e Production, o gate desligado usa `repo_catalog` revisão `v2`, e o gate ligado usa exclusivamente `supabase_operational` com revisão decimal ativa.
+• Fonte canônica: `lib/openai-workloads/registry.ts` mantém identidade, baseline local e allowlist; Development usa `repo_catalog` revisão `v2`, e Preview/Production usam exclusivamente `supabase_operational` com revisão decimal ativa.
 • Workloads textuais validados operacionalmente: `niche_resolution` e `commercial_activation_draft_generation`, com modelo `gpt-5.4-mini` e esforço de raciocínio `none`.
 • Workload textual validado no ambiente alvo: `landing_page_draft_generation`, com modelo `gpt-5.6-luna`, esforço `max`, Responses API, Structured Output estrito, `store:false` e timeout de 120 s.
 • Workload de imagem validado no ambiente alvo: `landing_page_draft_image_generation`, com modelo `gpt-image-2`, saída WebP 1536 × 1024, qualidade `medium`, compressão 80, moderação `auto` e timeout de 120 s.
 • Validação operacional: `niche_resolution` e `commercial_activation_draft_generation` foram executados uma única vez em Production em 10/08/2026; os Runtime Logs confirmaram sucesso e telemetria sanitizada, sem prompt, resposta integral, credencial ou dado pessoal.
 • Validação dos workloads de draft: por decisão humana, o gate de canários isolados sem persistência foi substituído pelo primeiro append integrado; duas execuções integradas hospedadas em 18/08/2026 comprovaram texto, imagem e o caminho oficial sem retry ou fallback.
+• Validação do cutover E21.2: Preview aprovou lifecycle e provas reais dos quatro transportes; Production aprovou leitura das quatro baselines e execução comercial real com origem `supabase_operational` e revisão 1, sem publicação, erro ou warning na janela autenticada.
 • Duração da Function: o segmento produtivo permanece configurado com `maxDuration = 300`; deployment READY e duas execuções integradas completas sem timeout incompatível corroboraram operacionalmente o gate.
 • Variáveis legadas de modelo na Vercel
 • Nomes: `OPENAI_NICHE_RESOLVER_MODEL`, `OPENAI_LANDING_PAGE_GENERATION_PROFILE_MODEL` e `OPENAI_COMMERCIAL_ACTIVATION_MODEL`.
@@ -317,7 +318,7 @@
 • Finalidade: autenticação com OpenAI API; no Core, a mesma chave server-side pode atender os consumidores de produto autorizados.
 • Valor real: não versionar.
 
-• A seleção de modelo, esforço ou configuração de mídia dos workloads OpenAI de produto não usa variáveis Vercel no runtime atual; o contrato efetivo está no catálogo versionado do repositório.
+• A seleção de modelo, esforço ou configuração de mídia dos workloads OpenAI de produto não usa variáveis Vercel; Development usa o baseline versionado no repositório e Preview/Production resolvem a revisão ativa no Supabase por meio do gate operacional registrado em 3.5.
 • As três variáveis legadas de modelo estão ausentes da configuração vigente da Vercel conforme 3.5.
 
 6.3.1 Endpoint externo atual

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data: 20/08/2026
-• Versão: v1.5.171
+• Data: 21/08/2026
+• Versão: v1.5.172
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -2644,8 +2644,8 @@ Repositório — Ajustados
   * preservar E19.2, E19.3 e E19.4 sem alteração neste recorte.
 
 21. E21 — Gestão e governança dos workloads OpenAI
-- Objetivo: gerir e governar os workloads OpenAI por recortes aprovados, iniciando pela configuração explícita, observabilidade segura e leitura administrativa; a configuração dinâmica e o histórico permanecem para recortes posteriores, sem otimização automatizada.
-- Status: a fundação E21.1 permanece preservada; após a retirada concluída da E22.1.4, o catálogo vigente possui quatro workloads de produto e uma referência operacional, e os dois workloads de draft permanecem comprovados por execuções integradas hospedadas, sem pendência de canários isolados.
+- Objetivo: gerir e governar os workloads OpenAI por recortes aprovados, com configuração explícita, observabilidade segura, leitura administrativa e configuração operacional dinâmica por ambiente, sem otimização automatizada.
+- Status: a fundação E21.1 permanece preservada e a E21.2 está concluída com cutover aprovado em Preview e Production; a E21.3 permanece prevista e não iniciada.
 
 21.1 Fundação, normalização e leitura dos workloads OpenAI
 
@@ -2717,32 +2717,80 @@ Repositório — Ajustados
 
 21.2.1 Objetivo e status
 - Objetivo: permitir configuração ativa por ambiente e workload, com candidata, validação, ativação humana, rollback e mudança ordinária sem redeploy.
-- Status: implementação repo-only concluída e aprovada tecnicamente no PR #793; apply, inspeções, cutover e validações hospedadas permanecem pós-merge e pendentes.
-- O recorte preserva a E21.1 como boundary transversal, mantém Development determinístico/local e deixa a E21.3 fora da entrega.
+- Status: Concluída em 21/08/2026; implementação incorporada pelos PRs #793 e #796, migration aplicada, gates hospedados aprovados e cutover operacional concluído em Preview e Production.
+- O recorte preserva a E21.1 como boundary transversal, mantém Development determinístico/local e deixa a E21.3 prevista, sem início de execução.
 
-21.2.2 Registros de planejamento
-- Plano-base v1: `docs/lousa-plano-base-e21-2.md`, congelado pelo PR #790 e incorporado à `main` no merge `d260a82bf3e121e8be3f17a24229ecbd54f829ff`.
-- Plano-base v2 aprovado: `docs/lousa-plano-base-e21-2-v2.md`.
-- Matriz integral de tratamentos: `docs/matriz-consolidacao-e21-2.md`.
-- Execução autorizada em uma única branch e um único PR, inicialmente com o runtime dinâmico gate-off; apply e cutover permanecem pós-merge e sob controle humano.
+21.2.2 Registros do recorte
+- Banco:
+  - Criados:
+    - `public.openai_workload_operational_configurations`
+    - `public.openai_workload_configuration_revisions`
+    - `public.openai_workload_configuration_activations`
+    - `public.save_openai_workload_configuration_candidate_v1`
+    - `public.discard_openai_workload_configuration_candidate_v1`
+    - `public.promote_openai_workload_configuration_candidate_v1`
+    - `public.activate_openai_workload_configuration_revision_v1`
+    - `public.rollback_openai_workload_configuration_revision_v1`
+    - `public.prevent_openai_workload_append_only_mutation_v1`
+- Repositório:
+  - Criados:
+    - `app/admin/(protected)/workloads-openai/_components/OpenAiConfigurationManager.tsx`
+    - `app/admin/(protected)/workloads-openai/_proof.ts`
+    - `app/admin/(protected)/workloads-openai/actions.ts`
+    - `app/admin/(protected)/workloads-openai/commercialProof.ts`
+    - `app/admin/(protected)/workloads-openai/proofCore.ts`
+    - `app/admin/(protected)/workloads-openai/validation-cases.ts`
+    - `app/admin/(protected)/workloads-openai/validation-cases.tsx`
+    - `lib/openai-workloads/adapters/operationalConfigurationAdapter.ts`
+    - `lib/openai-workloads/adapters/operationalConfigurationAdapterCore.ts`
+    - `supabase/migrations/20260820190422_e21_2_3_openai_workload_operational_configurations.sql`
+    - `supabase/snippets/e21_2_3_openai_workload_operational_configurations_verify.sql`
+    - `supabase/tests/e21_2_3_openai_workload_operational_configurations.test.sql`
+  - Ajustados:
+    - `app/admin/(protected)/workloads-openai/page.tsx`
+    - `lib/access/guards.ts`
+    - `lib/conversion-content/adapters/commercialActivationOpenAiAdapter.ts`
+    - `lib/conversion-content/commercial-activation/draft-generation.ts`
+    - `lib/conversion-content/commercial-activation/validation-cases.ts`
+    - `lib/lp-builder/landing-page-draft-generation-validation-cases.ts`
+    - `lib/lp-builder/landingPageDraftGeneration.ts`
+    - `lib/lp-builder/landingPageDraftImageGeneration.ts`
+    - `lib/lp-builder/landingPageRevision.ts`
+    - `lib/onboarding/niche-resolution/adapters/openAiResolver.ts`
+    - `lib/openai-workloads/contracts.ts`
+    - `lib/openai-workloads/index.ts`
+    - `lib/openai-workloads/registry.ts`
+    - `lib/openai-workloads/resolve.ts`
+    - `lib/openai-workloads/validation-cases.ts`
+    - `lib/supabase/service.ts`
+- Referências:
+  - Plano-base v1: `docs/lousa-plano-base-e21-2.md`.
+  - Plano-base v2 aprovado: `docs/lousa-plano-base-e21-2-v2.md`.
+  - Matriz integral de tratamentos: `docs/matriz-consolidacao-e21-2.md`.
+  - Contrato técnico: `docs/base-tecnica.md` — 3.16.
+  - Configuração operacional: `docs/platform-config.md` — 3.5 e 6.3.
+  - Contrato de banco: `docs/schema.md` — 1.28, 1.29, 1.30 e 3.7.
 
 21.2.3 Fonte operacional dinâmica e resolução por ambiente/workload
-- Status: implementação repo-only concluída e aprovada tecnicamente no PR #793; apply, inspeção e cutover hospedados permanecem pós-merge e pendentes.
+- Status: Concluída; fonte operacional aplicada e cutover aprovado em Preview e Production.
 - Automação: não.
 - A migration forward-only materializa o agregado de configuração, revisões validadas e ativações/rollback por `ambiente + workload`, com bootstrap exato das oito unidades de Production e Preview, lifecycle transacional, concorrência otimista, constraints unit-safe, RLS/grants mínimos e metadados de prova fechados e sanitizados.
 - `lib/openai-workloads/` permanece o boundary público comum: resolvers assíncronos recebem ambiente explícito, Development continua no baseline local, e os quatro callsites preservam transporte, fallback funcional e proveniência ao consumir `repo_catalog` ou `supabase_operational`.
 - Adapter server-side, comportamento fail-closed, allowlists por workload, validação de snapshots funcionais, snippet SQL read-only, testes SQL e documentação canônica aplicável foram entregues; `npm ci`, `npm run check`, validadores focais e `git diff --check` foram aprovados.
-- Manter `OPENAI_OPERATIONAL_CONFIG_ENABLED` desabilitada no PR; após o merge humano, apply, Security Controls e snippet precedem o gate-on em Preview, e Production somente avança após Preview aprovado.
+- A migration foi aplicada pelo workflow canônico; o snippet hospedado aprovou 10/10 verificações e o Security Controls não apresentou alerta incompatível com as tabelas ou RPCs do recorte.
+- `OPENAI_OPERATIONAL_CONFIG_ENABLED=true` foi habilitada e redeployada primeiro em Preview e, somente após sua aprovação integral, em Production; os dois ambientes usam exclusivamente `supabase_operational`, enquanto Development permanece no baseline local.
 - Não usar `repo_catalog` como fallback quando o gate estiver ativo; não introduzir cache, Realtime, AI Gateway, Vercel Flags, Global Config, tracing, drains, workflow ou segunda residência.
 
 21.2.4 Gestão administrativa, validação, ativação e rollback
-- Status: implementação repo-only concluída e aprovada tecnicamente no PR #793; gates hospedados e operacionais permanecem pós-merge e pendentes, sem antecipar o cutover.
+- Status: Concluída; gestão administrativa, provas reais, lifecycle, QA hospedada e smoke mínimo de Production aprovados.
 - Automação: não.
 - `/admin/workloads-openai` passou a gerir ativa, candidata, prova, revisão validada pendente, ativação, histórico e rollback separadamente em Production e Preview; texto aceita somente `model + reasoning effort`, imagem somente `model + quality`, e o Supabase Inspect permanece referência read-only separada.
 - A página reautoriza `platform_admin` antes do read model service-role; cada action reexecuta o guard, deriva o ator no servidor, valida unidade, versão e allowlists e preserva concorrência otimista e estados fail-closed.
-- A prova despacha fixture segura pelos quatro transportes existentes, não cria persistência funcional, benchmark, ranking ou decisão autônoma e só promove após sucesso; erro preserva a candidata e nunca altera a revisão ativa.
-- `npm ci`, `npm run check`, os validadores focais de domínio, UI, actions/prova e `git diff --check` foram aprovados; o Analista encerrou o P1 de reautorização sem novos achados.
-- Após o merge humano, apply, Security Controls e snippet precedem gate-on em Preview; então permanecem obrigatórios lifecycle hospedado, papéis positivo/negativo, desktop/mobile, foco/erro/WCAG proporcional, prova real com a `OPENAI_API_KEY` já aprovada, ativação, próxima execução, isolamento de Production e rollback. A credencial não deve ser copiada, exibida ou versionada.
+- A prova despacha fixture segura pelos quatro transportes existentes, não cria persistência funcional, benchmark, ranking ou decisão autônoma e só promove após sucesso; erro preserva a candidata e nunca altera a revisão ativa. A prova comercial reutiliza o parser comum do shape REST real de `/v1/responses`.
+- O Preview aprovou os quatro transportes, criação/edição/descarte de candidata, promoção, ativação, execução subsequente com nova revisão, isolamento de Production e rollback, além de papéis positivo/negativo, desktop 1440 × 900, mobile 390 × 844, estados de sucesso/erro, reconhecimento do lifecycle e checklist proporcional WCAG 2.2.
+- O smoke mínimo de Production confirmou as quatro baselines ativas e uma execução comercial real com origem `supabase_operational` e revisão 1, criando somente draft não publicado; a janela autenticada permaneceu sem erro ou warning no runtime.
+- O estado operacional final mantém os quatro workloads de Preview e Production na revisão 1, sem candidata ou revisão pendente; os eventos append-only do lifecycle de Preview permanecem preservados e Production mantém somente os eventos de bootstrap.
+- `OPENAI_API_KEY` permaneceu server-side e foi reutilizada sem cópia, exposição ou versionamento. A E21.3 não foi iniciada.
 
 21.3 Evidências e avaliação de custo-benefício dos workloads OpenAI
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data da última atualização: 20/08/2026
-• Documento: LP Factory 10 — Schema (DB Contract) v1.0.49
+• Data da última atualização: 21/08/2026
+• Documento: LP Factory 10 — Schema (DB Contract) v1.0.50
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -846,10 +846,10 @@
 
 1.28 openai_workload_operational_configurations
 1.28.1 Função e unidade
-• Agregado operacional candidato da E21.2.3 com exatamente uma linha por `environment + workload`.
+• Agregado operacional aplicado da E21.2.3 com exatamente uma linha por `environment + workload`.
 • `environment` aceita somente `production | preview`; Development permanece fora desta residência dinâmica.
 • A PK composta `(environment, workload)` é o lock canônico das RPCs e impede mais de uma unidade para a mesma combinação.
-• A migration forward-only `supabase/migrations/20260820190422_e21_2_3_openai_workload_operational_configurations.sql` está versionada no repositório; apply e verificação hospedada permanecem pós-merge.
+• A migration forward-only `supabase/migrations/20260820190422_e21_2_3_openai_workload_operational_configurations.sql` está aplicada no ambiente hospedado; o snippet read-only aprovou 10/10 verificações e o Security Controls não apresentou alerta incompatível com o agregado ou suas RPCs.
 
 1.28.2 Colunas
 • environment text not null


### PR DESCRIPTION
## Escopo

- Conclui o ABC final da E21.2 após o merge dos PRs #793 e #796.
- Consolida o cutover aprovado em Preview e Production em docs/roadmap.md, docs/platform-config.md e docs/schema.md.
- Registra migration aplicada, snippet read-only 10/10, Security Controls compatível, lifecycle/QA de Preview aprovado e smoke mínimo de Production aprovado.

## Evidências pós-merge

- OPENAI_OPERATIONAL_CONFIG_ENABLED=true habilitada em Production somente após a aprovação integral de Preview.
- Redeploy Production READY no commit a9b903536bb32f1c879394f1b23acf1f55a8065a: dpl_D6pFsbYb8ACXyT3jnDZKqyfhDEez.
- /admin/workloads-openai confirmou as quatro baselines Production ativas na revisão 1, sem candidata ou revisão pendente.
- Smoke comercial real criou somente o draft v6, não publicado, com configuration_source=supabase_operational e configuration_revision=1.
- Janela autenticada do smoke sem erro ou warning; estado final preserva Preview e Production na revisão 1.

## Limites preservados

- Gates de Preview não foram repetidos.
- Production permanece com o gate operacional ativo como estado final aplicável.
- E21.3 não foi iniciada.
- Base Técnica, Design System, Services e Automations foram triados sem delta documental.

## Validação

- git diff --check: aprovado.
- npm ci e npm run check: não aplicáveis ao delta exclusivamente documental.