### PR TITLE
feat(e20.2): add v5 universal conversion fields

### DIFF
--- a/docs/lousa-plano-base-e20-2.md
+++ b/docs/lousa-plano-base-e20-2.md
@@ -982,3 +982,11 @@ O snippet não pode:
 - Parar se algum consumidor exigir mudança material de contrato, persistência ou experiência em vez do rótulo local previsto.
 - Parar antes de qualquer alteração no PR #750, registro de suficiência ou retomada da E20.6.
 - Devolver ao Estrategista qualquer conflito entre este plano e o repositório real; não adaptar o recorte por inferência.
+
+## 6. Atualização aditiva E20.2 — v5
+
+- A v5 preserva integralmente as versões executáveis v1–v4 e acrescenta somente dois fields universais, aplicáveis a `starter`, `lite`, `pro` e `ultra`.
+- `business_offerings_summary`: escopo `business`, origem `business_provided`, tipo `string`, obrigação `optional`, validação `type_only`, snapshot `include_if_used` e substituição por LP `forbidden`; é um resumo livre e não exaustivo, não um catálogo, whitelist ou restrição de `primary_service_or_offer`.
+- `primary_conversion_goal`: escopo `landing_page`, origem `landing_page_provided`, tipo `enum`, obrigação `required`, snapshot `include_if_used` e substituição `not_applicable`; aceita somente `contact`, `schedule`, `request_quote`, `purchase` e `register_interest`.
+- `primary_conversion_goal` declara a ação/conversão principal pretendida pela LP e permanece distinto de `funnel_stage`, `transaction_intent`, `primary_service_or_offer` e `primary_conversion_channel`; o canal autorizado pode variar independentemente do objetivo.
+- O recorte permanece repo-only: sem prefill/override entre os fields, UI, Supabase, migration, persistência, rota, API, agente, automação, workload ou integração externa.

--- a/lib/conversion-content/landing-page/input-catalog/registry.ts
+++ b/lib/conversion-content/landing-page/input-catalog/registry.ts
@@ -389,11 +389,49 @@ mutableTransactionIntentV4.evidence = evidence(
   "empirical:real-estate-research",
 );
 
+const v5UniversalFields: readonly LandingPageInputFieldDefinition[] = [
+  field({
+    fieldKey: "business_offerings_summary",
+    purpose: "Resumir de forma livre e não exaustiva o que o negócio oferece; não é catálogo, whitelist ou restrição de primary_service_or_offer e não limita ofertas diferentes, mais amplas ou mais específicas na landing page.",
+    valueType: "string",
+    valueScope: "business",
+    expectedValueOrigin: "business_provided",
+    obligation: "optional",
+    validation: { kind: "type_only" },
+    landingPageSubstitutionPolicy: "forbidden",
+    evidence: evidence("A decisão humana da E20.2 separa o resumo livre do negócio de uma oferta concreta da landing page e não cria whitelist.", "decision:e20-2-human"),
+    createdInVersion: 5,
+  }),
+  field({
+    fieldKey: "primary_conversion_goal",
+    purpose: "Declarar a ação ou conversão principal pretendida pela landing page, independentemente do canal autorizado usado para realizá-la, sem confundi-la com funnel_stage, transaction_intent, primary_service_or_offer ou primary_conversion_channel.",
+    valueType: "enum",
+    valueScope: "landing_page",
+    expectedValueOrigin: "landing_page_provided",
+    obligation: "required",
+    validation: { kind: "enum", allowedValues: ["contact", "schedule", "request_quote", "purchase", "register_interest"] },
+    landingPageSubstitutionPolicy: "not_applicable",
+    evidence: evidence("A decisão humana da E20.2 separa a ação ou conversão pretendida do estágio, da intenção comercial específica, da oferta e do canal de conversão.", "decision:e20-2-human"),
+    createdInVersion: 5,
+  }),
+];
+
+const catalogV5Base = cloneJson(catalogV4);
+const catalogV5: LandingPageInputCatalogRegistryEntry = {
+  ...catalogV5Base,
+  version: 5,
+  universal: {
+    ...catalogV5Base.universal,
+    entries: [...catalogV5Base.universal.entries, ...v5UniversalFields],
+  },
+};
+
 export const landingPageInputCatalogRegistry = deepFreeze({
   1: catalogV1,
   2: catalogV2,
   3: catalogV3,
   4: catalogV4,
+  5: catalogV5,
 } satisfies LandingPageInputCatalogRegistry);
 
 function field(

--- a/lib/conversion-content/landing-page/input-catalog/validation-cases.ts
+++ b/lib/conversion-content/landing-page/input-catalog/validation-cases.ts
@@ -52,11 +52,21 @@ const v4Input: ResolveLandingPageInputCatalogInput = {
   version: 4,
 };
 
+const v5Input: ResolveLandingPageInputCatalogInput = {
+  ...baseInput,
+  version: 5,
+};
+
 const starterV2FieldKeys = [
   "primary_service_or_offer",
   "primary_service_or_offer_description",
   "brand_logo_asset",
   "brand_color_palette",
+] as const;
+
+const v5UniversalFieldKeys = [
+  "business_offerings_summary",
+  "primary_conversion_goal",
 ] as const;
 
 const cases: Case[] = [
@@ -240,6 +250,108 @@ const cases: Case[] = [
       const planSnapshots = ["starter", "lite", "pro", "ultra"].map((plan) =>
         resolveRequired({ ...v4Input, plan }).fields,
       );
+      for (const snapshot of planSnapshots.slice(1)) {
+        assert.deepEqual(snapshot, planSnapshots[0]);
+      }
+    },
+  },
+  {
+    name: "v5 preserves v1 through v4 and adds only the two universal fields",
+    run: () => {
+      const historical = [baseInput, v2Input, v3Input, v4Input].map(resolveRequired);
+      assert.deepEqual(
+        historical.map((catalog) => ({ version: catalog.version, fieldCount: catalog.fields.length })),
+        [
+          { version: 1, fieldCount: 19 },
+          { version: 2, fieldCount: 23 },
+          { version: 3, fieldCount: 23 },
+          { version: 4, fieldCount: 23 },
+        ],
+      );
+
+      const v4 = historical[3];
+      const v5 = resolveRequired(v5Input);
+      const v5FieldKeySet = new Set<string>(v5UniversalFieldKeys);
+      assert.equal(v5.version, 5);
+      assert.equal(v5.fields.length, 25);
+      assert.deepEqual(
+        v5.fields.filter((field) => !v5FieldKeySet.has(field.fieldKey)),
+        v4.fields,
+      );
+      assert.deepEqual(
+        v5.fields
+          .filter((field) => v5FieldKeySet.has(field.fieldKey))
+          .map((field) => field.fieldKey),
+        v5UniversalFieldKeys,
+      );
+
+      const businessSummary = v5.fields.find(
+        (field) => field.fieldKey === "business_offerings_summary",
+      );
+      const conversionGoal = v5.fields.find(
+        (field) => field.fieldKey === "primary_conversion_goal",
+      );
+      assert.ok(businessSummary);
+      assert.ok(conversionGoal);
+
+      assert.equal(businessSummary.valueType, "string");
+      assert.equal(businessSummary.valueScope, "business");
+      assert.equal(businessSummary.expectedValueOrigin, "business_provided");
+      assert.equal(businessSummary.obligation, "optional");
+      assert.equal(businessSummary.requiredWhen, undefined);
+      assert.equal(businessSummary.applicableWhen, undefined);
+      assert.deepEqual(businessSummary.validation, { kind: "type_only" });
+      assert.equal(businessSummary.landingPageSubstitutionPolicy, "forbidden");
+      assert.equal(businessSummary.createdInVersion, 5);
+      assert.equal(businessSummary.snapshotPolicy, "include_if_used");
+      assert.equal(
+        businessSummary.purpose.includes("não é catálogo, whitelist ou restrição de primary_service_or_offer"),
+        true,
+      );
+
+      assert.equal(conversionGoal.valueType, "enum");
+      assert.equal(conversionGoal.valueScope, "landing_page");
+      assert.equal(conversionGoal.expectedValueOrigin, "landing_page_provided");
+      assert.equal(conversionGoal.obligation, "required");
+      assert.equal(conversionGoal.requiredWhen, undefined);
+      assert.equal(conversionGoal.applicableWhen, undefined);
+      assert.deepEqual(conversionGoal.validation, {
+        kind: "enum",
+        allowedValues: ["contact", "schedule", "request_quote", "purchase", "register_interest"],
+      });
+      assert.equal(conversionGoal.landingPageSubstitutionPolicy, "not_applicable");
+      assert.equal(conversionGoal.createdInVersion, 5);
+      assert.equal(conversionGoal.snapshotPolicy, "include_if_used");
+      assert.equal(
+        conversionGoal.purpose.includes("independentemente do canal autorizado"),
+        true,
+      );
+      assert.equal(
+        conversionGoal.purpose.includes("funnel_stage, transaction_intent, primary_service_or_offer ou primary_conversion_channel"),
+        true,
+      );
+
+      for (const field of [businessSummary, conversionGoal]) {
+        assert.deepEqual(field.allowedPlans, ["starter", "lite", "pro", "ultra"]);
+      }
+      assert.equal(validateLandingPageInputValue(businessSummary, "Atendimento imobiliário").ok, true);
+      for (const value of ["contact", "schedule", "request_quote", "purchase", "register_interest"]) {
+        assert.equal(validateLandingPageInputValue(conversionGoal, value).ok, true);
+      }
+      for (const value of ["bofu", "buy", "whatsapp", "other", "", "schedule "]) {
+        assert.equal(validateLandingPageInputValue(conversionGoal, value).ok, false);
+      }
+
+      const planSnapshots = ["starter", "lite", "pro", "ultra"].map((plan) => {
+        const catalog = resolveRequired({ ...v5Input, plan });
+        assert.deepEqual(
+          catalog.fields
+            .filter((field) => v5FieldKeySet.has(field.fieldKey))
+            .map((field) => field.fieldKey),
+          v5UniversalFieldKeys,
+        );
+        return catalog.fields;
+      });
       for (const snapshot of planSnapshots.slice(1)) {
         assert.deepEqual(snapshot, planSnapshots[0]);
       }


### PR DESCRIPTION
## Summary
- add E20.2 catalog v5 with business_offerings_summary and primary_conversion_goal
- preserve v1-v4 and add focused validation for metadata, enum values, optionality, and four plans
- document only the v5 delta in docs/lousa-plano-base-e20-2.md

## Scope
Repo-only. No UI, Supabase, migration, persistence, route, API, automation, workload, external integration, or E19.5 prefill/override.

## Validation
- npm ci: attempted; blocked by ENOTEMPTY in node_modules, then npm install --ignore-scripts completed as environment fallback
- npm run validate:landing-page-input-catalog: passed
- npm run check: passed with 0 errors and 24 pre-existing warnings
- git diff --check: passed

Merge is intentionally not performed.