### PR TITLE
E19.5.3: corrigir ACL e verificação pós-apply

### DIFF
--- a/supabase/migrations/20260823093031_e19_5_3_revoke_ai_readonly_helper_execute.sql
+++ b/supabase/migrations/20260823093031_e19_5_3_revoke_ai_readonly_helper_execute.sql
@@ -1,0 +1,12 @@
+begin;
+
+do $$
+begin
+  if to_regrole('ai_readonly') is not null then
+    execute 'revoke execute on function public.e19_5_actor_can_manage(uuid, uuid) from ai_readonly';
+    execute 'revoke execute on function public.e19_5_configuration_values_have_scopes(jsonb, text[]) from ai_readonly';
+  end if;
+end;
+$$;
+
+commit;

--- a/supabase/snippets/e19_5_3_landing_page_workspace_verify.sql
+++ b/supabase/snippets/e19_5_3_landing_page_workspace_verify.sql
@@ -296,7 +296,6 @@ begin
          select procedure.prosecdef
             or procedure.provolatile <> 'v'
             or pg_get_userbyid(procedure.proowner) <> 'postgres'
-            or pg_get_functiondef(procedure.oid) not ilike '%security invoker%'
             or pg_get_functiondef(procedure.oid) not ilike '%set search_path to ''public'', ''pg_catalog''%'
          from pg_proc procedure
          where procedure.oid = v_function
@@ -350,7 +349,6 @@ begin
      or (select prorettype <> 'boolean'::regtype from pg_proc where oid = v_function)
      or (select prolang <> (select oid from pg_language where lanname = 'sql') from pg_proc where oid = v_function)
      or (select pg_get_userbyid(proowner) <> 'postgres' from pg_proc where oid = v_function)
-     or pg_get_functiondef(v_function) not ilike '%security invoker%'
      or pg_get_functiondef(v_function) not ilike '%set search_path to ''pg_catalog''%'
      or not has_function_privilege('service_role', v_function, 'EXECUTE')
      or has_function_privilege('anon', v_function, 'EXECUTE')

--- a/supabase/tests/e19_5_3_landing_page_workspace.test.sql
+++ b/supabase/tests/e19_5_3_landing_page_workspace.test.sql
@@ -138,6 +138,17 @@ begin
      )
      or has_function_privilege(
        'authenticated', 'public.e19_5_configuration_values_have_scopes(jsonb,text[])', 'EXECUTE'
+     )
+     or (
+       to_regrole('ai_readonly') is not null
+       and (
+         has_function_privilege(
+           'ai_readonly', 'public.e19_5_actor_can_manage(uuid,uuid)', 'EXECUTE'
+         )
+         or has_function_privilege(
+           'ai_readonly', 'public.e19_5_configuration_values_have_scopes(jsonb,text[])', 'EXECUTE'
+         )
+       )
      ) then
     raise exception 'E19.5.3 helper grants are not service-only';
   end if;
@@ -151,7 +162,6 @@ begin
     if v_function is null
        or (select prosecdef from pg_proc where oid = v_function)
        or (select pg_get_userbyid(proowner) <> 'postgres' from pg_proc where oid = v_function)
-       or pg_get_functiondef(v_function) not ilike '%security invoker%'
        or pg_get_functiondef(v_function) not ilike '%set search_path to ''public'', ''pg_catalog''%'
        or not has_function_privilege('service_role', v_function, 'EXECUTE')
        or has_function_privilege('authenticated', v_function, 'EXECUTE') then


### PR DESCRIPTION
## Objetivo
Corrigir o gate pós-apply da E19.5.3 sem alterar a migration já aplicada, o runtime ou o contrato funcional.

## Delta
- adiciona migration forward-only que revoga EXECUTE de ai_readonly nos dois helpers, quando a role existe;
- usa pg_proc.prosecdef = false como prova canônica de SECURITY INVOKER no snippet e no teste;
- preserva verificações de owner, volatility, search_path e grants;
- amplia o teste para detectar EXECUTE efetivo de ai_readonly nos helpers.

## Validação
- npm ci
- npm run check
- npm run validate:landing-page-workspace
- git diff --check e git diff --cached --check
- migration 20260822170000_e19_5_3_landing_page_workspace confirmada sem alteração contra origin/main

## Gate pós-merge
Após merge humano e apply automático, reexecutar o snippet read-only e Security Controls. E19_5_WORKSPACE_ENABLED deve permanecer desabilitado em Preview até o snippet passar integralmente.