### PR TITLE
docs(E20): UX da E20.6.5 e versionamento escalável da E20.2

### DIFF
--- a/docs/lousa-plano-base-e20-2-8.md
+++ b/docs/lousa-plano-base-e20-2-8.md
@@ -4,12 +4,13 @@
 
 ### 1.1. Estado
 
-- Status: plano-base v1 consolidado a partir da decisão humana de 23/08/2026; implementação não autorizada por este documento.
+- Status: plano-base v1 consolidado a partir da decisão humana de 23/08/2026 e ajustado após revisão do Analista; implementação não autorizada por este documento.
 - Caso macro: `E20 — preparação e liberação de taxons`.
 - Recorte: `E20.2.8 — Versão atual e propagação escalável do catálogo E20.2`.
 - Este recorte é uma evolução operacional da E20.2 já versionada; não reescreve nem invalida o histórico de `docs/lousa-plano-base-e20-2.md`.
 - A E20.6 permanece responsável pela suficiência factual por taxon; este recorte altera a relação entre versão global do catálogo e necessidade de reavaliação, conforme a seção 2.3.
 - A implementação física da autoridade de versão atual, de sua persistência e da superfície administrativa permanece pendente de recorte técnico sobre o repositório real.
+- Rollback operacional para versão anterior não integra a primeira entrega da E20.2.8; eventual suporte futuro depende de contrato específico para compatibilidade com configurações persistidas em versões posteriores.
 
 ### 1.2. Fontes usadas
 
@@ -17,18 +18,25 @@
 - `AGENTS.md`.
 - `docs/lousa-plano-base-e20-2.md`.
 - `docs/lousa-plano-base-e20-6.md`, incluindo o refinamento funcional/UX da E20.6.5 em discussão no PR #809.
-- `docs/lousa-plano-base-e21-2-5.md`, como precedente recente de separar contrato funcional de governança operacional.
+- `docs/lousa-plano-base-e19-5.md`.
+- `docs/lousa-plano-base-e21-2-5.md`, cuja implementação repo-side foi mergeada pelos PRs #807 e #810; gates operacionais pós-merge permanecem independentes deste recorte.
 - `docs/base-tecnica.md`.
 - `docs/schema.md`.
 - `docs/design-system.md`.
 - `lib/conversion-content/landing-page/input-catalog/registry.ts`.
 - `lib/conversion-content/landing-page/input-catalog/resolver.ts`.
-- Decisões humanas desta conversa em 23/08/2026 sobre escala, versão default, rollback e experiência administrativa.
+- `lib/conversion-content/landing-page/taxon-preparation/preparation.ts`.
+- `lib/lp-builder/adapters/onboardingConfigurationAdapterCore.ts`, como consumidor E19.2 pré-handoff da versão operacional.
+- `lib/lp-builder/landingPageWorkspace.ts`, `lib/lp-builder/adapters/landingPageWorkspaceAdapter.ts` e `lib/lp-builder/adapters/generationContextAdapter.ts`, como consumidores E19.5 atualmente fixados na versão 5 e no gate de igualdade exata.
+- `lib/lp-builder/onboardingConfiguration.ts`, para a validação fail-closed de valores persistidos contra o catálogo resolvido.
+- Decisões humanas desta conversa em 23/08/2026 sobre escala, versão default e experiência administrativa.
+- Revisão do Analista de 23/08/2026 sobre autoridade `R → C`, consumidores E19.2/E19.5 e deferimento do rollback.
 
 ### 1.3. Problema e resultado esperado
 
 - A E20.2 possui versões executáveis globais e resolução hierárquica `universal → segmento → nicho → ultranicho`, mas o contrato histórico exige versão explícita por consumidor e não define uma autoridade operacional única de versão atual.
 - A E20.6 vigente grava `reviewed_input_catalog_version` por taxon e exige igualdade exata com a versão requerida. Essa combinação cria custo linear: uma nova versão pode obrigar o humano a visitar e reavaliar dezenas ou centenas de taxons apenas porque o número global mudou.
+- A E19.2 pré-handoff e a E19.5 implementada hoje também materializam a versão operacional a partir de contratos fixos/igualdade exata; portanto o carry-forward da E20.6 somente escala se a versão efetivamente autorizada chegar de forma canônica a esses consumidores.
 - O produto deve escalar para 100, 150 ou mais taxons sem transformar cada evolução do catálogo em trabalho administrativo repetitivo nicho a nicho.
 - O resultado esperado é:
   - existir uma versão atual global da E20.2 usada como default operacional;
@@ -36,8 +44,9 @@
   - a mesma versão alcançar todos os taxons pela herança existente;
   - distinguir taxons realmente afetados de taxons sem mudança material;
   - carregar automaticamente a suficiência E20.6 quando a evolução for comprovadamente compatível;
-  - exigir nova avaliação somente quando a mudança puder alterar materialmente a suficiência factual;
-  - permitir rollback explícito para versão executável anterior sem apagar histórico.
+  - distinguir a última versão humanamente revisada `R` da versão operacional efetivamente autorizada `C`;
+  - entregar `C` por uma autoridade canônica única à E19.2 pré-handoff, ao workspace E19.5 e à geração E19.5;
+  - exigir nova avaliação somente quando a mudança puder alterar materialmente a suficiência factual.
 
 ### 1.4. Versão atual global
 
@@ -45,8 +54,8 @@
 - Uma nova versão somente pode tornar-se atual depois de existir como versão executável, passar pelas validações aplicáveis e ser publicada/ativada pelo fluxo humano aprovado.
 - A publicação normal de uma nova versão executável deve torná-la a versão atual por padrão. Exemplo: se v7 é atual e v8 é publicada com sucesso, v8 passa a ser a versão atual sem atualização manual de cada taxon.
 - `Versão atual` não significa `Math.max(registry)`, maior chave encontrada, `latest` inferido ou fallback silencioso.
-- O resolver puro continua recebendo um número concreto e explícito; a responsabilidade de fornecer esse número pertence à autoridade comum de versão atual ou a um consumidor histórico explicitamente pinado.
-- Versões anteriores permanecem imutáveis, resolvíveis e disponíveis para reprodução histórica e rollback.
+- O resolver puro continua recebendo um número concreto e explícito; a responsabilidade de fornecer esse número pertence à autoridade canônica de versão efetiva ou a um consumidor histórico explicitamente pinado.
+- Versões anteriores permanecem imutáveis e resolvíveis para reprodução histórica; esta primeira entrega não autoriza torná-las novamente a versão operacional atual.
 - Snapshots e revisões históricas continuam registrando a versão efetivamente usada e nunca são reinterpretados como se tivessem usado a versão atual posterior.
 - Consumidor operacional que deva acompanhar a evolução normal da E20.2 não deve manter pin hardcoded indefinidamente; consumidor que precise de pin por motivo funcional real deve declará-lo explicitamente em seu próprio contrato.
 
@@ -82,94 +91,124 @@
 - A IA não decide a compatibilidade estrutural entre versões; essa classificação pertence ao processamento determinístico.
 - Este plano não autoriza uma engine genérica de diff. A implementação deve usar a menor comparação determinística capaz de provar as categorias acima sobre os contratos resolvidos reais.
 
-### 1.7. Rollback e ciclo de vida mínimo
+### 1.7. Autoridade `R → C` e ciclo de vida mínimo
 
-- O `platform_admin` deve poder tornar uma versão executável anterior novamente a versão atual quando houver motivo operacional.
-- Exemplo: v7 apresentou problema; o humano pode publicar v8 corrigida, que passa a ser atual, ou restaurar explicitamente v6 como versão atual.
-- Rollback altera apenas a autoridade de versão atual; não edita, renumera, apaga ou sobrescreve versões.
-- Depois do rollback, consumidores que acompanham a versão atual recebem o número restaurado; snapshots históricos permanecem intactos.
-- A compatibilidade E20.6 deve ser recalculada em direção à versão restaurada. Não presumir aprovação histórica que o estado vigente não consiga provar.
-- Status adicional de versão como `desativada`, `deprecated` ou equivalente não é necessário neste recorte. Deve ser reavaliado somente se houver benefício operacional demonstrado além de escolher a versão atual e preservar histórico.
+- `R` representa a última versão E20.2 que recebeu decisão humana explícita de suficiência para o taxon e continua registrada em `reviewed_input_catalog_version`.
+- `C` representa a versão operacional efetivamente autorizada para consumo corrente daquele taxon.
+- No fluxo normal, `C` é a versão atual global quando `R = C` ou quando a transição resolvida `R → C` for deterministicamente `sem mudança material` ou `evolução compatível`.
+- `C` não é persistida artificialmente em `reviewed_input_catalog_version`; ela é resultado do boundary canônico de preparação e deve ser entregue como número concreto aos consumidores operacionais.
+- Se `R → versão atual` exigir revisão, não existe carry-forward: o taxon permanece não preparado para a versão atual até nova decisão humana, quando o marcador passa a registrar essa versão.
+- E19.2, E19.5 ou qualquer consumidor não pode derivar `C` por conta própria, consultar `Math.max`, ler `latest` ou reinterpretar `R` como se fosse necessariamente a versão operacional corrente.
+- Se uma versão publicada apresentar defeito nesta primeira entrega, a correção operacional prevista é publicar uma nova versão forward-only. Rollback para versão anterior fica fora do recorte até existir contrato específico para configurações persistidas.
+- Status adicional de versão como `desativada`, `deprecated` ou equivalente também fica fora desta primeira entrega e depende de benefício operacional demonstrado.
 
 ## 2. Contrato do caso
 
 ### 2.1. Fluxo da versão atual
 
 - Gatilho:
-  - uma nova versão executável E20.2 conclui o fluxo aprovado de validação/publicação; ou o humano decide restaurar versão executável anterior.
+  - uma nova versão executável E20.2 conclui o fluxo aprovado de validação/publicação.
 - Entrada:
-  - versão alvo explícita;
+  - nova versão alvo explícita;
   - registry executável vigente;
   - validações aplicáveis da E20.2;
-  - decisão humana de publicação/rollback quando aplicável.
+  - decisão humana de publicação quando aplicável.
 - Processamento:
-  - provar que a versão alvo existe e é executável;
-  - tornar a versão publicada a autoridade operacional atual por default, ou aplicar a versão anterior escolhida no rollback;
-  - entregar o número concreto aos consumidores que seguem a versão atual;
+  - provar que a nova versão alvo existe e é executável;
+  - tornar a versão publicada a autoridade global atual por default;
+  - para cada taxon/consumidor corrente, derivar `C` somente pelo boundary canônico de preparação, considerando `R`, versão atual e compatibilidade;
+  - entregar o número concreto `C` aos consumidores que seguem a versão operacional efetiva;
   - preservar resolução pura, histórico e snapshots.
 - Validação:
   - nunca derivar a autoridade por maior número;
   - nunca ativar versão ainda não validada/publicada;
-  - nunca alterar versões históricas para simular rollback.
+  - nunca transformar carry-forward compatível em write fictício de revisão humana.
 - Persistência:
   - a residência física da autoridade de versão atual não é definida por este plano; deve ser escolhida em implementação própria após análise de `docs/schema.md`, `docs/base-tecnica.md` e boundaries existentes.
 - Consumo:
-  - consumidores correntes recebem o número da versão atual;
+  - consumidores correntes recebem `C` como número explícito da autoridade canônica;
   - consumidores históricos usam o número explicitamente registrado em seus snapshots/revisões.
 - Fallback:
   - ausência, inconsistência ou versão atual não executável falha fechado; não usar maior versão como substituto.
 
 ### 2.2. Fluxo de impacto por taxon
 
-- Para cada taxon relevante, comparar a versão de referência com a nova versão atual usando a mesma cadeia taxonômica autoritativa e as projeções factuais aplicáveis.
+- Para cada taxon relevante, comparar `R` com a nova versão atual usando a mesma cadeia taxonômica autoritativa e as projeções factuais aplicáveis.
 - A camada alterada define primeiro o conjunto potencialmente afetado; taxons fora desse alcance não precisam de análise semântica individual.
 - O resultado de impacto deve distinguir:
   - sem mudança material;
   - evolução compatível;
   - revisão necessária.
-- `Sem mudança material` e `evolução compatível` não exigem mutação repetitiva apenas para atualizar o número da versão no taxon.
-- `Revisão necessária` encaminha o taxon à E20.6.5 para nova avaliação semântica contra a versão atual.
+- `Sem mudança material` e `evolução compatível` autorizam `C = versão atual` sem mutação repetitiva de `R` apenas para atualizar o número do taxon.
+- `Revisão necessária` encaminha o taxon à E20.6.5 para nova avaliação semântica contra a versão atual; até a decisão humana, `C` não pode ser promovida para essa versão.
 - Falha de resolução, cadeia, plano ou comparação resulta em revisão necessária/fail-closed, nunca em aprovação automática.
 
 ### 2.3. Consequência vinculante para a E20.6
 
 - O modelo operacional futuro supera a regra histórica de que todo avanço numérico de `N` para `M` exige necessariamente uma nova avaliação individual.
 - `reviewed_input_catalog_version = R` deve representar a última versão que recebeu decisão humana explícita de suficiência para aquele taxon.
-- Quando a versão atual for `C`, a preparação poderá ser derivada se:
-  - `R = C`; ou
-  - a transição resolvida `R → C` for deterministicamente `sem mudança material` ou `evolução compatível` para aquele taxon.
-- Nesses casos não se deve gravar `reviewed_input_catalog_version = C` apenas para sincronizar o número; a ausência de mutação em massa preserva a informação sobre a última revisão humana real.
-- Quando a transição exigir revisão, a E20.6.5 avalia o taxon contra `C`; somente a decisão humana final de suficiência grava `reviewed_input_catalog_version = C`.
+- A preparação canônica passa a distinguir `R` da versão operacional efetivamente autorizada `C`.
+- Quando a versão atual global for `V`, a preparação poderá produzir `C = V` se:
+  - `R = V`; ou
+  - a transição resolvida `R → V` for deterministicamente `sem mudança material` ou `evolução compatível` para aquele taxon.
+- Nesses casos não se deve gravar `reviewed_input_catalog_version = V` apenas para sincronizar o número; a ausência de mutação em massa preserva a informação sobre a última revisão humana real.
+- Quando a transição exigir revisão, a E20.6.5 avalia o taxon contra `V`; somente a decisão humana final de suficiência grava `reviewed_input_catalog_version = V`, após o que `R = C = V`.
 - Pesquisa E20.5 alterada, avaliação reaberta, marcador `NULL`, cadeia taxonômica incompatível ou falha de resolução continuam bloqueando o carry-forward.
 - A igualdade exata da E20.6.4 permanece o runtime vigente até implementação completa e validada desta evolução. Não aplicar parcialmente o novo predicado em ambiente hospedado.
 - O refinamento de UX da E20.6.5 passa a usar a versão atual como escolha normal/default quando esta autoridade existir, sem exigir que o humano memorize a versão mais recente. A avaliação de versão histórica continua possível somente quando houver finalidade explícita.
 
-### 2.4. Experiência administrativa futura
+### 2.4. Contrato de consumo da versão efetiva
+
+- O boundary canônico de preparação é a única autoridade que transforma `R + versão atual + compatibilidade` em uma versão operacional efetivamente autorizada `C`.
+- O resultado conceitual desse boundary deve preservar separadamente:
+  - `reviewedInputCatalogVersion = R`, para auditoria da última decisão humana;
+  - `effectiveInputCatalogVersion = C`, para consumo operacional corrente.
+- A nomenclatura física final da API pode ser reconciliada na implementação, mas a separação semântica `R`/`C` é vinculante.
+- Consumidores materiais já conhecidos devem seguir o contrato abaixo quando a E20.2.8 for implementada:
+  - E19.2 pré-handoff usa `C` como `operationalCatalogVersion` para resolver, validar e persistir configuração nova ou ainda não vinculada;
+  - E19.5 workspace usa `C` para resolver e salvar a configuração operacional corrente;
+  - geração via E19.5 usa exatamente o mesmo `C` usado pelo workspace e pela revalidação operacional;
+  - nenhum desses consumidores resolve versão atual localmente, lê maior versão, consulta registry para inferir default ou substitui `C` por `R` apenas porque `R` é persistido.
+- Configurações E19.2/E19.5 já persistidas continuam registrando o `catalog_version` realmente usado em sua escrita; materializações e snapshots continuam preservando a versão efetivamente usada naquela geração.
+- Revalidação histórica pode resolver o `catalog_version` persistido para compreender o estado anterior, mas qualquer nova operação corrente usa a autoridade `C` aplicável e falha fechado diante de incompatibilidade.
+- A implementação da E20.2.8 deve remover ou reconciliar os pins operacionais atualmente conhecidos — incluindo `LANDING_PAGE_WORKSPACE_REQUIRED_INPUT_CATALOG_VERSION = 5` — somente dentro do recorte completo, sem substituí-los por outro hardcode ou por lookup local de versão atual.
+
+### 2.5. Experiência administrativa futura
 
 - O Admin deve oferecer uma visão central da E20.2 capaz de mostrar, de forma amigável:
   - versão atual;
-  - versões executáveis anteriores;
+  - versões executáveis anteriores para inspeção histórica;
   - resumo da mudança entre versões;
   - camada em que a mudança nasceu;
   - alcance potencial da mudança;
   - quantidade de taxons sem mudança material;
   - quantidade de taxons que acompanham automaticamente por compatibilidade;
   - quantidade de taxons que precisam de revisão E20.6.
-- A interface deve permitir ver diferenças e, quando autorizado, tornar versão anterior a versão atual sem editar o histórico.
 - O humano não deve precisar visitar 100 ou 150 páginas de taxon para sincronizar uma nova versão.
 - Taxons com revisão necessária devem aparecer em uma visão agregada de pendências, com acesso ao fluxo individual E20.6.5 quando necessário.
 - A rota e a composição física dessa superfície não são definidas neste plano. A implementação deve primeiro avaliar as superfícies existentes de Estrutura da LP e Taxonomia e escolher a menor evolução coerente com o Design System.
 - Não criar job, fila, agente, automação recorrente ou nova infraestrutura apenas para produzir essa experiência sem fonte técnica posterior.
+- Ação administrativa de restaurar versão anterior como atual não integra esta primeira entrega.
 
-### 2.5. Compatibilidade com consumidores e histórico
+### 2.6. Compatibilidade com consumidores e histórico
 
-- A versão atual é default para consumo operacional, não uma reescrita retroativa de contratos históricos.
-- Snapshots de geração, revisões de LP e qualquer artefato que registre versão usada preservam seu número original.
-- Consumidores atualmente hardcoded devem ser classificados na implementação futura:
-  - acompanham versão atual por natureza; ou
+- A versão atual é default para consumo operacional novo/corrente, não uma reescrita retroativa de contratos históricos.
+- `R` preserva a última decisão humana real; `C` preserva a versão operacional autorizada corrente; snapshots, revisões e residências preservam o número que efetivamente usaram.
+- E19.2 pré-handoff, E19.5 workspace e geração E19.5 são consumidores explícitos de `C` quando a E20.2.8 entrar em vigor.
+- Pins históricos ou residências já gravadas não são reescritos apenas porque a versão atual mudou.
+- Outros consumidores atualmente hardcoded devem ser classificados na implementação futura:
+  - acompanham `C` por natureza; ou
   - permanecem pinados por contrato funcional explícito.
 - Não remover pins apenas por conveniência sem verificar a responsabilidade do consumidor.
 - A E20.6 não deve voltar a ser usada como mecanismo de sincronização de número quando a compatibilidade puder ser derivada deterministicamente.
+
+### 2.7. Rollback operacional deferido
+
+- Rollback de `versão atual` para uma versão executável anterior não faz parte da primeira implementação da E20.2.8.
+- O motivo é concreto: E19.5 pode persistir valores de fields introduzidos em versões posteriores; resolver essa residência contra catálogo anterior que não contém esses `field_key` produz configuração inválida pelo contrato fail-closed vigente.
+- Manter rollback agora exigiria definir projeção/inativação de valores posteriores, preservação e recuperação ao avançar novamente, além da relação com revisões e snapshots. Esse custo não é necessário para resolver o problema principal de escala.
+- Se uma versão atual publicada apresentar defeito no MVP, o caminho suportado é corrigir e publicar nova versão forward-only.
+- Rollback pode ser reaberto em evolução própria somente depois de existir contrato que preserve dados e não relaxe validação fail-closed.
 
 ## 3. Fases e próxima ação
 
@@ -179,11 +218,12 @@
 - Próxima ação técnica futura:
   - reconciliar o plano com a `main` vigente no início da implementação;
   - identificar a menor autoridade real para `versão atual` sem criar segunda residência;
-  - definir a API pública que entrega o número concreto aos consumidores;
+  - definir a API pública que entrega `R` e `C` separadamente e fornece o número concreto `C` aos consumidores;
   - definir o comparador mínimo de compatibilidade sobre catálogos resolvidos;
   - adaptar o predicado E20.6.4 somente como unidade completa, preservando fail-closed;
+  - reconciliar E19.2 pré-handoff, E19.5 workspace e geração E19.5 para consumir a mesma `C`, removendo os pins operacionais somente dentro desse recorte completo;
   - projetar a experiência administrativa agregada sobre superfícies existentes antes de propor nova rota;
-  - validar propagação universal, por segmento, nicho e ultranicho, além de rollback e snapshots históricos.
+  - validar propagação universal, por segmento, nicho e ultranicho, carry-forward sem writes artificiais e snapshots/configurações históricas preservados.
 - Este PR documental não autoriza implementação, migration, schema, rota, job, agente, automação, engine ou nova infraestrutura.
 
 ## 4. Escopo negativo e critérios de parada
@@ -191,20 +231,24 @@
 ### 4.1. Fora de escopo
 
 - Não implementar `Math.max`, `latest` implícito ou descoberta automática da maior chave como autoridade operacional.
-- Não criar versão corrente por taxon.
+- Não criar versão corrente persistida por taxon.
 - Não duplicar o registry em banco apenas para resolver a versão atual.
-- Não reescrever versões ou snapshots históricos.
+- Não reescrever versões, residências ou snapshots históricos.
+- Não implementar rollback operacional para versão anterior nesta primeira entrega.
 - Não criar status `desativada/deprecated` sem benefício demonstrado.
 - Não criar job, fila, agente ou automação recorrente para reavaliar taxons.
 - Não aprovar semanticamente taxon por heurística determinística quando a transição for materialmente incompatível.
 - Não usar IA para classificar a compatibilidade estrutural das versões.
-- Não alterar E20.5, E19.2, E19.5 ou consumidores sem confirmar o impacto real no recorte técnico próprio.
+- Não permitir que E19.2, E19.5 ou geração resolvam `versão atual` localmente ou usem `R` como substituto implícito de `C`.
+- Não alterar consumidores além do necessário no futuro recorte técnico sem confirmar seu contrato real na `main` vigente.
 
 ### 4.2. Critérios de parada
 
 - Parar se a autoridade de versão atual exigir nova residência sem justificativa e sem reconciliação com a arquitetura existente.
 - Parar se não for possível distinguir de forma determinística e conservadora `sem mudança material`, `evolução compatível` e `revisão necessária`.
-- Parar se a propagação puder reinterpretar snapshots históricos ou alterar silenciosamente uma geração anterior.
+- Parar se não for possível fornecer uma única `C` coerente à E19.2 pré-handoff, ao workspace E19.5 e à geração E19.5.
+- Parar se a propagação puder reinterpretar snapshots históricos, invalidar silenciosamente residência persistida ou alterar uma geração anterior.
+- Parar se surgir necessidade de rollback antes de existir contrato específico para fields/valores posteriores; não ampliar silenciosamente este recorte.
 - Parar se uma mudança por plano tornar o marcador taxonômico E20.6 insuficiente ou ambíguo.
 - Parar se a experiência agregada exigir nova rota, persistência ou infraestrutura antes de analisar as superfícies administrativas já existentes.
 - Parar diante de conflito material com a E20.6 vigente; a transição do predicado de igualdade exata deve ocorrer somente por implementação completa e validada, nunca por ajuste parcial.

--- a/docs/lousa-plano-base-e20-2-8.md
+++ b/docs/lousa-plano-base-e20-2-8.md
@@ -252,3 +252,95 @@
 - Parar se uma mudança por plano tornar o marcador taxonômico E20.6 insuficiente ou ambíguo.
 - Parar se a experiência agregada exigir nova rota, persistência ou infraestrutura antes de analisar as superfícies administrativas já existentes.
 - Parar diante de conflito material com a E20.6 vigente; a transição do predicado de igualdade exata deve ocorrer somente por implementação completa e validada, nunca por ajuste parcial.
+
+## 5. Consolidação do lifecycle do catálogo — 24/08/2026
+
+### 5.1. Autoridade desta consolidação
+
+- Esta seção consolida as decisões humanas e revisões do Analista posteriores à redação inicial deste plano e supera somente formulações anteriores incompatíveis sobre draft, momento da análise de impacto, publicação e retirada de fields.
+- Permanecem integralmente preservados: versão global atual explícita, autoridade `R → C`, carry-forward determinístico, fail-closed, herança taxonômica, histórico imutável de versões publicadas, rollback fora do MVP e ausência de implementação física neste PR.
+- O lifecycle do MVP é deliberadamente mínimo: `versão publicada atual → único próximo draft mutável → publicar → nova versão publicada atual`.
+
+### 5.2. Próxima versão única em draft
+
+- Enquanto existir uma versão publicada atual `V`, pode existir no máximo uma próxima versão em draft, correspondente à evolução sequencial imediatamente posterior de `V`.
+- O draft é mutável e não operacional. E19.2, E19.5 workspace, geração E19.5 e demais consumidores correntes nunca usam o draft como `C`.
+- Alterações aprovadas provenientes de diferentes avaliações ou taxons acumulam-se no mesmo draft enquanto ele não tiver sido publicado. Uma segunda alteração antes da publicação não cria outra versão candidata.
+- Salvar o draft persiste apenas seu estado corrente; não cria uma nova versão histórica e não exige histórico de cada salvamento no MVP.
+- Não permitir múltiplos drafts concorrentes, branches funcionais do catálogo ou seleção entre várias candidatas.
+- A forma física de residência, edição e autorização do draft não é definida por este plano e deve ser escolhida somente no recorte técnico sobre as superfícies e boundaries reais.
+
+### 5.3. Lifecycle dos fields
+
+- Field criado exclusivamente no draft ainda não pertence ao contrato publicado e pode ser editado, renomeado, ter metadata, obrigação ou validação corrigidas e ser excluído integralmente antes da publicação.
+- Field excluído antes de sua primeira publicação nunca existiu para E19.2/E19.5 e não precisa permanecer no histórico do catálogo.
+- Depois de publicado, o contrato histórico do field é imutável nas versões em que existiu. Ele não pode ser apagado retroativamente.
+- Quando um field publicado deixar de ser necessário, a evolução é forward-only: a próxima versão pode declará-lo `retirado a partir daquela versão`.
+- Usar `retirado` como semântica do MVP; não criar lifecycle `ativo/inativo`, reativação ou alternância de status.
+- `optional` e `required` usam o mesmo mecanismo de retirada. Na versão corrente em que foi retirado, o field deixa de ser exibido/coletado, deixa de participar de novas gerações e seu valor anterior deixa de participar do contrato operacional ativo.
+- Quando o field retirado era `required`, ele também deixa de participar da completude a partir da versão que efetivou a retirada.
+- Valores anteriormente persistidos não precisam ser apagados por migration ou backfill. O runtime futuro deve conseguir distinguir `field_key` historicamente publicado e depois retirado, que permanece reconhecível porém inerte, de key que nunca pertenceu a qualquer contrato publicado, que continua inválida/fail-closed.
+- A representação física dessa distinção — nome de propriedade, shape, projeção ou mecanismo equivalente — não é definida neste plano e deve ser escolhida após análise dos contratos reais.
+- Retirada não cria nova capacidade de override hierárquico: nicho ou ultranicho não pode simplesmente retirar/desligar um field herdado que permaneça ativo em camada superior. A retirada ocorre na evolução versionada do contrato ao qual o field pertence.
+- Para a primeira E20.2.8, toda retirada de field publicado é classificada como `revisão necessária` para os taxons aos quais ele se aplica. Não implementar otimização por alegada cobertura semântica equivalente de outro field neste MVP.
+
+### 5.4. Draft validável e evidência stale
+
+- `Não operacional` não significa `não resolvível`: o draft final deve poder ser resolvido e validado administrativamente antes da publicação, usando as mesmas regras funcionais do catálogo que ele teria se publicado.
+- A validação pré-publicação deve conseguir resolver o draft nas cadeias taxonômicas e planos aplicáveis, validar fields, condições e contratos e calcular o impacto da mudança.
+- A análise de impacto de publicação considera o conteúdo integral corrente do draft, nunca um estado intermediário anterior.
+- Qualquer edição material posterior do draft torna stale toda evidência que dependia daquele conteúdo, incluindo classificação estrutural de impacto, compatibilidade por taxon, avaliação E20.6.5 pré-publicação e prova de validade estrutural das configurações operacionais correntes.
+- Antes de publicar, toda evidência material stale deve ser recalculada sobre o conteúdo exato que será publicado.
+- Snapshots, materializações e revisões históricas não são reinterpretados contra o draft; permanecem ligados ao contrato/versionamento com que foram produzidos.
+
+### 5.5. Duas dimensões do gate pré-publicação
+
+- A publicação do draft final deve avaliar separadamente `suficiência taxonômica E20.6` e `validade estrutural das configurações operacionais E19`.
+- Na dimensão E20.6:
+  - `sem mudança material` e `evolução compatível` seguem o carry-forward já definido;
+  - `revisão necessária` encaminha somente os taxons afetados à E20.6.5;
+  - quando a pendência de `revisão necessária` afetar taxon/consumo já operacional segundo os contratos vigentes do produto, ela deve ser resolvida no pré-publicação antes de o draft tornar-se a nova versão atual;
+  - taxon ainda não operacional não precisa bloquear a publicação e pode permanecer pendente até que sua preparação seja necessária.
+- Na dimensão E19:
+  - o gate pré-publicação protege validade e legibilidade estrutural das configurações operacionais correntes que passarão a consumir `C`, não a completude de toda a base;
+  - uma nova versão pode tornar uma configuração antiga `válida, porém incompleta` exclusivamente pela introdução de novos dados obrigatórios ainda sem valor; isso não bloqueia publicação e preserva o lifecycle já previsto pela E19.5;
+  - nesse caso, somente ações que dependem de completude permanecem bloqueadas até o preenchimento dos novos dados;
+  - deve bloquear publicação uma mudança que torne configuração corrente inválida ou ilegível, por exemplo estreitamento de enum incompatível com valor existente, mudança incompatível de tipo/scope/validação ou retirada que ainda não reconheça corretamente o valor histórico como legítimo e inerte.
+- O gate de continuidade não exige migração humana prévia de todas as contas nem backfill para preencher novo `required`.
+- A identificação física de quais taxons/configurações são operacionais e a forma de executar essa prova pertencem ao recorte técnico futuro; este plano fixa apenas o contrato de produto.
+
+### 5.6. E20.6.5 sobre o draft
+
+- A E20.6.5 pode analisar administrativamente o draft final antes da publicação quando a classificação determinística indicar `revisão necessária`.
+- Essa avaliação pré-publicação não torna o draft operacional e não autoriza E19.2/E19.5 a consumi-lo.
+- A decisão humana pré-publicação fica vinculada ao conteúdo exato do draft avaliado; qualquer edição material posterior a torna stale e exige nova avaliação quando ainda necessária.
+- A avaliação pré-publicação não deve gravar prematuramente `reviewed_input_catalog_version` como se o draft já fosse uma versão operacional publicada.
+- A decisão pré-publicação é uma autorização condicionada: somente a publicação daquele mesmo conteúdo pode produzir seu efeito administrativo sobre a nova versão. O mecanismo físico para materializar esse efeito de forma segura no evento de publicação não é definido neste PR documental.
+- Taxons não operacionais podem permanecer sem essa decisão e continuarão fail-closed quando sua preparação for requerida posteriormente.
+
+### 5.7. Publicação
+
+- `Publicar` é o único evento que encerra a mutabilidade do draft, transforma aquele conteúdo em versão publicada e imutável, torna essa versão a atual global e a disponibiliza ao consumo operacional conforme `R → C` e os gates aplicáveis.
+- Não existe segundo passo humano de `tornar atual`, seletor de versão titular nem escolha manual da versão operacional pelos consumidores E19.2/E19.5.
+- A publicação é uma decisão global do catálogo, não uma decisão pertencente ao taxon que originou um field ou uma alteração.
+- A publicação deve falhar fechado quando o draft final estiver inválido, quando evidência material necessária estiver stale, quando houver pendência E20.6 obrigatória para consumo operacional vigente ou quando a mudança puder tornar configuração operacional corrente inválida/ilegível.
+- A publicação não é bloqueada apenas porque um novo `required` torna configuração anterior incompleta, nem por pendência E20.6 de taxon ainda não operacional.
+- Depois da publicação, a primeira alteração posterior inicia o próximo draft sequencial; a versão publicada permanece imutável.
+- A superfície física da ação `Publicar` não é definida neste PR. A implementação deve primeiro avaliar as superfícies administrativas existentes e escolher a menor evolução coerente com o Design System e boundaries atuais.
+
+### 5.8. Simplificações vinculantes do MVP
+
+- A primeira E20.2.8 não necessita de:
+  - rollback para versão anterior;
+  - seletor de versão titular;
+  - versão publicada ativa/inativa ou `deprecated`;
+  - múltiplos drafts;
+  - branches de catálogo;
+  - histórico de salvamentos do draft;
+  - reativação de field retirado;
+  - deleção física de fields históricos;
+  - backfill para apagar valores antigos;
+  - escolha manual da versão operacional por E19.2/E19.5;
+  - engine de equivalência semântica para evitar revisão após retirada de field.
+- O lifecycle desejado fica: `versão publicada atual → único draft mutável → validação pré-publicação → publicar → nova versão publicada atual`.
+- O lifecycle do field fica: `criado no draft → livremente mutável/excluível → publicado → histórico imutável → eventualmente retirado forward-only`.

--- a/docs/lousa-plano-base-e20-2-8.md
+++ b/docs/lousa-plano-base-e20-2-8.md
@@ -1,0 +1,210 @@
+23/08/2026 — Plano-base v1 — E20.2.8 — Versão atual e propagação escalável do catálogo E20.2
+
+## 1. Estado e decisões fixas
+
+### 1.1. Estado
+
+- Status: plano-base v1 consolidado a partir da decisão humana de 23/08/2026; implementação não autorizada por este documento.
+- Caso macro: `E20 — preparação e liberação de taxons`.
+- Recorte: `E20.2.8 — Versão atual e propagação escalável do catálogo E20.2`.
+- Este recorte é uma evolução operacional da E20.2 já versionada; não reescreve nem invalida o histórico de `docs/lousa-plano-base-e20-2.md`.
+- A E20.6 permanece responsável pela suficiência factual por taxon; este recorte altera a relação entre versão global do catálogo e necessidade de reavaliação, conforme a seção 2.3.
+- A implementação física da autoridade de versão atual, de sua persistência e da superfície administrativa permanece pendente de recorte técnico sobre o repositório real.
+
+### 1.2. Fontes usadas
+
+- `README.md`.
+- `AGENTS.md`.
+- `docs/lousa-plano-base-e20-2.md`.
+- `docs/lousa-plano-base-e20-6.md`, incluindo o refinamento funcional/UX da E20.6.5 em discussão no PR #809.
+- `docs/lousa-plano-base-e21-2-5.md`, como precedente recente de separar contrato funcional de governança operacional.
+- `docs/base-tecnica.md`.
+- `docs/schema.md`.
+- `docs/design-system.md`.
+- `lib/conversion-content/landing-page/input-catalog/registry.ts`.
+- `lib/conversion-content/landing-page/input-catalog/resolver.ts`.
+- Decisões humanas desta conversa em 23/08/2026 sobre escala, versão default, rollback e experiência administrativa.
+
+### 1.3. Problema e resultado esperado
+
+- A E20.2 possui versões executáveis globais e resolução hierárquica `universal → segmento → nicho → ultranicho`, mas o contrato histórico exige versão explícita por consumidor e não define uma autoridade operacional única de versão atual.
+- A E20.6 vigente grava `reviewed_input_catalog_version` por taxon e exige igualdade exata com a versão requerida. Essa combinação cria custo linear: uma nova versão pode obrigar o humano a visitar e reavaliar dezenas ou centenas de taxons apenas porque o número global mudou.
+- O produto deve escalar para 100, 150 ou mais taxons sem transformar cada evolução do catálogo em trabalho administrativo repetitivo nicho a nicho.
+- O resultado esperado é:
+  - existir uma versão atual global da E20.2 usada como default operacional;
+  - uma nova versão publicada passar a ser atual por padrão;
+  - a mesma versão alcançar todos os taxons pela herança existente;
+  - distinguir taxons realmente afetados de taxons sem mudança material;
+  - carregar automaticamente a suficiência E20.6 quando a evolução for comprovadamente compatível;
+  - exigir nova avaliação somente quando a mudança puder alterar materialmente a suficiência factual;
+  - permitir rollback explícito para versão executável anterior sem apagar histórico.
+
+### 1.4. Versão atual global
+
+- A E20.2 deve possuir uma autoridade explícita de `versão atual` global.
+- Uma nova versão somente pode tornar-se atual depois de existir como versão executável, passar pelas validações aplicáveis e ser publicada/ativada pelo fluxo humano aprovado.
+- A publicação normal de uma nova versão executável deve torná-la a versão atual por padrão. Exemplo: se v7 é atual e v8 é publicada com sucesso, v8 passa a ser a versão atual sem atualização manual de cada taxon.
+- `Versão atual` não significa `Math.max(registry)`, maior chave encontrada, `latest` inferido ou fallback silencioso.
+- O resolver puro continua recebendo um número concreto e explícito; a responsabilidade de fornecer esse número pertence à autoridade comum de versão atual ou a um consumidor histórico explicitamente pinado.
+- Versões anteriores permanecem imutáveis, resolvíveis e disponíveis para reprodução histórica e rollback.
+- Snapshots e revisões históricas continuam registrando a versão efetivamente usada e nunca são reinterpretados como se tivessem usado a versão atual posterior.
+- Consumidor operacional que deva acompanhar a evolução normal da E20.2 não deve manter pin hardcoded indefinidamente; consumidor que precise de pin por motivo funcional real deve declará-lo explicitamente em seu próprio contrato.
+
+### 1.5. Alcance hierárquico
+
+- A versão atual é única e global; não existe versão corrente diferente por nicho.
+- A personalização continua ocorrendo exclusivamente pelas camadas da mesma versão.
+- O alcance potencial de uma alteração é determinado pela camada em que ela nasce:
+  - `universal`: todos os taxons ativos;
+  - `segment`: o segmento e todos os nichos/ultranichos descendentes que o herdam;
+  - `niche`: o nicho e seus ultranichos descendentes;
+  - `ultra_niche`: somente o ultranicho autorizado correspondente.
+- Alcance potencial não equivale a impacto material. O impacto real deve ser obtido comparando o catálogo resolvido do mesmo taxon entre a versão anterior e a nova versão.
+- Taxons fora do alcance hierárquico da alteração devem acompanhar a nova versão atual sem ação humana quando o catálogo resolvido permanecer semanticamente equivalente.
+- Não criar fork de versão por taxon para contornar propagação.
+
+### 1.6. Compatibilidade de revisão
+
+- Para a finalidade da E20.6, a transição entre a última versão humanamente revisada e a versão atual deve ser classificada deterministicamente por taxon em três situações:
+  - `sem mudança material`;
+  - `evolução compatível`;
+  - `revisão necessária`.
+- `sem mudança material` significa que, desconsiderando o número da versão e metadados editoriais sem efeito funcional, o contrato factual resolvido continua equivalente.
+- `evolução compatível` significa que o contrato mudou, mas a nova versão apenas amplia cobertura factual e não remove, restringe ou reinterpreta cobertura anteriormente aprovada.
+- São candidatos naturais a evolução compatível, quando isolados e deterministicamente comprovados:
+  - adição de novo field sem alteração destrutiva dos fields existentes;
+  - ampliação de conjunto permitido que aumente a capacidade representacional de um field;
+  - alteração apenas de evidência ou texto editorial sem mudança do contrato factual efetivo.
+- A adição de field `required` pode continuar compatível para a pergunta de suficiência taxonômica porque aumenta cobertura disponível; eventual incompletude dos valores concretos passa a ser tratada pelos recortes de configuração da conta/LP, e não pela E20.6.
+- Uma suficiência anteriormente reaberta ou invalidada não pode ser carregada automaticamente, mesmo que a nova versão seja aditiva.
+- Deve ser `revisão necessária` quando houver remoção de field, estreitamento de valores/validação, mudança material de finalidade, tipo, scope, origem esperada, condição, obrigação, aplicabilidade por plano ou qualquer transformação cuja compatibilidade não possa ser demonstrada com segurança.
+- Diante de ambiguidade, falhar para `revisão necessária`.
+- A IA não decide a compatibilidade estrutural entre versões; essa classificação pertence ao processamento determinístico.
+- Este plano não autoriza uma engine genérica de diff. A implementação deve usar a menor comparação determinística capaz de provar as categorias acima sobre os contratos resolvidos reais.
+
+### 1.7. Rollback e ciclo de vida mínimo
+
+- O `platform_admin` deve poder tornar uma versão executável anterior novamente a versão atual quando houver motivo operacional.
+- Exemplo: v7 apresentou problema; o humano pode publicar v8 corrigida, que passa a ser atual, ou restaurar explicitamente v6 como versão atual.
+- Rollback altera apenas a autoridade de versão atual; não edita, renumera, apaga ou sobrescreve versões.
+- Depois do rollback, consumidores que acompanham a versão atual recebem o número restaurado; snapshots históricos permanecem intactos.
+- A compatibilidade E20.6 deve ser recalculada em direção à versão restaurada. Não presumir aprovação histórica que o estado vigente não consiga provar.
+- Status adicional de versão como `desativada`, `deprecated` ou equivalente não é necessário neste recorte. Deve ser reavaliado somente se houver benefício operacional demonstrado além de escolher a versão atual e preservar histórico.
+
+## 2. Contrato do caso
+
+### 2.1. Fluxo da versão atual
+
+- Gatilho:
+  - uma nova versão executável E20.2 conclui o fluxo aprovado de validação/publicação; ou o humano decide restaurar versão executável anterior.
+- Entrada:
+  - versão alvo explícita;
+  - registry executável vigente;
+  - validações aplicáveis da E20.2;
+  - decisão humana de publicação/rollback quando aplicável.
+- Processamento:
+  - provar que a versão alvo existe e é executável;
+  - tornar a versão publicada a autoridade operacional atual por default, ou aplicar a versão anterior escolhida no rollback;
+  - entregar o número concreto aos consumidores que seguem a versão atual;
+  - preservar resolução pura, histórico e snapshots.
+- Validação:
+  - nunca derivar a autoridade por maior número;
+  - nunca ativar versão ainda não validada/publicada;
+  - nunca alterar versões históricas para simular rollback.
+- Persistência:
+  - a residência física da autoridade de versão atual não é definida por este plano; deve ser escolhida em implementação própria após análise de `docs/schema.md`, `docs/base-tecnica.md` e boundaries existentes.
+- Consumo:
+  - consumidores correntes recebem o número da versão atual;
+  - consumidores históricos usam o número explicitamente registrado em seus snapshots/revisões.
+- Fallback:
+  - ausência, inconsistência ou versão atual não executável falha fechado; não usar maior versão como substituto.
+
+### 2.2. Fluxo de impacto por taxon
+
+- Para cada taxon relevante, comparar a versão de referência com a nova versão atual usando a mesma cadeia taxonômica autoritativa e as projeções factuais aplicáveis.
+- A camada alterada define primeiro o conjunto potencialmente afetado; taxons fora desse alcance não precisam de análise semântica individual.
+- O resultado de impacto deve distinguir:
+  - sem mudança material;
+  - evolução compatível;
+  - revisão necessária.
+- `Sem mudança material` e `evolução compatível` não exigem mutação repetitiva apenas para atualizar o número da versão no taxon.
+- `Revisão necessária` encaminha o taxon à E20.6.5 para nova avaliação semântica contra a versão atual.
+- Falha de resolução, cadeia, plano ou comparação resulta em revisão necessária/fail-closed, nunca em aprovação automática.
+
+### 2.3. Consequência vinculante para a E20.6
+
+- O modelo operacional futuro supera a regra histórica de que todo avanço numérico de `N` para `M` exige necessariamente uma nova avaliação individual.
+- `reviewed_input_catalog_version = R` deve representar a última versão que recebeu decisão humana explícita de suficiência para aquele taxon.
+- Quando a versão atual for `C`, a preparação poderá ser derivada se:
+  - `R = C`; ou
+  - a transição resolvida `R → C` for deterministicamente `sem mudança material` ou `evolução compatível` para aquele taxon.
+- Nesses casos não se deve gravar `reviewed_input_catalog_version = C` apenas para sincronizar o número; a ausência de mutação em massa preserva a informação sobre a última revisão humana real.
+- Quando a transição exigir revisão, a E20.6.5 avalia o taxon contra `C`; somente a decisão humana final de suficiência grava `reviewed_input_catalog_version = C`.
+- Pesquisa E20.5 alterada, avaliação reaberta, marcador `NULL`, cadeia taxonômica incompatível ou falha de resolução continuam bloqueando o carry-forward.
+- A igualdade exata da E20.6.4 permanece o runtime vigente até implementação completa e validada desta evolução. Não aplicar parcialmente o novo predicado em ambiente hospedado.
+- O refinamento de UX da E20.6.5 passa a usar a versão atual como escolha normal/default quando esta autoridade existir, sem exigir que o humano memorize a versão mais recente. A avaliação de versão histórica continua possível somente quando houver finalidade explícita.
+
+### 2.4. Experiência administrativa futura
+
+- O Admin deve oferecer uma visão central da E20.2 capaz de mostrar, de forma amigável:
+  - versão atual;
+  - versões executáveis anteriores;
+  - resumo da mudança entre versões;
+  - camada em que a mudança nasceu;
+  - alcance potencial da mudança;
+  - quantidade de taxons sem mudança material;
+  - quantidade de taxons que acompanham automaticamente por compatibilidade;
+  - quantidade de taxons que precisam de revisão E20.6.
+- A interface deve permitir ver diferenças e, quando autorizado, tornar versão anterior a versão atual sem editar o histórico.
+- O humano não deve precisar visitar 100 ou 150 páginas de taxon para sincronizar uma nova versão.
+- Taxons com revisão necessária devem aparecer em uma visão agregada de pendências, com acesso ao fluxo individual E20.6.5 quando necessário.
+- A rota e a composição física dessa superfície não são definidas neste plano. A implementação deve primeiro avaliar as superfícies existentes de Estrutura da LP e Taxonomia e escolher a menor evolução coerente com o Design System.
+- Não criar job, fila, agente, automação recorrente ou nova infraestrutura apenas para produzir essa experiência sem fonte técnica posterior.
+
+### 2.5. Compatibilidade com consumidores e histórico
+
+- A versão atual é default para consumo operacional, não uma reescrita retroativa de contratos históricos.
+- Snapshots de geração, revisões de LP e qualquer artefato que registre versão usada preservam seu número original.
+- Consumidores atualmente hardcoded devem ser classificados na implementação futura:
+  - acompanham versão atual por natureza; ou
+  - permanecem pinados por contrato funcional explícito.
+- Não remover pins apenas por conveniência sem verificar a responsabilidade do consumidor.
+- A E20.6 não deve voltar a ser usada como mecanismo de sincronização de número quando a compatibilidade puder ser derivada deterministicamente.
+
+## 3. Fases e próxima ação
+
+### 3.1. E20.2.8 — Versão atual e propagação escalável
+
+- Automação: não definida/necessária neste plano; a decisão é de contrato operacional e UX.
+- Próxima ação técnica futura:
+  - reconciliar o plano com a `main` vigente no início da implementação;
+  - identificar a menor autoridade real para `versão atual` sem criar segunda residência;
+  - definir a API pública que entrega o número concreto aos consumidores;
+  - definir o comparador mínimo de compatibilidade sobre catálogos resolvidos;
+  - adaptar o predicado E20.6.4 somente como unidade completa, preservando fail-closed;
+  - projetar a experiência administrativa agregada sobre superfícies existentes antes de propor nova rota;
+  - validar propagação universal, por segmento, nicho e ultranicho, além de rollback e snapshots históricos.
+- Este PR documental não autoriza implementação, migration, schema, rota, job, agente, automação, engine ou nova infraestrutura.
+
+## 4. Escopo negativo e critérios de parada
+
+### 4.1. Fora de escopo
+
+- Não implementar `Math.max`, `latest` implícito ou descoberta automática da maior chave como autoridade operacional.
+- Não criar versão corrente por taxon.
+- Não duplicar o registry em banco apenas para resolver a versão atual.
+- Não reescrever versões ou snapshots históricos.
+- Não criar status `desativada/deprecated` sem benefício demonstrado.
+- Não criar job, fila, agente ou automação recorrente para reavaliar taxons.
+- Não aprovar semanticamente taxon por heurística determinística quando a transição for materialmente incompatível.
+- Não usar IA para classificar a compatibilidade estrutural das versões.
+- Não alterar E20.5, E19.2, E19.5 ou consumidores sem confirmar o impacto real no recorte técnico próprio.
+
+### 4.2. Critérios de parada
+
+- Parar se a autoridade de versão atual exigir nova residência sem justificativa e sem reconciliação com a arquitetura existente.
+- Parar se não for possível distinguir de forma determinística e conservadora `sem mudança material`, `evolução compatível` e `revisão necessária`.
+- Parar se a propagação puder reinterpretar snapshots históricos ou alterar silenciosamente uma geração anterior.
+- Parar se uma mudança por plano tornar o marcador taxonômico E20.6 insuficiente ou ambíguo.
+- Parar se a experiência agregada exigir nova rota, persistência ou infraestrutura antes de analisar as superfícies administrativas já existentes.
+- Parar diante de conflito material com a E20.6 vigente; a transição do predicado de igualdade exata deve ocorrer somente por implementação completa e validada, nunca por ajuste parcial.

--- a/docs/lousa-plano-base-e20-6.md
+++ b/docs/lousa-plano-base-e20-6.md
@@ -2,6 +2,7 @@
 
 - Data: 15/08/2026.
 - Versão: v2 da E20.6.5 consolidada em 20/08/2026 sobre a v1 imutável do PR #764 e aprovada pelo Analista após Passagens 1 e 2, revisões delta e ABC do roadmap.
+- Refinamento funcional/UX: decisão humana de 23/08/2026 registrada na seção 5, sem reabrir os contratos determinísticos das seções 1–4.
 - Status: E20.6.3 e E20.6.4 concluídas e operacionais; checkpoint pré-integração da E20.6.5 implementado e validado, sem integração OpenAI iniciada.
 - Recorte previsto para roadmap: `20.6 — Avaliação de suficiência factual da E20.2 por taxon`.
 - Path canônico: `docs/lousa-plano-base-e20-6.md`.
@@ -566,3 +567,102 @@ Execute a avaliação E20.6 do taxon `[taxon_slug]`, usando a cadeia taxonômica
 - Após merge e apply, parar antes do rollout somente se a API pública exigir consulta direta ao Supabase, configuração paralela, resolver/transporte exclusivo ou redesenho transversal material.
 - Parar se o caminho executável vigente não fornecer `requiredInputCatalogVersion` explicitamente a partir da leitura canônica ou se uma mudança material tornar essa autoridade ambígua; não assumir v4, v5, `latest`, maior versão, fallback nem dependência automática da E19.5.
 - Encerrar a E20.6.5 somente após o runtime do Admin executar avaliação sistemática e focal com IA em Preview e Production aprovados, preservar decisão humana separada, falhar fechado, continuar alimentando o mesmo predicado determinístico da E20.6.4 e concluir a contração documental/operacional aprovada pelo Estrategista.
+
+## 5. Refinamento funcional e de experiência da E20.6.5 — 23/08/2026
+
+### 5.1. Objetivo funcional em linguagem de produto
+
+- Este refinamento não cria nova responsabilidade funcional e não altera a semântica determinística das seções anteriores; ele explicita o objetivo da E20.6.5 em linguagem de produto e define como essa responsabilidade deve ser apresentada ao `platform_admin`.
+- A pergunta principal para o humano é: `temos os dados factuais necessários para gerar LPs confiáveis para este taxon?`.
+- A E20.6.5 existe para verificar essa suficiência com apoio semântico da IA, apontar possíveis faltas factuais reais e permitir que o humano tome a decisão administrativa final.
+- `E20.2`, `E20.5`, nomes de status, nomes de fields, camadas taxonômicas e identificadores de workload continuam sendo contratos técnicos necessários, mas não devem dominar a linguagem primária da interface.
+- O resultado útil para o humano permanece semanticamente limitado a três situações:
+  - os dados atuais parecem suficientes;
+  - existem possíveis informações factuais faltando que precisam de revisão humana;
+  - a análise não conseguiu chegar a uma conclusão segura.
+- A IA permanece não autoritativa em todos os casos: não aprova o taxon, não altera a E20.2 e não transforma recomendação em decisão administrativa.
+- Em caso de conflito apenas de terminologia de apresentação entre esta seção e a seção 2.10, prevalece esta seção 5; contratos técnicos, estados internos, validações e invariantes das seções 1–4 permanecem preservados.
+
+### 5.2. Separação entre E20.6.5 e E21.2.5
+
+- Fonte adicional deste refinamento: `docs/lousa-plano-base-e21-2-5.md`, mergeada na `main` como plano da evolução `E21.2.5 — Catálogo administrável e UX compacta dos workloads OpenAI`.
+- A E21.2.5 não altera o objetivo, a barreira de gap factual, o Structured Output, a autoridade humana ou o predicado determinístico da E20.6.5.
+- A E21.2.5 passa a responder pela elegibilidade operacional de `modelo + reasoning effort`, pelo catálogo global disponível para novas candidatas e pelo lifecycle de configuração por `ambiente + workload`.
+- A E20.6.5 responde somente pelo caso funcional de avaliação factual e consome a configuração ativa do workload `taxon_input_catalog_sufficiency_evaluation` por meio do boundary comum E21.
+- Quando a E21.2.5 estiver implementada, adicionar ou indisponibilizar combinações de modelo e effort já suportadas pelo boundary não deve exigir alteração do domínio, do prompt funcional ou da UI da E20.6.5.
+- A superfície da E20.6.5 não deve pedir ao usuário que escolha modelo, effort, revisão operacional ou fonte de configuração; essas decisões pertencem à área de Workloads OpenAI e à governança E21.
+- O bootstrap histórico `gpt-5.6-terra + low` permanece registrado nas seções anteriores como estado de implementação da E21.2 original, mas não constitui requisito funcional da E20.6.5 nem deve ser promovido a regra permanente deste recorte.
+- Uma decisão humana futura por outra combinação elegível, inclusive alteração de effort, deve ser aplicada pelo lifecycle E21 vigente e não codificada neste plano como hardcode do consumidor.
+- Novo nome de parâmetro ainda desconhecido pelo contrato tipado do boundary permanece matéria de recorte técnico E21 próprio, conforme a E21.2.5; a E20.6.5 não amplia esse vocabulário.
+
+### 5.3. Linguagem primária da interface
+
+- O título principal da superfície deve ser orientado ao objetivo humano, preferencialmente `Verificar se este nicho tem os dados necessários`, em vez de usar `Avaliação factual do catálogo E20.2` como título primário.
+- A explicação curta deve ser equivalente a: `A IA compara a pesquisa aprovada deste nicho com os dados que a LP pode precisar. Nenhuma alteração é feita automaticamente.`
+- Os identificadores internos de modo permanecem `systematic` e `hypothesis`, mas a apresentação deve usar linguagem amigável:
+  - `systematic` → `Verificação completa`, com descrição equivalente a `Procure qualquer informação factual importante que possa estar faltando.`;
+  - `hypothesis` → `Verificar uma dúvida específica`, com descrição equivalente a `Tenho uma dúvida sobre um dado que talvez precise ser coletado.`
+- Termos como `field`, `candidate_gaps`, `refine_existing_field`, `possible_new_field`, `taxonomic layer`, versão de schema e identidade do workload podem aparecer em `Detalhes técnicos`, mas não como linguagem obrigatória para compreender ou concluir a decisão.
+- A interface deve continuar adequada a `platform_admin`: simplificar linguagem não significa ocultar rastreabilidade técnica, e sim colocá-la em segundo nível de leitura.
+
+### 5.4. Apresentação do resultado e da decisão humana
+
+- Os estados internos permanecem `sufficient | candidate_gaps | inconclusive`, mas a apresentação primária deve usar:
+  - `sufficient` → `Os dados atuais parecem suficientes`;
+  - `candidate_gaps` → `Encontramos possíveis informações faltando`;
+  - `inconclusive` → `A análise não conseguiu chegar a uma conclusão segura`.
+- Para `sufficient`, a explicação deve deixar claro que a IA não encontrou uma necessidade factual adicional que tenha passado pela barreira de admissão, sem declarar aprovação automática.
+- Para `candidate_gaps`, cada candidato deve priorizar perguntas compreensíveis pelo humano:
+  - `O que pode estar faltando`;
+  - `Por que isso pode ser necessário`;
+  - `Onde essa informação seria usada`;
+  - `Já existe algo parecido hoje?`.
+- Evidência, origem operacional, consumidor, prejuízo, fields relacionados, conclusão técnica e camada sugerida continuam disponíveis, mas detalhes de contrato podem ficar em nível secundário.
+- As ações humanas devem usar verbos que expressem a decisão real, por exemplo:
+  - `Confirmar que esta versão é suficiente`;
+  - `Sim, esta informação realmente está faltando`;
+  - `Não, os dados atuais já são suficientes`;
+  - `Reavaliar`.
+- Resultado `inconclusive`, refusal, erro técnico, output inválido ou estado stale deve informar em linguagem direta que nenhuma decisão foi aplicada e manter as ações administrativas incompatíveis bloqueadas.
+- A interface não deve apresentar o JSON/Structured Output bruto como superfície principal de decisão.
+
+### 5.5. Escolha explícita da versão E20.2
+
+- A exigência arquitetural de escolha explícita da versão executável `N` permanece inalterada; este refinamento não autoriza `latest`, maior versão ou seleção implícita.
+- A linguagem primária deve ser equivalente a `Versão dos dados que você quer revisar`, mantendo `E20.2` e o identificador técnico como informação secundária quando útil.
+- A UI deve apresentar somente versões executáveis obtidas do contrato autorizado como opções explícitas e selecionáveis; não exigir que o humano memorize ou digite livremente um número positivo quando o sistema já conhece as opções válidas.
+- A existência de uma versão numericamente maior não autoriza marcá-la como `atual`, `recomendada` ou pré-selecioná-la sem uma autoridade real do produto.
+- A escolha continua efêmera para a avaliação; somente a decisão humana final de suficiência pode gravar `reviewed_input_catalog_version = N`.
+
+### 5.6. Fluxo visual da experiência
+
+- A superfície deve organizar o trabalho em quatro etapas reconhecíveis, sem criar nova rota ou lifecycle:
+  - `O que será revisado`: taxon, pesquisa selecionada e versão executável escolhida;
+  - `Como você quer verificar`: verificação completa ou dúvida específica;
+  - `Resultado da IA`: suficiente, possíveis informações faltando ou inconclusivo;
+  - `Sua decisão`: confirmar suficiência, reconhecer informação faltante ou reavaliar.
+- A ordem visual deve separar claramente recomendação da IA e decisão humana, preservando a revalidação server-side antes de qualquer mutação.
+- Feedback humano e reavaliação permanecem novas chamadas explícitas com contexto reconstruído, sem transformar a tela em chat persistente.
+- O histórico Admin → Codex permanece apenas como mecanismo legado condicionado ao gate enquanto a contração ainda não tiver sido concluída; ele não deve competir visualmente com o fluxo principal quando o runtime estiver comprovado e habilitado.
+
+### 5.7. Critérios de aceite do refinamento de experiência
+
+- Um `platform_admin` deve compreender sem instrução externa:
+  - qual pergunta a funcionalidade está tentando responder;
+  - quais dados serão confrontados;
+  - a diferença entre verificação completa e dúvida específica;
+  - que o resultado é recomendação de IA e não aprovação;
+  - qual ação humana confirma suficiência ou reconhece uma falta factual real;
+  - que falha, inconclusão ou invalidação não alteram o estado administrativo.
+- A escolha de modelo, effort e revisão operacional não aparece como responsabilidade da E20.6.5.
+- A escolha da versão E20.2 permanece explícita, porém por opções válidas e linguagem compreensível, sem regra implícita de versão mais recente.
+- Termos técnicos necessários à auditoria permanecem acessíveis em nível secundário sem serem pré-requisito para executar o fluxo corretamente.
+- Continuam obrigatórios os critérios existentes de desktop, mobile, teclado, foco, labels, feedback de erro, ausência de overflow e fail-closed; uma futura implementação deste refinamento deve executar QA proporcional somente sobre o delta de experiência realmente alterado.
+- Este refinamento não autoriza nova tabela, coluna, rota, memória, agente, job, engine ou infraestrutura; reutiliza o boundary, a rota, a persistência mínima e o lifecycle existentes.
+
+### 5.8. Consequência para o fechamento da E20.6.5
+
+- A implementação da E21.2.5 é uma dependência de governança para flexibilizar de forma correta a configuração do workload; ela não redefine a responsabilidade funcional da E20.6.5.
+- Depois que a E21.2.5 estiver implementada e operacionalmente validada, a E20.6.5 deve consumir a configuração ativa escolhida sob governança E21 e executar as provas focais necessárias à retomada do rollout, sem criar exceção hardcoded no consumidor.
+- Se o refinamento de UX desta seção for implementado antes do contract final, a validação deve concentrar-se no delta de apresentação e nas decisões humanas afetadas, preservando as provas determinísticas e operacionais já válidas que não tenham sofrido mudança material.
+- O contract final continua responsável por remover definitivamente o caminho legado somente depois de Preview e Production aprovados no runtime vigente e por reconciliar a documentação canônica com o estado operacional final.

--- a/docs/lousa-plano-base-e20-6.md
+++ b/docs/lousa-plano-base-e20-6.md
@@ -776,4 +776,8 @@ Execute a avaliação E20.6 do taxon `[taxon_slug]`, usando a cadeia taxonômica
 - O contract final não pode fechar a E20.6.5 com uma versão operacional hardcoded que contradiga a E20.2.8 já aprovada para o produto.
 - A implementação da E20.2.8 deve ocorrer como unidade completa antes de trocar o predicado atual de igualdade exata: autoridade global `V`, derivação `R → C`, comparador determinístico de compatibilidade e consumo coerente de `C` pela E19.2/E19.5.
 - Até essa implementação completa, o runtime vigente permanece inalterado e fail-closed com igualdade exata.
+- Sob a E20.2.8, quando a transição para o draft final exigir `revisão necessária`, a E20.6.5 pode avaliar administrativamente esse draft no pré-publicação.
+- Essa avaliação não torna o draft operacional e não grava antecipadamente `reviewed_input_catalog_version`.
+- A decisão humana pré-publicação fica vinculada ao conteúdo exato avaliado; qualquer edição material posterior torna essa avaliação stale.
+- O efeito administrativo dessa decisão somente nasce se aquele mesmo conteúdo for efetivamente publicado.
 - O PR #809 permanece exclusivamente documental: nenhuma tabela, coluna, migration, rota, RPC, job, agente, engine, nova infraestrutura ou alteração de runtime é autorizada por esta reconciliação.

--- a/docs/lousa-plano-base-e20-6.md
+++ b/docs/lousa-plano-base-e20-6.md
@@ -3,6 +3,7 @@
 - Data: 15/08/2026.
 - Versão: v2 da E20.6.5 consolidada em 20/08/2026 sobre a v1 imutável do PR #764 e aprovada pelo Analista após Passagens 1 e 2, revisões delta e ABC do roadmap.
 - Refinamento funcional/UX: decisão humana de 23/08/2026 registrada na seção 5, sem reabrir os contratos determinísticos das seções 1–4.
+- Reconciliação pós-Analista do PR #809: registrada na seção 7 em 23/08/2026; essa seção supera apenas as formulações conflitantes sobre `R → C`, rollback e estado da E21.2.5, preservando o histórico anterior.
 - Status: E20.6.3 e E20.6.4 concluídas e operacionais; checkpoint pré-integração da E20.6.5 implementado e validado, sem integração OpenAI iniciada.
 - Recorte previsto para roadmap: `20.6 — Avaliação de suficiência factual da E20.2 por taxon`.
 - Path canônico: `docs/lousa-plano-base-e20-6.md`.
@@ -728,3 +729,51 @@ Execute a avaliação E20.6 do taxon `[taxon_slug]`, usando a cadeia taxonômica
 - Não criar nova persistência de aprovação apenas para propagar versões sem demonstrar necessidade; o desenho preferencial evita writes de sincronização quando a compatibilidade pode ser derivada.
 - Qualquer necessidade de nova tabela, coluna, view, RPC, rota ou infraestrutura deve voltar ao planejamento com fonte real do repositório, `docs/schema.md` e `docs/base-tecnica.md` antes de implementação.
 - O contract final da E20.6.5 não deve encerrar o recorte ignorando a E20.2.8 se essa evolução já estiver aprovada para o produto; deve reconciliar a versão atual, a UX amigável e a governança E21.2.5 como contratos distintos porém compatíveis.
+
+## 7. Reconciliação pós-Analista do PR #809 — 23/08/2026
+
+### 7.1. Autoridade canônica entre revisão humana e versão operacional
+
+- Esta seção supera, para a futura E20.2.8, a formulação simplificada da seção 6.2 que usa `C` apenas como sinônimo de versão global atual.
+- `R` é a última versão humanamente revisada e continua representada por `reviewed_input_catalog_version`.
+- `V` é a versão global atual da E20.2.
+- `C` é a versão operacional efetivamente autorizada pelo boundary canônico de preparação para aquele taxon.
+- No fluxo normal, o boundary produz `C = V` quando `R = V` ou quando a transição resolvida `R → V` for deterministicamente `sem mudança material` ou `evolução compatível`.
+- Quando `R → V` exigir revisão, a versão global atual não é promovida silenciosamente a `C`; o taxon permanece bloqueado para essa versão até nova decisão humana de suficiência.
+- O resultado conceitual da preparação deve preservar separadamente `R` para auditoria da última decisão humana e `C` para consumo operacional corrente; a nomenclatura física da API será reconciliada no recorte técnico, sem autorizar nova persistência por este documento.
+- Não regravar `R = C` apenas para sincronizar número quando a autorização de `C` vier de carry-forward determinístico.
+
+### 7.2. Consumidores materiais obrigatórios de `C`
+
+- A implementação futura da E20.2.8 deve tratar explicitamente os consumidores reais já presentes na `main`:
+  - E19.2 pré-handoff consome `C` como versão operacional para resolução, validação e persistência de configuração nova ou ainda não vinculada;
+  - E19.5 workspace consome `C` para resolver e salvar a configuração operacional corrente;
+  - geração via E19.5 consome exatamente a mesma `C` usada pelo workspace e pela revalidação operacional.
+- Nenhum desses consumidores pode resolver `versão atual` localmente, consultar `Math.max`, inferir `latest`, manter um novo pin substituto ou usar `R` como se fosse necessariamente a versão operacional autorizada.
+- O pin vigente `LANDING_PAGE_WORKSPACE_REQUIRED_INPUT_CATALOG_VERSION = 5` e contratos equivalentes somente podem ser removidos/reconciliados dentro da implementação completa da E20.2.8, quando a autoridade única de `C` estiver disponível.
+- Configurações E19.2/E19.5 já persistidas continuam registrando o `catalog_version` realmente usado em sua escrita; revisões, materializações e snapshots preservam a versão efetivamente usada e não são reinterpretados pela mudança de `V` ou `C`.
+- Revalidação histórica pode ler a versão persistida para compreender o estado anterior, mas qualquer nova operação corrente usa a `C` autorizada e permanece fail-closed diante de incompatibilidade.
+
+### 7.3. Rollback operacional deferido
+
+- Esta seção supera integralmente a seção 6.6 para a primeira entrega da E20.2.8.
+- Tornar uma versão executável anterior novamente a versão atual não integra o MVP da E20.2.8.
+- O motivo é material: a E19.5 pode possuir valores persistidos para fields introduzidos em versões posteriores, e o contrato vigente rejeita como `INVALID_CONFIGURATION` um valor cujo `fieldKey` não exista no catálogo usado para resolver a residência.
+- Suportar rollback corretamente exigiria definir preservação, inativação/projeção e recuperação de valores posteriores sem perda de dados e sem relaxar a validação fail-closed; isso amplia desnecessariamente o recorte atual.
+- Se uma versão publicada apresentar defeito nesta primeira entrega, o fluxo operacional previsto é corrigi-la e publicar nova versão forward-only.
+- Rollback poderá ser reaberto somente em evolução própria após existir contrato explícito com as residências E19.5 e os snapshots históricos.
+
+### 7.4. Estado factual da E21.2.5
+
+- Esta seção supera o tempo futuro usado nas seções 5.2 e 5.8 sobre a implementação da E21.2.5.
+- A implementação repo-side da E21.2.5 já foi mergeada na `main` pelos PRs #807 e #810.
+- O catálogo global administrável e a separação entre elegibilidade de modelo/parâmetro e lifecycle por workload já pertencem ao código vigente; isso não altera a responsabilidade funcional da E20.6.5.
+- Os gates operacionais pós-merge da E21.2.5 — apply canônico, Security Controls e QA hospedado conforme seu próprio plano/estado — permanecem independentes do PR #809 e não são declarados concluídos aqui.
+- A E20.6.5 continua sem expor modelo, effort ou revisão operacional como escolha da sua superfície funcional; consome a configuração ativa sob governança E21 quando operacionalmente comprovada.
+
+### 7.5. Consequência para o contract final da E20.6.5
+
+- O contract final não pode fechar a E20.6.5 com uma versão operacional hardcoded que contradiga a E20.2.8 já aprovada para o produto.
+- A implementação da E20.2.8 deve ocorrer como unidade completa antes de trocar o predicado atual de igualdade exata: autoridade global `V`, derivação `R → C`, comparador determinístico de compatibilidade e consumo coerente de `C` pela E19.2/E19.5.
+- Até essa implementação completa, o runtime vigente permanece inalterado e fail-closed com igualdade exata.
+- O PR #809 permanece exclusivamente documental: nenhuma tabela, coluna, migration, rota, RPC, job, agente, engine, nova infraestrutura ou alteração de runtime é autorizada por esta reconciliação.

--- a/docs/lousa-plano-base-e20-6.md
+++ b/docs/lousa-plano-base-e20-6.md
@@ -666,3 +666,65 @@ Execute a avaliação E20.6 do taxon `[taxon_slug]`, usando a cadeia taxonômica
 - Depois que a E21.2.5 estiver implementada e operacionalmente validada, a E20.6.5 deve consumir a configuração ativa escolhida sob governança E21 e executar as provas focais necessárias à retomada do rollout, sem criar exceção hardcoded no consumidor.
 - Se o refinamento de UX desta seção for implementado antes do contract final, a validação deve concentrar-se no delta de apresentação e nas decisões humanas afetadas, preservando as provas determinísticas e operacionais já válidas que não tenham sofrido mudança material.
 - O contract final continua responsável por remover definitivamente o caminho legado somente depois de Preview e Production aprovados no runtime vigente e por reconciliar a documentação canônica com o estado operacional final.
+
+## 6. Escalabilidade da E20.6 diante da versão atual da E20.2 — 23/08/2026
+
+### 6.1. Fonte e relação com a E20.2.8
+
+- Fonte vinculante deste refinamento: `docs/lousa-plano-base-e20-2-8.md`.
+- A E20.2.8 cria o contrato de produto de uma versão atual global da E20.2 e de propagação hierárquica escalável; esta seção registra apenas a consequência sobre a suficiência e a experiência E20.6.
+- O runtime atual continua usando igualdade exata de versão e escolha explícita enquanto a E20.2.8 não estiver implementada e validada. Esta seção não autoriza mudança parcial do gate vigente.
+- Quando a E20.2.8 entrar em vigor, as regras desta seção superam somente os pontos históricos que exigem nova avaliação por simples incremento numérico de versão ou seleção manual da versão corrente; autoridade humana, pesquisa E20.5, fail-closed e avaliação semântica permanecem preservados.
+
+### 6.2. Nova semântica de preparação
+
+- `reviewed_input_catalog_version = R` passa a representar a última versão que recebeu decisão humana explícita de suficiência para o taxon.
+- A versão atual E20.2 `C` é a referência operacional normal para preparação e para novas avaliações.
+- O taxon poderá ser derivado como preparado quando:
+  - `R = C`; ou
+  - a transição do catálogo resolvido `R → C` for deterministicamente classificada como `sem mudança material` ou `evolução compatível` conforme a E20.2.8.
+- O sistema não deve regravar `reviewed_input_catalog_version = C` apenas para sincronizar um taxon cuja suficiência foi carregada por compatibilidade.
+- A ausência de escrita em massa preserva a informação correta sobre qual foi a última revisão humana real e impede que uma atualização global gere centenas de mutações administrativas artificiais.
+- Pesquisa E20.5 alterada, avaliação reaberta, marcador `NULL`, cadeia incompatível, falha de resolução ou compatibilidade inconclusiva continuam bloqueando a preparação.
+
+### 6.3. Quando a E20.6.5 deve executar novamente
+
+- Nova avaliação semântica individual é necessária somente quando a transição para a versão atual for classificada como `revisão necessária` ou quando a avaliação anterior estiver ausente/inválida por outro motivo previsto no contrato.
+- Taxon sem mudança material entre versões não deve chamar IA apenas porque o número mudou.
+- Taxon com evolução compatível não deve chamar IA apenas para confirmar uma ampliação factual determinística já provada como não destrutiva.
+- Taxon com alteração potencialmente destrutiva, restritiva, reinterpretativa ou impossível de classificar deterministicamente deve continuar fail-closed e entrar na E20.6.5.
+- A decisão final após nova avaliação permanece humana; somente suficiência explicitamente confirmada grava a versão atual no marcador.
+
+### 6.4. Experiência normal da E20.6.5 com versão atual
+
+- Quando a autoridade de versão atual existir, a interface E20.6.5 deve tratar essa versão como alvo normal/default da verificação.
+- O humano não deve precisar descobrir qual é o maior número nem escolher manualmente a versão corrente em cada taxon.
+- A versão continua visível e auditável na interface, mas sua seleção deixa de ser uma tarefa repetitiva no fluxo normal.
+- Avaliação de versão histórica pode continuar disponível quando existir finalidade explícita de diagnóstico ou reprodução; não deve competir com o fluxo padrão.
+- A seção 5.5 permanece histórica para o runtime atual; após a E20.2.8, sua exigência de escolha manual da versão corrente é substituída pela autoridade explícita de versão atual, sem introduzir `Math.max` ou `latest` inferido.
+
+### 6.5. Visão agregada das pendências
+
+- O Admin deve permitir identificar centralmente quais taxons:
+  - acompanham a nova versão sem mudança material;
+  - acompanham automaticamente por evolução compatível;
+  - precisam realmente de revisão E20.6.
+- O humano não deve ser obrigado a abrir dezenas ou centenas de taxons apenas para descobrir quais ficaram pendentes.
+- A página individual da Taxonomia continua sendo uma superfície válida para executar/revisar um taxon, mas deixa de ser a única forma de localizar trabalho pendente.
+- A rota e a composição da visão agregada não são definidas aqui. A implementação deve avaliar as superfícies existentes e escolher a menor evolução coerente, sem criar nova rota por antecipação.
+- Este refinamento não cria job, fila, agente, rotina recorrente ou processamento em background; apenas define que o resultado de impacto deve ser apresentável de forma agregada.
+
+### 6.6. Rollback
+
+- Se a versão atual E20.2 voltar de `C` para uma versão executável anterior `P`, a E20.6 deve derivar preparação usando `P` como alvo operacional.
+- A compatibilidade entre a última versão humanamente revisada do taxon e `P` deve ser reavaliada deterministicamente; não presumir que uma versão antiga já foi aprovada se o estado atual não consegue provar isso.
+- Taxons compatíveis continuam operacionais sem mutação em massa; taxons incompatíveis ou inconclusivos entram na visão agregada de revisão necessária.
+- Rollback não altera pesquisas E20.5, não reescreve marcadores e não apaga decisões históricas existentes.
+
+### 6.7. Limites de implementação
+
+- Não implementar este novo predicado de preparação antes de existir a autoridade E20.2 de versão atual e o comparador determinístico de compatibilidade aprovados no mesmo recorte técnico.
+- Não usar a IA para decidir se uma transição de versão é estruturalmente compatível.
+- Não criar nova persistência de aprovação apenas para propagar versões sem demonstrar necessidade; o desenho preferencial evita writes de sincronização quando a compatibilidade pode ser derivada.
+- Qualquer necessidade de nova tabela, coluna, view, RPC, rota ou infraestrutura deve voltar ao planejamento com fonte real do repositório, `docs/schema.md` e `docs/base-tecnica.md` antes de implementação.
+- O contract final da E20.6.5 não deve encerrar o recorte ignorando a E20.2.8 se essa evolução já estiver aprovada para o produto; deve reconciliar a versão atual, a UX amigável e a governança E21.2.5 como contratos distintos porém compatíveis.


### PR DESCRIPTION
## 1. Escopo

- Registra em `docs/lousa-plano-base-e20-6.md` o refinamento funcional e de experiência da E20.6.5.
- Cria e consolida `docs/lousa-plano-base-e20-2-8.md` como plano da evolução `E20.2.8 — Versão atual e propagação escalável do catálogo E20.2`, preservando o histórico da E20.2.
- Fecha documentalmente o lifecycle do MVP após as revisões Humano ↔ Analista ↔ Estrategista, sem implementação física neste PR.

## 2. Lifecycle consolidado da E20.2.8

- Existe uma única versão publicada atual global.
- Pode existir no máximo uma próxima versão em draft.
- O draft é mutável, acumulativo e não operacional; E19.2, E19.5 e geração nunca o consomem como versão efetiva.
- Salvar o draft não cria nova versão histórica nem histórico de cada salvamento.
- `Publicar` é o único evento que congela o draft, transforma-o em versão publicada imutável e o torna a nova versão atual global.
- Não existe segundo passo de `tornar atual`, seletor de versão titular, múltiplos drafts, branches de catálogo ou rollback no MVP.
- Problemas após publicação são corrigidos forward-only pela próxima versão.

## 3. Autoridade `R → C`

- `R = reviewed_input_catalog_version`: última versão com decisão humana explícita de suficiência.
- `V`: versão global atual publicada.
- `C`: versão operacional efetivamente autorizada pelo boundary canônico de preparação.
- O boundary pode produzir `C = V` quando `R = V` ou quando `R → V` for deterministicamente `sem mudança material` ou `evolução compatível`.
- Carry-forward não regrava `R` artificialmente.
- E19.2 pré-handoff, E19.5 workspace e geração E19.5 consomem a mesma `C`; nenhum deles resolve `latest`, maior versão ou versão atual localmente.
- Configurações, residências, revisões, materializações e snapshots preservam a versão realmente usada.

## 4. Lifecycle dos fields

- Field criado somente no draft pode ser editado, renomeado, corrigido ou excluído livremente antes da primeira publicação.
- Depois de publicado, seu contrato histórico permanece imutável nas versões em que existiu.
- Quando deixar de ser necessário, o field é `retirado a partir da nova versão`, em evolução forward-only.
- O MVP usa `retirado`, não lifecycle `ativo/inativo` nem reativação.
- `optional` e `required` usam o mesmo mecanismo de retirada; se era `required`, deixa também de participar da completude na nova versão.
- Valor antigo pode permanecer armazenado: field historicamente publicado e depois retirado deve continuar reconhecível porém inerte; key que nunca pertenceu a contrato publicado continua inválida/fail-closed.
- Retirada não cria override hierárquico: camada inferior não pode desligar field herdado ainda vigente em camada superior.
- Toda retirada de field publicado é `revisão necessária` para os taxons afetados no MVP; não há otimização por equivalência semântica entre fields nesta primeira entrega.

## 5. Pré-publicação

- Draft não operacional continua resolvível e validável administrativamente.
- Impacto é calculado sobre o conteúdo integral final do draft.
- Qualquer edição material torna stale as evidências dependentes: impacto estrutural, compatibilidade por taxon, avaliação E20.6.5 pré-publicação e prova de validade estrutural das configurações operacionais correntes.
- A publicação avalia duas dimensões separadas:
  - suficiência taxonômica E20.6;
  - validade estrutural das configurações operacionais E19.
- Taxon já operacional que cair em `revisão necessária` deve resolver essa pendência antes da publicação; taxon não operacional pode permanecer pendente sem bloquear a versão global.
- Configuração operacional corrente deve continuar válida/legível.
- Novo `required` sem valor anterior pode produzir estado `válido, porém incompleto`; isso não bloqueia publicação e apenas bloqueia ações que dependem de completude até o preenchimento.
- Mudança que torne configuração corrente inválida/ilegível bloqueia publicação.
- Snapshots e revisões históricas não são revalidados contra o draft.

## 6. E20.6.5 sobre draft

- A E20.6.5 pode analisar administrativamente o draft final quando houver `revisão necessária`.
- Essa análise não torna o draft operacional nem permite consumo por E19.
- A decisão humana fica vinculada ao conteúdo exato avaliado; alteração material posterior a torna stale.
- A avaliação pré-publicação não grava prematuramente `reviewed_input_catalog_version` como se o draft já estivesse publicado.
- O efeito administrativo somente pode nascer quando exatamente aquele conteúdo for publicado; o mecanismo físico não é definido neste PR.

## 7. E21.2.5

- E21.2.5 governa catálogo de modelos, parâmetros e lifecycle operacional dos workloads OpenAI; E20.6.5 continua responsável pelo caso funcional de suficiência factual.
- A implementação repo-side da E21.2.5 foi mergeada pelos PRs #807 e #810.
- Gates operacionais próprios da E21.2.5 permanecem independentes deste PR documental.

## 8. Limites preservados

- Alteração exclusivamente documental; nenhuma implementação de código, banco, migration, rota, RPC, job, agente, automação, engine ou nova infraestrutura.
- O runtime vigente da E20.6.4 continua com igualdade exata até implementação completa e validada da E20.2.8.
- Nenhum `Math.max`/`latest` implícito.
- Nenhum rollback operacional no MVP.
- Nenhuma deleção retroativa de versões, fields publicados, residências ou snapshots.
- Nenhuma IA decide compatibilidade estrutural entre versões.
- A residência física do draft, da versão atual, do efeito das decisões pré-publicação e da ação `Publicar` permanece decisão do futuro recorte técnico, após análise de `docs/schema.md`, `docs/base-tecnica.md` e boundaries reais.

## 9. Validação

- Consolidação final registrada em `docs/lousa-plano-base-e20-2-8.md`, seção 5, em 24/08/2026.
- `docs/lousa-plano-base-e20-6.md` mantém a E20.2.8 como fonte vinculante para sua consequência funcional e preserva o histórico das formulações anteriores.
- PR continua exclusivamente documental.
- `npm ci`: não aplicável.
- `npm run check`: não aplicável.
- Merge final permanece humano.