### PR TITLE
fix(e21.2.5): habilitar RLS antes do bootstrap

### DIFF
--- a/supabase/migrations/20260823144334_e21_2_5_openai_model_catalog.sql
+++ b/supabase/migrations/20260823144334_e21_2_5_openai_model_catalog.sql
@@ -78,6 +78,9 @@ create index openai_model_catalog_parameters_updated_by_idx
   on public.openai_model_catalog_parameters (updated_by)
   where updated_by is not null;
 
+alter table public.openai_model_catalog_models enable row level security;
+alter table public.openai_model_catalog_parameters enable row level security;
+
 create or replace function public.prevent_openai_model_catalog_delete_v1()
 returns trigger
 language plpgsql
@@ -922,9 +925,6 @@ alter function public.save_openai_workload_configuration_candidate_v1(text, text
   owner to postgres;
 alter function public.promote_openai_workload_configuration_candidate_v1(text, text, jsonb, uuid, bigint)
   owner to postgres;
-
-alter table public.openai_model_catalog_models enable row level security;
-alter table public.openai_model_catalog_parameters enable row level security;
 
 revoke all on table public.openai_model_catalog_models
   from public, anon, authenticated, service_role;


### PR DESCRIPTION
## Contexto

Correção mínima pós-merge do PR #807. A migration `20260823144334_e21_2_5_openai_model_catalog.sql` ainda não foi aplicada.

## Correção

- Move `ENABLE ROW LEVEL SECURITY` das duas tabelas do catálogo para imediatamente após a criação das tabelas/índices.
- Garante RLS habilitado antes da criação/execução do constraint trigger diferido e antes do bootstrap/DML.
- Preserva integralmente funções, triggers, bootstrap, grants, revokes e demais contratos.

## Escopo

- Um único arquivo alterado.
- Nenhuma migration nova.
- Nenhum apply manual ou remoto.
- Nenhuma alteração de runtime, UI, allowlist ou lifecycle.

## Validações

- `npm ci`: aprovado.
- Validação focal de ordem: cada `ENABLE ROW LEVEL SECURITY` ocorre exatamente uma vez e antes do constraint trigger diferido e do primeiro DML.
- `npm run check`: aprovado, 0 erros e 24 warnings preexistentes.
- `git diff --check`: aprovado.
- Execução SQL local não disponível por ausência de `psql`, Docker, Podman e Supabase CLI; a migration não foi aplicada.