### PR TITLE
fix(e21.2.5): corrigir contraste dos botões primários

### DIFF
--- a/app/admin/(protected)/workloads-openai/_components/OpenAiModelCatalogManager.tsx
+++ b/app/admin/(protected)/workloads-openai/_components/OpenAiModelCatalogManager.tsx
@@ -30,7 +30,7 @@ const initialState: OpenAiModelCatalogActionState = {
 const buttonClassName =
   "inline-flex min-h-11 items-center justify-center rounded-md border border-border bg-background px-3 py-2 text-sm font-medium text-foreground outline-none transition hover:bg-muted focus-visible:ring-4 focus-visible:ring-brand-600/30 disabled:cursor-not-allowed disabled:opacity-60";
 const primaryButtonClassName =
-  "inline-flex min-h-11 items-center justify-center rounded-md bg-brand-600 px-4 py-2 text-sm font-medium text-white outline-none transition hover:bg-brand-700 focus-visible:ring-4 focus-visible:ring-brand-600/30 disabled:cursor-not-allowed disabled:opacity-60";
+  "inline-flex min-h-11 items-center justify-center rounded-md bg-brand-700 px-4 py-2 text-sm font-medium text-white outline-none transition hover:bg-brand-dark-800 focus-visible:ring-4 focus-visible:ring-brand-600/30 disabled:cursor-not-allowed disabled:opacity-60";
 const fieldClassName =
   "mt-1 min-h-11 w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground outline-none focus-visible:ring-4 focus-visible:ring-brand-600/30 disabled:cursor-not-allowed disabled:opacity-60";
 

--- a/app/admin/(protected)/workloads-openai/_components/OpenAiWorkloadDetail.tsx
+++ b/app/admin/(protected)/workloads-openai/_components/OpenAiWorkloadDetail.tsx
@@ -57,7 +57,7 @@ const eventLabels = {
 const selectClassName =
   "mt-1 min-h-11 w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground outline-none focus-visible:ring-4 focus-visible:ring-brand-600/30 disabled:cursor-not-allowed disabled:opacity-60";
 const primaryButtonClassName =
-  "inline-flex min-h-11 items-center justify-center rounded-md bg-brand-600 px-4 py-2 text-sm font-medium text-white outline-none transition hover:bg-brand-700 focus-visible:ring-4 focus-visible:ring-brand-600/30 disabled:cursor-not-allowed disabled:opacity-60";
+  "inline-flex min-h-11 items-center justify-center rounded-md bg-brand-700 px-4 py-2 text-sm font-medium text-white outline-none transition hover:bg-brand-dark-800 focus-visible:ring-4 focus-visible:ring-brand-600/30 disabled:cursor-not-allowed disabled:opacity-60";
 const secondaryButtonClassName =
   "inline-flex min-h-11 items-center justify-center rounded-md border border-border bg-background px-4 py-2 text-sm font-medium text-foreground outline-none transition hover:bg-muted focus-visible:ring-4 focus-visible:ring-brand-600/30 disabled:cursor-not-allowed disabled:opacity-60";
 


### PR DESCRIPTION
## Contexto

Correção mínima do gate de contraste hospedado da E21.2.5.

## Alteração

- troca somente os botões primários de OpenAiModelCatalogManager.tsx e OpenAiWorkloadDetail.tsx de rand-600 para rand-700;
- usa rand-dark-800 no hover;
- preserva foco, estados disabled, banco, lifecycle e escopo funcional.

## Contraste

- normal renderizado no Preview: branco 14px/500 sobre gb(23, 99, 214) = 5,54:1;
- hover compilado no Preview: .hover\\:bg-brand-dark-800:hover resolve para gb(15, 43, 92) = 13,81:1;
- ambos superam 4,5:1 para texto normal.

## Validações

- 
pm ci: aprovado;
- 
pm run check: aprovado, 0 erros e 24 warnings preexistentes;
- git diff --check: aprovado;
- revisão React focal: sem alteração estrutural, de hooks, tipos ou performance;
- deployment Preview autenticado: aprovado para o escopo do contraste.

## Gates preservados

- nenhum banco, migration ou lifecycle alterado;
- QA mobile e papel negativo permanecem pendentes até merge/deploy;
- ABC final não consolidado;
- E21.3 não iniciada.