### PR TITLE
docs(e21.2.5): consolidar ABC final

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data: 23/08/2026
-• Versão: v1.5.181
+• Data: 24/08/2026
+• Versão: v1.5.182
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -2781,7 +2781,7 @@ Repositório — Ajustados
 
 21. E21 — Gestão e governança dos workloads OpenAI
 - Objetivo: gerir e governar os workloads OpenAI por recortes aprovados, com configuração explícita, observabilidade segura, leitura administrativa e configuração operacional dinâmica por ambiente, sem otimização automatizada.
-- Status: a fundação E21.1 permanece preservada; a entrega original da E21.2 está concluída com cutover aprovado em Preview e Production; a E21.2.5 está implementada no PR #807 e aguarda merge humano e gates pós-merge; a E21.3 permanece prevista e não iniciada.
+- Status: a fundação E21.1 permanece preservada; a E21.2, incluindo o catálogo operacional da E21.2.5, está concluída com apply e gates hospedados aprovados; a E21.3 permanece prevista e não iniciada.
 
 21.1 Fundação, normalização e leitura dos workloads OpenAI
 
@@ -2853,7 +2853,7 @@ Repositório — Ajustados
 
 21.2.1 Objetivo e status
 - Objetivo: permitir configuração ativa por ambiente e workload, com candidata, validação, ativação humana, rollback e mudança ordinária sem redeploy.
-- Status: a entrega original foi concluída em 21/08/2026, com migration aplicada, gates hospedados aprovados e cutover operacional em Preview e Production; a E21.2.5 está implementada no PR #807, com merge, apply e validações hospedadas ainda pendentes.
+- Status: concluída em 24/08/2026, com fonte operacional e catálogo global aplicados, cutover preservado em Preview e Production e gates hospedados integralmente aprovados.
 - O recorte preserva a E21.1 como boundary transversal, mantém Development determinístico/local e deixa a E21.3 prevista, sem início de execução.
 
 21.2.2 Registros do recorte
@@ -2950,13 +2950,15 @@ Repositório — Ajustados
 - `OPENAI_API_KEY` permaneceu server-side e foi reutilizada sem cópia, exposição ou versionamento. A E21.3 não foi iniciada.
 
 21.2.5 Catálogo administrável e UX compacta dos workloads OpenAI
-- Status: Implementação repo-only concluída no PR #807; merge humano, apply da migration, snippet read-only, Security Controls e QA hospedado permanecem pendentes.
+- Status: Concluída em 24/08/2026; catálogo aplicado e QA hospedado/autenticado integralmente aprovado em Production.
 - Automação: não.
 - O catálogo global separa elegibilidade corrente de novas candidatas do lifecycle por ambiente e workload; save e promoção revalidam a combinação de forma transacional, e a prova confirma a elegibilidade imediatamente antes do transporte sem manter lock durante a chamada externa.
 - Falha ou indisponibilidade exclusiva do catálogo bloqueia catálogo, save, prova e promoção, sem afetar resolução ativa, ativação de revisão validada ou rollback histórico; revisões e snapshots preservam qualquer identificador técnico com parâmetro tipado válido.
 - As leituras administrativas são completas, ordenadas e fail-closed; páginas acumuladas só são aceitas no término esperado, nunca após erro ou resposta parcial.
 - A superfície administrativa mantém catálogo global superior, seletor Preview/Production, lista compacta com cabeçalho sticky e um detalhe expandido; a geração de Landing Page agrupa texto e imagem apenas visualmente, preservando lifecycle independente.
-- Apply, prova SQL, Security Controls e QA autenticado de papéis, desktop/mobile, lifecycle e WCAG 2.2 permanecem gates pós-merge. A E21.3 não foi iniciada.
+- A migration foi aplicada pelo fluxo canônico; o snippet read-only aprovou 8/8 verificações e o Security Controls não apresentou alerta incompatível com tabelas, constraints, RLS, policies, grants, RPCs ou triggers do catálogo. O INFO de RLS sem policy permaneceu compatível com a residência exclusiva de `service_role`.
+- O QA autenticado de Production aprovou `platform_admin` em desktop 1280 × 720 e mobile responsivo 482 × 698, sem overflow horizontal, com cabeçalho sticky, controles da superfície de 44 px ou mais, nomes/labels, lifecycle reconhecível e contraste de 5,54:1 no estado normal e 13,81:1 no hover dos botões primários.
+- O papel negativo foi redirecionado para o estado de acesso indisponível, sem formulário, catálogo, lifecycle ou controle administrativo exposto. O QA não alterou catálogo, candidata, revisão ou lifecycle; a E21.3 não foi iniciada.
 
 21.3 Evidências e avaliação de custo-benefício dos workloads OpenAI
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data da última atualização: 23/08/2026
-• Documento: LP Factory 10 — Schema (DB Contract) v1.0.54
+• Data da última atualização: 24/08/2026
+• Documento: LP Factory 10 — Schema (DB Contract) v1.0.55
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -1027,7 +1027,7 @@
 • RLS habilitado, zero policies e ACLs idênticas às da tabela de modelos; o trigger `openai_model_catalog_parameters_prevent_delete` rejeita DELETE.
 • Migration forward-only: `supabase/migrations/20260823144334_e21_2_5_openai_model_catalog.sql`.
 • Teste transacional: `supabase/tests/e21_2_5_openai_model_catalog.test.sql`; verificador read-only: `supabase/snippets/e21_2_5_openai_model_catalog_verify.sql`.
-• Estado atual: contrato materializado no PR técnico, sem apply hospedado; apply, snippet real e Security Controls permanecem gates pós-merge.
+• Estado atual: migration aplicada no ambiente hospedado pelo fluxo canônico; o verificador read-only aprovou 8/8 verificações e o Security Controls não apresentou alerta incompatível com as tabelas, constraints, RLS, policies, ACLs, RPCs ou triggers do catálogo. O INFO de RLS sem policy é esperado e compatível com acesso exclusivo por service_role.
 
 2. Views
 


### PR DESCRIPTION
## Resultado

Consolida o ABC final da E21.2.5 após aprovação integral dos gates pós-apply e pós-merge.

## Evidências finais

- migration 20260823144334_e21_2_5_openai_model_catalog.sql aplicada pelo fluxo canônico;
- snippet read-only versionado: 8/8 verificações ok;
- Security Controls: nenhum alerta incompatível com os objetos do catálogo; INFO de RLS sem policy compatível com acesso exclusivo por service_role;
- Production platform_admin, desktop 1280 × 720: contraste normal 5,54:1 e hover 13,81:1, sem overflow horizontal;
- Production platform_admin, mobile responsivo 482 × 698: cabeçalho sticky, sem overflow horizontal, controles da superfície com 44 px ou mais, labels/names e lifecycle aprovados;
- papel negativo +convite7: redirecionado para acesso indisponível, sem formulário, catálogo, lifecycle ou controle administrativo;
- nenhuma mutação de catálogo, candidata, revisão, banco ou lifecycle durante o QA.

## Delta ABC

- docs/roadmap.md: v1.5.182, fechamento da E21.2.5 e preservação explícita da E21.3 como não iniciada;
- docs/schema.md: v1.0.55, estado de apply e gates reais do catálogo;
- Base Técnica, Design System e Platform Config: sem alterações necessárias segundo os gates de residência documental.

## Validações

- git diff --check: aprovado;
- 
pm ci: não aplicável, delta exclusivamente documental;
- 
pm run check: não aplicável, delta exclusivamente documental;
- revisão do diff main...HEAD: somente os dois documentos autorizados.

A E21.3 não foi iniciada. O merge final permanece humano.