### PR TITLE
E20.2.8 — versão atual e propagação escalável do catálogo

### DIFF
--- a/app/admin/(protected)/estrutura-lp/_components/AdminInputCatalogLifecycle.tsx
+++ b/app/admin/(protected)/estrutura-lp/_components/AdminInputCatalogLifecycle.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { useActionState } from "react";
+
+import type { AdminInputCatalogLifecycleState } from "@/lib/admin/adapters/adminInputCatalogLifecycleAdapter";
+import {
+  initialInputCatalogLifecycleActionState,
+  initializeInputCatalogDraftAction,
+  prepareInputCatalogPublicationAction,
+  reconcileInputCatalogPublishedDraftAction,
+  saveInputCatalogDraftAction,
+  validateInputCatalogDraftAction,
+} from "../actions";
+
+export function AdminInputCatalogLifecycle({
+  state,
+}: {
+  state: AdminInputCatalogLifecycleState;
+}) {
+  const [initializeState, initializeAction, initializePending] = useActionState(
+    initializeInputCatalogDraftAction,
+    initialInputCatalogLifecycleActionState,
+  );
+  const [saveState, saveAction, savePending] = useActionState(
+    saveInputCatalogDraftAction,
+    initialInputCatalogLifecycleActionState,
+  );
+  const [validationState, validationAction, validationPending] = useActionState(
+    validateInputCatalogDraftAction,
+    initialInputCatalogLifecycleActionState,
+  );
+  const [publicationState, publicationAction, publicationPending] = useActionState(
+    prepareInputCatalogPublicationAction,
+    initialInputCatalogLifecycleActionState,
+  );
+  const [reconciliationState, reconciliationAction, reconciliationPending] = useActionState(
+    reconcileInputCatalogPublishedDraftAction,
+    initialInputCatalogLifecycleActionState,
+  );
+  const feedback = [reconciliationState, publicationState, validationState, saveState, initializeState]
+    .find((item) => item.revision > 0);
+  const draft = state.draft;
+
+  return (
+    <section
+      aria-labelledby="input-catalog-lifecycle-title"
+      className="space-y-4 rounded-lg border border-border bg-card p-4"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Lifecycle repo-only
+          </p>
+          <h2 id="input-catalog-lifecycle-title" className="mt-1 text-lg font-semibold text-foreground">
+            Versão atual e próximo draft
+          </h2>
+          <p className="mt-1 max-w-3xl text-sm leading-6 text-muted-foreground">
+            A versão publicada permanece no repositório. O draft abaixo é administrativo,
+            não operacional e só prepara um handoff para materialização, revisão e deploy.
+          </p>
+        </div>
+        <span className="rounded-full bg-brand-50 px-3 py-1 text-sm font-semibold text-brand-700">
+          Atual v{state.currentVersion}
+        </span>
+      </div>
+
+      <dl className="grid gap-2 text-sm sm:grid-cols-3">
+        <Metric label="Versões publicadas" value={state.publishedVersions.join(", ")} />
+        <Metric label="Taxons ativos" value={String(state.totalActiveTaxons)} />
+        <Metric label="Taxons operacionais" value={String(state.totalOperationalTaxons)} />
+      </dl>
+
+      {state.error ? (
+        <Status tone="error">{state.error}</Status>
+      ) : null}
+      {feedback?.error ? <Status tone="error">{feedback.error}</Status> : null}
+      {feedback?.message ? <Status tone="success">{feedback.message}</Status> : null}
+
+      {!state.error && !draft ? (
+        <form action={initializeAction}>
+          <ActionButton pending={initializePending} pendingLabel="Criando draft…">
+            Criar próximo draft v{state.currentVersion + 1}
+          </ActionButton>
+        </form>
+      ) : null}
+
+      {draft ? (
+        <div className="space-y-4">
+          <div className="grid gap-2 text-sm sm:grid-cols-2 lg:grid-cols-5">
+            <Metric label="Draft" value={`v${draft.targetVersion}`} />
+            <Metric label="Revisão administrativa" value={String(draft.revision)} />
+            <Metric label="Validação" value={draft.validationCurrent ? "Atual" : "Pendente"} />
+            <Metric label="Handoff" value={draft.publicationPrepared ? "Preparado" : "Pendente"} />
+          </div>
+
+          {draft.publishedReconciliationRequired ? (
+            <div className="rounded-md border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-900">
+              <p className="font-semibold">Registry implantado e fingerprint comprovado</p>
+              <p className="mt-1">
+                {draft.publishedReconciliationAllowed
+                  ? "Encerre somente a residência temporária. Esta ação não publica nem altera a versão atual."
+                  : "A reconciliação permanece bloqueada neste ambiente e só pode ser concluída no runtime de Production."}
+              </p>
+              <form action={reconciliationAction} className="mt-3">
+                <input type="hidden" name="expectedRevision" value={draft.revision} />
+                <ActionButton
+                  disabled={!draft.publishedReconciliationAllowed}
+                  pending={reconciliationPending}
+                  pendingLabel="Reconciliando…"
+                >
+                  Reconciliar draft já implantado
+                </ActionButton>
+              </form>
+            </div>
+          ) : (
+            <>
+          <div className="grid gap-2 text-sm sm:grid-cols-2 lg:grid-cols-4">
+            <Metric label="Sem mudança material" value={String(draft.totals.noMaterialChange)} />
+            <Metric label="Evolução compatível" value={String(draft.totals.compatibleEvolution)} />
+            <Metric label="Revisão necessária" value={String(draft.totals.reviewRequired)} />
+            <Metric label="Bloqueios operacionais" value={String(draft.totals.blockingOperationalReviews)} />
+            <Metric label="Configurações inválidas" value={String(draft.totals.invalidOperationalConfigurations)} />
+          </div>
+
+          <details className="rounded-md border border-border bg-background p-3">
+            <summary className="cursor-pointer font-medium text-foreground">
+              Taxons que exigem revisão ({draft.totals.reviewRequired})
+            </summary>
+            <ul className="mt-3 space-y-2 text-sm">
+              {draft.impacts
+                .filter((impact) => impact.classification === "review_required")
+                .map((impact) => (
+                  <li key={impact.taxon.id} className="flex flex-wrap items-center justify-between gap-2 rounded border border-border px-3 py-2">
+                    <span>
+                      <span className="font-medium text-foreground">{impact.taxon.name}</span>
+                      <span className="ml-2 text-muted-foreground">{impact.taxon.slug}</span>
+                      {draft.reviewedTaxonIds.includes(impact.taxon.id) ? (
+                        <span className="ml-2 font-medium text-emerald-700">Decisão vinculada ao draft atual</span>
+                      ) : null}
+                    </span>
+                    <a
+                      href={`/admin/taxonomia/${impact.taxon.id}?catalogDraftRevision=${draft.revision}`}
+                      className="rounded px-2 py-1 font-medium text-brand-700 outline-none focus-visible:ring-4 focus-visible:ring-brand-600/20"
+                    >
+                      {draft.reviewedTaxonIds.includes(impact.taxon.id)
+                        ? "Reavaliar E20.6.5"
+                        : "Avaliar draft na E20.6.5"}
+                    </a>
+                  </li>
+                ))}
+            </ul>
+          </details>
+
+          <form action={saveAction} className="space-y-3">
+            <input type="hidden" name="expectedRevision" value={draft.revision} />
+            <label className="block space-y-2">
+              <span className="text-sm font-medium text-foreground">Conteúdo estruturado do draft</span>
+              <span className="block text-xs leading-5 text-muted-foreground">
+                Edite somente a próxima versão. Salvar invalida validações e handoffs anteriores.
+              </span>
+              <textarea
+                key={`${draft.revision}-${draft.contentFingerprint}`}
+                name="catalogJson"
+                defaultValue={draft.catalogJson}
+                spellCheck={false}
+                className="min-h-72 w-full rounded-md border border-border bg-background p-3 font-mono text-xs leading-5 text-foreground outline-none focus-visible:ring-4 focus-visible:ring-brand-600/20"
+              />
+            </label>
+            <ActionButton pending={savePending} pendingLabel="Salvando…">
+              Salvar draft
+            </ActionButton>
+          </form>
+
+          <div className="flex flex-wrap gap-3">
+            <form action={validationAction}>
+              <input type="hidden" name="expectedRevision" value={draft.revision} />
+              <ActionButton pending={validationPending} pendingLabel="Validando…" secondary>
+                Revalidar conteúdo e impacto
+              </ActionButton>
+            </form>
+            <form action={publicationAction}>
+              <input type="hidden" name="expectedRevision" value={draft.revision} />
+              <ActionButton
+                pending={publicationPending}
+                pendingLabel="Preparando…"
+                disabled={
+                  !draft.validationCurrent ||
+                  draft.totals.blockingOperationalReviews > 0 ||
+                  draft.totals.invalidOperationalConfigurations > 0
+                }
+              >
+                Preparar handoff repo-only
+              </ActionButton>
+            </form>
+          </div>
+
+          {publicationState.handoff ? (
+            <label className="block space-y-2">
+              <span className="text-sm font-medium text-foreground">Handoff congelado e copiável</span>
+              <textarea
+                readOnly
+                value={publicationState.handoff}
+                className="min-h-56 w-full rounded-md border border-border bg-muted/30 p-3 font-mono text-xs leading-5 text-foreground outline-none focus-visible:ring-4 focus-visible:ring-brand-600/20"
+              />
+            </label>
+          ) : null}
+            </>
+          )}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-border bg-background px-3 py-2">
+      <dt className="text-xs text-muted-foreground">{label}</dt>
+      <dd className="mt-1 font-semibold text-foreground">{value}</dd>
+    </div>
+  );
+}
+
+function Status({ children, tone }: { children: string; tone: "error" | "success" }) {
+  return (
+    <p
+      role={tone === "error" ? "alert" : "status"}
+      aria-live="polite"
+      className={tone === "error"
+        ? "rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800"
+        : "rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-800"}
+    >
+      {children}
+    </p>
+  );
+}
+
+function ActionButton({
+  children,
+  pending,
+  pendingLabel,
+  secondary = false,
+  disabled = false,
+}: {
+  children: React.ReactNode;
+  pending: boolean;
+  pendingLabel: string;
+  secondary?: boolean;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="submit"
+      disabled={pending || disabled}
+      className={secondary
+        ? "min-h-11 rounded-md border border-border bg-background px-4 py-2 text-sm font-medium text-foreground outline-none transition hover:bg-muted focus-visible:ring-4 focus-visible:ring-brand-600/20 disabled:cursor-not-allowed disabled:opacity-50"
+        : "min-h-11 rounded-md bg-brand-600 px-4 py-2 text-sm font-medium text-white outline-none transition hover:bg-brand-700 focus-visible:ring-4 focus-visible:ring-brand-600/20 disabled:cursor-not-allowed disabled:opacity-50"}
+    >
+      {pending ? pendingLabel : children}
+    </button>
+  );
+}

--- a/app/admin/(protected)/estrutura-lp/actions.ts
+++ b/app/admin/(protected)/estrutura-lp/actions.ts
@@ -1,0 +1,131 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { requirePlatformAdmin } from "@/lib/access/guards";
+import {
+  initializeAdminInputCatalogDraft,
+  prepareAdminInputCatalogPublication,
+  reconcileAdminInputCatalogPublishedDraft,
+  saveAdminInputCatalogDraft,
+  validateAdminInputCatalogDraft,
+} from "@/lib/admin/adapters/adminInputCatalogLifecycleAdapter";
+
+export type InputCatalogLifecycleActionState = Readonly<{
+  error: string | null;
+  message: string | null;
+  handoff: string | null;
+  revision: number;
+}>;
+
+export const initialInputCatalogLifecycleActionState: InputCatalogLifecycleActionState = {
+  error: null,
+  message: null,
+  handoff: null,
+  revision: 0,
+};
+
+export async function initializeInputCatalogDraftAction(
+  previous: InputCatalogLifecycleActionState,
+): Promise<InputCatalogLifecycleActionState> {
+  const actor = await requirePlatformAdmin();
+  if (!actor.allowed) return denied(previous);
+  const result = await initializeAdminInputCatalogDraft({
+    actorUserId: actor.actorUserId,
+  });
+  return complete(previous, result, "Draft sequencial criado sem efeito operacional.");
+}
+
+export async function saveInputCatalogDraftAction(
+  previous: InputCatalogLifecycleActionState,
+  formData: FormData,
+): Promise<InputCatalogLifecycleActionState> {
+  const actor = await requirePlatformAdmin();
+  if (!actor.allowed) return denied(previous);
+  const result = await saveAdminInputCatalogDraft({
+    actorUserId: actor.actorUserId,
+    expectedRevision: Number(formData.get("expectedRevision")),
+    catalogJson: String(formData.get("catalogJson") ?? ""),
+  });
+  return complete(previous, result, "Draft salvo; evidências anteriores foram invalidadas.");
+}
+
+export async function validateInputCatalogDraftAction(
+  previous: InputCatalogLifecycleActionState,
+  formData: FormData,
+): Promise<InputCatalogLifecycleActionState> {
+  const actor = await requirePlatformAdmin();
+  if (!actor.allowed) return denied(previous);
+  const result = await validateAdminInputCatalogDraft({
+    actorUserId: actor.actorUserId,
+    expectedRevision: Number(formData.get("expectedRevision")),
+  });
+  return complete(previous, result, "Draft e impacto foram revalidados sobre o conteúdo atual.");
+}
+
+export async function prepareInputCatalogPublicationAction(
+  previous: InputCatalogLifecycleActionState,
+  formData: FormData,
+): Promise<InputCatalogLifecycleActionState> {
+  const actor = await requirePlatformAdmin();
+  if (!actor.allowed) return denied(previous);
+  const result = await prepareAdminInputCatalogPublication({
+    actorUserId: actor.actorUserId,
+    expectedRevision: Number(formData.get("expectedRevision")),
+  });
+  return complete(
+    previous,
+    result,
+    "Handoff congelado. A versão atual não mudou e depende de materialização, revisão, merge e deploy.",
+  );
+}
+
+export async function reconcileInputCatalogPublishedDraftAction(
+  previous: InputCatalogLifecycleActionState,
+  formData: FormData,
+): Promise<InputCatalogLifecycleActionState> {
+  const actor = await requirePlatformAdmin();
+  if (!actor.allowed) return denied(previous);
+  const result = await reconcileAdminInputCatalogPublishedDraft({
+    expectedRevision: Number(formData.get("expectedRevision")),
+    runtimeEnvironment: process.env.VERCEL_ENV,
+  });
+  return complete(
+    previous,
+    result,
+    "O draft temporário foi reconciliado com o registry já implantado.",
+  );
+}
+
+function complete(
+  previous: InputCatalogLifecycleActionState,
+  result: Awaited<ReturnType<typeof initializeAdminInputCatalogDraft>>,
+  message: string,
+): InputCatalogLifecycleActionState {
+  const revision = nextRevision(previous.revision);
+  if (!result.ok) {
+    return { error: result.message, message: null, handoff: null, revision };
+  }
+  revalidatePath("/admin/estrutura-lp");
+  return {
+    error: null,
+    message,
+    handoff: result.handoff ?? null,
+    revision,
+  };
+}
+
+function denied(
+  previous: InputCatalogLifecycleActionState,
+): InputCatalogLifecycleActionState {
+  return {
+    error: "Acesso administrativo não autorizado.",
+    message: null,
+    handoff: null,
+    revision: nextRevision(previous.revision),
+  };
+}
+
+function nextRevision(value: number): number {
+  return Number.isSafeInteger(value) && value >= 0 ? value + 1 : 1;
+}

--- a/app/admin/(protected)/estrutura-lp/page.tsx
+++ b/app/admin/(protected)/estrutura-lp/page.tsx
@@ -10,6 +10,8 @@ import {
   type AdminLandingPageStructureView,
 } from "@/lib/admin/adapters/adminLandingPageStructureAdapter";
 import { cn } from "@/lib/utils";
+import { readAdminInputCatalogLifecycle } from "@/lib/admin/adapters/adminInputCatalogLifecycleAdapter";
+import { AdminInputCatalogLifecycle } from "./_components/AdminInputCatalogLifecycle";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -35,7 +37,10 @@ export default async function AdminLandingPageStructurePage({ searchParams }: Pa
     Object.entries(rawParams).map(([key, value]) => [key, Array.isArray(value) ? value[0] : value]),
   );
   const view = normalizeAdminLandingPageStructureView(query.view);
-  const structure = await readAdminLandingPageStructure(view, query);
+  const [structure, inputCatalogLifecycle] = await Promise.all([
+    readAdminLandingPageStructure(view, query),
+    view === "entradas" ? readAdminInputCatalogLifecycle() : Promise.resolve(null),
+  ]);
 
   return (
     <div className="space-y-4">
@@ -63,7 +68,12 @@ export default async function AdminLandingPageStructurePage({ searchParams }: Pa
       </nav>
 
       {structure.view === "parametros" ? <RootView data={structure.data} /> : null}
-      {structure.view === "entradas" ? <InputView data={structure.data} /> : null}
+      {structure.view === "entradas" && inputCatalogLifecycle ? (
+        <>
+          <AdminInputCatalogLifecycle state={inputCatalogLifecycle} />
+          <InputView data={structure.data} />
+        </>
+      ) : null}
     </div>
   );
 }

--- a/app/admin/(protected)/estrutura-lp/validation-cases.ts
+++ b/app/admin/(protected)/estrutura-lp/validation-cases.ts
@@ -1,9 +1,38 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
+import { collectCompletePaginatedRows } from "../../../../lib/admin/adapters/adminInputCatalogLifecyclePagination";
+import {
+  countInvalidInputCatalogOperationalConfigurations,
+  fingerprintInputCatalogOperationalContext,
+} from "../../../../lib/admin/adapters/adminInputCatalogLifecycleValidation";
+import {
+  createNextLandingPageInputCatalogDraft,
+  realEstateBrokerNicheTaxon,
+  realEstateSegmentTaxon,
+  validateLandingPageInputCatalogDraft,
+} from "../../../../lib/conversion-content/landing-page/input-catalog";
+
 const page = readFileSync(new URL("./page.tsx", import.meta.url), "utf8");
 const adapter = readFileSync(
   new URL("../../../../lib/admin/adapters/adminLandingPageStructureAdapter.ts", import.meta.url),
+  "utf8",
+);
+const lifecycleAdapter = readFileSync(
+  new URL("../../../../lib/admin/adapters/adminInputCatalogLifecycleAdapter.ts", import.meta.url),
+  "utf8",
+);
+const lifecycleValidation = readFileSync(
+  new URL("../../../../lib/admin/adapters/adminInputCatalogLifecycleValidation.ts", import.meta.url),
+  "utf8",
+);
+const lifecycleComponent = readFileSync(
+  new URL("./_components/AdminInputCatalogLifecycle.tsx", import.meta.url),
+  "utf8",
+);
+const lifecycleActions = readFileSync(new URL("./actions.ts", import.meta.url), "utf8");
+const lifecycleMigration = readFileSync(
+  new URL("../../../../supabase/migrations/20260824180000_e20_2_8_input_catalog_lifecycle.sql", import.meta.url),
   "utf8",
 );
 const navigation = readFileSync(
@@ -47,5 +76,128 @@ assert.doesNotMatch(packageJson, /validate:landing-page-research|research-resolu
 assert.match(packageJson, /validate:commercial-activation/);
 assert.match(packageJson, /validate:taxon-preparation/);
 assert.match(packageJson, /validate:lp-builder-generation-context/);
+assert.match(page, /view === "entradas"[\s\S]*AdminInputCatalogLifecycle/);
+assert.match(lifecycleAdapter, /CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION/);
+assert.match(lifecycleAdapter, /account_landing_page_shared_configurations/);
+assert.match(lifecycleAdapter, /account_landing_page_configurations/);
+assert.match(lifecycleAdapter, /account_landing_page_onboarding_configurations/);
+assert.match(lifecycleAdapter, /invalidOperationalConfigurations/);
+assert.match(lifecycleValidation, /resolveAccountLandingPageOnboardingConfiguration/);
+assert.match(lifecycleAdapter, /publication_fingerprint/);
+assert.match(lifecycleAdapter, /validation_context_fingerprint/);
+assert.match(lifecycleAdapter, /publication_context_fingerprint/);
+assert.match(lifecycleAdapter, /taxon_review_evidence/);
+assert.match(lifecycleAdapter, /reconstructDraftInputCatalogEvaluationContext/);
+assert.match(lifecycleAdapter, /recordAdminInputCatalogDraftSufficiencyDecision/);
+assert.match(lifecycleAdapter, /reconcileAdminInputCatalogPublishedDraft/);
+assert.match(lifecycleAdapter, /runtimeEnvironment !== "production"/);
+assert.doesNotMatch(lifecycleAdapter, /Math\.max|versions\.at\(-1\)|latest/i);
+assert.match(lifecycleComponent, /Preparar handoff repo-only/);
+assert.match(lifecycleComponent, /Configurações inválidas/);
+assert.match(lifecycleComponent, /catalogDraftRevision/);
+assert.match(lifecycleComponent, /Decisão vinculada ao draft atual/);
+assert.match(lifecycleComponent, /Reconciliar draft já implantado/);
+assert.match(lifecycleActions, /requirePlatformAdmin/);
+assert.match(lifecycleMigration, /create table public\.landing_page_input_catalog_drafts/);
+assert.match(lifecycleMigration, /revoke all on table public\.landing_page_input_catalog_drafts[\s\S]*from public, anon, authenticated/);
+assert.match(lifecycleMigration, /grant select, insert, update, delete[\s\S]*to service_role/);
+assert.match(lifecycleMigration, /taxon_review_evidence jsonb not null default '\{\}'::jsonb/);
+assert.doesNotMatch(lifecycleMigration, /insert into public\.landing_page_input_catalog_drafts/);
 
-console.log("ok - admin retires E10.8 surfaces and preserves active consumers");
+async function validateBehavioralContracts(): Promise<void> {
+const largeCollection = Array.from({ length: 1_207 }, (_, index) => index);
+const completePagination = await collectCompletePaginatedRows({
+  pageSize: 500,
+  readPage: async (offset, limit) => ({
+    rows: largeCollection.slice(offset, offset + Math.min(limit, 173)),
+    total: largeCollection.length,
+  }),
+});
+assert.equal(completePagination.ok, true);
+if (!completePagination.ok) throw new Error("Expected complete pagination");
+assert.deepEqual(completePagination.rows, largeCollection);
+
+let divergentReads = 0;
+const divergentPagination = await collectCompletePaginatedRows({
+  pageSize: 500,
+  readPage: async (offset) => ({
+    rows: largeCollection.slice(offset, offset + 400),
+    total: divergentReads++ === 0 ? largeCollection.length : largeCollection.length + 1,
+  }),
+});
+assert.equal(divergentPagination.ok, false);
+
+const truncatedPagination = await collectCompletePaginatedRows({
+  pageSize: 500,
+  readPage: async (offset) => ({
+    rows: offset === 0 ? largeCollection.slice(0, 200) : [],
+    total: largeCollection.length,
+  }),
+});
+assert.equal(truncatedPagination.ok, false);
+
+const candidate = validateLandingPageInputCatalogDraft({
+  draft: createNextLandingPageInputCatalogDraft(),
+  taxons: [
+    { identity: realEstateSegmentTaxon, reviewedVersion: 5, operational: false },
+    { identity: realEstateBrokerNicheTaxon, reviewedVersion: 5, operational: true },
+  ],
+});
+assert.equal(candidate.ok, true);
+if (!candidate.ok) throw new Error("Expected executable draft candidate");
+const preHandoffBase = {
+  accountId: "00000000-0000-4000-8000-000000000101",
+  landingPageId: null,
+  planKey: "starter" as const,
+  taxonChain: { segment: realEstateSegmentTaxon, niche: realEstateBrokerNicheTaxon },
+  authoritativeValues: { business_display_name: "Conta operacional" },
+};
+assert.equal(
+  countInvalidInputCatalogOperationalConfigurations(candidate.value, [
+    { ...preHandoffBase, storedValues: {} },
+  ]),
+  0,
+);
+assert.equal(
+  countInvalidInputCatalogOperationalConfigurations(candidate.value, [
+    {
+      ...preHandoffBase,
+      storedValues: {
+        never_published: { scope: "business", value: "inválido" },
+      },
+    },
+  ]),
+  1,
+);
+const operationalContext = {
+  taxons: [
+    { identity: realEstateSegmentTaxon, reviewedVersion: 5, operational: false },
+    { identity: realEstateBrokerNicheTaxon, reviewedVersion: 5, operational: true },
+  ],
+  operationalTaxonIds: new Set([realEstateBrokerNicheTaxon.id]),
+  operationalConfigurations: [{ ...preHandoffBase, storedValues: {} }],
+};
+const originalContextFingerprint = fingerprintInputCatalogOperationalContext(
+  operationalContext,
+);
+const staleContextFingerprint = fingerprintInputCatalogOperationalContext({
+  ...operationalContext,
+  operationalConfigurations: [
+    {
+      ...preHandoffBase,
+      storedValues: {
+        traffic_source: { scope: "landing_page", value: "organic" },
+      },
+    },
+  ],
+});
+assert.match(originalContextFingerprint, /^[0-9a-f]{64}$/);
+assert.notEqual(staleContextFingerprint, originalContextFingerprint);
+
+console.log("ok - admin preserves consumers and proves complete service-only lifecycle pagination");
+}
+
+void validateBehavioralContracts().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/app/admin/(protected)/taxonomia/[taxonId]/_components/AdminTaxonInputCatalogEvaluation.tsx
+++ b/app/admin/(protected)/taxonomia/[taxonId]/_components/AdminTaxonInputCatalogEvaluation.tsx
@@ -16,7 +16,9 @@ import type {
 
 export type AdminTaxonInputCatalogEvaluationRuntimeProps = Readonly<{
   taxonId: string;
+  currentInputCatalogVersion: number;
   currentReviewedVersion: number | null;
+  draftRevision?: number;
   evaluateAction: (input: Readonly<{
     taxonId: string;
     inputCatalogVersion: number;
@@ -27,6 +29,7 @@ export type AdminTaxonInputCatalogEvaluationRuntimeProps = Readonly<{
       previousOutput: InputCatalogEvaluationPresentationOutput;
       reference: InputCatalogEvaluationReference;
     }> | null;
+    draftRevision?: number;
   }>) => Promise<InputCatalogEvaluationActionResult>;
   confirmAction: (input: Readonly<{
     reference: InputCatalogEvaluationReference;
@@ -52,6 +55,7 @@ export type InputCatalogEvaluationPresentationState =
 
 export type AdminTaxonInputCatalogEvaluationProps = Readonly<{
   currentReviewedVersion: number | null;
+  draftMode?: boolean;
   mode: InputCatalogEvaluationPresentationMode;
   inputCatalogVersion: string;
   inputCatalogVersionError?: string | null;
@@ -135,14 +139,19 @@ const conclusionLabels: Record<InputCatalogEvaluationPresentationCandidate["conc
 
 export function AdminTaxonInputCatalogEvaluationRuntime({
   taxonId,
+  currentInputCatalogVersion,
   currentReviewedVersion,
   evaluateAction,
   confirmAction,
   rejectCandidatesAndConfirmAction,
   acknowledgeGapAction,
+  draftRevision,
 }: AdminTaxonInputCatalogEvaluationRuntimeProps) {
+  const draftMode = draftRevision !== undefined;
   const [mode, setMode] = useState<InputCatalogEvaluationPresentationMode>("systematic");
-  const [inputCatalogVersion, setInputCatalogVersion] = useState("");
+  const [inputCatalogVersion, setInputCatalogVersion] = useState(
+    String(currentInputCatalogVersion),
+  );
   const [hypothesis, setHypothesis] = useState("");
   const [feedback, setFeedback] = useState("");
   const [state, setState] = useState<InputCatalogEvaluationPresentationState>({ kind: "idle" });
@@ -183,6 +192,7 @@ export function AdminTaxonInputCatalogEvaluationRuntime({
         mode: input.mode,
         focalHypothesis: input.hypothesis,
         feedback: feedbackInput,
+        ...(draftMode ? { draftRevision } : {}),
       });
     } catch {
       setState({
@@ -223,7 +233,9 @@ export function AdminTaxonInputCatalogEvaluationRuntime({
     }
     setDecisionFeedback({
       kind: "success",
-      message: `Versão E20.2 ${result.reviewedVersion} confirmada por decisão administrativa.`,
+      message: draftMode
+        ? `Suficiência pré-publicação do draft v${result.reviewedVersion} registrada sem alterar a versão revisada do taxon.`
+        : `Versão E20.2 ${result.reviewedVersion} confirmada por decisão administrativa.`,
     });
   }
 
@@ -287,7 +299,9 @@ export function AdminTaxonInputCatalogEvaluationRuntime({
     }
     setDecisionFeedback({
       kind: "success",
-      message: `Todos os candidatos foram rejeitados e a versão E20.2 ${result.reviewedVersion} foi confirmada como suficiente.`,
+      message: draftMode
+        ? `Todos os candidatos foram rejeitados e a suficiência pré-publicação do draft v${result.reviewedVersion} foi registrada.`
+        : `Todos os candidatos foram rejeitados e a versão E20.2 ${result.reviewedVersion} foi confirmada como suficiente.`,
     });
   }
 
@@ -311,6 +325,7 @@ export function AdminTaxonInputCatalogEvaluationRuntime({
       administrativeDecisionFeedback={decisionFeedback}
       administrativeDecisionPending={decisionPending}
       currentReviewedVersion={currentReviewedVersion}
+      draftMode={draftMode}
       feedback={feedback}
       hypothesis={hypothesis}
       inputCatalogVersion={inputCatalogVersion}
@@ -329,6 +344,7 @@ export function AdminTaxonInputCatalogEvaluationRuntime({
       }}
       onCopyGapHandoff={copyGapHandoff}
       onInputCatalogVersionChange={(value) => {
+        if (draftMode) return;
         setInputCatalogVersion(value);
         setFeedback("");
         setSelectedCandidateIndexes([]);
@@ -372,6 +388,7 @@ const taxonomyLayerLabels: Record<
 
 export function AdminTaxonInputCatalogEvaluation({
   currentReviewedVersion,
+  draftMode = false,
   mode,
   inputCatalogVersion,
   inputCatalogVersionError = null,
@@ -449,7 +466,7 @@ export function AdminTaxonInputCatalogEvaluation({
     >
       <div className="min-w-0">
         <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-          Checkpoint de integração final
+          {draftMode ? "Gate pré-publicação" : "Checkpoint de integração final"}
         </p>
         <h2
           className="mt-1 text-lg font-semibold text-card-foreground"
@@ -458,7 +475,9 @@ export function AdminTaxonInputCatalogEvaluation({
           Avaliação factual do catálogo E20.2
         </h2>
         <p className="mt-1 text-sm text-muted-foreground">
-          A avaliação é uma recomendação não autoritativa. Ela não altera fields, catálogo ou suficiência.
+          {draftMode
+            ? "A avaliação é vinculada ao conteúdo exato do draft e não altera a versão revisada nem torna o catálogo operacional."
+            : "A avaliação é uma recomendação não autoritativa. Ela não altera fields, catálogo ou suficiência."}
         </p>
       </div>
 
@@ -467,13 +486,15 @@ export function AdminTaxonInputCatalogEvaluation({
           Versão executável E20.2 para esta análise
         </label>
         <p className="mt-1 text-sm text-muted-foreground" id="input-catalog-evaluation-version-instruction">
-          Escolha N explicitamente. A seleção não é persistida; hoje está registrada {currentReviewedVersion === null ? "nenhuma versão" : `a versão ${currentReviewedVersion}`}.
+          {draftMode
+            ? "A próxima versão sequencial é fixada pelo draft administrativo atual."
+            : <>Escolha N explicitamente. A seleção não é persistida; hoje está registrada {currentReviewedVersion === null ? "nenhuma versão" : `a versão ${currentReviewedVersion}`}.</>}
         </p>
         <input
           aria-describedby={`input-catalog-evaluation-version-instruction${inputCatalogVersionError ? " input-catalog-evaluation-version-error" : ""}`}
           aria-invalid={inputCatalogVersionError ? true : undefined}
           className="mt-2 min-h-11 w-full rounded-md border border-border bg-background px-3 text-sm text-foreground outline-none focus-visible:ring-4 focus-visible:ring-brand-600/20 disabled:opacity-60 sm:max-w-48"
-          disabled={isLoading}
+          disabled={isLoading || draftMode}
           id="input-catalog-evaluation-version"
           inputMode="numeric"
           min={1}

--- a/app/admin/(protected)/taxonomia/[taxonId]/page.tsx
+++ b/app/admin/(protected)/taxonomia/[taxonId]/page.tsx
@@ -25,16 +25,26 @@ import {
 } from "../actions";
 import { AdminTaxonInputCatalogEvaluationRuntime } from "./_components/AdminTaxonInputCatalogEvaluation";
 import { AdminTaxonInputCatalogReview } from "./_components/AdminTaxonInputCatalogReview";
+import { CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION } from "@/conversion-content/landing-page/input-catalog";
+import { loadAdminInputCatalogDraftEvaluationContext } from "@/lib/admin/adapters/adminInputCatalogLifecycleAdapter";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 type AdminTaxonDetailPageProps = {
   params: Promise<{ taxonId: string }>;
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
 };
 
-export default async function AdminTaxonDetailPage({ params }: AdminTaxonDetailPageProps) {
+export default async function AdminTaxonDetailPage({ params, searchParams }: AdminTaxonDetailPageProps) {
   const { taxonId } = await params;
+  const rawDraftRevision = (await searchParams)?.catalogDraftRevision;
+  const parsedDraftRevision = Number(
+    Array.isArray(rawDraftRevision) ? rawDraftRevision[0] : rawDraftRevision,
+  );
+  const draftRevision = Number.isSafeInteger(parsedDraftRevision) && parsedDraftRevision > 0
+    ? parsedDraftRevision
+    : null;
   const taxon = await getAdminTaxonDetail(taxonId);
 
   if (!taxon) notFound();
@@ -49,12 +59,23 @@ export default async function AdminTaxonDetailPage({ params }: AdminTaxonDetailP
         ? "rollout_gate_off"
         : "operational_configuration_unproven";
   const legacyAvailable = inputCatalogLegacyMode === "rollout_gate_off";
+  const draftEvaluation = draftRevision === null
+    ? null
+    : await loadAdminInputCatalogDraftEvaluationContext({
+        expectedRevision: draftRevision,
+        taxonId,
+      });
 
   return (
     <div className="space-y-6">
       <Link className="text-sm font-medium text-brand-700 hover:underline" href="/admin/taxonomia">
         Voltar para taxonomia
       </Link>
+      {draftEvaluation ? (
+        <Link className="ml-4 text-sm font-medium text-brand-700 hover:underline" href="/admin/estrutura-lp?view=entradas">
+          Voltar para o draft
+        </Link>
+      ) : null}
 
       <AdminPageHeader
         title={taxon.name}
@@ -134,15 +155,25 @@ export default async function AdminTaxonDetailPage({ params }: AdminTaxonDetailP
         />
       )}
 
-      {taxon.inputCatalogReview.status === "available" && inputCatalogEvaluationRuntime?.ok ? (
+      {taxon.inputCatalogReview.status === "available" && inputCatalogEvaluationRuntime?.ok && (!draftEvaluation || draftEvaluation.ok) ? (
         <AdminTaxonInputCatalogEvaluationRuntime
           acknowledgeGapAction={acknowledgeInputCatalogGapAction}
           confirmAction={confirmInputCatalogEvaluationAction}
+          currentInputCatalogVersion={draftEvaluation?.ok
+            ? draftEvaluation.value.targetVersion
+            : CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION}
           currentReviewedVersion={taxon.inputCatalogReview.reviewedVersion}
           evaluateAction={evaluateInputCatalogAction}
           rejectCandidatesAndConfirmAction={rejectInputCatalogCandidatesAndConfirmSufficientAction}
           taxonId={taxon.id}
+          {...(draftEvaluation?.ok ? { draftRevision: Number(draftRevision) } : {})}
         />
+      ) : null}
+
+      {draftEvaluation && !draftEvaluation.ok ? (
+        <section className="rounded-lg border border-red-200 bg-red-50 p-5 text-sm text-red-800" role="alert">
+          O gate pré-publicação não pôde ser aberto: {draftEvaluation.message}
+        </section>
       ) : null}
 
       {taxon.inputCatalogReview.status === "available" && inputCatalogEvaluationRuntime && !inputCatalogEvaluationRuntime.ok ? (

--- a/app/admin/(protected)/taxonomia/actions.ts
+++ b/app/admin/(protected)/taxonomia/actions.ts
@@ -24,6 +24,10 @@ import {
 } from "@/conversion-content/landing-page/taxon-preparation";
 import { nextInputCatalogReviewActionRevision } from "@/lib/admin/adapters/adminTaxonomyReviewPolicy";
 import {
+  loadAdminInputCatalogDraftEvaluationContext,
+  recordAdminInputCatalogDraftSufficiencyDecision,
+} from "@/lib/admin/adapters/adminInputCatalogLifecycleAdapter";
+import {
   addAdminTaxonAlias,
   createAdminTaxon,
   deleteAdminTaxon,
@@ -56,6 +60,9 @@ export type InputCatalogReviewActionState = {
 
 export type InputCatalogEvaluationReference = Readonly<{
   decisionToken: string;
+  source?: "published" | "draft";
+  draftRevision?: number;
+  draftContentFingerprint?: string;
 }>;
 
 export type InputCatalogEvaluationActionResult =
@@ -92,6 +99,7 @@ export async function evaluateInputCatalogAction(input: Readonly<{
     previousOutput: InputCatalogEvaluationOutput;
     reference: InputCatalogEvaluationReference;
   }> | null;
+  draftRevision?: number;
 }>): Promise<InputCatalogEvaluationActionResult> {
   const gate = await requirePlatformAdmin();
   if (!gate.allowed) {
@@ -103,6 +111,31 @@ export async function evaluateInputCatalogAction(input: Readonly<{
     return { ok: false, code: runtime.code, message: runtime.message };
   }
 
+  const source = input.draftRevision === undefined ? "published" : "draft";
+  let draftContentFingerprint: string | undefined;
+  const reconstructContext: typeof reconstructCanonicalInputCatalogEvaluationContext =
+    source === "published"
+      ? reconstructCanonicalInputCatalogEvaluationContext
+      : async (reconstructionInput) => {
+          const draft = await loadAdminInputCatalogDraftEvaluationContext({
+            expectedRevision: input.draftRevision as number,
+            taxonId: reconstructionInput.taxonId,
+          });
+          if (!draft.ok || draft.value.targetVersion !== reconstructionInput.inputCatalogVersion) {
+            return {
+              ok: false as const,
+              error: {
+                code: "CONTEXT_IDENTITY_INVALID" as const,
+                message: draft.ok
+                  ? "A versão solicitada não corresponde ao draft atual."
+                  : draft.message,
+              },
+            };
+          }
+          draftContentFingerprint = draft.value.contentFingerprint;
+          return { ok: true as const, value: draft.value.context };
+        };
+
   let feedback: Parameters<typeof coordinateInputCatalogEvaluation>[0]["feedback"] = null;
   if (input.feedback) {
     const previousEvidence = readInputCatalogEvaluationDecisionToken(
@@ -113,6 +146,8 @@ export async function evaluateInputCatalogAction(input: Readonly<{
       !previousEvidence ||
       previousEvidence.taxonId !== input.taxonId ||
       previousEvidence.inputCatalogVersion !== input.inputCatalogVersion ||
+      (input.feedback.reference.source ?? "published") !== source ||
+      (source === "draft" && input.feedback.reference.draftRevision !== input.draftRevision) ||
       previousEvidence.status !== input.feedback.previousOutput.status ||
       fingerprintInputCatalogEvaluationOutput(input.feedback.previousOutput) !==
         previousEvidence.outputFingerprint
@@ -123,7 +158,7 @@ export async function evaluateInputCatalogAction(input: Readonly<{
         message: "O contexto da avaliação anterior não corresponde à execução atual.",
       };
     }
-    const previousContext = await reconstructCanonicalInputCatalogEvaluationContext({
+    const previousContext = await reconstructContext({
       taxonId: previousEvidence.taxonId,
       inputCatalogVersion: previousEvidence.inputCatalogVersion,
     });
@@ -157,7 +192,7 @@ export async function evaluateInputCatalogAction(input: Readonly<{
       feedback,
     },
     {
-      reconstructContext: reconstructCanonicalInputCatalogEvaluationContext,
+      reconstructContext,
       evaluate: async (request) => {
         return evaluateInputCatalogWithOpenAi({
           apiKey: process.env.OPENAI_API_KEY,
@@ -196,7 +231,16 @@ export async function evaluateInputCatalogAction(input: Readonly<{
   return {
     ok: true,
     output: result.value.output,
-    reference: { decisionToken },
+    reference: {
+      decisionToken,
+      source,
+      ...(source === "draft"
+        ? {
+            draftRevision: input.draftRevision,
+            draftContentFingerprint,
+          }
+        : {}),
+    },
   };
 }
 
@@ -281,6 +325,74 @@ async function executeAdministrativeEvaluationDecision(input: Readonly<{
   const gate = await requirePlatformAdmin();
   if (!gate.allowed) {
     return { ok: false as const, stale: false, message: "Acesso administrativo não autorizado." };
+  }
+  if ((input.reference.source ?? "published") === "draft") {
+    const expectedRevision = input.reference.draftRevision;
+    const expectedContentFingerprint = input.reference.draftContentFingerprint;
+    if (
+      !Number.isSafeInteger(expectedRevision) ||
+      Number(expectedRevision) <= 0 ||
+      typeof expectedContentFingerprint !== "string"
+    ) {
+      return { ok: false as const, stale: true, message: "A referência do draft é inválida." };
+    }
+    const result = await executeInputCatalogEvaluationAdministrativeActionCore(
+      {
+        decision: input.decision,
+        decisionToken: input.reference.decisionToken,
+        decisionTokenSecret: process.env.OPENAI_API_KEY,
+        output: input.output,
+        selectedCandidateIndexes: input.selectedCandidateIndexes,
+      },
+      {
+        requireRuntime: async () => {
+          const runtime = await resolveInputCatalogEvaluationRuntimeReadiness();
+          return runtime.ok
+            ? { ok: true as const }
+            : { ok: false as const, message: runtime.message };
+        },
+        revalidate: async (evidence) => {
+          const draft = await loadAdminInputCatalogDraftEvaluationContext({
+            expectedRevision: Number(expectedRevision),
+            taxonId: evidence.taxonId,
+          });
+          if (
+            !draft.ok ||
+            draft.value.targetVersion !== evidence.inputCatalogVersion ||
+            draft.value.contentFingerprint !== expectedContentFingerprint ||
+            fingerprintEvaluationContext(draft.value.context.identity) !==
+              evidence.contextFingerprint
+          ) {
+            return {
+              ok: false as const,
+              message: draft.ok
+                ? "O draft ou suas fontes mudaram desde a avaliação."
+                : draft.message,
+            };
+          }
+          return { ok: true as const };
+        },
+        recordReviewedVersion: async (evidence) => {
+          if (input.decision === "acknowledge_factual_gap") {
+            return { ok: false as const, message: "Reconhecimento de gap não registra suficiência." };
+          }
+          const recorded = await recordAdminInputCatalogDraftSufficiencyDecision({
+            actorUserId: gate.actorUserId,
+            expectedRevision: Number(expectedRevision),
+            taxonId: evidence.taxonId,
+            expectedContentFingerprint,
+            expectedContextFingerprint: evidence.contextFingerprint,
+            decision: input.decision,
+          });
+          if (!recorded.ok) return recorded;
+          return { ok: true as const, reviewedVersion: evidence.inputCatalogVersion };
+        },
+      },
+    );
+    if (result.ok && result.kind !== "factual_gap_acknowledged") {
+      revalidatePath("/admin/estrutura-lp");
+    }
+    return result;
   }
   return executeInputCatalogEvaluationAdministrativeActionCore(
     {

--- a/docs/base-tecnica.md
+++ b/docs/base-tecnica.md
@@ -2,8 +2,8 @@
 
 0.1 Cabeçalho
 • Documento: Base Técnica LP Factory 10
-• Versão: v2.0.74
-• Data: 23/08/2026
+• Versão: v2.0.75
+• Data: 24/08/2026
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -282,16 +282,22 @@
 3.15.4 Catálogo de entradas de `landing_page`
 • Boundary canônico: `lib/conversion-content/landing-page/input-catalog/`; registry, contracts, schema e resolver são fontes executáveis.
 • O resolver é puro e repo-only, sem consultar Supabase, Stripe, assinatura, entitlement ou valores operacionais.
+• As versões publicadas e a declaração explícita da versão atual permanecem repo-only; consumidores operacionais não podem inferir `latest`, maior chave ou outra versão por fallback.
+• Persistência administrativa pode guardar somente o próximo draft sequencial, mutável e não operacional. Publicação exige materialização imutável no registry, validação, revisão, merge e deploy antes de a declaração repo-only da versão atual produzir efeito.
 • Resolução segue `universal → segmento → nicho → ultranicho`; especializações só podem restringir e devem preservar identidade, tipo, origem, condições e evidência.
+• Evolução forward-only pode retirar um field publicado somente a partir de nova versão; valores históricos dessa chave permanecem reconhecíveis e inertes, enquanto chaves nunca publicadas continuam inválidas.
+• O draft deve preservar cada field já publicado e sua `createdInVersion`; remoção direta e proveniência retroativa são inválidas. Field novo nasce na versão alvo e retirada de field publicado usa exclusivamente `retiredInVersion` igual à nova versão.
 • Referências condicionais devem existir e permanecer válidas após o filtro de plano; avaliação dos valores concretos pertence ao consumidor.
 • A saída deve ser determinística, rastreável e profundamente imutável.
 
 3.15.7 Preparação factual do taxon para `landing_page`
 • Boundary canônico: `lib/conversion-content/landing-page/taxon-preparation/`; a derivação permanece pura e não persiste estado de prontidão.
-• O adapter server-only deve ler pelo caminho único da pesquisa selecionada o taxon ativo, a pesquisa E20.5 integralmente válida e a versão E20.2 avaliada; UI e componentes client não consultam esses marcadores diretamente.
-• O consumidor deve fornecer uma versão executável explícita, validada pela API pública do catálogo E20.2; maior versão, `latest` e qualquer fallback implícito são proibidos.
-• O sucesso exige igualdade exata entre a versão avaliada e a versão requerida; ausência, incompatibilidade, feature gate ou falha operacional devem permanecer erros tipados e fail-closed.
-• A avaliação semântica é assistida por IA no Codex App e permanece externa ao runtime do produto; a decisão final de suficiência e seu registro administrativo são humanos, e o boundary apenas aplica deterministicamente a decisão já registrada.
+• O adapter server-only deve ler pelo caminho único da pesquisa selecionada o taxon ativo, a pesquisa E20.5 integralmente válida e a última versão E20.2 efetivamente revisada; UI e componentes client não consultam esses marcadores diretamente.
+• Avaliações administrativas históricas continuam recebendo uma versão executável explícita. Consumidores operacionais correntes recebem a versão atual explícita da API pública do catálogo; maior versão, `latest` e qualquer fallback implícito são proibidos.
+• A versão efetiva corrente é a versão atual quando coincide com a revisada ou quando a comparação resolvida em todos os planos classifica a transição como sem mudança material ou evolução compatível. Mudança fora da allowlist conservadora exige nova revisão; ausência, incompatibilidade, feature gate ou falha operacional permanecem erros tipados e fail-closed.
+• Carry-forward compatível não reescreve a versão revisada e não reinterpreta snapshots ou configurações históricas; cada residência preserva o número concretamente usado.
+• O gate pré-publicação lê integralmente, com cardinalidade comprovada, tanto a residência E19.2 pré-handoff quanto as residências E19.5. A evidência congela separadamente o fingerprint do conteúdo e o fingerprint da coleção operacional; drift em qualquer uma torna validação/handoff stale.
+• A avaliação semântica usa o workload OpenAI comum autorizado e permanece não autoritativa; a decisão final de suficiência e seu registro administrativo são humanos, e o boundary apenas aplica deterministicamente a decisão autenticada e revalidada.
 
 3.15.8 Geração controlada da candidata de `landing_page`
 • A geração server-side consome somente o pacote público autorizado do LP Builder e deve separar contexto semântico enviado ao modelo de valores operacionais usados apenas pelo servidor.

--- a/docs/lousa-plano-base-e20-2-8.md
+++ b/docs/lousa-plano-base-e20-2-8.md
@@ -1,16 +1,17 @@
-23/08/2026 — Plano-base v1 — E20.2.8 — Versão atual e propagação escalável do catálogo E20.2
+24/08/2026 — Plano-base v2 — E20.2.8 — Versão atual e propagação escalável do catálogo E20.2
 
 ## 1. Estado e decisões fixas
 
 ### 1.1. Estado
 
-- Status: plano-base v1 consolidado a partir da decisão humana de 23/08/2026 e ajustado após revisão do Analista; implementação não autorizada por este documento.
+- Status: plano-base v2 consolidado sobre o blob imutável `14718243ce834b5e37406e9d560d1db2d1f3db9e` da v1 incorporada à `main` pelo PR #809; implementação condicionada ao gate do Analista deste workflow.
 - Caso macro: `E20 — preparação e liberação de taxons`.
 - Recorte: `E20.2.8 — Versão atual e propagação escalável do catálogo E20.2`.
 - Este recorte é uma evolução operacional da E20.2 já versionada; não reescreve nem invalida o histórico de `docs/lousa-plano-base-e20-2.md`.
 - A E20.6 permanece responsável pela suficiência factual por taxon; este recorte altera a relação entre versão global do catálogo e necessidade de reavaliação, conforme a seção 2.3.
-- A implementação física da autoridade de versão atual, de sua persistência e da superfície administrativa permanece pendente de recorte técnico sobre o repositório real.
+- A forma física do draft administrativo e a composição da superfície permanecem condicionadas à análise técnica sobre o repositório real; a autoridade das versões publicadas e da versão atual é repo-only conforme a decisão humana registrada abaixo.
 - Rollback operacional para versão anterior não integra a primeira entrega da E20.2.8; eventual suporte futuro depende de contrato específico para compatibilidade com configurações persistidas em versões posteriores.
+- Decisão humana de 24/08/2026: o registry repo-only permanece autoridade das versões publicadas. Eventual persistência em banco pode servir somente como residência do draft administrativo não operacional, se continuar sendo a menor solução após análise técnica; v1–v5 não serão migradas para tornar o banco autoridade do catálogo publicado.
 
 ### 1.2. Fontes usadas
 
@@ -31,6 +32,7 @@
 - `lib/lp-builder/onboardingConfiguration.ts`, para a validação fail-closed de valores persistidos contra o catálogo resolvido.
 - Decisões humanas desta conversa em 23/08/2026 sobre escala, versão default e experiência administrativa.
 - Revisão do Analista de 23/08/2026 sobre autoridade `R → C`, consumidores E19.2/E19.5 e deferimento do rollback.
+- Plano conceitual: `N/A`; não existe referência competente nem vínculo inequívoco adicional para este recorte além das fontes canônicas e decisões já registradas.
 
 ### 1.3. Problema e resultado esperado
 
@@ -54,6 +56,7 @@
 - Uma nova versão somente pode tornar-se atual depois de existir como versão executável, passar pelas validações aplicáveis e ser publicada/ativada pelo fluxo humano aprovado.
 - A publicação normal de uma nova versão executável deve torná-la a versão atual por padrão. Exemplo: se v7 é atual e v8 é publicada com sucesso, v8 passa a ser a versão atual sem atualização manual de cada taxon.
 - `Versão atual` não significa `Math.max(registry)`, maior chave encontrada, `latest` inferido ou fallback silencioso.
+- A versão atual publicada deve ser uma declaração explícita, versionada e revisável no mesmo boundary repo-only do catálogo; sua alteração integra a materialização da nova versão no repositório e somente produz efeito operacional depois de validação e deploy bem-sucedidos.
 - O resolver puro continua recebendo um número concreto e explícito; a responsabilidade de fornecer esse número pertence à autoridade canônica de versão efetiva ou a um consumidor histórico explicitamente pinado.
 - Versões anteriores permanecem imutáveis e resolvíveis para reprodução histórica; esta primeira entrega não autoriza torná-las novamente a versão operacional atual.
 - Snapshots e revisões históricas continuam registrando a versão efetivamente usada e nunca são reinterpretados como se tivessem usado a versão atual posterior.
@@ -90,6 +93,7 @@
 - Diante de ambiguidade, falhar para `revisão necessária`.
 - A IA não decide a compatibilidade estrutural entre versões; essa classificação pertence ao processamento determinístico.
 - Este plano não autoriza uma engine genérica de diff. A implementação deve usar a menor comparação determinística capaz de provar as categorias acima sobre os contratos resolvidos reais.
+- No MVP, `sem mudança material` exige igualdade da sequência ordenada de fields e de todas as propriedades funcionais resolvidas, desconsiderando somente número da versão e metadata de evidência sem efeito runtime. `Evolução compatível` admite exclusivamente: adição de field válido; ampliação estrita de `allowedValues` preservando todas as demais propriedades; e mudança apenas de evidência editorial. Múltiplas diferenças são compatíveis somente quando todas pertencem a essa allowlist. Reordenação, retirada, mudança de `purpose`, origem, camada, scope, tipo, obligation, plans, conditions, substitution policy, capability binding ou qualquer validação fora da ampliação permitida resulta em `revisão necessária`.
 
 ### 1.7. Autoridade `R → C` e ciclo de vida mínimo
 
@@ -172,6 +176,7 @@
 - Configurações E19.2/E19.5 já persistidas continuam registrando o `catalog_version` realmente usado em sua escrita; materializações e snapshots continuam preservando a versão efetivamente usada naquela geração.
 - Revalidação histórica pode resolver o `catalog_version` persistido para compreender o estado anterior, mas qualquer nova operação corrente usa a autoridade `C` aplicável e falha fechado diante de incompatibilidade.
 - A implementação da E20.2.8 deve remover ou reconciliar os pins operacionais atualmente conhecidos — incluindo `LANDING_PAGE_WORKSPACE_REQUIRED_INPUT_CATALOG_VERSION = 5` — somente dentro do recorte completo, sem substituí-los por outro hardcode ou por lookup local de versão atual.
+- O cutover da E20.2.8 deve substituir, na mesma unidade ativável, todos os caminhos operacionais que derivam versão de `R`, de maior versão ou do pin v5. O inventário mínimo inclui `LANDING_PAGE_WORKSPACE_REQUIRED_INPUT_CATALOG_VERSION`, `save_account_landing_page_configuration_v1`, `loadTaxonPreparationForReviewedVersion`, workspace, geração, contexto de geração e o default `versions.at(-1)` da Estrutura da LP. Símbolo, export, branch legado ou validação que perder consumidor funcional deve ser removido no mesmo recorte; permanência exige consumidor histórico real e contrato de pin explícito.
 
 ### 2.5. Experiência administrativa futura
 
@@ -186,9 +191,11 @@
   - quantidade de taxons que precisam de revisão E20.6.
 - O humano não deve precisar visitar 100 ou 150 páginas de taxon para sincronizar uma nova versão.
 - Taxons com revisão necessária devem aparecer em uma visão agregada de pendências, com acesso ao fluxo individual E20.6.5 quando necessário.
-- A rota e a composição física dessa superfície não são definidas neste plano. A implementação deve primeiro avaliar as superfícies existentes de Estrutura da LP e Taxonomia e escolher a menor evolução coerente com o Design System.
+- A visão central da E20.2 deve evoluir `/admin/estrutura-lp?view=entradas`; a página `/admin/taxonomia/[taxonId]` permanece responsável pela execução individual E20.6.5. Não criar nova rota de primeiro nível. Componentes com estado ou actions próprias permanecem route-local; cada mutação reexecuta `requirePlatformAdmin()`, deriva o ator no servidor e acessa o banco somente por adapter server-only do boundary Admin.
 - Não criar job, fila, agente, automação recorrente ou nova infraestrutura apenas para produzir essa experiência sem fonte técnica posterior.
 - Ação administrativa de restaurar versão anterior como atual não integra esta primeira entrega.
+- A superfície administrativa deve ser validada proporcionalmente em Preview, em desktop e mobile, cobrindo o papel administrativo autorizado, os controles negativos de acesso aplicáveis, a navegação entre a visão agregada e a E20.6.5, os estados de carregamento, vazio, pendência, sucesso e erro e a integridade da coleção paginada; resposta parcial não pode ser apresentada como lista completa (`prod#16`).
+- A superfície administrativa deve aplicar o baseline WCAG 2.2 pertinente ao fluxo, incluindo operação por teclado, foco visível e reposicionado após transições ou falhas, nomes e labels acessíveis, anúncio de mensagens dinâmicas, contraste, alvos de toque e ausência de interação exclusivamente por hover; a validação deve combinar inspeção automática e manual, sem declarar conformidade integral sem auditoria própria (`prod#17`).
 
 ### 2.6. Compatibilidade com consumidores e histórico
 
@@ -214,16 +221,22 @@
 
 ### 3.1. E20.2.8 — Versão atual e propagação escalável
 
-- Automação: não definida/necessária neste plano; a decisão é de contrato operacional e UX.
+- Automação: não; a implementação é um lifecycle administrativo determinístico, sem agente, IA decisória, job, fila ou rotina recorrente.
 - Próxima ação técnica futura:
   - reconciliar o plano com a `main` vigente no início da implementação;
-  - identificar a menor autoridade real para `versão atual` sem criar segunda residência;
+  - preservar o registry repo-only como autoridade das versões publicadas e da versão atual implantada;
+  - avaliar se o draft administrativo exige persistência em banco; se exigir, limitar essa residência ao conteúdo não operacional e não duplicar nela a autoridade das versões publicadas;
+  - implementar a publicação como materialização/versionamento no repositório, validação e deploy; somente depois de o artefato executável estar implantado a nova versão pode tornar-se atual e observável como `C`;
   - definir a API pública que entrega `R` e `C` separadamente e fornece o número concreto `C` aos consumidores;
   - definir o comparador mínimo de compatibilidade sobre catálogos resolvidos;
   - adaptar o predicado E20.6.4 somente como unidade completa, preservando fail-closed;
   - reconciliar E19.2 pré-handoff, E19.5 workspace e geração E19.5 para consumir a mesma `C`, removendo os pins operacionais somente dentro desse recorte completo;
   - projetar a experiência administrativa agregada sobre superfícies existentes antes de propor nova rota;
   - validar propagação universal, por segmento, nicho e ultranicho, carry-forward sem writes artificiais e snapshots/configurações históricas preservados.
+- Qualquer objeto de banco novo ou alterado exige migration forward-only versionada e atualização simultânea de `docs/schema.md`. O runtime não pode depender do objeto antes do apply validado. Tabela em schema exposto nasce com RLS e decisão explícita de policies, GRANTs e Data API: acesso direto por `anon` ou `authenticated` exige policies autorizativas e grants correspondentes; acesso exclusivamente server-side exige revogação de `PUBLIC`, `anon`, `authenticated` e `ai_readonly`, grants mínimos ao papel operacional e registro explícito de que não há policy consumidora. Views expostas usam `security_invoker = true`; função privilegiada exige justificativa, `search_path` fixado e EXECUTE revogado de `PUBLIC`.
+- A prova de publicação e a visão agregada devem demonstrar completude sobre todos os taxons e configurações operacionais relevantes. Paginação, chunking ou agregação não pode tratar primeira página como conjunto integral. Falha, truncamento, timeout ou cardinalidade divergente bloqueia publicação; não autoriza carry-forward parcial.
+- A leitura SQL hospedada read-only de 24/08/2026 confirmou 11 taxons ativos, 1 LP operacional, 1 configuração operacional específica, 1 configuração compartilhada para conta operacional e 1 conta com LP operacional; um taxon possui `R = 5`, dez possuem `R = NULL` e as duas residências operacionais estão na v5. Esses números são evidência do estado atual, não limites de implementação; os testes devem incluir cardinalidade superior a uma página.
+- Antes do gate da implementação que alterar o banco, reconciliar por ABC o drift factual de `docs/schema.md` sobre o apply já concluído da migration E19.5 `20260822170000_e19_5_3_landing_page_workspace.sql`.
 - Este PR documental não autoriza implementação, migration, schema, rota, job, agente, automação, engine ou nova infraestrutura.
 
 ## 4. Escopo negativo e critérios de parada
@@ -242,7 +255,16 @@
 - Não permitir que E19.2, E19.5 ou geração resolvam `versão atual` localmente ou usem `R` como substituto implícito de `C`.
 - Não alterar consumidores além do necessário no futuro recorte técnico sem confirmar seu contrato real na `main` vigente.
 
-### 4.2. Critérios de parada
+### 4.2. Oportunidades estratégicas condicionais sem implementação
+
+- `supa#29`: preservar apenas como hipótese de auditoria futura se, após definição do lifecycle físico, Git, migrations e registros publicados imutáveis não responderem ator, conteúdo, momento ou transição de publicação. Não criar função, trigger, tabela, cabeçalho YAML ou changelog automatizado neste recorte.
+- `supa#53`: preservar apenas como alternativa de transporte durável se medição em volume real demonstrar que o processamento determinístico excede o orçamento interativo ou exige retry. Não instalar `pgmq`, criar fila, worker, job ou estado paralelo neste recorte.
+- `supa#63`: preservar apenas como possibilidade de ampliar testes de RLS se a implementação futura criar múltiplas tabelas/policies e uma prova isolada demonstrar benefício líquido. Não instalar Python, `pgtap`, ferramenta, extensão ou workflow e nunca executar isso em Production neste recorte.
+- `supa#68`: preservar apenas se surgir requisito aprovado de atualização em tempo real e medição demonstrar insuficiência de consulta sob demanda ou polling. Não atualizar dependência nem criar publicação, channel, subscription, migration ou rota Realtime neste recorte.
+- `supa#54` é não aplicável à classificação estrutural `R → C`; similaridade vetorial não substitui a comparação determinística, conservadora e fail-closed.
+- `vercel#20` é não aplicável como autoridade ou rollout segmentado da versão global; targeting não pode selecionar `C` por usuário ou taxon.
+
+### 4.3. Critérios de parada
 
 - Parar se a autoridade de versão atual exigir nova residência sem justificativa e sem reconciliação com a arquitetura existente.
 - Parar se não for possível distinguir de forma determinística e conservadora `sem mudança material`, `evolução compatível` e `revisão necessária`.
@@ -324,6 +346,8 @@
 - Não existe segundo passo humano de `tornar atual`, seletor de versão titular nem escolha manual da versão operacional pelos consumidores E19.2/E19.5.
 - A publicação é uma decisão global do catálogo, não uma decisão pertencente ao taxon que originou um field ou uma alteração.
 - A publicação deve falhar fechado quando o draft final estiver inválido, quando evidência material necessária estiver stale, quando houver pendência E20.6 obrigatória para consumo operacional vigente ou quando a mudança puder tornar configuração operacional corrente inválida/ilegível.
+- A publicação deve constituir um único boundary indivisível de cutover, vinculando o conteúdo exato do draft, sua revisão ou identidade imutável, as validações, a análise de impacto e as autorizações pré-publicação aplicáveis. Edição concorrente, evidência stale, decisão vinculada a conteúdo diferente, publicação duplicada ou falha parcial impedem que a nova versão se torne atual. Nenhum consumidor pode observar a nova `C` antes da conclusão integral desse boundary.
+- Como o registry repo-only é a autoridade publicada, o boundary administrativo não promove diretamente o conteúdo do draft: ele produz o handoff/materialização versionável no repositório e aguarda validação e deploy do artefato executável correspondente. Somente a confirmação de que exatamente esse conteúdo está implantado pode concluir o cutover da versão atual.
 - A publicação não é bloqueada apenas porque um novo `required` torna configuração anterior incompleta, nem por pendência E20.6 de taxon ainda não operacional.
 - Depois da publicação, a primeira alteração posterior inicia o próximo draft sequencial; a versão publicada permanece imutável.
 - A superfície física da ação `Publicar` não é definida neste PR. A implementação deve primeiro avaliar as superfícies administrativas existentes e escolher a menor evolução coerente com o Design System e boundaries atuais.

--- a/docs/lousa-plano-base-e20-2-8.md
+++ b/docs/lousa-plano-base-e20-2-8.md
@@ -85,15 +85,15 @@
 - `evolução compatível` significa que o contrato mudou, mas a nova versão apenas amplia cobertura factual e não remove, restringe ou reinterpreta cobertura anteriormente aprovada.
 - São candidatos naturais a evolução compatível, quando isolados e deterministicamente comprovados:
   - adição de novo field sem alteração destrutiva dos fields existentes;
-  - ampliação de conjunto permitido que aumente a capacidade representacional de um field;
-  - alteração apenas de evidência ou texto editorial sem mudança do contrato factual efetivo.
+  - ampliação de conjunto permitido que aumente a capacidade representacional de um field.
+- Alteração exclusivamente de evidência ou texto editorial sem efeito runtime pertence somente a `sem mudança material`; não pode ser classificada também como `evolução compatível`.
 - A adição de field `required` pode continuar compatível para a pergunta de suficiência taxonômica porque aumenta cobertura disponível; eventual incompletude dos valores concretos passa a ser tratada pelos recortes de configuração da conta/LP, e não pela E20.6.
 - Uma suficiência anteriormente reaberta ou invalidada não pode ser carregada automaticamente, mesmo que a nova versão seja aditiva.
 - Deve ser `revisão necessária` quando houver remoção de field, estreitamento de valores/validação, mudança material de finalidade, tipo, scope, origem esperada, condição, obrigação, aplicabilidade por plano ou qualquer transformação cuja compatibilidade não possa ser demonstrada com segurança.
 - Diante de ambiguidade, falhar para `revisão necessária`.
 - A IA não decide a compatibilidade estrutural entre versões; essa classificação pertence ao processamento determinístico.
 - Este plano não autoriza uma engine genérica de diff. A implementação deve usar a menor comparação determinística capaz de provar as categorias acima sobre os contratos resolvidos reais.
-- No MVP, `sem mudança material` exige igualdade da sequência ordenada de fields e de todas as propriedades funcionais resolvidas, desconsiderando somente número da versão e metadata de evidência sem efeito runtime. `Evolução compatível` admite exclusivamente: adição de field válido; ampliação estrita de `allowedValues` preservando todas as demais propriedades; e mudança apenas de evidência editorial. Múltiplas diferenças são compatíveis somente quando todas pertencem a essa allowlist. Reordenação, retirada, mudança de `purpose`, origem, camada, scope, tipo, obligation, plans, conditions, substitution policy, capability binding ou qualquer validação fora da ampliação permitida resulta em `revisão necessária`.
+- No MVP, `sem mudança material` exige igualdade da sequência ordenada de fields e de todas as propriedades funcionais resolvidas, desconsiderando somente número da versão e metadata de evidência sem efeito runtime. `Evolução compatível` admite exclusivamente adição de field válido ou ampliação estrita de `allowedValues`, sempre preservando todas as demais propriedades. Múltiplas diferenças são compatíveis somente quando todas pertencem a essa allowlist. Reordenação, retirada, mudança de `purpose`, origem, camada, scope, tipo, obligation, plans, conditions, substitution policy, capability binding ou qualquer validação fora da ampliação permitida resulta em `revisão necessária`.
 
 ### 1.7. Autoridade `R → C` e ciclo de vida mínimo
 
@@ -128,7 +128,7 @@
   - nunca ativar versão ainda não validada/publicada;
   - nunca transformar carry-forward compatível em write fictício de revisão humana.
 - Persistência:
-  - a residência física da autoridade de versão atual não é definida por este plano; deve ser escolhida em implementação própria após análise de `docs/schema.md`, `docs/base-tecnica.md` e boundaries existentes.
+  - versões publicadas e versão atual residem exclusivamente no registry/boundary repo-only; somente o draft administrativo não operacional pode receber residência adicional, e apenas se a análise técnica demonstrar que essa é a menor solução sem criar segunda autoridade.
 - Consumo:
   - consumidores correntes recebem `C` como número explícito da autoridade canônica;
   - consumidores históricos usam o número explicitamente registrado em seus snapshots/revisões.
@@ -255,12 +255,8 @@
 - Não permitir que E19.2, E19.5 ou geração resolvam `versão atual` localmente ou usem `R` como substituto implícito de `C`.
 - Não alterar consumidores além do necessário no futuro recorte técnico sem confirmar seu contrato real na `main` vigente.
 
-### 4.2. Oportunidades estratégicas condicionais sem implementação
+### 4.2. Travas de não adoção
 
-- `supa#29`: preservar apenas como hipótese de auditoria futura se, após definição do lifecycle físico, Git, migrations e registros publicados imutáveis não responderem ator, conteúdo, momento ou transição de publicação. Não criar função, trigger, tabela, cabeçalho YAML ou changelog automatizado neste recorte.
-- `supa#53`: preservar apenas como alternativa de transporte durável se medição em volume real demonstrar que o processamento determinístico excede o orçamento interativo ou exige retry. Não instalar `pgmq`, criar fila, worker, job ou estado paralelo neste recorte.
-- `supa#63`: preservar apenas como possibilidade de ampliar testes de RLS se a implementação futura criar múltiplas tabelas/policies e uma prova isolada demonstrar benefício líquido. Não instalar Python, `pgtap`, ferramenta, extensão ou workflow e nunca executar isso em Production neste recorte.
-- `supa#68`: preservar apenas se surgir requisito aprovado de atualização em tempo real e medição demonstrar insuficiência de consulta sob demanda ou polling. Não atualizar dependência nem criar publicação, channel, subscription, migration ou rota Realtime neste recorte.
 - `supa#54` é não aplicável à classificação estrutural `R → C`; similaridade vetorial não substitui a comparação determinística, conservadora e fail-closed.
 - `vercel#20` é não aplicável como autoridade ou rollout segmentado da versão global; targeting não pode selecionar `C` por usuário ou taxon.
 
@@ -346,11 +342,13 @@
 - Não existe segundo passo humano de `tornar atual`, seletor de versão titular nem escolha manual da versão operacional pelos consumidores E19.2/E19.5.
 - A publicação é uma decisão global do catálogo, não uma decisão pertencente ao taxon que originou um field ou uma alteração.
 - A publicação deve falhar fechado quando o draft final estiver inválido, quando evidência material necessária estiver stale, quando houver pendência E20.6 obrigatória para consumo operacional vigente ou quando a mudança puder tornar configuração operacional corrente inválida/ilegível.
-- A publicação deve constituir um único boundary indivisível de cutover, vinculando o conteúdo exato do draft, sua revisão ou identidade imutável, as validações, a análise de impacto e as autorizações pré-publicação aplicáveis. Edição concorrente, evidência stale, decisão vinculada a conteúdo diferente, publicação duplicada ou falha parcial impedem que a nova versão se torne atual. Nenhum consumidor pode observar a nova `C` antes da conclusão integral desse boundary.
-- Como o registry repo-only é a autoridade publicada, o boundary administrativo não promove diretamente o conteúdo do draft: ele produz o handoff/materialização versionável no repositório e aguarda validação e deploy do artefato executável correspondente. Somente a confirmação de que exatamente esse conteúdo está implantado pode concluir o cutover da versão atual.
+- A publicação não afirma atomicidade transacional entre Admin, GitHub e deploy. Ela segue uma sequência observável e fail-closed: congelar a identidade exata do draft e suas evidências; materializar no repositório uma nova versão executável e a declaração explícita de versão atual; validar o diff e o artefato em CI/Preview; obter revisão e merge humanos; concluir o deploy de Production; e comprovar no runtime de Production que versão, conteúdo e identidade correspondem ao draft congelado.
+- A transição que torna a nova versão observável como `C` é a ativação bem-sucedida em Production do artefato repo-only que contém simultaneamente a versão executável e a declaração explícita de versão atual. Até essa ativação, o deployment anterior continua sendo a autoridade e toda falha de materialização, validação, revisão, merge ou deploy preserva a versão anterior como atual.
+- A residência administrativa, quando existir, registra a reconciliação do draft somente depois da comprovação do runtime. Falha ou atraso nessa reconciliação não pode substituir nem reverter a autoridade repo-only já implantada, mas bloqueia novo draft/publicação administrativa até que o estado seja reconciliado com o artefato ativo exato.
+- Edição concorrente, evidência stale, decisão E20.6.5 vinculada a conteúdo diferente ou tentativa duplicada impedem iniciar ou continuar a sequência para aquele draft. Todos os gates E20.6/E19 aplicáveis devem estar concluídos antes da revisão/merge que pode levar o artefato a Production.
 - A publicação não é bloqueada apenas porque um novo `required` torna configuração anterior incompleta, nem por pendência E20.6 de taxon ainda não operacional.
 - Depois da publicação, a primeira alteração posterior inicia o próximo draft sequencial; a versão publicada permanece imutável.
-- A superfície física da ação `Publicar` não é definida neste PR. A implementação deve primeiro avaliar as superfícies administrativas existentes e escolher a menor evolução coerente com o Design System e boundaries atuais.
+- A composição visual da ação `Publicar` não é definida neste plano. A implementação deve evoluir a superfície administrativa já escolhida com a menor UI coerente com o Design System e com a sequência operacional acima.
 
 ### 5.8. Simplificações vinculantes do MVP
 

--- a/docs/matriz-consolidacao-e20-2-8.md
+++ b/docs/matriz-consolidacao-e20-2-8.md
@@ -1,0 +1,40 @@
+# Matriz de consolidação — E20.2.8
+
+- V1 congelada: commit `ebde94d2757994e2121fd974ad667584a7f62203`, blob `14718243ce834b5e37406e9d560d1db2d1f3db9e`, `docs/lousa-plano-base-e20-2-8.md`.
+- V2 avaliada na Passagem 1: commit `258e493f42e0c4a8ee5885c4fed2bcedc8f9848f`, blob `b95c18b250bb5744d6f0c9e11cba753f02cfec9e`.
+- V2 após correções da Passagem 1: commit `6a3e6adbd45ab777a1b455d7fc87a0a7d300de0d`, blob `2b8ae1e122c163d7831c18f7da00ed538864ba8e`.
+- Plano conceitual: `N/A` — nenhuma referência competente ou vínculo inequívoco adicional.
+- Gestor de Automações: `N/A — nenhuma fase com Automação: sim`.
+
+## Achados e tratamentos
+
+| Especialista | ID | Achado fiel e classificação original | Relação com o escopo | Tratamento | Destino do update | Localização na v2 | Evidência ou justificativa |
+|---|---|---|---|---|---|---|---|
+| Gestor Estrutural | `GE-E20.2.8-01` | Identidade congelada confirmada; achado estrutural. | preservação | incorporado | N/A | Seção 1.1, linha 7 | V1, PR #809, branch, HEAD e blob estão identificados por referências imutáveis. |
+| Gestor Estrutural | `GE-E20.2.8-02` | A autoridade física admitia catálogo persistido ou registry repo-only; bloqueio por decisão humana. | preservação | incorporado | N/A | Seções 1.1, 1.4, 2.1, 3.1 e 5.7 | Decisão humana de 24/08/2026 escolheu registry repo-only; somente o draft não operacional pode ter residência adicional. |
+| Gestor Estrutural | `GE-E20.2.8-03` | Inventário de substituição incompleto; patch estrutural. | extensão adjacente necessária e proporcional | incorporado | N/A | Seção 2.4, linha 179 | O inventário cobre pin TypeScript, RPC, preparação, workspace, geração, contexto e `versions.at(-1)`, com remoção do legado sem consumidor. |
+| Gestor Estrutural | `GE-E20.2.8-04` | Comparador sem regra executável suficiente; patch estrutural. | extensão adjacente necessária e proporcional | incorporado | N/A | Seção 1.6 | A v2 fixa projeção funcional, categorias mutuamente exclusivas, allowlist fechada e fallback conservador. |
+| Gestor Estrutural | `GE-E20.2.8-05` | Publicação sem vínculo seguro entre conteúdo e evidências; patch estrutural. | extensão adjacente necessária e proporcional | incorporado | N/A | Seção 5.7, linhas 345–348 | Após a Passagem 1, a alegação de atomicidade cross-system foi substituída por sequência observável, identidade congelada e preservação da versão anterior em falha. |
+| Gestor Estrutural | `GE-E20.2.8-06` | Paths administrativos mínimos já determináveis; patch estrutural. | extensão adjacente necessária e proporcional | incorporado | N/A | Seção 2.5, linha 194 | Reutiliza `/admin/estrutura-lp?view=entradas` e `/admin/taxonomia/[taxonId]`, com guard e adapter server-only. |
+| Gestor Estrutural | `GE-E20.2.8-07` | Governança de banco ausente; patch estrutural condicional. | extensão adjacente necessária e proporcional | incorporado | N/A | Seção 3.1, linha 236 | A regra somente incide se o draft exigir banco e cobre migration, apply, RLS, policies, grants, Data API, views e funções. |
+| Gestor Estrutural | `GE-E20.2.8-08` | `docs/schema.md` stale sobre o apply E19.5; condicionante objetiva. | extensão adjacente necessária e proporcional | incorporado | N/A | Seção 3.1, linha 239 | O plano exige reconciliação via ABC antes do gate de implementação que alterar banco; o documento canônico não foi editado na consolidação da v2. |
+| Gestor Estrutural | `GE-E20.2.8-09` | Gate global sem prova de paginação, cardinalidade e completude; patch estrutural. | extensão adjacente necessária e proporcional | incorporado | N/A | Seções 2.5 e 3.1, linhas 197 e 237–238 | A v2 exige total autoritativo, falha fechada e teste acima de uma página; SQL read-only registrou o snapshot atual sem convertê-lo em limite. |
+| Gestor de Updates | `prod#16` | Complementar, horizonte atual; QA proporcional da superfície Admin. | extensão adjacente necessária e proporcional | incorporado | usar como referência, validação ou trava | Seção 2.5, linha 197 | Critérios incluem Preview, desktop/mobile, acesso, estados e coleção paginada completa. |
+| Gestor de Updates | `prod#17` | Complementar, horizonte atual; baseline acessível verificável. | extensão adjacente necessária e proporcional | incorporado | usar como referência, validação ou trava | Seção 2.5, linha 198 | Critérios incluem teclado, foco, labels, anúncios, contraste, toque e inspeção manual sem alegação global de conformidade. |
+| Gestor de Updates | `supa#29` | Sobreposto, horizonte condicional; auditoria automatizada futura. | expansão | não incorporado — justificado | preservar como oportunidade estratégica condicional | N/A | A Passagem 1 confirmou que é adiável e cria frente independente; eventual interesse exige recorte futuro próprio. |
+| Gestor de Updates | `supa#53` | Complementar, horizonte condicional; fila durável futura. | expansão | não incorporado — justificado | preservar como oportunidade estratégica condicional | N/A | A solução síncrona determinística ainda não demonstrou insuficiência; fila, worker e retries constituem frente independente. |
+| Gestor de Updates | `supa#63` | Complementar, horizonte condicional; tooling de matriz RLS. | expansão | não incorporado — justificado | preservar como oportunidade estratégica condicional | N/A | Ferramenta, Python e pgtap são adiáveis e não necessários aos testes SQL dirigidos deste recorte. |
+| Gestor de Updates | `supa#68` | Complementar, horizonte condicional; Realtime futuro. | expansão | não incorporado — justificado | preservar como oportunidade estratégica condicional | N/A | Não há requisito nem medição que torne Realtime indispensável; consulta completa sob demanda permanece suficiente. |
+| Gestor de Updates | `supa#54` | Incompatível, horizonte futuro; similaridade vetorial. | preservação | incorporado | não aplicável ao recorte | Seção 4.2, linha 260 | A trava preserva classificação determinística e proíbe embeddings como autoridade de `R → C`. |
+| Gestor de Updates | `vercel#20` | Sobreposto, horizonte condicional; targeting ou rollout segmentado. | preservação | incorporado | não aplicável ao recorte | Seção 4.2, linha 261 | A trava preserva versão global única e impede selecionar `C` por usuário ou taxon. |
+| Gestor de Updates | `GU-GITHUB-N/A` | Nenhum item GitHub preliminarmente elegível. | preservação | não incorporado — justificado | não aplicável ao recorte | N/A | O parecer integral não encontrou relação objetiva com lifecycle, comparador ou superfície administrativa. |
+| Gestor de Automações | `GA-N/A` | Nenhuma fase marcada exatamente como `Automação: sim`. | preservação | não incorporado — justificado | N/A | Seção 3.1, linha 224 | O plano registra `Automação: não` e proíbe agente, IA decisória, job, fila e rotina recorrente. |
+
+## Correções da Passagem 1
+
+| ID | Correção obrigatória | Tratamento | Evidência |
+|---|---|---|---|
+| `P1-E20.2.8-01` | Eliminar a residência indefinida da autoridade publicada. | incorporado | Seção 2.1 fixa registry/boundary repo-only e deixa somente o draft condicionado. |
+| `P1-E20.2.8-02` | Tornar as categorias de compatibilidade mutuamente exclusivas. | incorporado | Seção 1.6 classifica mudança apenas editorial como `sem mudança material` e remove essa hipótese de `evolução compatível`. |
+| `P1-E20.2.8-03` | Definir sequência observável de publicação sem alegar transação entre sistemas. | incorporado | Seção 5.7 define congelamento, materialização, CI/Preview, revisão/merge humanos, deploy, transição observável e reconciliação administrativa. |
+| `P1-E20.2.8-04` | Remover oportunidades adiáveis do plano-alvo. | incorporado | `supa#29`, `supa#53`, `supa#63` e `supa#68` permanecem somente nesta matriz como oportunidades condicionais não incorporadas. |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 0. Introdução
 
 0.1 Cabeçalho
-• Data: 23/08/2026
-• Versão: v1.5.181
+• Data: 24/08/2026
+• Versão: v1.5.182
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -2603,6 +2603,40 @@ Repositório — Ajustados
   * As regressões focais, `npm ci`, `npm run check`, `git diff --check` e a inspeção autenticada do Preview em desktop e largura móvel foram aprovados; o servidor local iniciou na porta 3000, mas a renderização local ficou indisponível por ausência das chaves públicas do Supabase no worktree isolado.
   * A E20.6 deve ser executada novamente contra a versão explícita 4 antes de qualquer registro de suficiência.
   * O recorte não criou field, banco, migration, rota, API, nova UI, persistência, infraestrutura, automação, agente, job ou workload OpenAI e não alterou a E20.6.
+
+20.2.8 Versão atual e propagação escalável do catálogo E20.2
+
+20.2.8.1 Objetivo e status
+
+* Objetivo: definir uma versão atual global, explícita e repo-only para o catálogo E20.2, propagá-la de forma determinística aos consumidores correntes e evitar reavaliação humana por taxon quando a evolução for comprovadamente compatível.
+* Status: plano-base v2 aprovado; implementação pendente.
+
+20.2.8.3 Autoridade e lifecycle de publicação
+
+* Status: Definidos.
+* Conteúdo:
+  * O registry versionado no repositório permanece a autoridade exclusiva das versões publicadas e da versão atual; v1–v5 não serão migradas para o banco.
+  * Pode existir somente um próximo draft mutável e não operacional. Persistência administrativa em banco só é admissível se a análise técnica a demonstrar como menor solução e nunca constitui autoridade do catálogo publicado.
+  * Publicar exige congelar draft e evidências, materializar no repositório a nova versão executável e a declaração explícita de versão atual, validar em CI/Preview, obter revisão e merge humanos, concluir o deploy de Production e comprovar a identidade exata no runtime.
+  * A ativação bem-sucedida do artefato em Production torna a nova versão atual; qualquer falha anterior preserva a versão vigente. Eventual reconciliação administrativa posterior não pode substituir nem reverter a autoridade repo-only e, se atrasada, bloqueia novo draft/publicação administrativa até que o estado seja reconciliado com o artefato ativo exato.
+
+20.2.8.4 Versão revisada, versão efetiva e compatibilidade
+
+* Status: Definidas.
+* Conteúdo:
+  * `R` é a última versão com decisão humana explícita de suficiência; `C` é a versão operacional efetivamente autorizada pelo boundary canônico de preparação.
+  * `C` acompanha a versão atual quando `R = C` ou quando a transição resolvida for deterministicamente `sem mudança material` ou `evolução compatível`, sem escrita artificial em `reviewed_input_catalog_version`.
+  * Remoção, restrição, reinterpretação, ambiguidade ou mudança fora da allowlist conservadora exigem revisão E20.6.5; falhas permanecem fechadas e a IA não classifica compatibilidade estrutural.
+  * E19.2 pré-handoff, workspace E19.5 e geração E19.5 devem consumir o mesmo número concreto `C`; nenhum consumidor pode inferir `latest`, maior versão ou substituir `C` por `R`.
+
+20.2.8.5 Draft, gates e experiência administrativa
+
+* Status: Definidos para implementação futura.
+* Conteúdo:
+  * O draft pode ser resolvido e validado administrativamente, mas nunca é operacional; qualquer edição material torna stale as evidências dependentes.
+  * O gate pré-publicação separa suficiência taxonômica E20.6 de validade estrutural das configurações E19, cobre o conjunto integral paginado e bloqueia diante de truncamento, cardinalidade divergente ou configuração operacional inválida/ilegível.
+  * A visão agregada deve evoluir `/admin/estrutura-lp?view=entradas`; `/admin/taxonomia/[taxonId]` permanece responsável pela avaliação individual E20.6.5. Não criar nova rota de primeiro nível; qualquer proposta de nova rota depende de insuficiência comprovada das superfícies existentes.
+  * A primeira entrega preserva histórico imutável, retirada forward-only de fields publicados e snapshots/configurações na versão efetivamente usada; não inclui rollback, múltiplos drafts, targeting por taxon, job, fila, agente, automação recorrente ou engine genérica de diff.
 
 20.3 Perfil de orientação para geração
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 0.1 Cabeçalho
 • Data: 24/08/2026
-• Versão: v1.5.182
+• Versão: v1.5.183
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -2609,20 +2609,77 @@ Repositório — Ajustados
 20.2.8.1 Objetivo e status
 
 * Objetivo: definir uma versão atual global, explícita e repo-only para o catálogo E20.2, propagá-la de forma determinística aos consumidores correntes e evitar reavaliação humana por taxon quando a evolução for comprovadamente compatível.
-* Status: plano-base v2 aprovado; implementação pendente.
+* Status: Implementação concluída e validada localmente em 24/08/2026 no PR #814; merge humano, apply da migration e validação hospedada permanecem pendentes.
+
+20.2.8.2 Registros do recorte
+
+* Banco:
+  * Criados:
+    * `public.landing_page_input_catalog_drafts`
+  * Ajustados:
+    * `public.save_account_landing_page_configuration_v1`
+* Repositório:
+  * Criados:
+    * `lib/conversion-content/landing-page/input-catalog/lifecycle.ts`
+    * `lib/conversion-content/landing-page/input-catalog/draft.ts`
+    * `lib/admin/adapters/adminInputCatalogLifecycleAdapter.ts`
+    * `lib/admin/adapters/adminInputCatalogLifecyclePagination.ts`
+    * `lib/admin/adapters/adminInputCatalogLifecycleValidation.ts`
+    * `app/admin/(protected)/estrutura-lp/actions.ts`
+    * `app/admin/(protected)/estrutura-lp/_components/AdminInputCatalogLifecycle.tsx`
+    * `supabase/migrations/20260824180000_e20_2_8_input_catalog_lifecycle.sql`
+    * `supabase/tests/e20_2_8_input_catalog_lifecycle.test.sql`
+    * `supabase/snippets/e20_2_8_input_catalog_lifecycle_verify.sql`
+  * Ajustados:
+    * `lib/conversion-content/landing-page/input-catalog/contracts.ts`
+    * `lib/conversion-content/landing-page/input-catalog/schema.ts`
+    * `lib/conversion-content/landing-page/input-catalog/resolver.ts`
+    * `lib/conversion-content/landing-page/input-catalog/index.ts`
+    * `lib/conversion-content/landing-page/input-catalog/validation-cases.ts`
+    * `lib/conversion-content/landing-page/taxon-preparation/contracts.ts`
+    * `lib/conversion-content/landing-page/taxon-preparation/preparation.ts`
+    * `lib/conversion-content/landing-page/taxon-preparation/input-catalog-evaluation.ts`
+    * `lib/conversion-content/landing-page/taxon-preparation/index.ts`
+    * `lib/conversion-content/landing-page/taxon-preparation/validation-cases.ts`
+    * `lib/conversion-content/adapters/selectedEndCustomerResearchAdapter.ts`
+    * `lib/conversion-content/adapters/inputCatalogEvaluationContextAdapter.ts`
+    * `lib/lp-builder/onboardingConfiguration.ts`
+    * `lib/lp-builder/adapters/onboardingConfigurationAdapter.ts`
+    * `lib/lp-builder/adapters/onboardingConfigurationAdapterCore.ts`
+    * `lib/lp-builder/adapters/landingPageWorkspaceAdapter.ts`
+    * `lib/lp-builder/adapters/generationContextAdapter.ts`
+    * `lib/lp-builder/adapters/generationContextAdapterCore.ts`
+    * `lib/lp-builder/generationContext.ts`
+    * `lib/lp-builder/landingPageWorkspace.ts`
+    * `lib/lp-builder/index.ts`
+    * `lib/lp-builder/validation-cases.ts`
+    * `lib/lp-builder/generation-context-validation-cases.ts`
+    * `lib/lp-builder/landing-page-workspace-validation-cases.ts`
+    * `lib/admin/adapters/adminLandingPageStructureAdapter.ts`
+    * `app/admin/(protected)/estrutura-lp/page.tsx`
+    * `app/admin/(protected)/estrutura-lp/validation-cases.ts`
+    * `app/admin/(protected)/taxonomia/[taxonId]/page.tsx`
+    * `app/admin/(protected)/taxonomia/[taxonId]/_components/AdminTaxonInputCatalogEvaluation.tsx`
+    * `app/admin/(protected)/taxonomia/actions.ts`
+* Referências:
+  * Catálogo e preparação factual: `docs/base-tecnica.md` — seções 3.15.4 e 3.15.7.
+  * Draft administrativo e RPC de configuração: `docs/schema.md` — seções 1.35 e 3.8.2.
 
 20.2.8.3 Autoridade e lifecycle de publicação
 
-* Status: Definidos.
+* Status: Implementados.
 * Conteúdo:
   * O registry versionado no repositório permanece a autoridade exclusiva das versões publicadas e da versão atual; v1–v5 não serão migradas para o banco.
   * Pode existir somente um próximo draft mutável e não operacional. Persistência administrativa em banco só é admissível se a análise técnica a demonstrar como menor solução e nunca constitui autoridade do catálogo publicado.
+  * O draft preserva os fields publicados e sua `createdInVersion`; remoção direta ou proveniência retroativa falha fechada, e retirada usa somente `retiredInVersion` igual à versão alvo.
+  * A análise técnica confirmou um singleton service-only como menor residência robusta do draft e das evidências humanas vinculadas ao seu fingerprint, sem integração externa adicional e sem migrar v1–v5.
   * Publicar exige congelar draft e evidências, materializar no repositório a nova versão executável e a declaração explícita de versão atual, validar em CI/Preview, obter revisão e merge humanos, concluir o deploy de Production e comprovar a identidade exata no runtime.
   * A ativação bem-sucedida do artefato em Production torna a nova versão atual; qualquer falha anterior preserva a versão vigente. Eventual reconciliação administrativa posterior não pode substituir nem reverter a autoridade repo-only e, se atrasada, bloqueia novo draft/publicação administrativa até que o estado seja reconciliado com o artefato ativo exato.
+  * A reconciliação pós-deploy ocorre somente no runtime de Production e remove apenas a residência temporária quando a versão atual e o fingerprint do registry implantado coincidem exatamente com o handoff congelado; divergência falha fechada.
 
 20.2.8.4 Versão revisada, versão efetiva e compatibilidade
 
-* Status: Definidas.
+* Status: Implementadas.
 * Conteúdo:
   * `R` é a última versão com decisão humana explícita de suficiência; `C` é a versão operacional efetivamente autorizada pelo boundary canônico de preparação.
   * `C` acompanha a versão atual quando `R = C` ou quando a transição resolvida for deterministicamente `sem mudança material` ou `evolução compatível`, sem escrita artificial em `reviewed_input_catalog_version`.
@@ -2631,10 +2688,11 @@ Repositório — Ajustados
 
 20.2.8.5 Draft, gates e experiência administrativa
 
-* Status: Definidos para implementação futura.
+* Status: Implementados; publicação de nova versão permanece sujeita a handoff repo-only, validações e decisão humana.
 * Conteúdo:
   * O draft pode ser resolvido e validado administrativamente, mas nunca é operacional; qualquer edição material torna stale as evidências dependentes.
-  * O gate pré-publicação separa suficiência taxonômica E20.6 de validade estrutural das configurações E19, cobre o conjunto integral paginado e bloqueia diante de truncamento, cardinalidade divergente ou configuração operacional inválida/ilegível.
+  * O gate pré-publicação separa suficiência taxonômica E20.6 de validade estrutural das configurações E19.2 pré-handoff e E19.5, cobre o conjunto integral paginado com cardinalidade exata e bloqueia diante de truncamento, cardinalidade divergente ou configuração operacional inválida/ilegível.
+  * Validação e handoff congelam fingerprints distintos do conteúdo do draft e da coleção operacional completa; qualquer drift posterior de taxonomia, configurações, LPs ou elegibilidade deixa a evidência stale e exige nova preparação antes da revisão/merge.
   * A visão agregada deve evoluir `/admin/estrutura-lp?view=entradas`; `/admin/taxonomia/[taxonId]` permanece responsável pela avaliação individual E20.6.5. Não criar nova rota de primeiro nível; qualquer proposta de nova rota depende de insuficiência comprovada das superfícies existentes.
   * A primeira entrega preserva histórico imutável, retirada forward-only de fields publicados e snapshots/configurações na versão efetivamente usada; não inclui rollback, múltiplos drafts, targeting por taxon, job, fila, agente, automação recorrente ou engine genérica de diff.
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -2,7 +2,7 @@
 
 0.1 Cabeçalho
 • Data da última atualização: 24/08/2026
-• Documento: LP Factory 10 — Schema (DB Contract) v1.0.55
+• Documento: LP Factory 10 — Schema (DB Contract) v1.0.56
 
 0.2 Contrato do documento (consulta)
 • Esta seção define o objetivo do documento e quando/como a IA deve consultá-lo.
@@ -979,7 +979,7 @@
 1.32 account_landing_page_configurations
 1.32.1 Função e residência
 • Residência operacional lazy por LP dos fields E20.2 com `scope = offer | campaign | landing_page`.
-• A linha nasce no primeiro save da LP; configuração parcial é válida e completude continua derivada em runtime pelo catálogo v5 exato.
+• A linha nasce no primeiro save da LP; configuração parcial é válida e completude continua derivada em runtime pela versão atual explícita do catálogo repo-only.
 • O shape de `values` permanece declarativo por `scope`; a tabela não replica uma lista de fields do catálogo.
 
 1.32.2 Colunas, constraints e índice
@@ -1000,7 +1000,7 @@
 • service_role: SELECT, INSERT e UPDATE; sem DELETE ou TRUNCATE.
 • O trigger `account_landing_page_configurations_set_updated_at` atualiza updated_at antes de update.
 • Não há backfill, placeholder, inicialização eager ou cópia da configuração histórica de onboarding para este agregado.
-• O contrato está materializado repo-only em `supabase/migrations/20260822170000_e19_5_3_landing_page_workspace.sql`; apply hospedado e verificação read-only permanecem pós-merge.
+• O contrato foi aplicado no ambiente hospedado por `supabase/migrations/20260822170000_e19_5_3_landing_page_workspace.sql` e validado pelos testes e verificadores focais da E19.5.3.
 
 1.33 openai_model_catalog_models
 1.33.1 Função e colunas
@@ -1028,6 +1028,26 @@
 • Migration forward-only: `supabase/migrations/20260823144334_e21_2_5_openai_model_catalog.sql`.
 • Teste transacional: `supabase/tests/e21_2_5_openai_model_catalog.test.sql`; verificador read-only: `supabase/snippets/e21_2_5_openai_model_catalog_verify.sql`.
 • Estado atual: migration aplicada no ambiente hospedado pelo fluxo canônico; o verificador read-only aprovou 8/8 verificações e o Security Controls não apresentou alerta incompatível com as tabelas, constraints, RLS, policies, ACLs, RPCs ou triggers do catálogo. O INFO de RLS sem policy é esperado e compatível com acesso exclusivo por service_role.
+
+1.35 landing_page_input_catalog_drafts
+1.35.1 Função e autoridade
+• Residência singleton do único próximo draft administrativo do catálogo E20.2; o conteúdo é mutável e não operacional.
+• A tabela não armazena nem replica as versões publicadas e não define a versão atual. Registry, versionamento publicado e declaração de versão atual permanecem autoridade exclusiva do repositório implantado.
+• base_version e target_version são inteiros positivos e sequenciais; catalog_json é objeto JSON; revision é bigint positiva e suporta concorrência otimista.
+
+1.35.2 Evidências e constraints
+• content_fingerprint é SHA-256 hexadecimal obrigatório; validation_fingerprint/validation_context_fingerprint/validated_at e publication_fingerprint/publication_context_fingerprint/publication_prepared_at formam conjuntos consistentes.
+• Evidência de publicação só pode referenciar o mesmo conteúdo e a mesma coleção operacional integral validados. Drift de taxonomia, configuração E19.2 pré-handoff, configuração E19.5, LP ou elegibilidade torna o handoff stale. O registro significa handoff repo-only preparado, não publicação, ativação ou autoridade operacional.
+• taxon_review_evidence é objeto JSON server-only de decisões humanas pré-publicação vinculadas ao fingerprint exato do conteúdo e do contexto E20.6.5; editar o draft limpa essas evidências, e registrá-las não atualiza reviewed_input_catalog_version.
+• singleton é a primary key booleana e aceita somente true; no máximo uma linha pode existir.
+• created_by e updated_by referenciam auth.users(id) com ON UPDATE CASCADE e ON DELETE RESTRICT; created_at e updated_at são timestamptz não nulos, e trigger canônico mantém updated_at.
+
+1.35.3 Segurança e artefatos
+• RLS habilitado e nenhuma policy; public, anon, authenticated e ai_readonly não possuem grants.
+• service_role possui SELECT, INSERT, UPDATE e DELETE; não há acesso direto do client.
+• DELETE é usado somente pela reconciliação humana no runtime de Production pós-deploy, depois de o boundary comprovar que versão atual, conteúdo e fingerprint do registry implantado correspondem exatamente ao draft congelado.
+• Migration forward-only: `supabase/migrations/20260824180000_e20_2_8_input_catalog_lifecycle.sql`; teste transacional: `supabase/tests/e20_2_8_input_catalog_lifecycle.test.sql`; verificador read-only: `supabase/snippets/e20_2_8_input_catalog_lifecycle_verify.sql`.
+• A migration não cria linha e não migra v1–v5. Apply hospedado permanece pendente do merge humano.
 
 2. Views
 
@@ -1252,7 +1272,7 @@
 3.8.2 Save atômico versionado
 • `save_account_landing_page_configuration_v1(uuid, uuid, jsonb, jsonb, bigint, bigint, integer, uuid, uuid) → table(shared_revision bigint, landing_page_revision bigint)` grava as duas residências em uma transação; o último argumento é a materialização mais recente observada durante a validação dos baselines de identidade.
 • O RPC usa SECURITY INVOKER, search_path fixado, lock tenant-safe da LP, tokens otimistas independentes e comparação da última materialização; ausência esperada exige inexistência da linha, concorrência com append falha fechado e save sem mudança não incrementa revisão.
-• `catalog_version` deve ser exatamente 5; scope drift, versão diferente, LP não operacional, ator sem autoridade ou revisão stale falham fechados.
+• `catalog_version` deve ser inteiro positivo e corresponde à versão efetiva corrente validada pelo boundary repo-only antes da chamada; o banco não deriva current ou latest. Scope drift, versão inválida, LP não operacional, ator sem autoridade ou revisão stale falham fechados.
 • A residência compartilhada só é criada quando contém valor; a residência da LP nasce no primeiro save.
 • EXECUTE exclusivo de service_role; public, anon, authenticated e ai_readonly não executam.
 

--- a/lib/admin/adapters/adminInputCatalogLifecycleAdapter.ts
+++ b/lib/admin/adapters/adminInputCatalogLifecycleAdapter.ts
@@ -1,0 +1,1135 @@
+import "server-only";
+
+import { createHash } from "node:crypto";
+
+import {
+  CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION,
+  createNextLandingPageInputCatalogDraft,
+  landingPageInputCatalogRegistry,
+  listLandingPageInputCatalogVersions,
+  validateLandingPageInputCatalogDraft,
+  serializeLandingPageInputCatalogEntry,
+  buildLandingPageInputCatalogTaxonChain,
+  type LandingPageInputCatalogPlan,
+  type LandingPageInputCatalogDraftImpact,
+  type LandingPageInputCatalogTaxonIdentity,
+} from "@/conversion-content/landing-page/input-catalog";
+import type { AccountLandingPageOnboardingStoredValues } from "@/lp-builder/contracts";
+import { reconstructDraftInputCatalogEvaluationContext } from "@/conversion-content/adapters/inputCatalogEvaluationContextAdapter";
+import type {
+  BuildInputCatalogEvaluationContextResult,
+  InputCatalogEvaluationContextIdentity,
+} from "@/conversion-content/landing-page/taxon-preparation";
+import { createServiceClient } from "@/lib/supabase/service";
+import { collectCompletePaginatedRows } from "./adminInputCatalogLifecyclePagination";
+import {
+  countInvalidInputCatalogOperationalConfigurations,
+  fingerprintInputCatalogOperationalContext,
+  type InputCatalogOperationalConfiguration,
+} from "./adminInputCatalogLifecycleValidation";
+
+const PAGE_SIZE = 500;
+
+type ServiceClient = ReturnType<typeof createServiceClient>;
+
+export type AdminInputCatalogLifecycleState = Readonly<{
+  currentVersion: number;
+  publishedVersions: readonly number[];
+  totalActiveTaxons: number;
+  totalOperationalTaxons: number;
+  draft: null | Readonly<{
+    baseVersion: number;
+    targetVersion: number;
+    catalogJson: string;
+    contentFingerprint: string;
+    operationalContextFingerprint: string;
+    revision: number;
+    validationCurrent: boolean;
+    publicationPrepared: boolean;
+    publishedReconciliationRequired: boolean;
+    publishedReconciliationAllowed: boolean;
+    reviewedTaxonIds: readonly string[];
+    updatedAt: string;
+    impacts: readonly LandingPageInputCatalogDraftImpact[];
+    totals: Readonly<{
+      noMaterialChange: number;
+      compatibleEvolution: number;
+      reviewRequired: number;
+      blockingOperationalReviews: number;
+      invalidOperationalConfigurations: number;
+    }>;
+  }>;
+  error: string | null;
+}>;
+
+export type AdminInputCatalogLifecycleMutationResult =
+  | Readonly<{ ok: true; state: AdminInputCatalogLifecycleState; handoff?: string }>
+  | Readonly<{
+      ok: false;
+      code: "INVALID_INPUT" | "CONFLICT" | "UNAVAILABLE" | "BLOCKED";
+      message: string;
+    }>;
+
+export async function readAdminInputCatalogLifecycle(): Promise<AdminInputCatalogLifecycleState> {
+  const client = createServiceClient();
+  const context = await readCompleteLifecycleContext(client);
+  if (!context.ok) return unavailableState(context.message);
+  const row = await readDraftRow(client);
+  if (!row.ok) return unavailableState(row.message, context);
+  return await buildState(context, row.value);
+}
+
+export async function initializeAdminInputCatalogDraft(input: Readonly<{
+  actorUserId: string;
+}>): Promise<AdminInputCatalogLifecycleMutationResult> {
+  const client = createServiceClient();
+  const context = await readCompleteLifecycleContext(client);
+  if (!context.ok) return unavailable(context.message);
+  const candidate = validateLandingPageInputCatalogDraft({
+    draft: createNextLandingPageInputCatalogDraft(),
+    taxons: context.value.taxons,
+  });
+  if (!candidate.ok) return blocked(candidate.error.message);
+  const contentFingerprint = fingerprint(candidate.value.canonicalJson);
+  const { data, error } = await client
+    .from("landing_page_input_catalog_drafts")
+    .insert({
+      singleton: true,
+      base_version: CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION,
+      target_version: CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION + 1,
+      catalog_json: candidate.value.entry,
+      content_fingerprint: contentFingerprint,
+      revision: 1,
+      validation_fingerprint: null,
+      validation_context_fingerprint: null,
+      validated_at: null,
+      publication_fingerprint: null,
+      publication_context_fingerprint: null,
+      publication_prepared_at: null,
+      taxon_review_evidence: {},
+      created_by: input.actorUserId,
+      updated_by: input.actorUserId,
+    })
+    .select(DRAFT_SELECT)
+    .maybeSingle();
+  if (error?.code === "23505") return conflict("Já existe um draft administrativo.");
+  const row = normalizeDraftRow(data);
+  if (error || !row) return unavailable("O draft não pôde ser criado.");
+  return { ok: true, state: await buildState(context, row) };
+}
+
+export async function saveAdminInputCatalogDraft(input: Readonly<{
+  actorUserId: string;
+  expectedRevision: number;
+  catalogJson: string;
+}>): Promise<AdminInputCatalogLifecycleMutationResult> {
+  if (
+    !Number.isSafeInteger(input.expectedRevision) ||
+    input.expectedRevision <= 0 ||
+    typeof input.catalogJson !== "string" ||
+    input.catalogJson.length > 1_000_000
+  ) {
+    return invalid("O draft informado é inválido.");
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(input.catalogJson);
+  } catch {
+    return invalid("O draft não contém JSON válido.");
+  }
+  const client = createServiceClient();
+  const context = await readCompleteLifecycleContext(client);
+  if (!context.ok) return unavailable(context.message);
+  const candidate = validateLandingPageInputCatalogDraft({
+    draft: parsed,
+    taxons: context.value.taxons,
+  });
+  if (!candidate.ok) return invalid(candidate.error.message);
+  const contentFingerprint = fingerprint(candidate.value.canonicalJson);
+  const { data, error } = await client
+    .from("landing_page_input_catalog_drafts")
+    .update({
+      catalog_json: candidate.value.entry,
+      content_fingerprint: contentFingerprint,
+      revision: input.expectedRevision + 1,
+      validation_fingerprint: null,
+      validation_context_fingerprint: null,
+      validated_at: null,
+      publication_fingerprint: null,
+      publication_context_fingerprint: null,
+      publication_prepared_at: null,
+      taxon_review_evidence: {},
+      updated_by: input.actorUserId,
+    })
+    .eq("singleton", true)
+    .eq("revision", input.expectedRevision)
+    .maxAffected(1)
+    .select(DRAFT_SELECT)
+    .maybeSingle();
+  if (error) return unavailable("O draft não pôde ser salvo.");
+  const row = normalizeDraftRow(data);
+  if (!row) return conflict("O draft mudou em outra sessão. Recarregue antes de salvar.");
+  return { ok: true, state: await buildState(context, row) };
+}
+
+export async function validateAdminInputCatalogDraft(input: Readonly<{
+  actorUserId: string;
+  expectedRevision: number;
+}>): Promise<AdminInputCatalogLifecycleMutationResult> {
+  const client = createServiceClient();
+  const context = await readCompleteLifecycleContext(client);
+  if (!context.ok) return unavailable(context.message);
+  const current = await readDraftRow(client);
+  if (!current.ok || !current.value) {
+    return unavailable(current.ok ? "O draft não existe." : current.message);
+  }
+  if (current.value.revision !== input.expectedRevision) {
+    return conflict("O draft mudou em outra sessão. Recarregue antes de validar.");
+  }
+  const candidate = validateLandingPageInputCatalogDraft({
+    draft: current.value.catalogJson,
+    taxons: context.value.taxons,
+  });
+  if (!candidate.ok) return blocked(candidate.error.message);
+  const invalidOperationalConfigurations = countInvalidInputCatalogOperationalConfigurations(
+    candidate.value,
+    context.value.operationalConfigurations,
+  );
+  if (invalidOperationalConfigurations > 0) {
+    return blocked(
+      `${invalidOperationalConfigurations} configuração(ões) operacional(is) ficariam inválidas ou ilegíveis.`,
+    );
+  }
+  const fingerprintValue = fingerprint(candidate.value.canonicalJson);
+  const operationalContextFingerprint = fingerprintInputCatalogOperationalContext(
+    context.value,
+  );
+  if (fingerprintValue !== current.value.contentFingerprint) {
+    return conflict("A identidade do draft não corresponde ao conteúdo salvo.");
+  }
+  const { data, error } = await client
+    .from("landing_page_input_catalog_drafts")
+    .update({
+      validation_fingerprint: fingerprintValue,
+      validation_context_fingerprint: operationalContextFingerprint,
+      validated_at: new Date().toISOString(),
+      publication_fingerprint: null,
+      publication_context_fingerprint: null,
+      publication_prepared_at: null,
+      updated_by: input.actorUserId,
+    })
+    .eq("singleton", true)
+    .eq("revision", input.expectedRevision)
+    .eq("content_fingerprint", fingerprintValue)
+    .maxAffected(1)
+    .select(DRAFT_SELECT)
+    .maybeSingle();
+  if (error) return unavailable("A validação do draft não pôde ser registrada.");
+  const row = normalizeDraftRow(data);
+  if (!row) return conflict("O draft mudou durante a validação.");
+  return { ok: true, state: await buildState(context, row) };
+}
+
+export async function prepareAdminInputCatalogPublication(input: Readonly<{
+  actorUserId: string;
+  expectedRevision: number;
+}>): Promise<AdminInputCatalogLifecycleMutationResult> {
+  const client = createServiceClient();
+  const context = await readCompleteLifecycleContext(client);
+  if (!context.ok) return unavailable(context.message);
+  const current = await readDraftRow(client);
+  if (!current.ok || !current.value) {
+    return unavailable(current.ok ? "O draft não existe." : current.message);
+  }
+  if (current.value.revision !== input.expectedRevision) {
+    return conflict("O draft mudou em outra sessão.");
+  }
+  const candidate = validateLandingPageInputCatalogDraft({
+    draft: current.value.catalogJson,
+    taxons: context.value.taxons,
+  });
+  if (!candidate.ok) return blocked(candidate.error.message);
+  const fingerprintValue = fingerprint(candidate.value.canonicalJson);
+  const operationalContextFingerprint = fingerprintInputCatalogOperationalContext(
+    context.value,
+  );
+  if (
+    current.value.validationFingerprint !== fingerprintValue ||
+    current.value.validationContextFingerprint !== operationalContextFingerprint ||
+    current.value.contentFingerprint !== fingerprintValue
+  ) {
+    return blocked("Valide novamente o conteúdo exato antes de preparar a publicação.");
+  }
+  const operationalReviewStatus = await validateOperationalReviewEvidence(
+    candidate.value,
+    current.value,
+  );
+  if (operationalReviewStatus.blocking > 0) {
+    return blocked(
+      "Existem taxons operacionais que exigem decisão E20.6.5 antes da publicação.",
+    );
+  }
+  const invalidOperationalConfigurations = countInvalidInputCatalogOperationalConfigurations(
+    candidate.value,
+    context.value.operationalConfigurations,
+  );
+  if (invalidOperationalConfigurations > 0) {
+    return blocked(
+      `${invalidOperationalConfigurations} configuração(ões) operacional(is) ficariam inválidas ou ilegíveis.`,
+    );
+  }
+  const { data, error } = await client
+    .from("landing_page_input_catalog_drafts")
+    .update({
+      publication_fingerprint: fingerprintValue,
+      publication_context_fingerprint: operationalContextFingerprint,
+      publication_prepared_at: new Date().toISOString(),
+      updated_by: input.actorUserId,
+    })
+    .eq("singleton", true)
+    .eq("revision", input.expectedRevision)
+    .eq("validation_fingerprint", fingerprintValue)
+    .maxAffected(1)
+    .select(DRAFT_SELECT)
+    .maybeSingle();
+  if (error) return unavailable("A preparação da publicação falhou.");
+  const row = normalizeDraftRow(data);
+  if (!row) return conflict("O draft mudou durante a preparação.");
+  return {
+    ok: true,
+    state: await buildState(context, row),
+    handoff: buildPublicationHandoff(
+      row,
+      candidate.value.canonicalJson,
+      operationalContextFingerprint,
+    ),
+  };
+}
+
+export async function reconcileAdminInputCatalogPublishedDraft(input: Readonly<{
+  expectedRevision: number;
+  runtimeEnvironment: string | undefined;
+}>): Promise<AdminInputCatalogLifecycleMutationResult> {
+  if (input.runtimeEnvironment !== "production") {
+    return blocked("A reconciliação do draft só pode ocorrer no runtime de Production.");
+  }
+  const client = createServiceClient();
+  const current = await readDraftRow(client);
+  if (!current.ok || !current.value) {
+    return unavailable(current.ok ? "O draft não existe." : current.message);
+  }
+  const currentEntry = landingPageInputCatalogRegistry[
+    CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION
+  ];
+  const deployedFingerprint = fingerprint(
+    serializeLandingPageInputCatalogEntry(currentEntry),
+  );
+  if (
+    current.value.revision !== input.expectedRevision ||
+    current.value.targetVersion !== CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION ||
+    current.value.baseVersion !== CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION - 1 ||
+    current.value.contentFingerprint !== deployedFingerprint ||
+    current.value.publicationFingerprint !== deployedFingerprint ||
+    current.value.publicationContextFingerprint === null
+  ) {
+    return blocked(
+      "O registry implantado ainda não comprova exatamente o draft congelado.",
+    );
+  }
+  const { data, error } = await client
+    .from("landing_page_input_catalog_drafts")
+    .delete()
+    .eq("singleton", true)
+    .eq("revision", input.expectedRevision)
+    .eq("content_fingerprint", deployedFingerprint)
+    .maxAffected(1)
+    .select("revision")
+    .maybeSingle();
+  if (error || !isRecord(data)) {
+    return conflict("O draft mudou durante a reconciliação pós-deploy.");
+  }
+  const context = await readCompleteLifecycleContext(client);
+  if (!context.ok) return unavailable(context.message);
+  return {
+    ok: true,
+    state: await buildState(context, null),
+    handoff: `Versão ${CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION} reconciliada com o registry implantado; a residência temporária foi encerrada.`,
+  };
+}
+
+export async function loadAdminInputCatalogDraftEvaluationContext(input: Readonly<{
+  expectedRevision: number;
+  taxonId: string;
+}>): Promise<
+  | Readonly<{
+      ok: true;
+      value: Readonly<{
+        context: Extract<BuildInputCatalogEvaluationContextResult, { ok: true }>["value"];
+        contentFingerprint: string;
+        targetVersion: number;
+      }>;
+    }>
+  | Readonly<{ ok: false; message: string }>
+> {
+  if (!Number.isSafeInteger(input.expectedRevision) || input.expectedRevision <= 0) {
+    return { ok: false, message: "A revisão administrativa do draft é inválida." };
+  }
+  const client = createServiceClient();
+  const [context, row] = await Promise.all([
+    readCompleteLifecycleContext(client),
+    readDraftRow(client),
+  ]);
+  if (!context.ok || !row.ok || !row.value) {
+    return { ok: false, message: "O draft ou seu contexto administrativo está indisponível." };
+  }
+  if (row.value.revision !== input.expectedRevision) {
+    return { ok: false, message: "O draft mudou; recarregue antes de avaliar." };
+  }
+  const candidate = validateLandingPageInputCatalogDraft({
+    draft: row.value.catalogJson,
+    taxons: context.value.taxons,
+  });
+  if (!candidate.ok) return { ok: false, message: candidate.error.message };
+  const impact = candidate.value.impacts.find(
+    (candidateImpact) => candidateImpact.taxon.id === input.taxonId,
+  );
+  if (!impact || impact.classification !== "review_required") {
+    return {
+      ok: false,
+      message: "O taxon não exige avaliação semântica para o conteúdo atual do draft.",
+    };
+  }
+  const evaluation = await reconstructDraftInputCatalogEvaluationContext(
+    { taxonId: input.taxonId, inputCatalogVersion: candidate.value.entry.version },
+    candidate.value.registry,
+  );
+  if (!evaluation.ok) return { ok: false, message: evaluation.error.message };
+  return {
+    ok: true,
+    value: Object.freeze({
+      context: evaluation.value,
+      contentFingerprint: row.value.contentFingerprint,
+      targetVersion: row.value.targetVersion,
+    }),
+  };
+}
+
+export async function recordAdminInputCatalogDraftSufficiencyDecision(input: Readonly<{
+  actorUserId: string;
+  expectedRevision: number;
+  taxonId: string;
+  expectedContentFingerprint: string;
+  expectedContextFingerprint: string;
+  decision: "confirm_sufficient" | "reject_candidates_and_confirm_sufficient";
+}>): Promise<Readonly<{ ok: true; revision: number }> | Readonly<{ ok: false; message: string }>> {
+  const current = await loadAdminInputCatalogDraftEvaluationContext({
+    expectedRevision: input.expectedRevision,
+    taxonId: input.taxonId,
+  });
+  if (!current.ok) return current;
+  const contextFingerprint = fingerprintContext(current.value.context.identity);
+  if (
+    current.value.contentFingerprint !== input.expectedContentFingerprint ||
+    contextFingerprint !== input.expectedContextFingerprint
+  ) {
+    return { ok: false, message: "O draft, a pesquisa ou a cadeia mudaram desde a avaliação." };
+  }
+  const client = createServiceClient();
+  const row = await readDraftRow(client);
+  if (!row.ok || !row.value || row.value.revision !== input.expectedRevision) {
+    return { ok: false, message: "O draft mudou durante a decisão." };
+  }
+  const evidence = serializeDraftTaxonReviewEvidence(row.value.taxonReviewEvidence);
+  evidence[input.taxonId] = {
+    content_fingerprint: input.expectedContentFingerprint,
+    context_fingerprint: input.expectedContextFingerprint,
+    decision: input.decision,
+    decided_by: input.actorUserId,
+    decided_at: new Date().toISOString(),
+  };
+  const { data, error } = await client
+    .from("landing_page_input_catalog_drafts")
+    .update({
+      taxon_review_evidence: evidence,
+      revision: input.expectedRevision + 1,
+      publication_fingerprint: null,
+      publication_context_fingerprint: null,
+      publication_prepared_at: null,
+      updated_by: input.actorUserId,
+    })
+    .eq("singleton", true)
+    .eq("revision", input.expectedRevision)
+    .eq("content_fingerprint", input.expectedContentFingerprint)
+    .maxAffected(1)
+    .select("revision")
+    .maybeSingle();
+  if (error || !isRecord(data) || data.revision !== input.expectedRevision + 1) {
+    return { ok: false, message: "A decisão pré-publicação não pôde ser registrada." };
+  }
+  return { ok: true, revision: input.expectedRevision + 1 };
+}
+
+type LifecycleContext = Readonly<{
+  taxons: readonly Readonly<{
+    identity: LandingPageInputCatalogTaxonIdentity;
+    reviewedVersion: number | null;
+    operational: boolean;
+  }>[];
+  operationalTaxonIds: ReadonlySet<string>;
+  operationalConfigurations: readonly InputCatalogOperationalConfiguration[];
+}>;
+
+type DraftRow = Readonly<{
+  baseVersion: number;
+  targetVersion: number;
+  catalogJson: unknown;
+  contentFingerprint: string;
+  revision: number;
+  validationFingerprint: string | null;
+  validationContextFingerprint: string | null;
+  publicationFingerprint: string | null;
+  publicationContextFingerprint: string | null;
+  taxonReviewEvidence: Readonly<Record<string, DraftTaxonReviewEvidence>>;
+  updatedAt: string;
+}>;
+
+type DraftTaxonReviewEvidence = Readonly<{
+  contentFingerprint: string;
+  contextFingerprint: string;
+  decision: "confirm_sufficient" | "reject_candidates_and_confirm_sufficient";
+  decidedBy: string;
+  decidedAt: string;
+}>;
+
+const DRAFT_SELECT =
+  "base_version,target_version,catalog_json,content_fingerprint,revision,validation_fingerprint,validation_context_fingerprint,publication_fingerprint,publication_context_fingerprint,taxon_review_evidence,updated_at";
+
+async function readCompleteLifecycleContext(
+  client: ServiceClient,
+): Promise<
+  | Readonly<{ ok: true; value: LifecycleContext }>
+  | Readonly<{ ok: false; message: string }>
+> {
+  const [
+    taxonRows,
+    pageRows,
+    onboardingConfigurationRows,
+    taxonomyRows,
+    accountRows,
+    entitlementRows,
+    sharedConfigurationRows,
+    landingPageConfigurationRows,
+  ] = await Promise.all([
+    readAll(client, "business_taxons", "id,parent_id,level,name,slug,is_active,reviewed_input_catalog_version", (query) =>
+      query.in("level", ["segment", "niche", "ultra_niche"]).order("id", { ascending: true }),
+    ),
+    readAll(client, "account_landing_pages", "id,account_id,status", (query) =>
+      query.in("status", ["draft", "active"]).order("id", { ascending: true }),
+    ),
+    readAll(client, "account_landing_page_onboarding_configurations", "account_id,landing_page_id,values", (query) =>
+      query.is("landing_page_id", null).order("account_id", { ascending: true }),
+    ),
+    readAll(client, "account_taxonomy", "account_id,taxon_id,is_primary,status", (query) =>
+      query.eq("is_primary", true).eq("status", "active").order("account_id", { ascending: true }),
+    ),
+    readAll(client, "accounts", "id,name", (query) => query.order("id", { ascending: true })),
+    readAll(client, "v_account_commercial_entitlement_effective", "account_id,plan_key,is_commercially_eligible", (query) =>
+      query.order("account_id", { ascending: true }),
+    ),
+    readAll(client, "account_landing_page_shared_configurations", "account_id,values", (query) =>
+      query.order("account_id", { ascending: true }),
+    ),
+    readAll(client, "account_landing_page_configurations", "landing_page_id,account_id,values", (query) =>
+      query.order("landing_page_id", { ascending: true }),
+    ),
+  ]);
+  if (
+    !taxonRows.ok ||
+    !pageRows.ok ||
+    !onboardingConfigurationRows.ok ||
+    !taxonomyRows.ok ||
+    !accountRows.ok ||
+    !entitlementRows.ok ||
+    !sharedConfigurationRows.ok ||
+    !landingPageConfigurationRows.ok
+  ) {
+    return { ok: false, message: "A coleção administrativa não pôde ser lida integralmente." };
+  }
+  const normalizedTaxons = taxonRows.rows.map(normalizeTaxon);
+  if (normalizedTaxons.some((taxon) => taxon === null)) {
+    return { ok: false, message: "A coleção de taxons contém estado inválido." };
+  }
+  const taxonValues = normalizedTaxons as readonly NonNullable<ReturnType<typeof normalizeTaxon>>[];
+  const identities = taxonValues.map((taxon) => taxon.identity);
+
+  const activeAccounts = new Set<string>();
+  const operationalPages: Array<Readonly<{ id: string; accountId: string }>> = [];
+  const preHandoffConfigurations: Array<Readonly<{
+    accountId: string;
+    values: AccountLandingPageOnboardingStoredValues;
+  }>> = [];
+  for (const row of pageRows.rows) {
+    if (
+      !isRecord(row) ||
+      typeof row.id !== "string" ||
+      typeof row.account_id !== "string"
+    ) {
+      return { ok: false, message: "A coleção de LPs operacionais é inválida." };
+    }
+    activeAccounts.add(row.account_id);
+    operationalPages.push({ id: row.id, accountId: row.account_id });
+  }
+  for (const row of onboardingConfigurationRows.rows) {
+    if (
+      !isRecord(row) ||
+      typeof row.account_id !== "string" ||
+      row.landing_page_id !== null ||
+      !isRecord(row.values)
+    ) {
+      return { ok: false, message: "A residência E19.2 pré-handoff é inválida." };
+    }
+    activeAccounts.add(row.account_id);
+    preHandoffConfigurations.push({
+      accountId: row.account_id,
+      values: row.values as AccountLandingPageOnboardingStoredValues,
+    });
+  }
+  const primaryTaxonByAccount = new Map<string, string>();
+  const operationalTaxonIds = new Set<string>();
+  for (const row of taxonomyRows.rows) {
+    if (
+      !isRecord(row) ||
+      typeof row.account_id !== "string" ||
+      typeof row.taxon_id !== "string"
+    ) {
+      return { ok: false, message: "A coleção de taxonomia operacional é inválida." };
+    }
+    if (!activeAccounts.has(row.account_id)) continue;
+    if (primaryTaxonByAccount.has(row.account_id)) {
+      return { ok: false, message: "Uma conta operacional possui mais de um taxon primário ativo." };
+    }
+    primaryTaxonByAccount.set(row.account_id, row.taxon_id);
+    operationalTaxonIds.add(row.taxon_id);
+  }
+
+  const accountNames = normalizeStringMap(accountRows.rows, "id", "name");
+  const sharedValues = normalizeValuesMap(sharedConfigurationRows.rows, "account_id");
+  const landingPageValues = normalizeValuesMap(
+    landingPageConfigurationRows.rows,
+    "landing_page_id",
+  );
+  const plans = normalizeOperationalPlans(entitlementRows.rows, activeAccounts);
+  if (!accountNames || !sharedValues || !landingPageValues || !plans) {
+    return { ok: false, message: "As configurações operacionais contêm estado inválido." };
+  }
+
+  const operationalConfigurations: InputCatalogOperationalConfiguration[] = [];
+  for (const page of operationalPages) {
+    const taxonId = primaryTaxonByAccount.get(page.accountId);
+    const planKey = plans.get(page.accountId);
+    const accountName = accountNames.get(page.accountId);
+    const taxon = identities.find((identity) => identity.id === taxonId);
+    if (!taxonId || !planKey || accountName === undefined || !taxon) {
+      return { ok: false, message: "Uma LP operacional não possui autoridade completa de conta, plano ou taxon." };
+    }
+    const taxonChain = buildLandingPageInputCatalogTaxonChain(taxon, identities);
+    if (!taxonChain.ok) {
+      return { ok: false, message: "Uma LP operacional possui cadeia taxonômica inválida." };
+    }
+    operationalConfigurations.push({
+      accountId: page.accountId,
+      landingPageId: page.id,
+      planKey,
+      taxonChain: taxonChain.value,
+      storedValues: {
+        ...(sharedValues.get(page.accountId) ?? {}),
+        ...(landingPageValues.get(page.id) ?? {}),
+      },
+      authoritativeValues: accountName.trim()
+        ? { business_display_name: accountName.trim() }
+        : {},
+    });
+  }
+  for (const configuration of preHandoffConfigurations) {
+    const taxonId = primaryTaxonByAccount.get(configuration.accountId);
+    const planKey = plans.get(configuration.accountId);
+    const accountName = accountNames.get(configuration.accountId);
+    const taxon = identities.find((identity) => identity.id === taxonId);
+    if (!taxonId || !planKey || accountName === undefined || !taxon) {
+      return { ok: false, message: "Uma configuração E19.2 não possui autoridade completa de conta, plano ou taxon." };
+    }
+    const taxonChain = buildLandingPageInputCatalogTaxonChain(taxon, identities);
+    if (!taxonChain.ok) {
+      return { ok: false, message: "Uma configuração E19.2 possui cadeia taxonômica inválida." };
+    }
+    operationalConfigurations.push({
+      accountId: configuration.accountId,
+      landingPageId: null,
+      planKey,
+      taxonChain: taxonChain.value,
+      storedValues: configuration.values,
+      authoritativeValues: accountName.trim()
+        ? { business_display_name: accountName.trim() }
+        : {},
+    });
+  }
+
+  const taxons = taxonValues.map((normalized) => ({
+    identity: normalized.identity,
+    reviewedVersion: normalized.reviewedVersion,
+    operational: operationalTaxonIds.has(normalized.identity.id),
+  }));
+  return {
+    ok: true,
+    value: {
+      taxons,
+      operationalTaxonIds,
+      operationalConfigurations,
+    },
+  };
+}
+
+async function readAll(
+  client: ServiceClient,
+  relation: string,
+  columns: string,
+  refine: (query: any) => any,
+): Promise<Readonly<{ ok: true; rows: unknown[] }> | Readonly<{ ok: false }>> {
+  const result = await collectCompletePaginatedRows({
+    pageSize: PAGE_SIZE,
+    readPage: async (offset, limit) => {
+      const query = refine(
+        client.from(relation).select(columns, { count: "exact" }),
+      );
+      const { data, error, count } = await query.range(
+        offset,
+        offset + limit - 1,
+      );
+      return error || !Array.isArray(data) || count === null
+        ? null
+        : { rows: data, total: count };
+    },
+  });
+  return result.ok ? { ok: true, rows: [...result.rows] } : { ok: false };
+}
+
+async function readDraftRow(
+  client: ServiceClient,
+): Promise<
+  | Readonly<{ ok: true; value: DraftRow | null }>
+  | Readonly<{ ok: false; message: string }>
+> {
+  const { data, error } = await client
+    .from("landing_page_input_catalog_drafts")
+    .select(DRAFT_SELECT)
+    .eq("singleton", true)
+    .limit(1)
+    .maybeSingle();
+  if (error) return { ok: false, message: "A residência do draft está indisponível." };
+  if (!data) return { ok: true, value: null };
+  const row = normalizeDraftRow(data);
+  return row
+    ? { ok: true, value: row }
+    : { ok: false, message: "A residência do draft contém estado inválido." };
+}
+
+async function buildState(
+  contextResult: Extract<Awaited<ReturnType<typeof readCompleteLifecycleContext>>, { ok: true }> | LifecycleContext,
+  row: DraftRow | null,
+): Promise<AdminInputCatalogLifecycleState> {
+  const context = "value" in contextResult ? contextResult.value : contextResult;
+  if (!row) {
+    return {
+      currentVersion: CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION,
+      publishedVersions: listLandingPageInputCatalogVersions(),
+      totalActiveTaxons: context.taxons.filter((taxon) => taxon.identity.isActive).length,
+      totalOperationalTaxons: context.operationalTaxonIds.size,
+      draft: null,
+      error: null,
+    };
+  }
+  const operationalContextFingerprint = fingerprintInputCatalogOperationalContext(context);
+  if (row.targetVersion === CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION) {
+    const deployedFingerprint = fingerprint(
+      serializeLandingPageInputCatalogEntry(
+        landingPageInputCatalogRegistry[CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION],
+      ),
+    );
+    if (
+      row.baseVersion !== CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION - 1 ||
+      row.contentFingerprint !== deployedFingerprint ||
+      row.publicationFingerprint !== deployedFingerprint ||
+      row.publicationContextFingerprint === null
+    ) {
+      return unavailableState(
+        "O draft implantado diverge do registry atual e não pode ser reconciliado automaticamente.",
+        { ok: true, value: context },
+      );
+    }
+    return {
+      currentVersion: CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION,
+      publishedVersions: listLandingPageInputCatalogVersions(),
+      totalActiveTaxons: context.taxons.filter((taxon) => taxon.identity.isActive).length,
+      totalOperationalTaxons: context.operationalTaxonIds.size,
+      draft: {
+        baseVersion: row.baseVersion,
+        targetVersion: row.targetVersion,
+        catalogJson: JSON.stringify(row.catalogJson, null, 2),
+        contentFingerprint: row.contentFingerprint,
+        operationalContextFingerprint,
+        revision: row.revision,
+        validationCurrent: row.validationFingerprint === row.contentFingerprint,
+        publicationPrepared: true,
+        publishedReconciliationRequired: true,
+        publishedReconciliationAllowed: process.env.VERCEL_ENV === "production",
+        reviewedTaxonIds: Object.keys(row.taxonReviewEvidence).sort(),
+        updatedAt: row.updatedAt,
+        impacts: [],
+        totals: {
+          noMaterialChange: 0,
+          compatibleEvolution: 0,
+          reviewRequired: 0,
+          blockingOperationalReviews: 0,
+          invalidOperationalConfigurations: 0,
+        },
+      },
+      error: null,
+    };
+  }
+  if (row.baseVersion !== CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION) {
+    return unavailableState(
+      "A residência temporária não corresponde à versão atual nem ao próximo draft sequencial.",
+      { ok: true, value: context },
+    );
+  }
+  const candidate = validateLandingPageInputCatalogDraft({
+    draft: row.catalogJson,
+    taxons: context.taxons,
+  });
+  if (!candidate.ok) return unavailableState(candidate.error.message, { ok: true, value: context });
+  const invalidOperationalConfigurations = countInvalidInputCatalogOperationalConfigurations(
+    candidate.value,
+    context.operationalConfigurations,
+  );
+  const operationalReviewStatus = await validateOperationalReviewEvidence(
+    candidate.value,
+    row,
+  );
+  return {
+    currentVersion: CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION,
+    publishedVersions: listLandingPageInputCatalogVersions(),
+    totalActiveTaxons: context.taxons.filter((taxon) => taxon.identity.isActive).length,
+    totalOperationalTaxons: context.operationalTaxonIds.size,
+    draft: {
+      baseVersion: row.baseVersion,
+      targetVersion: row.targetVersion,
+      catalogJson: JSON.stringify(row.catalogJson, null, 2),
+      contentFingerprint: row.contentFingerprint,
+      operationalContextFingerprint,
+      revision: row.revision,
+      validationCurrent:
+        row.validationFingerprint === row.contentFingerprint &&
+        row.validationContextFingerprint === operationalContextFingerprint,
+      publicationPrepared:
+        row.publicationFingerprint === row.contentFingerprint &&
+        row.publicationContextFingerprint === operationalContextFingerprint &&
+        operationalReviewStatus.blocking === 0 &&
+        invalidOperationalConfigurations === 0,
+      publishedReconciliationRequired: false,
+      publishedReconciliationAllowed: false,
+      reviewedTaxonIds: operationalReviewStatus.validTaxonIds,
+      updatedAt: row.updatedAt,
+      impacts: candidate.value.impacts,
+      totals: {
+        ...candidate.value.totals,
+        blockingOperationalReviews: operationalReviewStatus.blocking,
+        invalidOperationalConfigurations,
+      },
+    },
+    error: null,
+  };
+}
+
+async function validateOperationalReviewEvidence(
+  candidate: Extract<
+    ReturnType<typeof validateLandingPageInputCatalogDraft>,
+    { ok: true }
+  >["value"],
+  row: DraftRow,
+): Promise<Readonly<{ blocking: number; validTaxonIds: readonly string[] }>> {
+  let blocking = 0;
+  const validTaxonIds: string[] = [];
+  for (const impact of candidate.impacts) {
+    if (impact.classification !== "review_required") continue;
+    const evidence = row.taxonReviewEvidence[impact.taxon.id];
+    if (!evidence || evidence.contentFingerprint !== row.contentFingerprint) {
+      if (impact.operational) blocking += 1;
+      continue;
+    }
+    const current = await reconstructDraftInputCatalogEvaluationContext(
+      { taxonId: impact.taxon.id, inputCatalogVersion: candidate.entry.version },
+      candidate.registry,
+    );
+    if (
+      !current.ok ||
+      fingerprintContext(current.value.identity) !== evidence.contextFingerprint
+    ) {
+      if (impact.operational) blocking += 1;
+      continue;
+    }
+    validTaxonIds.push(impact.taxon.id);
+  }
+  return Object.freeze({
+    blocking,
+    validTaxonIds: Object.freeze(validTaxonIds.sort()),
+  });
+}
+
+function normalizeStringMap(
+  rows: readonly unknown[],
+  keyColumn: string,
+  valueColumn: string,
+): Map<string, string> | null {
+  const result = new Map<string, string>();
+  for (const row of rows) {
+    if (
+      !isRecord(row) ||
+      typeof row[keyColumn] !== "string" ||
+      typeof row[valueColumn] !== "string" ||
+      result.has(row[keyColumn])
+    ) return null;
+    result.set(row[keyColumn], row[valueColumn]);
+  }
+  return result;
+}
+
+function normalizeValuesMap(
+  rows: readonly unknown[],
+  keyColumn: string,
+): Map<string, AccountLandingPageOnboardingStoredValues> | null {
+  const result = new Map<string, AccountLandingPageOnboardingStoredValues>();
+  for (const row of rows) {
+    if (
+      !isRecord(row) ||
+      typeof row[keyColumn] !== "string" ||
+      !isRecord(row.values) ||
+      result.has(row[keyColumn])
+    ) return null;
+    result.set(
+      row[keyColumn],
+      row.values as AccountLandingPageOnboardingStoredValues,
+    );
+  }
+  return result;
+}
+
+function normalizeOperationalPlans(
+  rows: readonly unknown[],
+  activeAccounts: ReadonlySet<string>,
+): Map<string, LandingPageInputCatalogPlan> | null {
+  const result = new Map<string, LandingPageInputCatalogPlan>();
+  for (const row of rows) {
+    if (
+      !isRecord(row) ||
+      typeof row.account_id !== "string" ||
+      typeof row.is_commercially_eligible !== "boolean" ||
+      (row.plan_key !== null && typeof row.plan_key !== "string")
+    ) return null;
+    if (!activeAccounts.has(row.account_id) || !row.is_commercially_eligible) continue;
+    if (
+      row.plan_key !== "starter" &&
+      row.plan_key !== "lite" &&
+      row.plan_key !== "pro" &&
+      row.plan_key !== "ultra"
+    ) return null;
+    if (result.has(row.account_id)) return null;
+    result.set(row.account_id, row.plan_key);
+  }
+  return result;
+}
+
+function normalizeTaxon(value: unknown): Readonly<{
+  identity: LandingPageInputCatalogTaxonIdentity;
+  reviewedVersion: number | null;
+}> | null {
+  if (!isRecord(value)) return null;
+  if (
+    typeof value.id !== "string" ||
+    (value.parent_id !== null && typeof value.parent_id !== "string") ||
+    (value.level !== "segment" && value.level !== "niche" && value.level !== "ultra_niche") ||
+    typeof value.name !== "string" ||
+    typeof value.slug !== "string" ||
+    typeof value.is_active !== "boolean" ||
+    (value.reviewed_input_catalog_version !== null &&
+      (!Number.isSafeInteger(value.reviewed_input_catalog_version) ||
+        Number(value.reviewed_input_catalog_version) <= 0))
+  ) return null;
+  return {
+    identity: {
+      id: value.id,
+      parentId: value.parent_id,
+      level: value.level,
+      name: value.name,
+      slug: value.slug,
+      isActive: value.is_active,
+    },
+    reviewedVersion: value.reviewed_input_catalog_version as number | null,
+  };
+}
+
+function normalizeDraftRow(value: unknown): DraftRow | null {
+  if (!isRecord(value)) return null;
+  if (
+    !Number.isSafeInteger(value.base_version) ||
+    !Number.isSafeInteger(value.target_version) ||
+    value.target_version !== Number(value.base_version) + 1 ||
+    !isRecord(value.catalog_json) ||
+    typeof value.content_fingerprint !== "string" ||
+    !/^[0-9a-f]{64}$/.test(value.content_fingerprint) ||
+    !Number.isSafeInteger(value.revision) ||
+    Number(value.revision) <= 0 ||
+    (value.validation_fingerprint !== null &&
+      (typeof value.validation_fingerprint !== "string" ||
+        !/^[0-9a-f]{64}$/.test(value.validation_fingerprint))) ||
+    (value.validation_context_fingerprint !== null &&
+      (typeof value.validation_context_fingerprint !== "string" ||
+        !/^[0-9a-f]{64}$/.test(value.validation_context_fingerprint))) ||
+    (value.publication_fingerprint !== null &&
+      (typeof value.publication_fingerprint !== "string" ||
+        !/^[0-9a-f]{64}$/.test(value.publication_fingerprint))) ||
+    (value.publication_context_fingerprint !== null &&
+      (typeof value.publication_context_fingerprint !== "string" ||
+        !/^[0-9a-f]{64}$/.test(value.publication_context_fingerprint))) ||
+    typeof value.updated_at !== "string"
+  ) return null;
+  const taxonReviewEvidence = normalizeDraftTaxonReviewEvidence(
+    value.taxon_review_evidence,
+  );
+  if (!taxonReviewEvidence) return null;
+  return {
+    baseVersion: value.base_version as number,
+    targetVersion: value.target_version as number,
+    catalogJson: value.catalog_json,
+    contentFingerprint: value.content_fingerprint,
+    revision: value.revision as number,
+    validationFingerprint: value.validation_fingerprint as string | null,
+    validationContextFingerprint:
+      value.validation_context_fingerprint as string | null,
+    publicationFingerprint: value.publication_fingerprint as string | null,
+    publicationContextFingerprint:
+      value.publication_context_fingerprint as string | null,
+    taxonReviewEvidence,
+    updatedAt: value.updated_at,
+  };
+}
+
+function normalizeDraftTaxonReviewEvidence(
+  value: unknown,
+): Readonly<Record<string, DraftTaxonReviewEvidence>> | null {
+  if (!isRecord(value)) return null;
+  const normalized: Record<string, DraftTaxonReviewEvidence> = {};
+  for (const [taxonId, raw] of Object.entries(value)) {
+    if (
+      !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(taxonId) ||
+      !isRecord(raw) ||
+      typeof raw.content_fingerprint !== "string" ||
+      !/^[0-9a-f]{64}$/.test(raw.content_fingerprint) ||
+      typeof raw.context_fingerprint !== "string" ||
+      !/^[0-9a-f]{64}$/.test(raw.context_fingerprint) ||
+      (raw.decision !== "confirm_sufficient" &&
+        raw.decision !== "reject_candidates_and_confirm_sufficient") ||
+      typeof raw.decided_by !== "string" ||
+      typeof raw.decided_at !== "string"
+    ) return null;
+    normalized[taxonId] = Object.freeze({
+      contentFingerprint: raw.content_fingerprint,
+      contextFingerprint: raw.context_fingerprint,
+      decision: raw.decision,
+      decidedBy: raw.decided_by,
+      decidedAt: raw.decided_at,
+    });
+  }
+  return Object.freeze(normalized);
+}
+
+function serializeDraftTaxonReviewEvidence(
+  value: Readonly<Record<string, DraftTaxonReviewEvidence>>,
+): Record<string, Record<string, string>> {
+  return Object.fromEntries(
+    Object.entries(value).map(([taxonId, evidence]) => [
+      taxonId,
+      {
+        content_fingerprint: evidence.contentFingerprint,
+        context_fingerprint: evidence.contextFingerprint,
+        decision: evidence.decision,
+        decided_by: evidence.decidedBy,
+        decided_at: evidence.decidedAt,
+      },
+    ]),
+  );
+}
+
+function buildPublicationHandoff(
+  row: DraftRow,
+  canonicalJson: string,
+  operationalContextFingerprint: string,
+): string {
+  return [
+    `E20.2.8 — materializar versão ${row.targetVersion} no registry repo-only`,
+    `Base publicada: ${row.baseVersion}`,
+    `Fingerprint do conteúdo SHA-256: ${row.contentFingerprint}`,
+    `Fingerprint do contexto operacional SHA-256: ${operationalContextFingerprint}`,
+    "",
+    "Instruções vinculantes:",
+    "- materializar este conteúdo como nova versão imutável no registry;",
+    "- alterar a declaração explícita de versão atual no mesmo diff;",
+    "- imediatamente antes da revisão/merge, reabrir o Admin e comprovar que validação e handoff continuam atuais para estes dois fingerprints;",
+    "- validar CI/Preview e obter revisão/merge humanos;",
+    "- somente o deploy de Production torna a versão atual observável;",
+    "- não copiar este draft para uma autoridade publicada em banco.",
+    "",
+    canonicalJson,
+  ].join("\n");
+}
+
+function fingerprint(canonicalJson: string): string {
+  return createHash("sha256").update(canonicalJson).digest("hex");
+}
+
+function fingerprintContext(identity: InputCatalogEvaluationContextIdentity): string {
+  return fingerprint(JSON.stringify(identity));
+}
+
+function unavailableState(
+  message: string,
+  context?: Extract<Awaited<ReturnType<typeof readCompleteLifecycleContext>>, { ok: true }>,
+): AdminInputCatalogLifecycleState {
+  return {
+    currentVersion: CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION,
+    publishedVersions: listLandingPageInputCatalogVersions(),
+    totalActiveTaxons: context?.value.taxons.length ?? 0,
+    totalOperationalTaxons: context?.value.operationalTaxonIds.size ?? 0,
+    draft: null,
+    error: message,
+  };
+}
+
+function invalid(message: string): AdminInputCatalogLifecycleMutationResult {
+  return { ok: false, code: "INVALID_INPUT", message };
+}
+
+function conflict(message: string): AdminInputCatalogLifecycleMutationResult {
+  return { ok: false, code: "CONFLICT", message };
+}
+
+function unavailable(message: string): AdminInputCatalogLifecycleMutationResult {
+  return { ok: false, code: "UNAVAILABLE", message };
+}
+
+function blocked(message: string): AdminInputCatalogLifecycleMutationResult {
+  return { ok: false, code: "BLOCKED", message };
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/lib/admin/adapters/adminInputCatalogLifecyclePagination.ts
+++ b/lib/admin/adapters/adminInputCatalogLifecyclePagination.ts
@@ -1,0 +1,34 @@
+export type CompletePage = Readonly<{
+  rows: readonly unknown[];
+  total: number;
+}>;
+
+export async function collectCompletePaginatedRows(input: Readonly<{
+  pageSize: number;
+  readPage: (offset: number, limit: number) => Promise<CompletePage | null>;
+}>): Promise<Readonly<{ ok: true; rows: readonly unknown[] }> | Readonly<{ ok: false }>> {
+  if (!Number.isSafeInteger(input.pageSize) || input.pageSize <= 0) {
+    return { ok: false };
+  }
+  const rows: unknown[] = [];
+  let expectedTotal: number | null = null;
+
+  while (true) {
+    const page = await input.readPage(rows.length, input.pageSize);
+    if (
+      !page ||
+      !Number.isSafeInteger(page.total) ||
+      page.total < 0 ||
+      (expectedTotal !== null && page.total !== expectedTotal)
+    ) {
+      return { ok: false };
+    }
+    expectedTotal ??= page.total;
+    if (page.rows.length === 0) {
+      return rows.length === expectedTotal ? { ok: true, rows } : { ok: false };
+    }
+    rows.push(...page.rows);
+    if (rows.length > expectedTotal) return { ok: false };
+    if (rows.length === expectedTotal) return { ok: true, rows };
+  }
+}

--- a/lib/admin/adapters/adminInputCatalogLifecycleValidation.ts
+++ b/lib/admin/adapters/adminInputCatalogLifecycleValidation.ts
@@ -1,0 +1,90 @@
+import { createHash } from "node:crypto";
+
+import type {
+  LandingPageInputCatalogPlan,
+  LandingPageInputCatalogTaxonChain,
+  LandingPageInputCatalogTaxonIdentity,
+  ValidateLandingPageInputCatalogDraftResult,
+} from "@/conversion-content/landing-page/input-catalog";
+import type { AccountLandingPageOnboardingStoredValues } from "@/lp-builder/contracts";
+import { resolveAccountLandingPageOnboardingConfiguration } from "@/lp-builder/onboardingConfiguration";
+
+export type InputCatalogOperationalConfiguration = Readonly<{
+  accountId: string;
+  landingPageId: string | null;
+  planKey: LandingPageInputCatalogPlan;
+  taxonChain: LandingPageInputCatalogTaxonChain;
+  storedValues: AccountLandingPageOnboardingStoredValues;
+  authoritativeValues: Readonly<Record<string, unknown>>;
+}>;
+
+export function countInvalidInputCatalogOperationalConfigurations(
+  candidate: Extract<ValidateLandingPageInputCatalogDraftResult, { ok: true }>["value"],
+  configurations: readonly InputCatalogOperationalConfiguration[],
+): number {
+  return configurations.filter((configuration) => {
+    const result = resolveAccountLandingPageOnboardingConfiguration({
+      accountId: configuration.accountId,
+      landingPageId: configuration.landingPageId,
+      catalogVersion: candidate.entry.version,
+      revision: 1,
+      planKey: configuration.planKey,
+      taxonChain: configuration.taxonChain,
+      storedValues: configuration.storedValues,
+      authoritativeValues: configuration.authoritativeValues,
+      registry: candidate.registry,
+    });
+    return !result.ok;
+  }).length;
+}
+
+export function fingerprintInputCatalogOperationalContext(input: Readonly<{
+  taxons: readonly Readonly<{
+    identity: LandingPageInputCatalogTaxonIdentity;
+    reviewedVersion: number | null;
+    operational: boolean;
+  }>[];
+  operationalTaxonIds: ReadonlySet<string>;
+  operationalConfigurations: readonly InputCatalogOperationalConfiguration[];
+}>): string {
+  const canonical = stableJson({
+    taxons: input.taxons
+      .map((taxon) => ({
+        identity: taxon.identity,
+        reviewedVersion: taxon.reviewedVersion,
+        operational: taxon.operational,
+      }))
+      .sort((left, right) => left.identity.id.localeCompare(right.identity.id)),
+    operationalTaxonIds: [...input.operationalTaxonIds].sort(),
+    operationalConfigurations: input.operationalConfigurations
+      .map((configuration) => ({
+        accountId: configuration.accountId,
+        landingPageId: configuration.landingPageId,
+        planKey: configuration.planKey,
+        taxonChain: configuration.taxonChain,
+        storedValues: configuration.storedValues,
+        authoritativeValues: configuration.authoritativeValues,
+      }))
+      .sort((left, right) =>
+        `${left.accountId}:${left.landingPageId ?? ""}`.localeCompare(
+          `${right.accountId}:${right.landingPageId ?? ""}`,
+        ),
+      ),
+  });
+  return createHash("sha256").update(canonical).digest("hex");
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (isRecord(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/lib/admin/adapters/adminLandingPageStructureAdapter.ts
+++ b/lib/admin/adapters/adminLandingPageStructureAdapter.ts
@@ -6,8 +6,9 @@ import {
 } from "@/conversion-content/landing-page";
 import {
   landingPageInputCatalogPlans,
-  landingPageInputCatalogRegistry,
   buildLandingPageInputCatalogTaxonChain,
+  CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION,
+  listLandingPageInputCatalogVersions,
   resolveLandingPageInputCatalog,
   type LandingPageInputCatalogPlan,
   type LandingPageInputCatalogTaxonIdentity,
@@ -78,15 +79,12 @@ function readRootParameters(query: StructureQuery) {
 
 async function readInputs(query: StructureQuery) {
   const taxonRead = await readActiveTaxons();
-  const versions = Object.keys(landingPageInputCatalogRegistry)
-    .map(Number)
-    .filter(Number.isInteger)
-    .sort((left, right) => left - right);
+  const versions = listLandingPageInputCatalogVersions();
   const requestedVersion = parseInteger(query.catalogVersion);
   const version =
     requestedVersion !== null && versions.includes(requestedVersion)
       ? requestedVersion
-      : versions.at(-1) ?? null;
+      : CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION;
   const plan = landingPageInputCatalogPlans.includes(
     query.plan as LandingPageInputCatalogPlan,
   )
@@ -133,23 +131,30 @@ async function readActiveTaxons(): Promise<{
   error: string | null;
 }> {
   const supabase = createServiceClient();
-  const { data, error } = await supabase
-    .from("business_taxons")
-    .select("id,parent_id,level,name,slug,is_active")
-    .eq("is_active", true)
-    .in("level", ["segment", "niche", "ultra_niche"])
-    .order("level", { ascending: true })
-    .order("name", { ascending: true });
-
-  if (error) {
-    console.error("readAdminLandingPageStructure taxons failed:", {
-      code: error.code,
-      message: error.message,
-    });
-    return { taxons: [], error: "Não foi possível ler os taxons ativos." };
+  const rows: unknown[] = [];
+  let offset = 0;
+  const pageSize = 500;
+  while (true) {
+    const { data, error } = await supabase
+      .from("business_taxons")
+      .select("id,parent_id,level,name,slug,is_active")
+      .eq("is_active", true)
+      .in("level", ["segment", "niche", "ultra_niche"])
+      .order("level", { ascending: true })
+      .order("name", { ascending: true })
+      .order("id", { ascending: true })
+      .range(offset, offset + pageSize - 1);
+    if (error || !Array.isArray(data)) {
+      console.error("readAdminLandingPageStructure taxons failed:", {
+        code: error?.code,
+        message: error?.message,
+      });
+      return { taxons: [], error: "Não foi possível ler os taxons ativos integralmente." };
+    }
+    rows.push(...data);
+    if (data.length < pageSize) break;
+    offset += data.length;
   }
-
-  const rows = Array.isArray(data) ? data : [];
   const validRows = rows.filter(isStructureTaxonRow);
   if (validRows.length !== rows.length) {
     return { taxons: [], error: "A lista de taxons não pôde ser normalizada com segurança." };

--- a/lib/conversion-content/adapters/inputCatalogEvaluationContextAdapter.ts
+++ b/lib/conversion-content/adapters/inputCatalogEvaluationContextAdapter.ts
@@ -2,10 +2,13 @@ import "server-only";
 
 import {
   buildLandingPageInputCatalogTaxonChain,
+  resolveLandingPageInputCatalogFromRegistry,
+  type LandingPageInputCatalogRegistry,
   type LandingPageInputCatalogTaxonIdentity,
 } from "../landing-page/input-catalog";
 import {
   buildInputCatalogEvaluationContext,
+  resolveInputCatalogReview,
   type BuildInputCatalogEvaluationContextResult,
   type InputCatalogEvaluationReconstructionInput,
 } from "../landing-page/taxon-preparation";
@@ -36,20 +39,57 @@ export async function reconstructCanonicalInputCatalogEvaluationContext(
   });
 }
 
+export async function reconstructDraftInputCatalogEvaluationContext(
+  input: InputCatalogEvaluationReconstructionInput,
+  registry: LandingPageInputCatalogRegistry,
+): Promise<BuildInputCatalogEvaluationContextResult> {
+  const selectedResearch = await loadSelectedEndCustomerResearchForTaxon({
+    taxonId: input.taxonId,
+  });
+  if (!selectedResearch.ok) {
+    return failure("AUTHORIZED_RESEARCH_INVALID", selectedResearch.error.message);
+  }
+  const taxonChain = await readCanonicalTaxonChain(input.taxonId);
+  if (!taxonChain.ok) return failure("CONTEXT_IDENTITY_INVALID", taxonChain.error);
+  return buildInputCatalogEvaluationContext(
+    {
+      selectedResearch,
+      taxonChain: taxonChain.value,
+      inputCatalogVersion: input.inputCatalogVersion,
+    },
+    {
+      allowNonPublishedVersion: true,
+      resolveReview: (reviewInput) => resolveInputCatalogReview(
+        reviewInput,
+        (catalogInput) => resolveLandingPageInputCatalogFromRegistry(catalogInput, registry),
+      ),
+    },
+  );
+}
+
 async function readCanonicalTaxonChain(taxonId: string) {
   const supabase = createServiceClient();
-  const { data, error } = await supabase
-    .from("business_taxons")
-    .select("id,parent_id,level,name,slug,is_active")
-    .in("level", ["segment", "niche", "ultra_niche"]);
-  if (error || !Array.isArray(data)) {
-    return { ok: false as const, error: "Não foi possível ler a cadeia taxonômica." };
+  const rows: unknown[] = [];
+  let offset = 0;
+  while (true) {
+    const { data, error } = await supabase
+      .from("business_taxons")
+      .select("id,parent_id,level,name,slug,is_active")
+      .in("level", ["segment", "niche", "ultra_niche"])
+      .order("id", { ascending: true })
+      .range(offset, offset + 499);
+    if (error || !Array.isArray(data)) {
+      return { ok: false as const, error: "Não foi possível ler a cadeia taxonômica integralmente." };
+    }
+    rows.push(...data);
+    if (data.length < 500) break;
+    offset += data.length;
   }
 
-  const identities = data
+  const identities = rows
     .map(normalizeTaxonIdentity)
     .filter((taxon): taxon is LandingPageInputCatalogTaxonIdentity => taxon !== null);
-  if (identities.length !== data.length) {
+  if (identities.length !== rows.length) {
     return { ok: false as const, error: "A cadeia taxonômica contém identidade inválida." };
   }
   const selected = identities.find((taxon) => taxon.id === taxonId);

--- a/lib/conversion-content/adapters/selectedEndCustomerResearchAdapter.ts
+++ b/lib/conversion-content/adapters/selectedEndCustomerResearchAdapter.ts
@@ -2,10 +2,14 @@ import "server-only";
 
 import { createServiceClient } from "@/lib/supabase/service";
 import {
+  buildLandingPageInputCatalogTaxonChain,
+  CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION,
+  type LandingPageInputCatalogTaxonIdentity,
+} from "../landing-page/input-catalog";
+import {
   isEndCustomerResearchSelectionEnabled,
   isInputCatalogReviewEnabled,
-  classifyRequiredInputCatalogVersion,
-  deriveTaxonPreparationForVersion,
+  deriveEffectiveTaxonPreparation,
   type LoadSelectedEndCustomerResearchResult,
   type TaxonPreparationResult,
 } from "../landing-page/taxon-preparation";
@@ -28,64 +32,20 @@ export async function loadSelectedEndCustomerResearchForTaxon(input: {
   return loadSelectedEndCustomerResearchFromClient(input, supabase);
 }
 
-export async function loadTaxonPreparationForVersion(input: {
-  taxonId: string;
-  requiredInputCatalogVersion: number;
-}): Promise<TaxonPreparationResult> {
-  if (!isInputCatalogReviewEnabled()) {
-    return {
-      ok: false,
-      error: {
-        code: "INPUT_CATALOG_REVIEW_DISABLED",
-        message: "A preparação E20.6 está desabilitada.",
-      },
-    };
-  }
-  if (!isEndCustomerResearchSelectionEnabled()) {
-    return {
-      ok: false,
-      error: {
-        code: "FEATURE_DISABLED",
-        message: "A leitura da pesquisa selecionada está desabilitada.",
-      },
-    };
-  }
-  const versionFailure = classifyRequiredInputCatalogVersion(
-    input.requiredInputCatalogVersion,
-  );
-  if (versionFailure) return versionFailure;
-
-  const supabase = createServiceClient();
-  const selectedResearch = await loadSelectedEndCustomerResearchFromClient(
-    { taxonId: input.taxonId, includeInputCatalogReview: true },
-    supabase,
-  );
-  return deriveTaxonPreparationForVersion({
-    selectedResearch,
-    requiredInputCatalogVersion: input.requiredInputCatalogVersion,
-  });
-}
-
-export async function loadTaxonPreparationForReviewedVersion(input: {
+export async function loadTaxonPreparationForCurrentVersion(input: {
   taxonId: string;
 }): Promise<TaxonPreparationResult> {
   if (!isInputCatalogReviewEnabled()) {
-    return {
-      ok: false,
-      error: {
-        code: "INPUT_CATALOG_REVIEW_DISABLED",
-        message: "A preparação E20.6 está desabilitada.",
-      },
-    };
+    return preparationFailure(
+      "INPUT_CATALOG_REVIEW_DISABLED",
+      "A preparação E20.6 está desabilitada.",
+    );
   }
   if (!isEndCustomerResearchSelectionEnabled()) {
-    return {
-      ok: false,
-      error: {
-        code: "FEATURE_DISABLED",
-        message: "A leitura da pesquisa selecionada está desabilitada.",
-      },
-    };
+    return preparationFailure(
+      "FEATURE_DISABLED",
+      "A leitura da pesquisa selecionada está desabilitada.",
+    );
   }
 
   const supabase = createServiceClient();
@@ -95,21 +55,114 @@ export async function loadTaxonPreparationForReviewedVersion(input: {
   );
   if (!selectedResearch.ok) return selectedResearch;
 
-  const reviewedVersion = selectedResearch.value.reviewedInputCatalogVersion;
-  if (reviewedVersion === undefined || reviewedVersion === null) {
-    return Object.freeze({
-      ok: false,
-      error: Object.freeze({
-        code: "INPUT_CATALOG_REVIEW_ABSENT" as const,
-        message: "O taxon ainda não possui uma versão E20.2 avaliada.",
-      }),
-    });
-  }
-  const versionFailure = classifyRequiredInputCatalogVersion(reviewedVersion);
-  if (versionFailure) return versionFailure;
-
-  return deriveTaxonPreparationForVersion({
+  const chain = await readCompleteInputCatalogTaxonChain(
+    supabase,
+    selectedResearch.value.taxonId,
+  );
+  if (!chain.ok) return chain.result;
+  return deriveEffectiveTaxonPreparation({
     selectedResearch,
-    requiredInputCatalogVersion: reviewedVersion,
+    currentInputCatalogVersion: CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION,
+    taxonChain: chain.value,
   });
+}
+
+const TAXON_CHAIN_PAGE_SIZE = 500;
+
+async function readCompleteInputCatalogTaxonChain(
+  client: ReturnType<typeof createServiceClient>,
+  taxonId: string,
+): Promise<
+  | Readonly<{
+      ok: true;
+      value: Parameters<typeof deriveEffectiveTaxonPreparation>[0]["taxonChain"];
+    }>
+  | Readonly<{ ok: false; result: TaxonPreparationResult }>
+> {
+  const taxons: LandingPageInputCatalogTaxonIdentity[] = [];
+  let offset = 0;
+  while (true) {
+    const { data, error } = await client
+      .from("business_taxons")
+      .select("id,parent_id,level,name,slug,is_active")
+      .in("level", ["segment", "niche", "ultra_niche"])
+      .order("id", { ascending: true })
+      .range(offset, offset + TAXON_CHAIN_PAGE_SIZE - 1);
+    if (error || !Array.isArray(data)) {
+      return {
+        ok: false,
+        result: preparationFailure(
+          "DATABASE_READ_FAILED",
+          "A cadeia taxonômica não pôde ser lida integralmente.",
+        ),
+      };
+    }
+    const page = data.map(normalizeTaxonIdentity);
+    if (page.some((taxon) => taxon === null)) {
+      return {
+        ok: false,
+        result: preparationFailure(
+          "TAXON_IDENTITY_INVALID",
+          "A cadeia taxonômica contém identidade inválida.",
+        ),
+      };
+    }
+    taxons.push(...(page as LandingPageInputCatalogTaxonIdentity[]));
+    if (data.length < TAXON_CHAIN_PAGE_SIZE) break;
+    offset += data.length;
+  }
+  const selected = taxons.find((taxon) => taxon.id === taxonId);
+  if (!selected) {
+    return {
+      ok: false,
+      result: preparationFailure(
+        "TAXON_NOT_FOUND",
+        "O taxon não pertence à cadeia taxonômica autoritativa.",
+      ),
+    };
+  }
+  const chain = buildLandingPageInputCatalogTaxonChain(selected, taxons);
+  return chain.ok
+    ? { ok: true, value: chain.value }
+    : {
+        ok: false,
+        result: preparationFailure(
+          "TAXON_IDENTITY_INVALID",
+          chain.error.message,
+        ),
+      };
+}
+
+function normalizeTaxonIdentity(
+  value: unknown,
+): LandingPageInputCatalogTaxonIdentity | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const row = value as Record<string, unknown>;
+  if (
+    typeof row.id !== "string" ||
+    (row.parent_id !== null && typeof row.parent_id !== "string") ||
+    (row.level !== "segment" &&
+      row.level !== "niche" &&
+      row.level !== "ultra_niche") ||
+    typeof row.name !== "string" ||
+    typeof row.slug !== "string" ||
+    typeof row.is_active !== "boolean"
+  ) {
+    return null;
+  }
+  return {
+    id: row.id,
+    parentId: row.parent_id,
+    level: row.level,
+    name: row.name,
+    slug: row.slug,
+    isActive: row.is_active,
+  };
+}
+
+function preparationFailure(
+  code: Extract<TaxonPreparationResult, { ok: false }>["error"]["code"],
+  message: string,
+): Extract<TaxonPreparationResult, { ok: false }> {
+  return Object.freeze({ ok: false, error: Object.freeze({ code, message }) });
 }

--- a/lib/conversion-content/landing-page/input-catalog/contracts.ts
+++ b/lib/conversion-content/landing-page/input-catalog/contracts.ts
@@ -162,6 +162,7 @@ type LandingPageInputFieldDefinitionBase = Readonly<{
   capabilityBindings?: readonly LandingPageInputCapabilityBinding[];
   evidence: LandingPageInputEvidence;
   createdInVersion: number;
+  retiredInVersion?: number;
 }>;
 
 export type LandingPageInputFieldDefinition =
@@ -235,7 +236,24 @@ export type ResolvedLandingPageInputCatalog = Readonly<{
     taxon?: LandingPageInputCatalogTaxonIdentity;
   }>[];
   fields: readonly ResolvedLandingPageInputField[];
+  retiredFieldKeys: readonly string[];
   valid: true;
+}>;
+
+export const landingPageInputCatalogTransitionClassifications = [
+  "no_material_change",
+  "compatible_evolution",
+  "review_required",
+] as const;
+
+export type LandingPageInputCatalogTransitionClassification =
+  (typeof landingPageInputCatalogTransitionClassifications)[number];
+
+export type LandingPageInputCatalogTransitionResult = Readonly<{
+  classification: LandingPageInputCatalogTransitionClassification;
+  addedFieldKeys: readonly string[];
+  expandedAllowedValueFieldKeys: readonly string[];
+  reviewRequiredFieldKeys: readonly string[];
 }>;
 
 export type LandingPageInputCatalogErrorCode =

--- a/lib/conversion-content/landing-page/input-catalog/draft.ts
+++ b/lib/conversion-content/landing-page/input-catalog/draft.ts
@@ -1,0 +1,303 @@
+import type {
+  LandingPageInputCatalogRegistry,
+  LandingPageInputCatalogRegistryEntry,
+  LandingPageInputFieldDefinition,
+  LandingPageInputCatalogTaxonIdentity,
+  LandingPageInputCatalogTransitionClassification,
+} from "./contracts";
+import {
+  CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION,
+  classifyLandingPageInputCatalogTransitionForTaxon,
+} from "./lifecycle";
+import { landingPageInputCatalogRegistry } from "./registry";
+import { landingPageInputCatalogLayerSchema } from "./schema";
+import { buildLandingPageInputCatalogTaxonChain } from "./taxon-chain";
+
+export type LandingPageInputCatalogDraftImpact = Readonly<{
+  taxon: LandingPageInputCatalogTaxonIdentity;
+  reviewedVersion: number | null;
+  operational: boolean;
+  classification: LandingPageInputCatalogTransitionClassification;
+  addedFieldKeys: readonly string[];
+  expandedAllowedValueFieldKeys: readonly string[];
+  reviewRequiredFieldKeys: readonly string[];
+}>;
+
+export type ValidateLandingPageInputCatalogDraftResult =
+  | Readonly<{
+      ok: true;
+      value: Readonly<{
+        entry: LandingPageInputCatalogRegistryEntry;
+        registry: LandingPageInputCatalogRegistry;
+        canonicalJson: string;
+        impacts: readonly LandingPageInputCatalogDraftImpact[];
+        totals: Readonly<{
+          noMaterialChange: number;
+          compatibleEvolution: number;
+          reviewRequired: number;
+          blockingOperationalReviews: number;
+        }>;
+      }>;
+    }>
+  | Readonly<{
+      ok: false;
+      error: Readonly<{
+        code:
+          | "INVALID_DRAFT"
+          | "INVALID_VERSION"
+          | "INVALID_TAXON_CHAIN"
+          | "CATALOG_RESOLUTION_FAILED";
+        message: string;
+      }>;
+    }>;
+
+export function createNextLandingPageInputCatalogDraft(): LandingPageInputCatalogRegistryEntry {
+  const current = landingPageInputCatalogRegistry[
+    CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION
+  ];
+  return deepFreeze({
+    ...cloneJson(current),
+    version: CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION + 1,
+  });
+}
+
+export function validateLandingPageInputCatalogDraft(input: Readonly<{
+  draft: unknown;
+  taxons: readonly Readonly<{
+    identity: LandingPageInputCatalogTaxonIdentity;
+    reviewedVersion: number | null;
+    operational: boolean;
+  }>[];
+}>): ValidateLandingPageInputCatalogDraftResult {
+  const entry = parseDraftEntry(input.draft);
+  if (!entry.ok) return entry;
+  const continuityFailure = validatePublishedFieldContinuity(entry.value);
+  if (continuityFailure) return continuityFailure;
+  const registry = deepFreeze({
+    ...cloneJson(landingPageInputCatalogRegistry),
+    [entry.value.version]: cloneJson(entry.value),
+  } satisfies LandingPageInputCatalogRegistry);
+  const identities = input.taxons.map((taxon) => taxon.identity);
+  const impacts: LandingPageInputCatalogDraftImpact[] = [];
+
+  for (const taxon of input.taxons) {
+    if (!taxon.identity.isActive) continue;
+    const chain = buildLandingPageInputCatalogTaxonChain(
+      taxon.identity,
+      identities,
+    );
+    if (!chain.ok) {
+      return failure("INVALID_TAXON_CHAIN", chain.error.message);
+    }
+    if (taxon.reviewedVersion === null) {
+      impacts.push({
+        taxon: taxon.identity,
+        reviewedVersion: null,
+        operational: taxon.operational,
+        classification: "review_required",
+        addedFieldKeys: [],
+        expandedAllowedValueFieldKeys: [],
+        reviewRequiredFieldKeys: [],
+      });
+      continue;
+    }
+    if (!(landingPageInputCatalogRegistry as LandingPageInputCatalogRegistry)[taxon.reviewedVersion]) {
+      return failure(
+        "CATALOG_RESOLUTION_FAILED",
+        `A versão revisada ${taxon.reviewedVersion} não é executável.`,
+      );
+    }
+    const transition = classifyLandingPageInputCatalogTransitionForTaxon({
+      previousVersion: taxon.reviewedVersion,
+      nextVersion: entry.value.version,
+      taxonChain: chain.value,
+      registry,
+    });
+    impacts.push({
+      taxon: taxon.identity,
+      reviewedVersion: taxon.reviewedVersion,
+      operational: taxon.operational,
+      ...transition,
+    });
+  }
+
+  const totals = {
+    noMaterialChange: impacts.filter(
+      (impact) => impact.classification === "no_material_change",
+    ).length,
+    compatibleEvolution: impacts.filter(
+      (impact) => impact.classification === "compatible_evolution",
+    ).length,
+    reviewRequired: impacts.filter(
+      (impact) => impact.classification === "review_required",
+    ).length,
+    blockingOperationalReviews: impacts.filter(
+      (impact) =>
+        impact.operational && impact.classification === "review_required",
+    ).length,
+  };
+  return {
+    ok: true,
+    value: deepFreeze({
+      entry: cloneJson(entry.value),
+      registry,
+      canonicalJson: serializeLandingPageInputCatalogEntry(entry.value),
+      impacts,
+      totals,
+    }),
+  };
+}
+
+function validatePublishedFieldContinuity(
+  candidate: LandingPageInputCatalogRegistryEntry,
+): Extract<ValidateLandingPageInputCatalogDraftResult, { ok: false }> | null {
+  const current = landingPageInputCatalogRegistry[
+    CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION
+  ];
+  const targetVersion = CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION + 1;
+  const publishedFields = collectDefinedFields(current);
+  const candidateFields = collectDefinedFields(candidate);
+
+  for (const [location, published] of publishedFields) {
+    const next = candidateFields.get(location);
+    if (!next) {
+      return failure(
+        "INVALID_DRAFT",
+        `O field publicado ${published.fieldKey} deve permanecer no draft e ser retirado somente por retiredInVersion.`,
+      );
+    }
+    if (next.createdInVersion !== published.createdInVersion) {
+      return failure(
+        "INVALID_DRAFT",
+        `A proveniência publicada de ${published.fieldKey} é imutável.`,
+      );
+    }
+    if (
+      published.retiredInVersion !== undefined
+        ? next.retiredInVersion !== published.retiredInVersion
+        : next.retiredInVersion !== undefined &&
+          next.retiredInVersion !== targetVersion
+    ) {
+      return failure(
+        "INVALID_DRAFT",
+        `A retirada de ${published.fieldKey} deve ser forward-only na versão ${targetVersion}.`,
+      );
+    }
+  }
+
+  for (const [location, candidateField] of candidateFields) {
+    if (publishedFields.has(location)) continue;
+    if (
+      candidateField.createdInVersion !== targetVersion ||
+      candidateField.retiredInVersion !== undefined
+    ) {
+      return failure(
+        "INVALID_DRAFT",
+        `O novo field ${candidateField.fieldKey} deve nascer na versão ${targetVersion}.`,
+      );
+    }
+  }
+  return null;
+}
+
+function collectDefinedFields(
+  entry: LandingPageInputCatalogRegistryEntry,
+): ReadonlyMap<string, LandingPageInputFieldDefinition> {
+  const fields = new Map<string, LandingPageInputFieldDefinition>();
+  collectLayerFields("universal", entry.universal.entries, fields);
+  for (const [taxonKey, layer] of Object.entries(entry.taxonLayers)) {
+    collectLayerFields(`taxon:${taxonKey}`, layer.entries, fields);
+  }
+  return fields;
+}
+
+function collectLayerFields(
+  layerKey: string,
+  entries: LandingPageInputCatalogRegistryEntry["universal"]["entries"],
+  fields: Map<string, LandingPageInputFieldDefinition>,
+): void {
+  for (const entry of entries) {
+    if (entry.kind === "field") fields.set(`${layerKey}:${entry.fieldKey}`, entry);
+  }
+}
+
+export function serializeLandingPageInputCatalogEntry(
+  entry: LandingPageInputCatalogRegistryEntry,
+): string {
+  return stableStringify(entry);
+}
+
+function parseDraftEntry(
+  value: unknown,
+):
+  | Readonly<{ ok: true; value: LandingPageInputCatalogRegistryEntry }>
+  | Extract<ValidateLandingPageInputCatalogDraftResult, { ok: false }> {
+  if (!isRecord(value)) return failure("INVALID_DRAFT", "O draft precisa ser um objeto JSON.");
+  if (
+    Object.keys(value).some(
+      (key) => !["version", "universal", "taxonLayers"].includes(key),
+    ) ||
+    value.version !== CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION + 1
+  ) {
+    return failure(
+      "INVALID_VERSION",
+      "O draft deve representar exatamente a próxima versão sequencial.",
+    );
+  }
+  if (!landingPageInputCatalogLayerSchema.safeParse(value.universal).success) {
+    return failure("INVALID_DRAFT", "A camada universal do draft é inválida.");
+  }
+  if (!isRecord(value.taxonLayers)) {
+    return failure("INVALID_DRAFT", "As camadas taxonômicas do draft são inválidas.");
+  }
+  for (const layer of Object.values(value.taxonLayers)) {
+    if (!landingPageInputCatalogLayerSchema.safeParse(layer).success) {
+      return failure("INVALID_DRAFT", "Uma camada taxonômica do draft é inválida.");
+    }
+  }
+  return {
+    ok: true,
+    value: deepFreeze(cloneJson(value)) as LandingPageInputCatalogRegistryEntry,
+  };
+}
+
+function failure(
+  code: Extract<ValidateLandingPageInputCatalogDraftResult, { ok: false }>["error"]["code"],
+  message: string,
+): Extract<ValidateLandingPageInputCatalogDraftResult, { ok: false }> {
+  return Object.freeze({ ok: false, error: Object.freeze({ code, message }) });
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  if (isRecord(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === "object") {
+    for (const property of Object.getOwnPropertyNames(value)) {
+      const nested = value[property as keyof T];
+      if (nested && typeof nested === "object" && !Object.isFrozen(nested)) {
+        deepFreeze(nested);
+      }
+    }
+    Object.freeze(value);
+  }
+  return value;
+}

--- a/lib/conversion-content/landing-page/input-catalog/index.ts
+++ b/lib/conversion-content/landing-page/input-catalog/index.ts
@@ -1,4 +1,6 @@
 export * from "./contracts";
+export * from "./draft";
+export * from "./lifecycle";
 export * from "./registry";
 export * from "./resolver";
 export * from "./schema";

--- a/lib/conversion-content/landing-page/input-catalog/lifecycle.ts
+++ b/lib/conversion-content/landing-page/input-catalog/lifecycle.ts
@@ -1,0 +1,217 @@
+import type {
+  LandingPageInputCatalogPlan,
+  LandingPageInputCatalogRegistry,
+  LandingPageInputCatalogTaxonChain,
+  LandingPageInputCatalogTransitionClassification,
+  LandingPageInputCatalogTransitionResult,
+  ResolvedLandingPageInputCatalog,
+  ResolvedLandingPageInputField,
+} from "./contracts";
+import { landingPageInputCatalogRegistry } from "./registry";
+import { resolveLandingPageInputCatalogFromRegistry } from "./resolver";
+
+export const CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION = 5 as const;
+
+const currentCatalogEntry = landingPageInputCatalogRegistry[
+  CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION
+];
+if (
+  !currentCatalogEntry ||
+  currentCatalogEntry.version !== CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION
+) {
+  throw new Error("The explicit current input catalog version is not executable.");
+}
+
+export const landingPageInputCatalogOperationalPlans = [
+  "starter",
+  "lite",
+  "pro",
+  "ultra",
+] as const satisfies readonly LandingPageInputCatalogPlan[];
+
+export function listLandingPageInputCatalogVersions(): readonly number[] {
+  return Object.freeze(
+    Object.keys(landingPageInputCatalogRegistry)
+      .map(Number)
+      .filter((version) => Number.isSafeInteger(version) && version > 0)
+      .sort((left, right) => left - right),
+  );
+}
+
+export function classifyLandingPageInputCatalogTransition(
+  previous: ResolvedLandingPageInputCatalog,
+  next: ResolvedLandingPageInputCatalog,
+): LandingPageInputCatalogTransitionResult {
+  if (
+    previous.plan !== next.plan ||
+    previous.servedTaxon.id !== next.servedTaxon.id ||
+    previous.version >= next.version
+  ) {
+    return freezeResult(result("review_required", [], [], collectFieldKeys(previous, next)));
+  }
+
+  const previousKeys = previous.fields.map((field) => field.fieldKey);
+  const nextKeys = next.fields.map((field) => field.fieldKey);
+  const previousByKey = new Map(previous.fields.map((field) => [field.fieldKey, field]));
+  const nextByKey = new Map(next.fields.map((field) => [field.fieldKey, field]));
+  const added = nextKeys.filter((fieldKey) => !previousByKey.has(fieldKey));
+  const removed = previousKeys.filter((fieldKey) => !nextByKey.has(fieldKey));
+  const expanded: string[] = [];
+  const reviewRequired = new Set<string>(removed);
+
+  const previousOrderWithinNext = nextKeys.filter((fieldKey) => previousByKey.has(fieldKey));
+  if (!sameJson(previousOrderWithinNext, previousKeys)) {
+    previousKeys.forEach((fieldKey) => reviewRequired.add(fieldKey));
+  }
+
+  for (const fieldKey of previousKeys) {
+    const before = previousByKey.get(fieldKey);
+    const after = nextByKey.get(fieldKey);
+    if (!before || !after) continue;
+    if (sameJson(functionalField(before), functionalField(after))) continue;
+    if (isStrictAllowedValuesExpansion(before, after)) {
+      expanded.push(fieldKey);
+      continue;
+    }
+    reviewRequired.add(fieldKey);
+  }
+
+  if (reviewRequired.size > 0) {
+    return freezeResult(result("review_required", added, expanded, [...reviewRequired]));
+  }
+  if (added.length > 0 || expanded.length > 0) {
+    return freezeResult(result("compatible_evolution", added, expanded, []));
+  }
+  return freezeResult(result("no_material_change", [], [], []));
+}
+
+export function classifyLandingPageInputCatalogTransitionForTaxon(input: Readonly<{
+  previousVersion: number;
+  nextVersion: number;
+  taxonChain: LandingPageInputCatalogTaxonChain;
+  registry?: LandingPageInputCatalogRegistry;
+}>): LandingPageInputCatalogTransitionResult {
+  const registry = input.registry ?? landingPageInputCatalogRegistry;
+  const aggregate = result("no_material_change", [], [], []);
+  for (const plan of landingPageInputCatalogOperationalPlans) {
+    const previous = resolveLandingPageInputCatalogFromRegistry(
+      { version: input.previousVersion, plan, taxonChain: input.taxonChain },
+      registry,
+    );
+    const next = resolveLandingPageInputCatalogFromRegistry(
+      { version: input.nextVersion, plan, taxonChain: input.taxonChain },
+      registry,
+    );
+    if (!previous.ok || !next.ok) {
+      return result("review_required", [], [], []);
+    }
+    mergeTransition(
+      aggregate,
+      classifyLandingPageInputCatalogTransition(previous.value, next.value),
+    );
+  }
+  return freezeResult(aggregate);
+}
+
+function isStrictAllowedValuesExpansion(
+  before: ResolvedLandingPageInputField,
+  after: ResolvedLandingPageInputField,
+): boolean {
+  if (before.validation.kind !== "enum" || after.validation.kind !== "enum") {
+    return false;
+  }
+  const beforeFunctional = functionalField(before);
+  const afterFunctional = functionalField(after);
+  beforeFunctional.validation = { kind: "enum", allowedValues: [] };
+  afterFunctional.validation = { kind: "enum", allowedValues: [] };
+  if (!sameJson(beforeFunctional, afterFunctional)) return false;
+  const beforeValues = before.validation.allowedValues;
+  const afterValues = after.validation.allowedValues;
+  return (
+    afterValues.length > beforeValues.length &&
+    beforeValues.every((value) => afterValues.includes(value)) &&
+    sameJson(
+      afterValues.filter((value) => beforeValues.includes(value)),
+      beforeValues,
+    )
+  );
+}
+
+function functionalField(field: ResolvedLandingPageInputField): Record<string, unknown> {
+  const {
+    evidence: _evidence,
+    provenance: _provenance,
+    ...functional
+  } = field;
+  return JSON.parse(JSON.stringify(functional)) as Record<string, unknown>;
+}
+
+function mergeTransition(
+  aggregate: MutableTransition,
+  next: LandingPageInputCatalogTransitionResult,
+): void {
+  if (rank(next.classification) > rank(aggregate.classification)) {
+    aggregate.classification = next.classification;
+  }
+  appendUnique(aggregate.addedFieldKeys, next.addedFieldKeys);
+  appendUnique(
+    aggregate.expandedAllowedValueFieldKeys,
+    next.expandedAllowedValueFieldKeys,
+  );
+  appendUnique(aggregate.reviewRequiredFieldKeys, next.reviewRequiredFieldKeys);
+}
+
+type MutableTransition = {
+  classification: LandingPageInputCatalogTransitionClassification;
+  addedFieldKeys: string[];
+  expandedAllowedValueFieldKeys: string[];
+  reviewRequiredFieldKeys: string[];
+};
+
+function result(
+  classification: LandingPageInputCatalogTransitionClassification,
+  addedFieldKeys: readonly string[],
+  expandedAllowedValueFieldKeys: readonly string[],
+  reviewRequiredFieldKeys: readonly string[],
+): MutableTransition {
+  return {
+    classification,
+    addedFieldKeys: [...addedFieldKeys],
+    expandedAllowedValueFieldKeys: [...expandedAllowedValueFieldKeys],
+    reviewRequiredFieldKeys: [...reviewRequiredFieldKeys],
+  };
+}
+
+function freezeResult(value: MutableTransition): LandingPageInputCatalogTransitionResult {
+  return Object.freeze({
+    classification: value.classification,
+    addedFieldKeys: Object.freeze([...value.addedFieldKeys]),
+    expandedAllowedValueFieldKeys: Object.freeze([
+      ...value.expandedAllowedValueFieldKeys,
+    ]),
+    reviewRequiredFieldKeys: Object.freeze([...value.reviewRequiredFieldKeys]),
+  });
+}
+
+function rank(classification: LandingPageInputCatalogTransitionClassification): number {
+  return {
+    no_material_change: 0,
+    compatible_evolution: 1,
+    review_required: 2,
+  }[classification];
+}
+
+function appendUnique(target: string[], values: readonly string[]): void {
+  for (const value of values) if (!target.includes(value)) target.push(value);
+}
+
+function collectFieldKeys(
+  previous: ResolvedLandingPageInputCatalog,
+  next: ResolvedLandingPageInputCatalog,
+): readonly string[] {
+  return [...new Set([...previous.fields, ...next.fields].map((field) => field.fieldKey))];
+}
+
+function sameJson(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}

--- a/lib/conversion-content/landing-page/input-catalog/resolver.ts
+++ b/lib/conversion-content/landing-page/input-catalog/resolver.ts
@@ -113,11 +113,17 @@ export function resolveLandingPageInputCatalogFromRegistry(
     }
   }
 
-  const conditionError = validateConditions(fields);
-  if (conditionError) return conditionError;
+  const retirementError = validateRetirements(fields, input.version);
+  if (retirementError) return retirementError;
+
+  const activeFields = fields.filter(
+    (field) =>
+      field.retiredInVersion === undefined ||
+      field.retiredInVersion > input.version,
+  );
 
   const plan = input.plan as LandingPageInputCatalogPlan;
-  const effectiveFields = fields.filter((field) => field.allowedPlans.includes(plan));
+  const effectiveFields = activeFields.filter((field) => field.allowedPlans.includes(plan));
   const effectiveConditionError = validateConditions(effectiveFields);
   if (effectiveConditionError) return effectiveConditionError;
 
@@ -130,9 +136,36 @@ export function resolveLandingPageInputCatalogFromRegistry(
       plan,
       appliedLayers: selectedLayers.map((layer) => ({ level: layer.level, taxon: layer.taxon })),
       fields: effectiveFields,
+      retiredFieldKeys: fields
+        .filter(
+          (field) =>
+            field.retiredInVersion !== undefined &&
+            field.retiredInVersion <= input.version &&
+            field.allowedPlans.includes(plan),
+        )
+        .map((field) => field.fieldKey),
       valid: true as const,
     })),
   };
+}
+
+function validateRetirements(
+  fields: readonly ResolvedLandingPageInputField[],
+  catalogVersion: number,
+): ResolveLandingPageInputCatalogResult | null {
+  for (const field of fields) {
+    if (
+      field.retiredInVersion !== undefined &&
+      (field.retiredInVersion <= field.createdInVersion ||
+        field.retiredInVersion > catalogVersion)
+    ) {
+      return invalid(
+        "INVALID_LAYER",
+        `Invalid forward-only retirement: ${field.fieldKey}`,
+      );
+    }
+  }
+  return null;
 }
 
 function applySpecialization(

--- a/lib/conversion-content/landing-page/input-catalog/schema.ts
+++ b/lib/conversion-content/landing-page/input-catalog/schema.ts
@@ -179,6 +179,7 @@ export const landingPageInputFieldDefinitionSchema = z
     capabilityBindings: z.array(capabilityBindingSchema).min(1).optional(),
     evidence: evidenceSchema,
     createdInVersion: z.number().int().min(1),
+    retiredInVersion: z.number().int().min(2).optional(),
   })
   .strict()
   .superRefine((field, context) => {
@@ -226,6 +227,16 @@ export const landingPageInputFieldDefinitionSchema = z
         code: "custom",
         path: ["landingPageSubstitutionPolicy"],
         message: "fields created in v2 or later require an explicit landing-page substitution policy",
+      });
+    }
+    if (
+      field.retiredInVersion !== undefined &&
+      field.retiredInVersion <= field.createdInVersion
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["retiredInVersion"],
+        message: "retirement must be forward-only",
       });
     }
     if (

--- a/lib/conversion-content/landing-page/input-catalog/validation-cases.ts
+++ b/lib/conversion-content/landing-page/input-catalog/validation-cases.ts
@@ -24,6 +24,16 @@ import {
   landingPageInputFieldDefinitionSchema,
   validateLandingPageInputValue,
 } from "./schema";
+import {
+  CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION,
+  classifyLandingPageInputCatalogTransition,
+  classifyLandingPageInputCatalogTransitionForTaxon,
+  listLandingPageInputCatalogVersions,
+} from "./lifecycle";
+import {
+  createNextLandingPageInputCatalogDraft,
+  validateLandingPageInputCatalogDraft,
+} from "./draft";
 
 type Case = Readonly<{ name: string; run: () => void }>;
 
@@ -867,6 +877,140 @@ const cases: Case[] = [
       assertRegistryError(baseInput, invalidKeywordMap, "INVALID_PAID_SEARCH_KEYWORD_MAP");
     },
   },
+  {
+    name: "explicit current version is executable without deriving latest",
+    run: () => {
+      assert.equal(CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION, 5);
+      assert.deepEqual(listLandingPageInputCatalogVersions(), [1, 2, 3, 4, 5]);
+      assert.equal(resolveLandingPageInputCatalog({ ...baseInput, version: CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION }).ok, true);
+    },
+  },
+  {
+    name: "transition comparator ignores evidence and distinguishes compatible evolution from review",
+    run: () => {
+      const v4 = resolveRequired(v4Input);
+      const v5 = resolveRequired(v5Input);
+      const actual = classifyLandingPageInputCatalogTransition(v4, v5);
+      assert.equal(actual.classification, "compatible_evolution");
+      assert.deepEqual(actual.addedFieldKeys, v5UniversalFieldKeys);
+      assert.equal(Object.isFrozen(actual), true);
+
+      const evidenceRegistry = registryWithCandidate((candidate) => {
+        const field = mutableFieldInEntry(candidate, "business_display_name");
+        field.evidence = { summary: "Updated documentary evidence only.", references: ["decision:e20-2-human"] };
+      });
+      assert.equal(classifyCandidateTransition(evidenceRegistry).classification, "no_material_change");
+
+      const expansionRegistry = registryWithCandidate((candidate) => {
+        const field = mutableFieldInEntry(candidate, "traffic_source");
+        assert.equal(field.validation.kind, "enum");
+        if (field.validation.kind === "enum") {
+          field.validation = { ...field.validation, allowedValues: [...field.validation.allowedValues, "referral"] };
+        }
+      });
+      const expansion = classifyCandidateTransition(expansionRegistry);
+      assert.equal(expansion.classification, "compatible_evolution");
+      assert.deepEqual(expansion.expandedAllowedValueFieldKeys, ["traffic_source"]);
+
+      const changedRegistry = registryWithCandidate((candidate) => {
+        mutableFieldInEntry(candidate, "business_display_name").purpose = "A materially different purpose.";
+      });
+      assert.equal(classifyCandidateTransition(changedRegistry).classification, "review_required");
+    },
+  },
+  {
+    name: "forward retirement removes the field only from the candidate executable view",
+    run: () => {
+      const registry = registryWithCandidate((candidate) => {
+        mutableFieldInEntry(candidate, "business_display_name").retiredInVersion = 6;
+      });
+      const previous = resolveLandingPageInputCatalogFromRegistry(v5Input, registry);
+      const next = resolveLandingPageInputCatalogFromRegistry({ ...v5Input, version: 6 }, registry);
+      assert.equal(previous.ok, true);
+      assert.equal(next.ok, true);
+      if (!previous.ok || !next.ok) throw new Error("Expected executable retirement fixture");
+      assert.equal(previous.value.fields.some((field) => field.fieldKey === "business_display_name"), true);
+      assert.equal(next.value.fields.some((field) => field.fieldKey === "business_display_name"), false);
+      assert.deepEqual(next.value.retiredFieldKeys, ["business_display_name"]);
+      assert.equal(classifyLandingPageInputCatalogTransition(previous.value, next.value).classification, "review_required");
+    },
+  },
+  {
+    name: "draft remains non operational and blocks operational taxons without an executable review",
+    run: () => {
+      const draft = createNextLandingPageInputCatalogDraft();
+      assert.equal(draft.version, 6);
+      const unchanged = validateLandingPageInputCatalogDraft({
+        draft,
+        taxons: [
+          { identity: realEstateSegmentTaxon, reviewedVersion: 5, operational: false },
+          { identity: realEstateBrokerNicheTaxon, reviewedVersion: 5, operational: true },
+          { identity: mediumStandardRealEstateBrokerTaxon, reviewedVersion: null, operational: true },
+        ],
+      });
+      assert.equal(unchanged.ok, true);
+      if (!unchanged.ok) throw new Error("Expected valid draft fixture");
+      assert.equal(unchanged.value.totals.noMaterialChange, 2);
+      assert.equal(unchanged.value.totals.blockingOperationalReviews, 1);
+      assert.equal(unchanged.value.entry.version, CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION + 1);
+      assert.equal(Object.isFrozen(unchanged.value), true);
+
+      const invalidVersion = validateLandingPageInputCatalogDraft({
+        draft: { ...draft, version: 7 },
+        taxons: [],
+      });
+      assert.equal(invalidVersion.ok, false);
+      if (invalidVersion.ok) throw new Error("Expected invalid draft version");
+      assert.equal(invalidVersion.error.code, "INVALID_VERSION");
+    },
+  },
+  {
+    name: "draft preserves published fields and their immutable creation provenance",
+    run: () => {
+      const removed = JSON.parse(
+        JSON.stringify(createNextLandingPageInputCatalogDraft()),
+      ) as LandingPageInputCatalogRegistry[5];
+      const removedEntries = mutableEntries(removed.universal);
+      removedEntries.splice(
+        removedEntries.findIndex((entry) => entry.fieldKey === "business_display_name"),
+        1,
+      );
+      const removedResult = validateLandingPageInputCatalogDraft({
+        draft: removed,
+        taxons: [],
+      });
+      assert.equal(removedResult.ok, false);
+      if (removedResult.ok) throw new Error("Expected direct published-field removal to fail");
+      assert.equal(removedResult.error.code, "INVALID_DRAFT");
+
+      const forged = JSON.parse(
+        JSON.stringify(createNextLandingPageInputCatalogDraft()),
+      ) as LandingPageInputCatalogRegistry[5];
+      mutableFieldInEntry(forged, "business_display_name").createdInVersion = 6;
+      const forgedResult = validateLandingPageInputCatalogDraft({
+        draft: forged,
+        taxons: [],
+      });
+      assert.equal(forgedResult.ok, false);
+      if (forgedResult.ok) throw new Error("Expected forged published provenance to fail");
+      assert.equal(forgedResult.error.code, "INVALID_DRAFT");
+
+      const createdInPast = JSON.parse(
+        JSON.stringify(createNextLandingPageInputCatalogDraft()),
+      ) as LandingPageInputCatalogRegistry[5];
+      mutableEntries(createdInPast.universal).push({
+        ...fixtureField("new_draft_field"),
+        createdInVersion: 1,
+      });
+      const createdInPastResult = validateLandingPageInputCatalogDraft({
+        draft: createdInPast,
+        taxons: [],
+      });
+      assert.equal(createdInPastResult.ok, false);
+      if (createdInPastResult.ok) throw new Error("Expected false new-field provenance to fail");
+      assert.equal(createdInPastResult.error.code, "INVALID_DRAFT");
+    },
+  },
 ];
 
 for (const validationCase of cases) {
@@ -899,6 +1043,37 @@ function assertRegistryError(input: ResolveLandingPageInputCatalogInput, registr
 
 function cloneRegistry(): LandingPageInputCatalogRegistry {
   return JSON.parse(JSON.stringify(landingPageInputCatalogRegistry)) as LandingPageInputCatalogRegistry;
+}
+
+function registryWithCandidate(
+  mutate: (candidate: LandingPageInputCatalogRegistry[5]) => void,
+): LandingPageInputCatalogRegistry {
+  const registry = cloneRegistry() as Record<number, LandingPageInputCatalogRegistry[5]>;
+  const candidate = JSON.parse(JSON.stringify(registry[5])) as LandingPageInputCatalogRegistry[5];
+  (candidate as { version: number }).version = 6;
+  mutate(candidate);
+  registry[6] = candidate;
+  return registry;
+}
+
+function mutableFieldInEntry(
+  entry: LandingPageInputCatalogRegistry[5],
+  fieldKey: string,
+): MutableField {
+  const field = entry.universal.entries.find(
+    (candidate) => candidate.kind === "field" && candidate.fieldKey === fieldKey,
+  );
+  assert.ok(field && field.kind === "field");
+  return field as MutableField;
+}
+
+function classifyCandidateTransition(registry: LandingPageInputCatalogRegistry) {
+  return classifyLandingPageInputCatalogTransitionForTaxon({
+    previousVersion: 5,
+    nextVersion: 6,
+    taxonChain: baseInput.taxonChain,
+    registry,
+  });
 }
 
 function mutableTaxonLayers(registry: LandingPageInputCatalogRegistry): Record<string, LandingPageInputCatalogLayer> {

--- a/lib/conversion-content/landing-page/taxon-preparation/contracts.ts
+++ b/lib/conversion-content/landing-page/taxon-preparation/contracts.ts
@@ -1,5 +1,6 @@
 import type {
   LandingPageInputCatalogPlan,
+  LandingPageInputCatalogTaxonChain,
   LandingPageInputCatalogTaxonIdentity,
   ResolvedLandingPageInputCatalog,
 } from "../input-catalog";
@@ -115,11 +116,18 @@ export type TaxonPreparationErrorCode =
   | "REQUIRED_INPUT_CATALOG_VERSION_INVALID"
   | "REQUIRED_INPUT_CATALOG_VERSION_NOT_EXECUTABLE"
   | "INPUT_CATALOG_REVIEW_ABSENT"
-  | "INPUT_CATALOG_REVIEW_VERSION_MISMATCH";
+  | "INPUT_CATALOG_REVIEW_VERSION_MISMATCH"
+  | "INPUT_CATALOG_TRANSITION_REVIEW_REQUIRED";
 
 export type DeriveTaxonPreparationForVersionInput = Readonly<{
   selectedResearch: LoadSelectedEndCustomerResearchResult;
   requiredInputCatalogVersion: number;
+}>;
+
+export type DeriveEffectiveTaxonPreparationInput = Readonly<{
+  selectedResearch: LoadSelectedEndCustomerResearchResult;
+  currentInputCatalogVersion: number;
+  taxonChain: LandingPageInputCatalogTaxonChain;
 }>;
 
 export type TaxonPreparationResult =
@@ -132,6 +140,10 @@ export type TaxonPreparationResult =
         selectedResearchVersion: number;
         reviewedInputCatalogVersion: number;
         requiredInputCatalogVersion: number;
+        effectiveInputCatalogVersion: number;
+        transitionClassification:
+          | "no_material_change"
+          | "compatible_evolution";
         research: EndCustomerResearchContent;
       }>;
     }>

--- a/lib/conversion-content/landing-page/taxon-preparation/index.ts
+++ b/lib/conversion-content/landing-page/taxon-preparation/index.ts
@@ -7,6 +7,7 @@ export type {
   LoadEndCustomerResearchCandidateResult,
   SelectedEndCustomerResearchErrorCode,
   DeriveTaxonPreparationForVersionInput,
+  DeriveEffectiveTaxonPreparationInput,
   TaxonPreparationErrorCode,
   TaxonPreparationResult,
   BuildInputCatalogEvaluationContextResult,
@@ -58,6 +59,7 @@ export function isInputCatalogReviewEnabled(): boolean {
 export { buildInputCatalogReviewHandoff, resolveInputCatalogReview } from "./input-catalog-review";
 export {
   classifyRequiredInputCatalogVersion,
+  deriveEffectiveTaxonPreparation,
   deriveTaxonPreparationForVersion,
 } from "./preparation";
 export {

--- a/lib/conversion-content/landing-page/taxon-preparation/input-catalog-evaluation.ts
+++ b/lib/conversion-content/landing-page/taxon-preparation/input-catalog-evaluation.ts
@@ -53,15 +53,25 @@ export type BuildInputCatalogEvaluationContextInput = Readonly<{
 
 export type BuildInputCatalogEvaluationContextOptions = Readonly<{
   resolveReview?: typeof resolveInputCatalogReview;
+  allowNonPublishedVersion?: boolean;
 }>;
 
 export function buildInputCatalogEvaluationContext(
   input: BuildInputCatalogEvaluationContextInput,
   options: BuildInputCatalogEvaluationContextOptions = {},
 ): BuildInputCatalogEvaluationContextResult {
-  const versionFailure = classifyRequiredInputCatalogVersion(
-    input.inputCatalogVersion,
-  );
+  if (
+    options.allowNonPublishedVersion &&
+    (!Number.isSafeInteger(input.inputCatalogVersion) || input.inputCatalogVersion <= 0)
+  ) {
+    return contextFailure(
+      "INPUT_CATALOG_VERSION_INVALID",
+      "A versão E20.2 deve ser um inteiro positivo explícito.",
+    );
+  }
+  const versionFailure = options.allowNonPublishedVersion
+    ? null
+    : classifyRequiredInputCatalogVersion(input.inputCatalogVersion);
   if (versionFailure) {
     return contextFailure(
       versionFailure.error.code === "REQUIRED_INPUT_CATALOG_VERSION_INVALID"

--- a/lib/conversion-content/landing-page/taxon-preparation/preparation.ts
+++ b/lib/conversion-content/landing-page/taxon-preparation/preparation.ts
@@ -1,5 +1,9 @@
-import { isLandingPageInputCatalogVersionExecutable } from "../input-catalog";
+import {
+  classifyLandingPageInputCatalogTransitionForTaxon,
+  isLandingPageInputCatalogVersionExecutable,
+} from "../input-catalog";
 import type {
+  DeriveEffectiveTaxonPreparationInput,
   DeriveTaxonPreparationForVersionInput,
   TaxonPreparationResult,
 } from "./contracts";
@@ -54,6 +58,64 @@ export function deriveTaxonPreparationForVersion(
       selectedResearchVersion: input.selectedResearch.value.selectedResearchVersion,
       reviewedInputCatalogVersion: reviewedVersion,
       requiredInputCatalogVersion: input.requiredInputCatalogVersion,
+      effectiveInputCatalogVersion: reviewedVersion,
+      transitionClassification: "no_material_change" as const,
+      research: input.selectedResearch.value.research,
+    }),
+  });
+}
+
+export function deriveEffectiveTaxonPreparation(
+  input: DeriveEffectiveTaxonPreparationInput,
+): TaxonPreparationResult {
+  const versionFailure = classifyRequiredInputCatalogVersion(
+    input.currentInputCatalogVersion,
+  );
+  if (versionFailure) return versionFailure;
+  if (!input.selectedResearch.ok) return input.selectedResearch;
+
+  const reviewedVersion = input.selectedResearch.value.reviewedInputCatalogVersion;
+  if (reviewedVersion === undefined || reviewedVersion === null) {
+    return failure(
+      "INPUT_CATALOG_REVIEW_ABSENT",
+      "O taxon ainda não possui uma versão E20.2 avaliada.",
+    );
+  }
+  const reviewedFailure = classifyRequiredInputCatalogVersion(reviewedVersion);
+  if (reviewedFailure) return reviewedFailure;
+  if (reviewedVersion > input.currentInputCatalogVersion) {
+    return failure(
+      "INPUT_CATALOG_TRANSITION_REVIEW_REQUIRED",
+      "A versão E20.2 avaliada é posterior à versão atual autorizada.",
+    );
+  }
+
+  const transition =
+    reviewedVersion === input.currentInputCatalogVersion
+      ? { classification: "no_material_change" as const }
+      : classifyLandingPageInputCatalogTransitionForTaxon({
+          previousVersion: reviewedVersion,
+          nextVersion: input.currentInputCatalogVersion,
+          taxonChain: input.taxonChain,
+        });
+  if (transition.classification === "review_required") {
+    return failure(
+      "INPUT_CATALOG_TRANSITION_REVIEW_REQUIRED",
+      "A versão atual E20.2 exige nova decisão humana de suficiência para este taxon.",
+    );
+  }
+
+  return Object.freeze({
+    ok: true,
+    value: Object.freeze({
+      prepared: true as const,
+      taxonId: input.selectedResearch.value.taxonId,
+      taxonSlug: input.selectedResearch.value.taxonSlug,
+      selectedResearchVersion: input.selectedResearch.value.selectedResearchVersion,
+      reviewedInputCatalogVersion: reviewedVersion,
+      requiredInputCatalogVersion: input.currentInputCatalogVersion,
+      effectiveInputCatalogVersion: input.currentInputCatalogVersion,
+      transitionClassification: transition.classification,
       research: input.selectedResearch.value.research,
     }),
   });

--- a/lib/conversion-content/landing-page/taxon-preparation/validation-cases.ts
+++ b/lib/conversion-content/landing-page/taxon-preparation/validation-cases.ts
@@ -49,8 +49,11 @@ import {
   mediumStandardRealEstateBrokerTaxon,
   realEstateBrokerNicheTaxon,
   realEstateSegmentTaxon,
+  createNextLandingPageInputCatalogDraft,
+  validateLandingPageInputCatalogDraft,
   isLandingPageInputCatalogVersionExecutable,
   resolveLandingPageInputCatalog,
+  resolveLandingPageInputCatalogFromRegistry,
 } from "../input-catalog";
 import {
   collectAffectedReviewedTaxonIds,
@@ -159,21 +162,21 @@ const cases: readonly ValidationCase[] = [
         new URL("../../adapters/selectedEndCustomerResearchAdapter.ts", import.meta.url),
         "utf8",
       );
-      const start = adapterSource.indexOf("export async function loadTaxonPreparationForVersion");
+      const start = adapterSource.indexOf("export async function loadTaxonPreparationForCurrentVersion");
       const boundary = adapterSource.slice(start);
       const reviewGate = boundary.indexOf("if (!isInputCatalogReviewEnabled())");
       const researchGate = boundary.indexOf("if (!isEndCustomerResearchSelectionEnabled())");
-      const versionValidation = boundary.indexOf("classifyRequiredInputCatalogVersion");
       const serviceClient = boundary.indexOf("createServiceClient()");
       const selectedLoad = boundary.indexOf("loadSelectedEndCustomerResearchFromClient");
       const reviewedColumnOption = boundary.indexOf("includeInputCatalogReview: true");
+      const chainRead = boundary.indexOf("readCompleteInputCatalogTaxonChain");
       assert.ok(start >= 0);
       assert.ok(reviewGate >= 0);
       assert.ok(researchGate > reviewGate);
-      assert.ok(versionValidation > researchGate);
-      assert.ok(serviceClient > versionValidation);
+      assert.ok(serviceClient > researchGate);
       assert.ok(selectedLoad > serviceClient);
       assert.ok(reviewedColumnOption > serviceClient);
+      assert.ok(chainRead > selectedLoad);
     },
   },
   {
@@ -189,7 +192,7 @@ const cases: readonly ValidationCase[] = [
         classifyRequiredInputCatalogVersion(999),
         "REQUIRED_INPUT_CATALOG_VERSION_NOT_EXECUTABLE",
       );
-      for (const version of [1, 2, 3, 4]) {
+      for (const version of [1, 2, 3, 4, 5]) {
         assert.equal(isLandingPageInputCatalogVersionExecutable(version), true);
         assert.equal(classifyRequiredInputCatalogVersion(version), null);
       }
@@ -200,21 +203,18 @@ const cases: readonly ValidationCase[] = [
     },
   },
   {
-    name: "reviewed-version operation derives the explicit requirement from the single canonical read",
+    name: "current-version operation is the single operational adapter boundary",
     run: async () => {
       const adapterSource = readFileSync(
         new URL("../../adapters/selectedEndCustomerResearchAdapter.ts", import.meta.url),
         "utf8",
       );
       const start = adapterSource.indexOf(
-        "export async function loadTaxonPreparationForReviewedVersion",
+        "export async function loadTaxonPreparationForCurrentVersion",
       );
       const boundary = adapterSource.slice(start);
       assert.ok(start >= 0);
-      assert.doesNotMatch(
-        boundary.slice(0, boundary.indexOf("): Promise<TaxonPreparationResult>")),
-        /requiredInputCatalogVersion/,
-      );
+      assert.doesNotMatch(adapterSource, /export async function loadTaxonPreparationFor(?:Reviewed)?Version/);
       assert.equal(
         boundary.match(/loadSelectedEndCustomerResearchFromClient\(/g)?.length,
         1,
@@ -222,12 +222,7 @@ const cases: readonly ValidationCase[] = [
       assert.match(boundary, /includeInputCatalogReview: true/);
       assert.match(
         boundary,
-        /const reviewedVersion = selectedResearch\.value\.reviewedInputCatalogVersion/,
-      );
-      assert.match(boundary, /classifyRequiredInputCatalogVersion\(reviewedVersion\)/);
-      assert.match(
-        boundary,
-        /deriveTaxonPreparationForVersion\(\{[\s\S]*requiredInputCatalogVersion: reviewedVersion/,
+        /currentInputCatalogVersion: CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION/,
       );
       assert.doesNotMatch(boundary, /latest|Math\.max|= 4\b/i);
     },
@@ -953,6 +948,32 @@ const cases: readonly ValidationCase[] = [
         buildInputCatalogEvaluationContext(evaluationContextInput(999)),
         "INPUT_CATALOG_VERSION_NOT_EXECUTABLE",
       );
+      const draft = validateLandingPageInputCatalogDraft({
+        draft: createNextLandingPageInputCatalogDraft(),
+        taxons: [
+          { identity: realEstateSegmentTaxon, reviewedVersion: 5, operational: false },
+          { identity: realEstateBrokerNicheTaxon, reviewedVersion: 5, operational: true },
+          { identity: mediumStandardRealEstateBrokerTaxon, reviewedVersion: 5, operational: true },
+        ],
+      });
+      assert.equal(draft.ok, true);
+      if (!draft.ok) throw new Error("Expected executable draft fixture");
+      const draftContext = buildInputCatalogEvaluationContext(
+        evaluationContextInput(6),
+        {
+          allowNonPublishedVersion: true,
+          resolveReview: (reviewInput) => resolveInputCatalogReview(
+            reviewInput,
+            (catalogInput) => resolveLandingPageInputCatalogFromRegistry(
+              catalogInput,
+              draft.value.registry,
+            ),
+          ),
+        },
+      );
+      assert.equal(draftContext.ok, true);
+      if (!draftContext.ok) throw new Error("Expected draft evaluation context success");
+      assert.equal(draftContext.value.identity.inputCatalog.version, 6);
       assertContextBuildFailure(
         buildInputCatalogEvaluationContext({
           ...evaluationContextInput(4),
@@ -1848,6 +1869,7 @@ const cases: readonly ValidationCase[] = [
       assert.match(componentSource, /Resultado desatualizado/);
       assert.match(componentSource, /Ação humana separada/);
       assert.match(componentSource, /Checkpoint de integração final/);
+      assert.match(componentSource, /Gate pré-publicação/);
       assert.match(componentSource, /Reavaliar com feedback/);
       assert.match(componentSource, /input-catalog-evaluation-feedback/);
       assert.match(componentSource, /input-catalog-evaluation-version/);
@@ -1879,6 +1901,7 @@ const cases: readonly ValidationCase[] = [
       assert.match(pageSource, /\? \{ \.\.\.taxon\.inputCatalogReview, handoff: "" \}/);
       assert.match(pageSource, /O handoff Codex acima permanece o caminho autorizado/);
       assert.match(pageSource, /Runtime e caminhos legados permanecem bloqueados/);
+      assert.match(pageSource, /catalogDraftRevision/);
 
       const actionSource = readFileSync(
         new URL(
@@ -1893,6 +1916,7 @@ const cases: readonly ValidationCase[] = [
       assert.match(actionSource, /executeInputCatalogEvaluationAdministrativeActionCore/);
       assert.match(actionSource, /executeLegacyInputCatalogReviewRecordCore/);
       assert.match(actionSource, /reject_candidates_and_confirm_sufficient/);
+      assert.match(actionSource, /recordAdminInputCatalogDraftSufficiencyDecision/);
       assert.match(actionSource, /feedback,/);
       assert.doesNotMatch(actionSource, /loadTaxonPreparationForReviewedVersion/);
       const administrativeActionCore = readFileSync(
@@ -1910,6 +1934,8 @@ const cases: readonly ValidationCase[] = [
         "utf8",
       );
       assert.match(contextAdapterSource, /loadSelectedEndCustomerResearchForTaxon/);
+      assert.match(contextAdapterSource, /reconstructDraftInputCatalogEvaluationContext/);
+      assert.match(contextAdapterSource, /\.order\("id", \{ ascending: true \}\)[\s\S]*?\.range\(offset, offset \+ 499\)/);
       assert.doesNotMatch(contextAdapterSource, /loadTaxonPreparationForReviewedVersion/);
       assert.doesNotMatch(contextAdapterSource, /loadTaxonPreparationForVersion/);
 

--- a/lib/lp-builder/adapters/generationContextAdapter.ts
+++ b/lib/lp-builder/adapters/generationContextAdapter.ts
@@ -1,14 +1,12 @@
 import "server-only";
 
 import {
-  loadTaxonPreparationForReviewedVersion,
-  loadTaxonPreparationForVersion,
+  loadTaxonPreparationForCurrentVersion,
 } from "../../conversion-content/adapters/selectedEndCustomerResearchAdapter";
 import type {
   CompileLandingPageGenerationContextForDraftInput,
   CompileLandingPageGenerationContextResult,
 } from "../generationContextContracts";
-import { LANDING_PAGE_WORKSPACE_REQUIRED_INPUT_CATALOG_VERSION } from "../landingPageWorkspace";
 import { isLandingPageWorkspaceEnabled } from "../landingPageWorkspace";
 import { getAccountLandingPageOperationalRevalidationAuthority } from "./landingPageWorkspaceAdapter";
 import { getAccountLandingPageOnboardingRevalidationAuthority } from "./onboardingConfigurationAdapter";
@@ -25,19 +23,14 @@ export function compileLandingPageGenerationContextForDraft(
     return compileLegacyLandingPageGenerationContextForDraftWithDependencies(input, {
       loadRevalidationAuthority: getAccountLandingPageOnboardingRevalidationAuthority,
       loadLandingPage: readLandingPageDraft,
-      loadPreparation: loadTaxonPreparationForReviewedVersion,
+      loadPreparation: loadTaxonPreparationForCurrentVersion,
       log: (payload) => console.log(JSON.stringify(payload)),
     });
   }
   return compileLandingPageGenerationContextForDraftWithDependencies(input, {
     loadRevalidationAuthority: getAccountLandingPageOperationalRevalidationAuthority,
     loadLandingPage: readLandingPageDraft,
-    loadPreparation: ({ taxonId }) =>
-      loadTaxonPreparationForVersion({
-        taxonId,
-        requiredInputCatalogVersion:
-          LANDING_PAGE_WORKSPACE_REQUIRED_INPUT_CATALOG_VERSION,
-      }),
+    loadPreparation: loadTaxonPreparationForCurrentVersion,
     log: (payload) => console.log(JSON.stringify(payload)),
   });
 }

--- a/lib/lp-builder/adapters/generationContextAdapterCore.ts
+++ b/lib/lp-builder/adapters/generationContextAdapterCore.ts
@@ -8,7 +8,6 @@ import {
   compileLandingPageGenerationContext,
   compileLegacyLandingPageGenerationContext,
 } from "../generationContext";
-import { LANDING_PAGE_WORKSPACE_REQUIRED_INPUT_CATALOG_VERSION } from "../landingPageWorkspace";
 import type {
   CompileLandingPageGenerationContextResult,
   LandingPageGenerationContextFailureCode,
@@ -26,10 +25,7 @@ export type LandingPageGenerationContextBoundaryDependencies = Readonly<{
     | Readonly<{ ok: true; landingPage: AccountLandingPage }>
     | Readonly<{ ok: false; error: "not_found" | "read_failed" }>
   >;
-  loadPreparation: (input: {
-    taxonId: string;
-    requiredInputCatalogVersion: number;
-  }) => Promise<TaxonPreparationResult>;
+  loadPreparation: (input: { taxonId: string }) => Promise<TaxonPreparationResult>;
   log?: (payload: Readonly<Record<string, unknown>>) => void;
   now?: () => number;
 }>;
@@ -125,8 +121,6 @@ export async function compileLandingPageGenerationContextForDraftWithDependencie
       currentTaxonChain.segment;
     const preparation = await dependencies.loadPreparation({
       taxonId: servedTaxon.id,
-      requiredInputCatalogVersion:
-        LANDING_PAGE_WORKSPACE_REQUIRED_INPUT_CATALOG_VERSION,
     });
     if (!preparation.ok) preparationReason = preparation.error.code;
     result = compileLandingPageGenerationContext({

--- a/lib/lp-builder/adapters/landingPageWorkspaceAdapter.ts
+++ b/lib/lp-builder/adapters/landingPageWorkspaceAdapter.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
 import { getCommercialEntitlementSignal } from "../../commercial-entitlements";
-import { loadTaxonPreparationForVersion } from "../../conversion-content/adapters/selectedEndCustomerResearchAdapter";
+import { loadTaxonPreparationForCurrentVersion } from "../../conversion-content/adapters/selectedEndCustomerResearchAdapter";
 import type {
   LandingPageInputCatalogPlan,
   LandingPageInputCatalogTaxonChain,
@@ -20,7 +20,6 @@ import type {
   SaveAccountLandingPageOperationalConfigurationResult,
 } from "../contracts";
 import {
-  LANDING_PAGE_WORKSPACE_REQUIRED_INPUT_CATALOG_VERSION,
   deriveLandingPageWorkspaceState,
   isLandingPageWorkspaceEnabled,
   splitLandingPageWorkspaceValues,
@@ -35,6 +34,7 @@ type Authority = Readonly<{
   canMutate: boolean;
   planKey: LandingPageInputCatalogPlan;
   taxonChain: LandingPageInputCatalogTaxonChain;
+  effectiveInputCatalogVersion: number;
   authoritativeValues: Readonly<Record<string, unknown>>;
 }>;
 
@@ -225,7 +225,7 @@ export async function saveAccountLandingPageOperationalConfiguration(input: Read
   const candidate = resolveAccountLandingPageOnboardingConfiguration({
     accountId: authority.value.accountId,
     landingPageId: input.landingPageId,
-    catalogVersion: LANDING_PAGE_WORKSPACE_REQUIRED_INPUT_CATALOG_VERSION,
+    catalogVersion: authority.value.effectiveInputCatalogVersion,
     revision: input.expectedLandingPageRevision ?? 0,
     planKey: authority.value.planKey,
     taxonChain: authority.value.taxonChain,
@@ -266,7 +266,7 @@ export async function saveAccountLandingPageOperationalConfiguration(input: Read
         p_landing_page_values: canonicalSplit.landingPageValues,
         p_expected_shared_revision: input.expectedSharedRevision,
         p_expected_landing_page_revision: input.expectedLandingPageRevision,
-        p_catalog_version: LANDING_PAGE_WORKSPACE_REQUIRED_INPUT_CATALOG_VERSION,
+        p_catalog_version: authority.value.effectiveInputCatalogVersion,
         p_actor_user_id: authority.value.actorUserId,
         p_expected_latest_materialization_id: identity.latestMaterializationId,
       },
@@ -497,7 +497,7 @@ function resolveOperationalConfiguration(
   const resolved = resolveAccountLandingPageOnboardingConfiguration({
     accountId: authority.accountId,
     landingPageId,
-    catalogVersion: LANDING_PAGE_WORKSPACE_REQUIRED_INPUT_CATALOG_VERSION,
+    catalogVersion: authority.effectiveInputCatalogVersion,
     revision: page?.revision ?? 0,
     planKey: authority.planKey,
     taxonChain: authority.taxonChain,
@@ -760,14 +760,13 @@ async function loadAuthority(
     const taxonChain = await readTaxonChain(client, accountId);
     if (!taxonChain) return authorityFailure("unavailable");
     const servedTaxon = taxonChain.ultraNiche ?? taxonChain.niche ?? taxonChain.segment;
-    const preparation = await loadTaxonPreparationForVersion({
+    const preparation = await loadTaxonPreparationForCurrentVersion({
       taxonId: servedTaxon.id,
-      requiredInputCatalogVersion: LANDING_PAGE_WORKSPACE_REQUIRED_INPUT_CATALOG_VERSION,
     });
     if (
       !preparation.ok ||
-      preparation.value.requiredInputCatalogVersion !== LANDING_PAGE_WORKSPACE_REQUIRED_INPUT_CATALOG_VERSION ||
-      preparation.value.reviewedInputCatalogVersion !== LANDING_PAGE_WORKSPACE_REQUIRED_INPUT_CATALOG_VERSION
+      !Number.isSafeInteger(preparation.value.effectiveInputCatalogVersion) ||
+      preparation.value.effectiveInputCatalogVersion <= 0
     ) return authorityFailure("unavailable");
     return {
       ok: true,
@@ -777,6 +776,8 @@ async function loadAuthority(
         canMutate: ["owner", "admin"].includes(String(membership.role)),
         planKey: entitlement.planKey as LandingPageInputCatalogPlan,
         taxonChain,
+        effectiveInputCatalogVersion:
+          preparation.value.effectiveInputCatalogVersion,
         authoritativeValues:
           typeof account.name === "string" && account.name.trim()
             ? { business_display_name: account.name.trim() }

--- a/lib/lp-builder/adapters/onboardingConfigurationAdapter.ts
+++ b/lib/lp-builder/adapters/onboardingConfigurationAdapter.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
 import { getCommercialEntitlementSignal } from "../../commercial-entitlements";
-import { loadTaxonPreparationForReviewedVersion } from "../../conversion-content/adapters/selectedEndCustomerResearchAdapter";
+import { loadTaxonPreparationForCurrentVersion } from "../../conversion-content/adapters/selectedEndCustomerResearchAdapter";
 import { createClient } from "../../supabase/server";
 import { createServiceClient } from "../../supabase/service";
 import type {
@@ -29,7 +29,7 @@ export async function getAccountLandingPageOnboardingConfiguration(input: {
     { accountId: input.accountId, actorUserId },
     createServiceClient(),
     getCommercialEntitlementSignal,
-    loadTaxonPreparationForReviewedVersion,
+    loadTaxonPreparationForCurrentVersion,
   );
 }
 
@@ -43,7 +43,7 @@ export async function getAccountLandingPageOnboardingRevalidationAuthority(input
     { accountId: input.accountId, actorUserId },
     createServiceClient(),
     getCommercialEntitlementSignal,
-    loadTaxonPreparationForReviewedVersion,
+    loadTaxonPreparationForCurrentVersion,
   );
 }
 
@@ -57,7 +57,7 @@ export async function saveAccountLandingPageOnboardingConfiguration(
     { ...input, actorUserId },
     createServiceClient(),
     getCommercialEntitlementSignal,
-    loadTaxonPreparationForReviewedVersion,
+    loadTaxonPreparationForCurrentVersion,
   );
 }
 
@@ -71,7 +71,7 @@ export async function listAccountLandingPageDrafts(input: {
     { accountId: input.accountId, actorUserId },
     createServiceClient(),
     getCommercialEntitlementSignal,
-    loadTaxonPreparationForReviewedVersion,
+    loadTaxonPreparationForCurrentVersion,
   );
 }
 
@@ -85,7 +85,7 @@ export async function bindAccountLandingPageOnboardingConfiguration(
     { ...input, actorUserId },
     createServiceClient(),
     getCommercialEntitlementSignal,
-    loadTaxonPreparationForReviewedVersion,
+    loadTaxonPreparationForCurrentVersion,
   );
 }
 

--- a/lib/lp-builder/adapters/onboardingConfigurationAdapterCore.ts
+++ b/lib/lp-builder/adapters/onboardingConfigurationAdapterCore.ts
@@ -514,14 +514,12 @@ async function loadRuntimeContext(
         return failure("catalog_unavailable");
       }
       if (
-        !Number.isSafeInteger(preparation.value.reviewedInputCatalogVersion) ||
-        preparation.value.reviewedInputCatalogVersion <= 0 ||
-        preparation.value.requiredInputCatalogVersion !==
-          preparation.value.reviewedInputCatalogVersion
+        !Number.isSafeInteger(preparation.value.effectiveInputCatalogVersion) ||
+        preparation.value.effectiveInputCatalogVersion <= 0
       ) {
         return failure("catalog_unavailable");
       }
-      operationalCatalogVersion = preparation.value.reviewedInputCatalogVersion;
+      operationalCatalogVersion = preparation.value.effectiveInputCatalogVersion;
     }
 
     return {

--- a/lib/lp-builder/generation-context-validation-cases.ts
+++ b/lib/lp-builder/generation-context-validation-cases.ts
@@ -433,7 +433,7 @@ const cases: readonly Readonly<{ name: string; run: () => void | Promise<void> }
     run: async () => {
       const logs: Readonly<Record<string, unknown>>[] = [];
       const dependencyCalls: string[] = [];
-      const requiredCatalogVersions: number[] = [];
+      const preparedTaxonIds: string[] = [];
       const dependencies = {
         loadRevalidationAuthority: async () => {
           dependencyCalls.push("revalidation-authority");
@@ -446,13 +446,9 @@ const cases: readonly Readonly<{ name: string; run: () => void | Promise<void> }
           dependencyCalls.push("landing-page");
           return { ok: true as const, landingPage };
         },
-        loadPreparation: async ({
-          requiredInputCatalogVersion,
-        }: {
-          requiredInputCatalogVersion: number;
-        }) => {
+        loadPreparation: async ({ taxonId }: { taxonId: string }) => {
           dependencyCalls.push("preparation");
-          requiredCatalogVersions.push(requiredInputCatalogVersion);
+          preparedTaxonIds.push(taxonId);
           return preparation;
         },
         now: (() => {
@@ -474,7 +470,7 @@ const cases: readonly Readonly<{ name: string; run: () => void | Promise<void> }
         "landing-page",
         "preparation",
       ]);
-      assert.deepEqual(requiredCatalogVersions, [5]);
+      assert.deepEqual(preparedTaxonIds, [TAXON_ID]);
       assert.deepEqual(logs[0], {
         event: "landing_page_generation_context_compilation",
         result: "success",
@@ -497,7 +493,7 @@ const cases: readonly Readonly<{ name: string; run: () => void | Promise<void> }
         "landing-page",
         "preparation",
       ]);
-      assert.deepEqual(requiredCatalogVersions, [5, 5]);
+      assert.deepEqual(preparedTaxonIds, [TAXON_ID, TAXON_ID]);
       assert.equal(Object.hasOwn(logs[0], "request_id"), false);
       assert.equal(Object.hasOwn(logs[0], "preparation_reason"), false);
 
@@ -552,13 +548,9 @@ const cases: readonly Readonly<{ name: string; run: () => void | Promise<void> }
           { accountId: ACCOUNT_ID, landingPageId: LANDING_PAGE_ID },
           {
             ...dependencies,
-            loadPreparation: async ({
-              requiredInputCatalogVersion,
-            }: {
-              requiredInputCatalogVersion: number;
-            }) => {
+            loadPreparation: async ({ taxonId }: { taxonId: string }) => {
               dependencyCalls.push("preparation");
-              requiredCatalogVersions.push(requiredInputCatalogVersion);
+              preparedTaxonIds.push(taxonId);
               return {
                 ok: false as const,
                 error: {
@@ -579,7 +571,7 @@ const cases: readonly Readonly<{ name: string; run: () => void | Promise<void> }
         "landing-page",
         "preparation",
       ]);
-      assert.equal(requiredCatalogVersions.at(-1), 5);
+      assert.equal(preparedTaxonIds.at(-1), TAXON_ID);
       assert.equal(
         logs[0]?.preparation_reason,
         "INPUT_CATALOG_REVIEW_VERSION_MISMATCH",
@@ -782,6 +774,8 @@ function buildPreparation(): Extract<TaxonPreparationResult, { ok: true }> {
       selectedResearchVersion: 1,
       reviewedInputCatalogVersion: 5,
       requiredInputCatalogVersion: 5,
+      effectiveInputCatalogVersion: 5,
+      transitionClassification: "no_material_change",
       research: {
         taxonSlug: realEstateBrokerNicheTaxon.slug,
         audienceScope: "end_customer",

--- a/lib/lp-builder/generationContext.ts
+++ b/lib/lp-builder/generationContext.ts
@@ -1,6 +1,7 @@
 import { resolveLandingPageRootParameters } from "../conversion-content/landing-page";
-import type {
-  LandingPageInputValueType,
+import {
+  isLandingPageInputCatalogVersionExecutable,
+  type LandingPageInputValueType,
 } from "../conversion-content/landing-page/input-catalog";
 import type {
   AccountLandingPageOnboardingFieldState,
@@ -100,6 +101,7 @@ function compileValidatedLegacyLandingPageGenerationContext(
       "REQUIRED_INPUT_CATALOG_VERSION_INVALID",
       "REQUIRED_INPUT_CATALOG_VERSION_NOT_EXECUTABLE",
       "INPUT_CATALOG_REVIEW_VERSION_MISMATCH",
+      "INPUT_CATALOG_TRANSITION_REVIEW_REQUIRED",
     ].includes(input.preparation.error.code);
     return failure(
       catalogFailure
@@ -118,8 +120,8 @@ function compileValidatedLegacyLandingPageGenerationContext(
   if (
     preparation.taxonId !== servedTaxon.id ||
     preparation.taxonSlug !== servedTaxon.slug ||
-    preparation.requiredInputCatalogVersion !==
-      preparation.reviewedInputCatalogVersion ||
+    !Number.isSafeInteger(preparation.effectiveInputCatalogVersion) ||
+    preparation.effectiveInputCatalogVersion <= 0 ||
     preparation.research.taxonSlug !== servedTaxon.slug ||
     preparation.research.audienceScope !== "end_customer" ||
     preparation.research.researchVersion !== preparation.selectedResearchVersion
@@ -131,7 +133,7 @@ function compileValidatedLegacyLandingPageGenerationContext(
   }
   const revalidated = revalidateConfiguration(
     input.revalidationAuthority,
-    preparation.reviewedInputCatalogVersion,
+    preparation.effectiveInputCatalogVersion,
   );
   if (!revalidated.ok) {
     return failure(
@@ -158,7 +160,7 @@ function compileValidatedLegacyLandingPageGenerationContext(
       servedTaxon,
       taxonChain: currentTaxonChain,
       historicalConfigurationCatalogVersion: historicalConfiguration.catalogVersion,
-      effectiveInputCatalogVersion: preparation.reviewedInputCatalogVersion,
+      effectiveInputCatalogVersion: preparation.effectiveInputCatalogVersion,
       configurationRevision: historicalConfiguration.revision,
       rootVersion: root.value.rootVersion,
       endCustomerResearchVersion: preparation.selectedResearchVersion,
@@ -222,6 +224,7 @@ function compileValidatedLandingPageGenerationContext(
       "REQUIRED_INPUT_CATALOG_VERSION_INVALID",
       "REQUIRED_INPUT_CATALOG_VERSION_NOT_EXECUTABLE",
       "INPUT_CATALOG_REVIEW_VERSION_MISMATCH",
+      "INPUT_CATALOG_TRANSITION_REVIEW_REQUIRED",
     ].includes(input.preparation.error.code);
     return failure(
       catalogFailure
@@ -240,8 +243,8 @@ function compileValidatedLandingPageGenerationContext(
   if (
     preparation.taxonId !== servedTaxon.id ||
     preparation.taxonSlug !== servedTaxon.slug ||
-    preparation.requiredInputCatalogVersion !==
-      preparation.reviewedInputCatalogVersion ||
+    !Number.isSafeInteger(preparation.effectiveInputCatalogVersion) ||
+    preparation.effectiveInputCatalogVersion <= 0 ||
     preparation.research.taxonSlug !== servedTaxon.slug ||
     preparation.research.audienceScope !== "end_customer" ||
     preparation.research.researchVersion !== preparation.selectedResearchVersion
@@ -254,7 +257,7 @@ function compileValidatedLandingPageGenerationContext(
 
   const revalidated = revalidateConfiguration(
     input.revalidationAuthority,
-    preparation.reviewedInputCatalogVersion,
+    preparation.effectiveInputCatalogVersion,
   );
   if (!revalidated.ok) {
     return failure(
@@ -279,8 +282,10 @@ function compileValidatedLandingPageGenerationContext(
   if (!projectedFacts.ok) return projectedFacts.result;
 
   if (
-    input.revalidationAuthority.landingPageCatalogVersion !==
-      preparation.reviewedInputCatalogVersion ||
+    !isCompatibleHistoricalCatalogVersion(
+      input.revalidationAuthority.landingPageCatalogVersion,
+      preparation.effectiveInputCatalogVersion,
+    ) ||
     !Number.isSafeInteger(input.revalidationAuthority.landingPageRevision) ||
     input.revalidationAuthority.landingPageRevision <= 0 ||
     ((input.revalidationAuthority.sharedRevision === null) !==
@@ -288,8 +293,10 @@ function compileValidatedLandingPageGenerationContext(
     (input.revalidationAuthority.sharedRevision !== null &&
       (!Number.isSafeInteger(input.revalidationAuthority.sharedRevision) ||
         input.revalidationAuthority.sharedRevision <= 0 ||
-        input.revalidationAuthority.sharedCatalogVersion !==
-          preparation.reviewedInputCatalogVersion))
+        !isCompatibleHistoricalCatalogVersion(
+          input.revalidationAuthority.sharedCatalogVersion,
+          preparation.effectiveInputCatalogVersion,
+        )))
   ) {
     return failure(
       "CONFIGURATION_REVALIDATION_REQUIRED",
@@ -325,7 +332,7 @@ function compileValidatedLandingPageGenerationContext(
       taxonChain: currentTaxonChain,
       sharedCatalogVersion: input.revalidationAuthority.sharedCatalogVersion,
       landingPageCatalogVersion: input.revalidationAuthority.landingPageCatalogVersion,
-      effectiveInputCatalogVersion: preparation.reviewedInputCatalogVersion,
+      effectiveInputCatalogVersion: preparation.effectiveInputCatalogVersion,
       sharedRevision: input.revalidationAuthority.sharedRevision,
       landingPageRevision: input.revalidationAuthority.landingPageRevision,
       rootVersion: root.value.rootVersion,
@@ -352,6 +359,17 @@ function compileValidatedLandingPageGenerationContext(
       facts: projectedFacts.serverFacts,
     },
   });
+}
+
+function isCompatibleHistoricalCatalogVersion(
+  historicalVersion: number | null,
+  effectiveVersion: number,
+): historicalVersion is number {
+  return (
+    historicalVersion !== null &&
+    isLandingPageInputCatalogVersionExecutable(historicalVersion) &&
+    historicalVersion <= effectiveVersion
+  );
 }
 
 function revalidateConfiguration(

--- a/lib/lp-builder/index.ts
+++ b/lib/lp-builder/index.ts
@@ -95,7 +95,6 @@ export {
   saveAccountLandingPageOnboardingConfiguration,
 } from "./adapters/onboardingConfigurationAdapter";
 export {
-  LANDING_PAGE_WORKSPACE_REQUIRED_INPUT_CATALOG_VERSION,
   deriveLandingPageWorkspaceState,
   isLandingPageWorkspaceEnabled,
   landingPageWorkspaceStateLabels,

--- a/lib/lp-builder/landing-page-workspace-validation-cases.ts
+++ b/lib/lp-builder/landing-page-workspace-validation-cases.ts
@@ -2,8 +2,8 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 import type { AccountLandingPageOnboardingConfiguration } from "./contracts";
+import { CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION } from "../conversion-content/landing-page/input-catalog";
 import {
-  LANDING_PAGE_WORKSPACE_REQUIRED_INPUT_CATALOG_VERSION,
   deriveLandingPageWorkspaceState,
   isLandingPageWorkspaceEnabled,
   landingPageWorkspaceStateLabels,
@@ -12,7 +12,7 @@ import {
 
 const cases: readonly Readonly<{ name: string; run: () => void }>[] = [
   {
-    name: "workspace rollout accepts only literal true and pins explicit input catalog v5",
+    name: "workspace rollout accepts only literal true and consumes the explicit repo current version",
     run: () => {
       const previous = process.env.E19_5_WORKSPACE_ENABLED;
       try {
@@ -22,7 +22,7 @@ const cases: readonly Readonly<{ name: string; run: () => void }>[] = [
         assert.equal(isLandingPageWorkspaceEnabled(), false);
         process.env.E19_5_WORKSPACE_ENABLED = "true";
         assert.equal(isLandingPageWorkspaceEnabled(), true);
-        assert.equal(LANDING_PAGE_WORKSPACE_REQUIRED_INPUT_CATALOG_VERSION, 5);
+        assert.equal(CURRENT_LANDING_PAGE_INPUT_CATALOG_VERSION, 5);
       } finally {
         if (previous === undefined) delete process.env.E19_5_WORKSPACE_ENABLED;
         else process.env.E19_5_WORKSPACE_ENABLED = previous;
@@ -76,6 +76,10 @@ const cases: readonly Readonly<{ name: string; run: () => void }>[] = [
         new URL("../../supabase/migrations/20260822170000_e19_5_3_landing_page_workspace.sql", import.meta.url),
         "utf8",
       );
+      const lifecycleMigration = readFileSync(
+        new URL("../../supabase/migrations/20260824180000_e20_2_8_input_catalog_lifecycle.sql", import.meta.url),
+        "utf8",
+      );
       const generationAdapter = readFileSync(
         new URL("./adapters/generationContextAdapter.ts", import.meta.url),
         "utf8",
@@ -93,8 +97,9 @@ const cases: readonly Readonly<{ name: string; run: () => void }>[] = [
         "utf8",
       );
       assert.ok(adapter.indexOf("isLandingPageWorkspaceEnabled()") < adapter.indexOf("account_landing_page_shared_configurations"));
-      assert.match(adapter, /loadTaxonPreparationForVersion\(\{/);
-      assert.match(adapter, /requiredInputCatalogVersion:\s*LANDING_PAGE_WORKSPACE_REQUIRED_INPUT_CATALOG_VERSION/);
+      assert.match(adapter, /loadTaxonPreparationForCurrentVersion\(\{/);
+      assert.match(adapter, /effectiveInputCatalogVersion/);
+      assert.doesNotMatch(adapter, /LANDING_PAGE_WORKSPACE_REQUIRED_INPUT_CATALOG_VERSION/);
       assert.doesNotMatch(adapter, /loadTaxonPreparationForReviewedVersion|readAllLandingPageMaterializations|is_initialized|archive/i);
       assert.match(adapter, /count:\s*"exact"/);
       assert.match(adapter, /\.range\(/);
@@ -106,8 +111,10 @@ const cases: readonly Readonly<{ name: string; run: () => void }>[] = [
       );
       assert.match(generationAdapter, /if \(!isLandingPageWorkspaceEnabled\(\)\)/);
       assert.match(generationAdapter, /compileLegacyLandingPageGenerationContextForDraftWithDependencies/);
-      assert.match(generationAdapter, /loadTaxonPreparationForReviewedVersion/);
-      assert.match(generationAdapter, /loadTaxonPreparationForVersion/);
+      assert.match(generationAdapter, /loadTaxonPreparationForCurrentVersion/);
+      assert.doesNotMatch(generationAdapter, /loadTaxonPreparationForReviewedVersion|loadTaxonPreparationForVersion/);
+      assert.match(lifecycleMigration, /p_catalog_version is null or p_catalog_version <= 0/);
+      assert.doesNotMatch(lifecycleMigration, /p_catalog_version is distinct from 5/);
       assert.match(revisionAdapter, /append_account_landing_page_materialization_v2/);
       assert.match(migration, /p_expected_shared_revision is null/);
       assert.match(migration, /p_expected_landing_page_revision is null/);

--- a/lib/lp-builder/landingPageWorkspace.ts
+++ b/lib/lp-builder/landingPageWorkspace.ts
@@ -4,8 +4,6 @@ import type {
   AccountLandingPageWorkspaceState,
 } from "./contracts";
 
-export const LANDING_PAGE_WORKSPACE_REQUIRED_INPUT_CATALOG_VERSION = 5 as const;
-
 export function isLandingPageWorkspaceEnabled(): boolean {
   return process.env.E19_5_WORKSPACE_ENABLED === "true";
 }

--- a/lib/lp-builder/onboardingConfiguration.ts
+++ b/lib/lp-builder/onboardingConfiguration.ts
@@ -1,8 +1,10 @@
 import {
   landingPageInputColorPaletteRoles,
   resolveLandingPageInputCatalog,
+  resolveLandingPageInputCatalogFromRegistry,
   validateLandingPageInputValue,
   type LandingPageInputCatalogPlan,
+  type LandingPageInputCatalogRegistry,
   type LandingPageInputCatalogTaxonChain,
   type LandingPageInputCondition,
   type ResolvedLandingPageInputField,
@@ -12,7 +14,7 @@ import type {
   AccountLandingPageOnboardingStoredValues,
 } from "./contracts";
 
-type ResolveOnboardingConfigurationInput = Readonly<{
+export type ResolveOnboardingConfigurationInput = Readonly<{
   accountId: string;
   landingPageId: string | null;
   catalogVersion: number;
@@ -21,6 +23,7 @@ type ResolveOnboardingConfigurationInput = Readonly<{
   taxonChain: LandingPageInputCatalogTaxonChain;
   storedValues: AccountLandingPageOnboardingStoredValues;
   authoritativeValues: Readonly<Record<string, unknown>>;
+  registry?: LandingPageInputCatalogRegistry;
 }>;
 
 export type ResolveOnboardingConfigurationResult =
@@ -40,17 +43,21 @@ export type ResolveOnboardingConfigurationResult =
 export function resolveAccountLandingPageOnboardingConfiguration(
   input: ResolveOnboardingConfigurationInput,
 ): ResolveOnboardingConfigurationResult {
-  const catalog = resolveLandingPageInputCatalog({
+  const catalogInput = {
     version: input.catalogVersion,
     plan: input.planKey,
     taxonChain: input.taxonChain,
-  });
+  };
+  const catalog = input.registry
+    ? resolveLandingPageInputCatalogFromRegistry(catalogInput, input.registry)
+    : resolveLandingPageInputCatalog(catalogInput);
 
   if (!catalog.ok) return { ok: false, error: "CATALOG_UNAVAILABLE" };
 
   const fieldsByKey = new Map(
     catalog.value.fields.map((field) => [field.fieldKey, field]),
   );
+  const retiredFieldKeys = new Set(catalog.value.retiredFieldKeys);
   const canonicalStoredValues: Record<
     string,
     AccountLandingPageOnboardingStoredValues[string]
@@ -59,6 +66,12 @@ export function resolveAccountLandingPageOnboardingConfiguration(
 
   for (const [fieldKey, stored] of Object.entries(input.storedValues)) {
     const field = fieldsByKey.get(fieldKey);
+    if (retiredFieldKeys.has(fieldKey)) {
+      if (!isStoredValue(stored)) {
+        return { ok: false, error: "INVALID_CONFIGURATION", fieldKey };
+      }
+      continue;
+    }
     if (!field || !isStoredValue(stored) || stored.scope !== field.valueScope) {
       return { ok: false, error: "INVALID_CONFIGURATION", fieldKey };
     }

--- a/lib/lp-builder/validation-cases.ts
+++ b/lib/lp-builder/validation-cases.ts
@@ -75,6 +75,8 @@ function catalogVersionLoaderFor(
         selectedResearchVersion: 1,
         reviewedInputCatalogVersion: version,
         requiredInputCatalogVersion: version,
+        effectiveInputCatalogVersion: version,
+        transitionClassification: "no_material_change",
         research: {
           taxonSlug: realEstateSegmentTaxon.slug,
           audienceScope: "end_customer",
@@ -603,18 +605,13 @@ const cases: ReadonlyArray<
           { accountId: ACCOUNT_ID, actorUserId: ACTOR_ID },
           divergent,
           eligibleEntitlement,
-          async ({ taxonId }) => {
-            const prepared = await catalogVersionLoaderFor(5)({ taxonId });
-            assert.equal(prepared.ok, true);
-            if (!prepared.ok) throw new Error("fixture preparation failed");
-            return {
-              ok: true,
-              value: {
-                ...prepared.value,
-                requiredInputCatalogVersion: 4,
-              },
-            };
-          },
+          async () => ({
+            ok: false,
+            error: {
+              code: "INPUT_CATALOG_TRANSITION_REVIEW_REQUIRED" as const,
+              message: "A versão atual exige nova revisão taxonômica.",
+            },
+          }),
         );
       assert.deepEqual(divergentResult, {
         ok: false,

--- a/supabase/migrations/20260824180000_e20_2_8_input_catalog_lifecycle.sql
+++ b/supabase/migrations/20260824180000_e20_2_8_input_catalog_lifecycle.sql
@@ -1,0 +1,238 @@
+begin;
+
+create table public.landing_page_input_catalog_drafts (
+  singleton boolean primary key default true,
+  base_version integer not null,
+  target_version integer not null,
+  catalog_json jsonb not null,
+  content_fingerprint text not null,
+  revision bigint not null default 1,
+  validation_fingerprint text,
+  validation_context_fingerprint text,
+  validated_at timestamptz,
+  publication_fingerprint text,
+  publication_context_fingerprint text,
+  publication_prepared_at timestamptz,
+  taxon_review_evidence jsonb not null default '{}'::jsonb,
+  created_by uuid not null references auth.users(id) on update cascade on delete restrict,
+  updated_by uuid not null references auth.users(id) on update cascade on delete restrict,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint landing_page_input_catalog_drafts_singleton_chk
+    check (singleton),
+  constraint landing_page_input_catalog_drafts_versions_chk
+    check (base_version > 0 and target_version = base_version + 1),
+  constraint landing_page_input_catalog_drafts_catalog_chk
+    check (jsonb_typeof(catalog_json) = 'object'),
+  constraint landing_page_input_catalog_drafts_content_fingerprint_chk
+    check (content_fingerprint ~ '^[0-9a-f]{64}$'),
+  constraint landing_page_input_catalog_drafts_revision_chk
+    check (revision > 0),
+  constraint landing_page_input_catalog_drafts_validation_pair_chk
+    check (
+      (
+        (validation_fingerprint is null and validated_at is null)
+        or (
+          validation_fingerprint ~ '^[0-9a-f]{64}$'
+          and validation_context_fingerprint ~ '^[0-9a-f]{64}$'
+          and validated_at is not null
+        )
+      )
+      and ((validation_fingerprint is null) = (validation_context_fingerprint is null))
+    ),
+  constraint landing_page_input_catalog_drafts_publication_pair_chk
+    check (
+      (
+        (publication_fingerprint is null and publication_prepared_at is null)
+        or (
+          publication_fingerprint ~ '^[0-9a-f]{64}$'
+          and publication_context_fingerprint ~ '^[0-9a-f]{64}$'
+          and publication_prepared_at is not null
+          and validation_fingerprint = publication_fingerprint
+          and validation_context_fingerprint = publication_context_fingerprint
+        )
+      )
+      and ((publication_fingerprint is null) = (publication_context_fingerprint is null))
+    ),
+  constraint landing_page_input_catalog_drafts_taxon_review_evidence_chk
+    check (jsonb_typeof(taxon_review_evidence) = 'object')
+);
+
+alter table public.landing_page_input_catalog_drafts enable row level security;
+
+revoke all on table public.landing_page_input_catalog_drafts
+  from public, anon, authenticated;
+
+do $$
+begin
+  if to_regrole('ai_readonly') is not null then
+    execute 'revoke all on table public.landing_page_input_catalog_drafts from ai_readonly';
+  end if;
+end;
+$$;
+
+grant select, insert, update, delete
+  on table public.landing_page_input_catalog_drafts
+  to service_role;
+
+create trigger landing_page_input_catalog_drafts_set_updated_at
+before update on public.landing_page_input_catalog_drafts
+for each row execute function public.tg_set_updated_at();
+
+comment on table public.landing_page_input_catalog_drafts is
+  'E20.2.8: singleton draft administrativo, mutavel e nao operacional. Nunca e autoridade de versoes publicadas nem da versao atual repo-only.';
+comment on column public.landing_page_input_catalog_drafts.catalog_json is
+  'Snapshot candidato da unica proxima versao. Nao replica nem migra as versoes publicadas v1-v5.';
+comment on column public.landing_page_input_catalog_drafts.publication_fingerprint is
+  'Identidade congelada para o handoff repo-only; nao significa publicacao nem ativacao operacional.';
+comment on column public.landing_page_input_catalog_drafts.publication_context_fingerprint is
+  'Identidade da colecao operacional completa revalidada no handoff; drift torna a preparacao stale.';
+comment on column public.landing_page_input_catalog_drafts.taxon_review_evidence is
+  'Decisoes humanas pre-publicacao vinculadas ao fingerprint exato do draft; nao atualizam reviewed_input_catalog_version.';
+
+create or replace function public.save_account_landing_page_configuration_v1(
+  p_account_id uuid,
+  p_landing_page_id uuid,
+  p_shared_values jsonb,
+  p_landing_page_values jsonb,
+  p_expected_shared_revision bigint,
+  p_expected_landing_page_revision bigint,
+  p_catalog_version integer,
+  p_actor_user_id uuid,
+  p_expected_latest_materialization_id uuid
+)
+returns table(shared_revision bigint, landing_page_revision bigint)
+language plpgsql
+security invoker
+set search_path = public, pg_catalog
+as $$
+declare
+  v_shared_exists boolean := false;
+  v_landing_exists boolean := false;
+  v_shared_revision bigint;
+  v_landing_revision bigint;
+  v_shared_values jsonb;
+  v_landing_values jsonb;
+  v_shared_catalog integer;
+  v_landing_catalog integer;
+  v_latest_materialization_id uuid;
+begin
+  if p_catalog_version is null or p_catalog_version <= 0 then
+    raise exception using errcode = '22023', message = 'catalog_version_not_authorized';
+  end if;
+  if not public.e19_5_actor_can_manage(p_account_id, p_actor_user_id) then
+    raise exception using errcode = '42501', message = 'actor_not_authorized';
+  end if;
+  perform 1
+  from public.account_landing_pages
+  where id = p_landing_page_id
+    and account_id = p_account_id
+    and status in ('draft', 'active')
+  for update;
+  if not found then
+    raise exception using errcode = 'P0001', message = 'landing_page_not_operational';
+  end if;
+  select materialization.id
+  into v_latest_materialization_id
+  from public.account_landing_page_materializations materialization
+  where materialization.account_id = p_account_id
+    and materialization.landing_page_id = p_landing_page_id
+  order by materialization.revision_number desc
+  limit 1;
+  if v_latest_materialization_id is distinct from p_expected_latest_materialization_id then
+    raise exception using errcode = '40001', message = 'materialization_baseline_conflict';
+  end if;
+  if not public.e19_5_configuration_values_have_scopes(
+       p_shared_values, array['account', 'business']
+     )
+     or not public.e19_5_configuration_values_have_scopes(
+       p_landing_page_values, array['offer', 'campaign', 'landing_page']
+     ) then
+    raise exception using errcode = '22023', message = 'configuration_values_invalid';
+  end if;
+
+  select values, revision, catalog_version
+  into v_shared_values, v_shared_revision, v_shared_catalog
+  from public.account_landing_page_shared_configurations
+  where account_id = p_account_id
+  for update;
+  v_shared_exists := found;
+  if v_shared_exists then
+    if p_expected_shared_revision is null
+       or v_shared_revision <> p_expected_shared_revision then
+      raise exception using errcode = '40001', message = 'shared_revision_conflict';
+    end if;
+    if v_shared_values is distinct from p_shared_values
+       or v_shared_catalog is distinct from p_catalog_version then
+      update public.account_landing_page_shared_configurations
+      set values = p_shared_values,
+          catalog_version = p_catalog_version,
+          revision = revision + 1,
+          updated_by = p_actor_user_id
+      where account_id = p_account_id
+      returning revision into v_shared_revision;
+    end if;
+  else
+    if p_expected_shared_revision is not null then
+      raise exception using errcode = '40001', message = 'shared_revision_conflict';
+    end if;
+    if p_shared_values <> '{}'::jsonb then
+      insert into public.account_landing_page_shared_configurations (
+        account_id, catalog_version, values, revision, created_by, updated_by
+      ) values (
+        p_account_id, p_catalog_version, p_shared_values, 1,
+        p_actor_user_id, p_actor_user_id
+      )
+      returning revision into v_shared_revision;
+    else
+      v_shared_revision := null;
+    end if;
+  end if;
+
+  select values, revision, catalog_version
+  into v_landing_values, v_landing_revision, v_landing_catalog
+  from public.account_landing_page_configurations
+  where landing_page_id = p_landing_page_id
+    and account_id = p_account_id
+  for update;
+  v_landing_exists := found;
+  if v_landing_exists then
+    if p_expected_landing_page_revision is null
+       or v_landing_revision <> p_expected_landing_page_revision then
+      raise exception using errcode = '40001', message = 'landing_page_revision_conflict';
+    end if;
+    if v_landing_values is distinct from p_landing_page_values
+       or v_landing_catalog is distinct from p_catalog_version then
+      update public.account_landing_page_configurations
+      set values = p_landing_page_values,
+          catalog_version = p_catalog_version,
+          revision = revision + 1,
+          updated_by = p_actor_user_id
+      where landing_page_id = p_landing_page_id
+        and account_id = p_account_id
+      returning revision into v_landing_revision;
+    end if;
+  else
+    if p_expected_landing_page_revision is not null then
+      raise exception using errcode = '40001', message = 'landing_page_revision_conflict';
+    end if;
+    insert into public.account_landing_page_configurations (
+      landing_page_id, account_id, catalog_version, values, revision,
+      created_by, updated_by
+    ) values (
+      p_landing_page_id, p_account_id, p_catalog_version,
+      p_landing_page_values, 1, p_actor_user_id, p_actor_user_id
+    )
+    returning revision into v_landing_revision;
+  end if;
+
+  return query select v_shared_revision, v_landing_revision;
+end;
+$$;
+
+comment on function public.save_account_landing_page_configuration_v1(
+  uuid, uuid, jsonb, jsonb, bigint, bigint, integer, uuid, uuid
+) is
+  'E19.5/E20.2.8: persiste a versao efetiva C positiva, fornecida e validada pelo boundary repo-only antes da chamada; o banco nao deriva current/latest.';
+
+commit;

--- a/supabase/snippets/e20_2_8_input_catalog_lifecycle_verify.sql
+++ b/supabase/snippets/e20_2_8_input_catalog_lifecycle_verify.sql
@@ -1,0 +1,69 @@
+with checks as (
+  select
+    'draft_table'::text as check_name,
+    to_regclass('public.landing_page_input_catalog_drafts') is not null as ok
+  union all
+  select
+    'rls_service_only',
+    coalesce((
+      select c.relrowsecurity
+        and not exists (
+          select 1 from pg_policies p
+          where p.schemaname = 'public'
+            and p.tablename = 'landing_page_input_catalog_drafts'
+        )
+        and not has_table_privilege('anon', c.oid, 'SELECT')
+        and not has_table_privilege('anon', c.oid, 'INSERT')
+        and not has_table_privilege('anon', c.oid, 'UPDATE')
+        and not has_table_privilege('anon', c.oid, 'DELETE')
+        and not has_table_privilege('authenticated', c.oid, 'SELECT')
+        and not has_table_privilege('authenticated', c.oid, 'INSERT')
+        and not has_table_privilege('authenticated', c.oid, 'UPDATE')
+        and not has_table_privilege('authenticated', c.oid, 'DELETE')
+        and not exists (
+          select 1
+          from information_schema.role_table_grants grants
+          where grants.table_schema = 'public'
+            and grants.table_name = 'landing_page_input_catalog_drafts'
+            and grants.grantee = 'PUBLIC'
+        )
+        and (
+          to_regrole('ai_readonly') is null
+          or (
+            not has_table_privilege('ai_readonly', c.oid, 'SELECT')
+            and not has_table_privilege('ai_readonly', c.oid, 'INSERT')
+            and not has_table_privilege('ai_readonly', c.oid, 'UPDATE')
+            and not has_table_privilege('ai_readonly', c.oid, 'DELETE')
+          )
+        )
+        and has_table_privilege('service_role', c.oid, 'SELECT')
+        and has_table_privilege('service_role', c.oid, 'INSERT')
+        and has_table_privilege('service_role', c.oid, 'UPDATE')
+        and has_table_privilege('service_role', c.oid, 'DELETE')
+      from pg_class c
+      where c.oid = to_regclass('public.landing_page_input_catalog_drafts')
+    ), false)
+  union all
+  select
+    'single_non_operational_draft',
+    coalesce((
+      select count(*) <= 1
+        and bool_and(target_version = base_version + 1)
+        and bool_and(publication_fingerprint is null or publication_fingerprint = validation_fingerprint)
+        and bool_and(publication_context_fingerprint is null or publication_context_fingerprint = validation_context_fingerprint)
+        and bool_and(jsonb_typeof(taxon_review_evidence) = 'object')
+      from public.landing_page_input_catalog_drafts
+    ), true)
+  union all
+  select
+    'effective_version_rpc',
+    coalesce((
+      select position('is distinct from 5' in lower(pg_get_functiondef(p.oid))) = 0
+        and position('p_catalog_version <= 0' in pg_get_functiondef(p.oid)) > 0
+      from pg_proc p
+      where p.oid = 'public.save_account_landing_page_configuration_v1(uuid,uuid,jsonb,jsonb,bigint,bigint,integer,uuid,uuid)'::regprocedure
+    ), false)
+)
+select check_name, ok
+from checks
+order by check_name;

--- a/supabase/tests/e20_2_8_input_catalog_lifecycle.test.sql
+++ b/supabase/tests/e20_2_8_input_catalog_lifecycle.test.sql
@@ -1,0 +1,168 @@
+begin;
+set local search_path = public, pg_catalog;
+
+insert into auth.users (id, aud, role, email, created_at, updated_at)
+values (
+  'e2028000-0000-4000-8000-000000000001',
+  'authenticated',
+  'authenticated',
+  'e20.2.8-test@example.com',
+  now(),
+  now()
+);
+
+do $$
+declare
+  v_function_definition text;
+begin
+  if to_regclass('public.landing_page_input_catalog_drafts') is null then
+    raise exception 'E20.2.8 draft residence is missing';
+  end if;
+  if not (
+    select relrowsecurity
+    from pg_class
+    where oid = 'public.landing_page_input_catalog_drafts'::regclass
+  ) then
+    raise exception 'E20.2.8 draft RLS must be enabled';
+  end if;
+  if exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'landing_page_input_catalog_drafts'
+  ) then
+    raise exception 'E20.2.8 service-only draft must not expose consuming policies';
+  end if;
+  if exists (
+       select 1
+       from information_schema.role_table_grants
+       where table_schema = 'public'
+         and table_name = 'landing_page_input_catalog_drafts'
+         and grantee = 'PUBLIC'
+     )
+     or has_table_privilege('anon', 'public.landing_page_input_catalog_drafts', 'SELECT')
+     or has_table_privilege('anon', 'public.landing_page_input_catalog_drafts', 'INSERT')
+     or has_table_privilege('anon', 'public.landing_page_input_catalog_drafts', 'UPDATE')
+     or has_table_privilege('anon', 'public.landing_page_input_catalog_drafts', 'DELETE')
+     or has_table_privilege('authenticated', 'public.landing_page_input_catalog_drafts', 'SELECT')
+     or has_table_privilege('authenticated', 'public.landing_page_input_catalog_drafts', 'INSERT')
+     or has_table_privilege('authenticated', 'public.landing_page_input_catalog_drafts', 'UPDATE')
+     or has_table_privilege('authenticated', 'public.landing_page_input_catalog_drafts', 'DELETE')
+     or (to_regrole('ai_readonly') is not null and (
+       has_table_privilege('ai_readonly', 'public.landing_page_input_catalog_drafts', 'SELECT')
+       or has_table_privilege('ai_readonly', 'public.landing_page_input_catalog_drafts', 'INSERT')
+       or has_table_privilege('ai_readonly', 'public.landing_page_input_catalog_drafts', 'UPDATE')
+       or has_table_privilege('ai_readonly', 'public.landing_page_input_catalog_drafts', 'DELETE')
+     ))
+     or not has_table_privilege('service_role', 'public.landing_page_input_catalog_drafts', 'SELECT')
+     or not has_table_privilege('service_role', 'public.landing_page_input_catalog_drafts', 'INSERT')
+     or not has_table_privilege('service_role', 'public.landing_page_input_catalog_drafts', 'UPDATE')
+     or not has_table_privilege('service_role', 'public.landing_page_input_catalog_drafts', 'DELETE') then
+    raise exception 'E20.2.8 draft grants drifted';
+  end if;
+
+  select pg_get_functiondef(
+    'public.save_account_landing_page_configuration_v1(uuid,uuid,jsonb,jsonb,bigint,bigint,integer,uuid,uuid)'::regprocedure
+  ) into v_function_definition;
+  if position('is distinct from 5' in lower(v_function_definition)) > 0
+     or position('p_catalog_version <= 0' in v_function_definition) = 0 then
+    raise exception 'E20.2.8 effective catalog version guard drifted';
+  end if;
+
+  begin
+    insert into public.landing_page_input_catalog_drafts (
+      singleton, base_version, target_version, catalog_json,
+      content_fingerprint, created_by, updated_by
+    ) values (
+      false, 5, 6, '{}'::jsonb, repeat('a', 64),
+      'e2028000-0000-4000-8000-000000000001',
+      'e2028000-0000-4000-8000-000000000001'
+    );
+    raise exception 'singleton=false unexpectedly accepted';
+  exception when check_violation then
+    null;
+  end;
+
+  begin
+    insert into public.landing_page_input_catalog_drafts (
+      base_version, target_version, catalog_json,
+      content_fingerprint, created_by, updated_by
+    ) values (
+      5, 7, '{}'::jsonb, repeat('a', 64),
+      'e2028000-0000-4000-8000-000000000001',
+      'e2028000-0000-4000-8000-000000000001'
+    );
+    raise exception 'non-sequential target unexpectedly accepted';
+  exception when check_violation then
+    null;
+  end;
+end;
+$$;
+
+insert into public.landing_page_input_catalog_drafts (
+  base_version, target_version, catalog_json, content_fingerprint,
+  created_by, updated_by
+) values (
+  5,
+  6,
+  '{"version":6,"universal":{"level":"universal","entries":[]},"taxonLayers":{}}'::jsonb,
+  repeat('b', 64),
+  'e2028000-0000-4000-8000-000000000001',
+  'e2028000-0000-4000-8000-000000000001'
+);
+
+do $$
+begin
+  begin
+    update public.landing_page_input_catalog_drafts
+    set validation_fingerprint = repeat('b', 64),
+        validated_at = null;
+    raise exception 'partial validation evidence unexpectedly accepted';
+  exception when check_violation then
+    null;
+  end;
+
+  begin
+    update public.landing_page_input_catalog_drafts
+    set publication_fingerprint = repeat('c', 64),
+        publication_context_fingerprint = repeat('d', 64),
+        publication_prepared_at = now(),
+        validation_fingerprint = repeat('b', 64),
+        validation_context_fingerprint = repeat('e', 64),
+        validated_at = now();
+    raise exception 'mismatched publication evidence unexpectedly accepted';
+  exception when check_violation then
+    null;
+  end;
+end;
+$$;
+
+update public.landing_page_input_catalog_drafts
+set validation_fingerprint = content_fingerprint,
+    validation_context_fingerprint = repeat('c', 64),
+    validated_at = now(),
+    publication_fingerprint = content_fingerprint,
+    publication_context_fingerprint = repeat('c', 64),
+    publication_prepared_at = now();
+
+do $$
+begin
+  begin
+    update public.landing_page_input_catalog_drafts
+    set taxon_review_evidence = '[]'::jsonb;
+    raise exception 'non-object review evidence unexpectedly accepted';
+  exception when check_violation then
+    null;
+  end;
+end;
+$$;
+
+do $$
+begin
+  if (select count(*) from public.landing_page_input_catalog_drafts) <> 1 then
+    raise exception 'E20.2.8 must preserve exactly one draft';
+  end if;
+end;
+$$;
+
+rollback;


### PR DESCRIPTION
## Escopo

Orquestração e execução end-to-end da E20.2.8 em um único PR draft, com plano-base v2, matriz, roadmap, implementação técnica e artefatos de rollout.

## Decisão vinculante

O registry repo-only permanece a única autoridade das versões publicadas e da versão atual. O banco guarda somente o único próximo draft administrativo, mutável e não operacional. Não há migração de v1-v5, publicação pelo banco ou autoridade concorrente: publicar exige materialização/versionamento no repositório, validação, revisão e merge humanos, deploy de Production e prova da identidade exata.

## Implementação

- versão atual explícita e executável, sem `Math.max`, `latest` ou fallback;
- comparador conservador `R → C`, carry-forward sem writes artificiais e retirada forward-only;
- E19.2 pré-handoff, workspace E19.5 e geração E19.5 consumindo o mesmo `C` pelo boundary canônico;
- singleton service-only para o draft v6 não operacional, com concorrência otimista;
- gates E20.6.5 e E19 completos, paginados com cardinalidade exata e fingerprints separados de conteúdo/contexto operacional;
- handoff repo-only e reconciliação somente após o registry exato estar implantado em Production;
- UI na superfície existente `/admin/estrutura-lp?view=entradas` e avaliação individual na Taxonomia;
- migration, teste transacional e snippet read-only versionados.

## Gate do Analista

- revisão de implementação: `aprovado com correções obrigatórias`;
- seis correções objetivas aplicadas;
- revisão delta: `aprovado para avançar`;
- checkpoint: `46eefe7453b717d01f43af027e8fa247295fd719` (`LP-Factory-Phase: E20.2.8 — Versão atual e propagação escalável`).

## Validações

- `npm ci`: aprovado; dependências e lockfile não mudaram depois.
- `npm run check`: aprovado, 0 erros e 24 warnings preexistentes.
- validadores focais de Admin, input catalog, taxon preparation, onboarding, generation context e workspace: aprovados.
- TypeScript e `git diff --check`: aprovados.
- `origin/main` atual (`7dc40560`) está integralmente contida na branch.

## ABCs da implementação

- `docs/base-tecnica.md`: delta aplicado.
- `docs/schema.md`: delta aplicado.
- `docs/roadmap.md`: delta aplicado.
- `docs/design-system.md`, `docs/platform-config.md`, `docs/services.md` e `docs/automations.md`: sem alterações necessárias.

## Pendências pós-merge

- apply canônico da migration `20260824180000_e20_2_8_input_catalog_lifecycle.sql`;
- teste SQL e snippet no ambiente hospedado, com Security Controls;
- QA autenticado da superfície Admin após o apply.

A migration não foi aplicada, nenhum gate foi alterado e nenhum merge foi executado. O merge final permanece reservado ao humano pelo GitHub Web.